### PR TITLE
fix(auth): address all review findings for auth detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +59,16 @@ dependencies = [
  "anstyle",
  "once_cell_polyfill",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -103,6 +122,9 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]
@@ -183,6 +205,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,12 +292,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -265,6 +321,40 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -278,8 +368,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -312,6 +407,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +442,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -369,6 +489,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,9 +504,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -580,6 +708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +756,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +779,25 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -877,6 +1039,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1243,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1393,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,6 +1461,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1348,7 +1570,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1358,6 +1592,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1407,6 +1671,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "want"
@@ -1689,6 +1959,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,23 @@ dirs = "6"
 tabled = "0.17"
 thiserror = "2"
 colored = "3"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+wiremock = "0.6"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+unwrap_used = "deny"
+expect_used = "warn"
+panic = "deny"
+panic_in_result_fn = "deny"
+unimplemented = "deny"
+allow_attributes = "warn"
+dbg_macro = "deny"
+todo = "deny"
+print_stdout = "deny"
+print_stderr = "deny"
+module_name_repetitions = "allow"
+similar_names = "allow"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,209 @@
+use std::time::Duration;
+
+use reqwest::header::HeaderValue;
+use serde::Deserialize;
+
+use crate::config::{AuthMethod, Config};
+use crate::error::{BzrError, Result};
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Deserialize)]
+struct WhoAmIResponse {
+    #[serde(default)]
+    id: u64,
+}
+
+/// Returns the cached auth method for a server, or detects and persists it.
+pub async fn resolve_auth_method(config: &mut Config, server_name: &str) -> Result<AuthMethod> {
+    let srv = config
+        .servers
+        .get(server_name)
+        .ok_or_else(|| BzrError::config(format!("server '{server_name}' not found in config")))?;
+
+    if let Some(method) = srv.auth_method {
+        return Ok(method);
+    }
+
+    let url = srv.url.clone();
+    let api_key = srv.api_key.clone();
+
+    let http = reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|e| BzrError::Other(format!("failed to build HTTP client: {e}")))?;
+
+    let method = detect_auth_method(&http, &url, &api_key).await?;
+
+    tracing::info!(server = server_name, %method, "detected auth method");
+
+    let srv_mut = config
+        .servers
+        .get_mut(server_name)
+        .ok_or_else(|| BzrError::config(format!("server '{server_name}' not found in config")))?;
+    srv_mut.auth_method = Some(method);
+    config.save()?;
+
+    Ok(method)
+}
+
+async fn detect_auth_method(
+    http: &reqwest::Client,
+    base_url: &str,
+    api_key: &str,
+) -> Result<AuthMethod> {
+    let base = base_url.trim_end_matches('/');
+
+    if !base.starts_with("https://") {
+        tracing::warn!(
+            url = base,
+            "server URL is not HTTPS — API key will be sent in plaintext"
+        );
+    }
+
+    let whoami_url = format!("{base}/rest/whoami");
+
+    // Probe 1: header-based auth
+    let key_val = HeaderValue::from_str(api_key)
+        .map_err(|_| BzrError::config("invalid API key characters"))?;
+    let resp = http
+        .get(&whoami_url)
+        .header("X-BUGZILLA-API-KEY", key_val)
+        .send()
+        .await?;
+
+    if resp.status().is_success() {
+        let body: WhoAmIResponse = resp.json().await?;
+        if body.id > 0 {
+            return Ok(AuthMethod::Header);
+        }
+    } else {
+        tracing::debug!(status = %resp.status(), "header auth probe failed");
+    }
+
+    // Probe 2: query-param auth
+    let resp = http
+        .get(&whoami_url)
+        .query(&[("Bugzilla_api_key", api_key)])
+        .send()
+        .await?;
+
+    if resp.status().is_success() {
+        let body: WhoAmIResponse = resp.json().await?;
+        if body.id > 0 {
+            return Ok(AuthMethod::QueryParam);
+        }
+    } else {
+        tracing::debug!(status = %resp.status(), "query param auth probe failed");
+    }
+
+    Err(BzrError::Other(
+        "auth detection failed: neither header nor query param auth \
+         returned a valid user from rest/whoami. Check your API key \
+         and server URL."
+            .into(),
+    ))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use wiremock::matchers::{header, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    fn test_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn header_auth_succeeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/whoami"))
+            .and(header("X-BUGZILLA-API-KEY", "test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 42})))
+            .mount(&server)
+            .await;
+
+        let result = detect_auth_method(&test_client(), &server.uri(), "test-key")
+            .await
+            .unwrap();
+        assert_eq!(result, AuthMethod::Header);
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_query_param() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/whoami"))
+            .and(header("X-BUGZILLA-API-KEY", "test-key"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/whoami"))
+            .and(query_param("Bugzilla_api_key", "test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 7})))
+            .mount(&server)
+            .await;
+
+        let result = detect_auth_method(&test_client(), &server.uri(), "test-key")
+            .await
+            .unwrap();
+        assert_eq!(result, AuthMethod::QueryParam);
+    }
+
+    #[tokio::test]
+    async fn both_methods_fail() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/whoami"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        let result = detect_auth_method(&test_client(), &server.uri(), "test-key").await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("auth detection failed"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cached_method_skips_detection() {
+        let mut config = Config::default();
+        config.servers.insert(
+            "cached".into(),
+            crate::config::ServerConfig {
+                url: "https://example.com".into(),
+                api_key: "key".into(),
+                auth_method: Some(AuthMethod::Header),
+            },
+        );
+
+        let result = resolve_auth_method(&mut config, "cached").await.unwrap();
+        assert_eq!(result, AuthMethod::Header);
+    }
+
+    #[tokio::test]
+    async fn missing_server_returns_error() {
+        let mut config = Config::default();
+        let result = resolve_auth_method(&mut config, "nonexistent").await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("not found"), "unexpected error: {err}");
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,12 +1,25 @@
+use std::time::Duration;
+
 use base64::Engine;
-use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::header::HeaderValue;
+use reqwest::RequestBuilder;
 use serde::{Deserialize, Serialize};
 
+use crate::config::AuthMethod;
 use crate::error::{BzrError, Result};
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+enum AuthConfig {
+    Header(HeaderValue),
+    QueryParam(String),
+}
 
 pub struct BugzillaClient {
     http: reqwest::Client,
     base_url: String,
+    auth: AuthConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -196,24 +209,38 @@ struct ErrorResponse {
 }
 
 impl BugzillaClient {
-    pub fn new(base_url: &str, api_key: &str) -> Result<Self> {
-        let mut headers = HeaderMap::new();
-        let key_val = HeaderValue::from_str(api_key)
-            .map_err(|_| BzrError::config("invalid API key characters"))?;
-        headers.insert("X-BUGZILLA-API-KEY", key_val);
+    pub fn new(base_url: &str, api_key: &str, auth_method: AuthMethod) -> Result<Self> {
+        let auth = match auth_method {
+            AuthMethod::Header => {
+                let value = HeaderValue::from_str(api_key)
+                    .map_err(|_| BzrError::config("invalid API key characters"))?;
+                AuthConfig::Header(value)
+            }
+            AuthMethod::QueryParam => AuthConfig::QueryParam(api_key.to_string()),
+        };
 
         let http = reqwest::Client::builder()
-            .default_headers(headers)
-            .build()?;
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|e| BzrError::Other(format!("failed to build HTTP client: {e}")))?;
 
         Ok(BugzillaClient {
             http,
             base_url: base_url.trim_end_matches('/').to_string(),
+            auth,
         })
     }
 
     fn url(&self, path: &str) -> String {
         format!("{}/rest/{}", self.base_url, path.trim_start_matches('/'))
+    }
+
+    fn auth(&self, builder: RequestBuilder) -> RequestBuilder {
+        match &self.auth {
+            AuthConfig::Header(value) => builder.header("X-BUGZILLA-API-KEY", value.clone()),
+            AuthConfig::QueryParam(key) => builder.query(&[("Bugzilla_api_key", key)]),
+        }
     }
 
     async fn check_error(&self, response: reqwest::Response) -> Result<reqwest::Response> {
@@ -228,13 +255,16 @@ impl BugzillaClient {
                     });
                 }
             }
-            return Err(BzrError::Other(format!("HTTP {}: {}", status, body)));
+            return Err(BzrError::Other(format!("HTTP {status}: {body}")));
         }
         Ok(response)
     }
 
     pub async fn search_bugs(&self, params: &SearchParams) -> Result<Vec<Bug>> {
-        let resp = self.http.get(self.url("bug")).query(params).send().await?;
+        let resp = self
+            .auth(self.http.get(self.url("bug")).query(params))
+            .send()
+            .await?;
         let resp = self.check_error(resp).await?;
         let data: BugListResponse = resp.json().await?;
         Ok(data.bugs)
@@ -242,8 +272,7 @@ impl BugzillaClient {
 
     pub async fn get_bug(&self, id: u64) -> Result<Bug> {
         let resp = self
-            .http
-            .get(self.url(&format!("bug/{}", id)))
+            .auth(self.http.get(self.url(&format!("bug/{id}"))))
             .send()
             .await?;
         let resp = self.check_error(resp).await?;
@@ -251,11 +280,14 @@ impl BugzillaClient {
         data.bugs
             .into_iter()
             .next()
-            .ok_or_else(|| BzrError::Other(format!("bug {} not found", id)))
+            .ok_or_else(|| BzrError::Other(format!("bug {id} not found")))
     }
 
     pub async fn create_bug(&self, params: &CreateBugParams) -> Result<u64> {
-        let resp = self.http.post(self.url("bug")).json(params).send().await?;
+        let resp = self
+            .auth(self.http.post(self.url("bug")).json(params))
+            .send()
+            .await?;
         let resp = self.check_error(resp).await?;
         let data: BugCreateResponse = resp.json().await?;
         Ok(data.id)
@@ -263,9 +295,7 @@ impl BugzillaClient {
 
     pub async fn update_bug(&self, id: u64, params: &UpdateBugParams) -> Result<()> {
         let resp = self
-            .http
-            .put(self.url(&format!("bug/{}", id)))
-            .json(params)
+            .auth(self.http.put(self.url(&format!("bug/{id}"))).json(params))
             .send()
             .await?;
         self.check_error(resp).await?;
@@ -274,8 +304,7 @@ impl BugzillaClient {
 
     pub async fn get_comments(&self, bug_id: u64) -> Result<Vec<Comment>> {
         let resp = self
-            .http
-            .get(self.url(&format!("bug/{}/comment", bug_id)))
+            .auth(self.http.get(self.url(&format!("bug/{bug_id}/comment"))))
             .send()
             .await?;
         let resp = self.check_error(resp).await?;
@@ -291,8 +320,7 @@ impl BugzillaClient {
 
     pub async fn get_attachments(&self, bug_id: u64) -> Result<Vec<Attachment>> {
         let resp = self
-            .http
-            .get(self.url(&format!("bug/{}/attachment", bug_id)))
+            .auth(self.http.get(self.url(&format!("bug/{bug_id}/attachment"))))
             .send()
             .await?;
         let resp = self.check_error(resp).await?;
@@ -303,8 +331,10 @@ impl BugzillaClient {
 
     pub async fn get_attachment(&self, attachment_id: u64) -> Result<Attachment> {
         let resp = self
-            .http
-            .get(self.url(&format!("bug/attachment/{}", attachment_id)))
+            .auth(
+                self.http
+                    .get(self.url(&format!("bug/attachment/{attachment_id}"))),
+            )
             .send()
             .await?;
         let resp = self.check_error(resp).await?;
@@ -312,7 +342,7 @@ impl BugzillaClient {
         data.attachments
             .into_values()
             .next()
-            .ok_or_else(|| BzrError::Other(format!("attachment {} not found", attachment_id)))
+            .ok_or_else(|| BzrError::Other(format!("attachment {attachment_id} not found")))
     }
 
     pub async fn download_attachment(&self, attachment_id: u64) -> Result<(String, Vec<u8>)> {
@@ -322,7 +352,7 @@ impl BugzillaClient {
             .ok_or_else(|| BzrError::Other("attachment has no data".into()))?;
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(&data)
-            .map_err(|e| BzrError::Other(format!("failed to decode attachment: {}", e)))?;
+            .map_err(|e| BzrError::Other(format!("failed to decode attachment: {e}")))?;
         Ok((attachment.file_name, bytes))
     }
 
@@ -343,9 +373,11 @@ impl BugzillaClient {
             "data": encoded,
         });
         let resp = self
-            .http
-            .post(self.url(&format!("bug/{}/attachment", bug_id)))
-            .json(&body)
+            .auth(
+                self.http
+                    .post(self.url(&format!("bug/{bug_id}/attachment")))
+                    .json(&body),
+            )
             .send()
             .await?;
         let resp = self.check_error(resp).await?;
@@ -359,9 +391,11 @@ impl BugzillaClient {
     pub async fn add_comment(&self, bug_id: u64, text: &str) -> Result<u64> {
         let body = serde_json::json!({ "comment": text });
         let resp = self
-            .http
-            .post(self.url(&format!("bug/{}/comment", bug_id)))
-            .json(&body)
+            .auth(
+                self.http
+                    .post(self.url(&format!("bug/{bug_id}/comment")))
+                    .json(&body),
+            )
             .send()
             .await?;
         let resp = self.check_error(resp).await?;

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -9,27 +9,36 @@ use crate::output::{self, OutputFormat};
 pub async fn execute(
     action: &AttachmentAction,
     server: Option<&str>,
-    format: &OutputFormat,
+    format: OutputFormat,
 ) -> Result<()> {
-    let config = Config::load()?;
-    let srv = config.active_server(server)?;
-    let client = BugzillaClient::new(&srv.url, &srv.api_key)?;
+    let mut config = Config::load()?;
+    let (server_name, srv) = config.active_server_named(server)?;
+    let (server_name, url, api_key) = (
+        server_name.to_string(),
+        srv.url.clone(),
+        srv.api_key.clone(),
+    );
+    let auth = crate::auth::resolve_auth_method(&mut config, &server_name).await?;
+    let client = BugzillaClient::new(&url, &api_key, auth)?;
 
     match action {
         AttachmentAction::List { bug_id } => {
             let attachments = client.get_attachments(*bug_id).await?;
-            output::print_attachments(&attachments, format)?;
+            output::print_attachments(&attachments, format);
         }
         AttachmentAction::Download { id, output: out } => {
             let (filename, data) = client.download_attachment(*id).await?;
             let dest = out.as_deref().unwrap_or(&filename);
             std::fs::write(dest, &data)?;
-            println!(
-                "Downloaded attachment #{} to {} ({} bytes)",
-                id,
-                dest,
-                data.len()
-            );
+            #[expect(clippy::print_stdout)]
+            {
+                println!(
+                    "Downloaded attachment #{} to {} ({} bytes)",
+                    id,
+                    dest,
+                    data.len()
+                );
+            }
         }
         AttachmentAction::Upload {
             bug_id,
@@ -47,12 +56,15 @@ pub async fn execute(
             let att_id = client
                 .upload_attachment(*bug_id, file_name, summary, ct, &data)
                 .await?;
-            println!(
-                "Uploaded attachment #{} to bug #{} ({} bytes)",
-                att_id,
-                bug_id,
-                data.len()
-            );
+            #[expect(clippy::print_stdout)]
+            {
+                println!(
+                    "Uploaded attachment #{} to bug #{} ({} bytes)",
+                    att_id,
+                    bug_id,
+                    data.len()
+                );
+            }
         }
     }
     Ok(())
@@ -62,10 +74,12 @@ fn guess_content_type(filename: &str) -> &'static str {
     match filename
         .rsplit('.')
         .next()
-        .map(|e| e.to_lowercase())
+        .map(str::to_lowercase)
         .as_deref()
     {
-        Some("txt" | "log") => "text/plain",
+        Some(
+            "txt" | "log" | "c" | "h" | "cpp" | "rs" | "py" | "sh" | "pl" | "rb" | "js" | "ts",
+        ) => "text/plain",
         Some("html" | "htm") => "text/html",
         Some("json") => "application/json",
         Some("xml") => "application/xml",
@@ -78,7 +92,6 @@ fn guess_content_type(filename: &str) -> &'static str {
         Some("zip") => "application/zip",
         Some("tar") => "application/x-tar",
         Some("patch" | "diff") => "text/x-diff",
-        Some("c" | "h" | "cpp" | "rs" | "py" | "sh" | "pl" | "rb" | "js" | "ts") => "text/plain",
         _ => "application/octet-stream",
     }
 }

--- a/src/commands/bug.rs
+++ b/src/commands/bug.rs
@@ -4,14 +4,16 @@ use crate::config::Config;
 use crate::error::Result;
 use crate::output::{self, OutputFormat};
 
-pub async fn execute(
-    action: &BugAction,
-    server: Option<&str>,
-    format: &OutputFormat,
-) -> Result<()> {
-    let config = Config::load()?;
-    let srv = config.active_server(server)?;
-    let client = BugzillaClient::new(&srv.url, &srv.api_key)?;
+pub async fn execute(action: &BugAction, server: Option<&str>, format: OutputFormat) -> Result<()> {
+    let mut config = Config::load()?;
+    let (server_name, srv) = config.active_server_named(server)?;
+    let (server_name, url, api_key) = (
+        server_name.to_string(),
+        srv.url.clone(),
+        srv.api_key.clone(),
+    );
+    let auth = crate::auth::resolve_auth_method(&mut config, &server_name).await?;
+    let client = BugzillaClient::new(&url, &api_key, auth)?;
 
     match action {
         BugAction::List {
@@ -30,11 +32,11 @@ pub async fn execute(
                 ..Default::default()
             };
             let bugs = client.search_bugs(&params).await?;
-            output::print_bugs(&bugs, format)?;
+            output::print_bugs(&bugs, format);
         }
         BugAction::View { id } => {
             let bug = client.get_bug(*id).await?;
-            output::print_bug_detail(&bug, format)?;
+            output::print_bug_detail(&bug, format);
         }
         BugAction::Search { query, limit } => {
             let params = SearchParams {
@@ -43,7 +45,7 @@ pub async fn execute(
                 ..Default::default()
             };
             let bugs = client.search_bugs(&params).await?;
-            output::print_bugs(&bugs, format)?;
+            output::print_bugs(&bugs, format);
         }
         BugAction::Create {
             product,
@@ -66,7 +68,10 @@ pub async fn execute(
                 assigned_to: assignee.clone(),
             };
             let id = client.create_bug(&params).await?;
-            println!("Created bug #{}", id);
+            #[expect(clippy::print_stdout)]
+            {
+                println!("Created bug #{id}");
+            }
         }
         BugAction::Update {
             id,
@@ -88,7 +93,10 @@ pub async fn execute(
                 whiteboard: whiteboard.clone(),
             };
             client.update_bug(*id, &params).await?;
-            println!("Updated bug #{}", id);
+            #[expect(clippy::print_stdout)]
+            {
+                println!("Updated bug #{id}");
+            }
         }
     }
     Ok(())

--- a/src/commands/comment.rs
+++ b/src/commands/comment.rs
@@ -9,16 +9,22 @@ use crate::output::{self, OutputFormat};
 pub async fn execute(
     action: &CommentAction,
     server: Option<&str>,
-    format: &OutputFormat,
+    format: OutputFormat,
 ) -> Result<()> {
-    let config = Config::load()?;
-    let srv = config.active_server(server)?;
-    let client = BugzillaClient::new(&srv.url, &srv.api_key)?;
+    let mut config = Config::load()?;
+    let (server_name, srv) = config.active_server_named(server)?;
+    let (server_name, url, api_key) = (
+        server_name.to_string(),
+        srv.url.clone(),
+        srv.api_key.clone(),
+    );
+    let auth = crate::auth::resolve_auth_method(&mut config, &server_name).await?;
+    let client = BugzillaClient::new(&url, &api_key, auth)?;
 
     match action {
         CommentAction::List { bug_id } => {
             let comments = client.get_comments(*bug_id).await?;
-            output::print_comments(&comments, format)?;
+            output::print_comments(&comments, format);
         }
         CommentAction::Add { bug_id, body } => {
             let text = match body {
@@ -29,7 +35,10 @@ pub async fn execute(
                 return Err(BzrError::Other("empty comment, aborting".into()));
             }
             let id = client.add_comment(*bug_id, &text).await?;
-            println!("Added comment #{} to bug #{}", id, bug_id);
+            #[expect(clippy::print_stdout)]
+            {
+                println!("Added comment #{id} to bug #{bug_id}");
+            }
         }
     }
     Ok(())
@@ -45,7 +54,7 @@ fn edit_comment() -> Result<String> {
     let status = std::process::Command::new(&editor).arg(&path).status()?;
 
     if !status.success() {
-        return Err(BzrError::Other(format!("{} exited with error", editor)));
+        return Err(BzrError::Other(format!("{editor} exited with error")));
     }
 
     let content = std::fs::read_to_string(&path)?;

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -2,6 +2,7 @@ use crate::cli::ConfigAction;
 use crate::config::{Config, ServerConfig};
 use crate::error::Result;
 
+#[expect(clippy::print_stdout)]
 pub fn execute(action: &ConfigAction) -> Result<()> {
     match action {
         ConfigAction::SetServer { name, url, api_key } => {
@@ -11,13 +12,14 @@ pub fn execute(action: &ConfigAction) -> Result<()> {
                 ServerConfig {
                     url: url.clone(),
                     api_key: api_key.clone(),
+                    auth_method: None,
                 },
             );
             if config.default_server.is_none() {
                 config.default_server = Some(name.clone());
             }
             config.save()?;
-            println!("Server '{}' configured at {}", name, url);
+            println!("Server '{name}' configured at {url}");
             if config.default_server.as_deref() == Some(name.as_str()) {
                 println!("Set as default server.");
             }
@@ -26,20 +28,19 @@ pub fn execute(action: &ConfigAction) -> Result<()> {
             let mut config = Config::load()?;
             if !config.servers.contains_key(name) {
                 return Err(crate::error::BzrError::config(format!(
-                    "server '{}' not found",
-                    name
+                    "server '{name}' not found"
                 )));
             }
             config.default_server = Some(name.clone());
             config.save()?;
-            println!("Default server set to '{}'", name);
+            println!("Default server set to '{name}'");
         }
         ConfigAction::Show => {
             let config = Config::load()?;
             let path = Config::path()?;
             println!("Config file: {}\n", path.display());
             if let Some(ref def) = config.default_server {
-                println!("Default server: {}", def);
+                println!("Default server: {def}");
             }
             if config.servers.is_empty() {
                 println!("No servers configured.");
@@ -50,9 +51,14 @@ pub fn execute(action: &ConfigAction) -> Result<()> {
                     } else {
                         "***".into()
                     };
-                    println!("\n[{}]", name);
+                    let auth_display = match &srv.auth_method {
+                        Some(m) => m.to_string(),
+                        None => "auto (not yet detected)".into(),
+                    };
+                    println!("\n[{name}]");
                     println!("  URL:     {}", srv.url);
-                    println!("  API Key: {}", masked_key);
+                    println!("  API Key: {masked_key}");
+                    println!("  Auth:    {auth_display}");
                 }
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::fs;
 use std::path::PathBuf;
 
@@ -13,10 +14,28 @@ pub struct Config {
     pub servers: HashMap<String, ServerConfig>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthMethod {
+    Header,
+    QueryParam,
+}
+
+impl fmt::Display for AuthMethod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AuthMethod::Header => write!(f, "header"),
+            AuthMethod::QueryParam => write!(f, "query_param"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
     pub url: String,
     pub api_key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_method: Option<AuthMethod>,
 }
 
 impl Config {
@@ -46,16 +65,25 @@ impl Config {
         Ok(())
     }
 
-    pub fn active_server(&self, server_name: Option<&str>) -> Result<&ServerConfig> {
-        let name = server_name
+    pub fn active_server_named<'a>(
+        &'a self,
+        server_name: Option<&'a str>,
+    ) -> Result<(&'a str, &'a ServerConfig)> {
+        let name = self.resolve_server_name(server_name)?;
+        let srv = self
+            .servers
+            .get(name)
+            .ok_or_else(|| BzrError::config(format!("server '{name}' not found in config")))?;
+        Ok((name, srv))
+    }
+
+    pub fn resolve_server_name<'a>(&'a self, server_name: Option<&'a str>) -> Result<&'a str> {
+        server_name
             .or(self.default_server.as_deref())
             .ok_or_else(|| {
                 BzrError::config(
                     "no server configured. Run `bzr config set-server <name> --url <url> --api-key <key>` first",
                 )
-            })?;
-        self.servers
-            .get(name)
-            .ok_or_else(|| BzrError::config(format!("server '{}' not found in config", name)))
+            })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
+mod auth;
 mod cli;
 mod client;
 mod commands;
 mod config;
 mod error;
+#[expect(clippy::print_stdout, clippy::unwrap_used)]
 mod output;
 
 use clap::Parser;
@@ -11,10 +13,18 @@ use output::OutputFormat;
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .init();
+
     let cli = Cli::parse();
 
     if let Err(e) = run(cli).await {
-        eprintln!("error: {}", e);
+        #[expect(clippy::print_stderr)]
+        {
+            eprintln!("error: {e}");
+        }
         std::process::exit(1);
     }
 }
@@ -27,13 +37,13 @@ async fn run(cli: Cli) -> error::Result<()> {
 
     match &cli.command {
         Commands::Bug { action } => {
-            commands::bug::execute(action, cli.server.as_deref(), &format).await
+            commands::bug::execute(action, cli.server.as_deref(), format).await
         }
         Commands::Comment { action } => {
-            commands::comment::execute(action, cli.server.as_deref(), &format).await
+            commands::comment::execute(action, cli.server.as_deref(), format).await
         }
         Commands::Attachment { action } => {
-            commands::attachment::execute(action, cli.server.as_deref(), &format).await
+            commands::attachment::execute(action, cli.server.as_deref(), format).await
         }
         Commands::Config { action } => commands::config_cmd::execute(action),
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,7 +2,6 @@ use colored::Colorize;
 use tabled::{Table, Tabled};
 
 use crate::client::{Attachment, Bug, Comment};
-use crate::error::Result;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub enum OutputFormat {
@@ -17,7 +16,7 @@ impl std::str::FromStr for OutputFormat {
         match s.to_lowercase().as_str() {
             "table" => Ok(OutputFormat::Table),
             "json" => Ok(OutputFormat::Json),
-            other => Err(format!("unknown output format: {}", other)),
+            other => Err(format!("unknown output format: {other}")),
         }
     }
 }
@@ -70,7 +69,7 @@ fn colorize_status(status: &str) -> String {
     }
 }
 
-pub fn print_bugs(bugs: &[Bug], format: &OutputFormat) -> Result<()> {
+pub fn print_bugs(bugs: &[Bug], format: OutputFormat) {
     match format {
         OutputFormat::Json => {
             println!("{}", serde_json::to_string_pretty(bugs).unwrap());
@@ -78,17 +77,16 @@ pub fn print_bugs(bugs: &[Bug], format: &OutputFormat) -> Result<()> {
         OutputFormat::Table => {
             if bugs.is_empty() {
                 println!("No bugs found.");
-                return Ok(());
+                return;
             }
             let rows: Vec<BugRow> = bugs.iter().map(BugRow::from).collect();
             let table = Table::new(rows).to_string();
-            println!("{}", table);
+            println!("{table}");
         }
     }
-    Ok(())
 }
 
-pub fn print_bug_detail(bug: &Bug, format: &OutputFormat) -> Result<()> {
+pub fn print_bug_detail(bug: &Bug, format: OutputFormat) {
     match format {
         OutputFormat::Json => {
             println!("{}", serde_json::to_string_pretty(bug).unwrap());
@@ -103,7 +101,7 @@ pub fn print_bug_detail(bug: &Bug, format: &OutputFormat) -> Result<()> {
             println!("  Status:      {}", colorize_status(&bug.status));
             if let Some(ref r) = bug.resolution {
                 if !r.is_empty() {
-                    println!("  Resolution:  {}", r);
+                    println!("  Resolution:  {r}");
                 }
             }
             println!("  Product:     {}", bug.product.as_deref().unwrap_or("-"));
@@ -127,19 +125,26 @@ pub fn print_bug_detail(bug: &Bug, format: &OutputFormat) -> Result<()> {
                 println!("  Keywords:    {}", bug.keywords.join(", "));
             }
             if !bug.blocks.is_empty() {
-                let ids: Vec<String> = bug.blocks.iter().map(|i| i.to_string()).collect();
+                let ids: Vec<String> = bug
+                    .blocks
+                    .iter()
+                    .map(std::string::ToString::to_string)
+                    .collect();
                 println!("  Blocks:      {}", ids.join(", "));
             }
             if !bug.depends_on.is_empty() {
-                let ids: Vec<String> = bug.depends_on.iter().map(|i| i.to_string()).collect();
+                let ids: Vec<String> = bug
+                    .depends_on
+                    .iter()
+                    .map(std::string::ToString::to_string)
+                    .collect();
                 println!("  Depends on:  {}", ids.join(", "));
             }
         }
     }
-    Ok(())
 }
 
-pub fn print_attachments(attachments: &[Attachment], format: &OutputFormat) -> Result<()> {
+pub fn print_attachments(attachments: &[Attachment], format: OutputFormat) {
     match format {
         OutputFormat::Json => {
             println!("{}", serde_json::to_string_pretty(attachments).unwrap());
@@ -147,7 +152,7 @@ pub fn print_attachments(attachments: &[Attachment], format: &OutputFormat) -> R
         OutputFormat::Table => {
             if attachments.is_empty() {
                 println!("No attachments.");
-                return Ok(());
+                return;
             }
             for a in attachments {
                 let obsolete = if a.is_obsolete { " [OBSOLETE]" } else { "" };
@@ -170,10 +175,9 @@ pub fn print_attachments(attachments: &[Attachment], format: &OutputFormat) -> R
             }
         }
     }
-    Ok(())
 }
 
-pub fn print_comments(comments: &[Comment], format: &OutputFormat) -> Result<()> {
+pub fn print_comments(comments: &[Comment], format: OutputFormat) {
     match format {
         OutputFormat::Json => {
             println!("{}", serde_json::to_string_pretty(comments).unwrap());
@@ -181,7 +185,7 @@ pub fn print_comments(comments: &[Comment], format: &OutputFormat) -> Result<()>
         OutputFormat::Table => {
             if comments.is_empty() {
                 println!("No comments.");
-                return Ok(());
+                return;
             }
             for c in comments {
                 println!(
@@ -196,12 +200,11 @@ pub fn print_comments(comments: &[Comment], format: &OutputFormat) -> Result<()>
                 }
                 println!();
                 for line in c.text.lines() {
-                    println!("  {}", line);
+                    println!("  {line}");
                 }
                 println!();
                 println!("{}", "─".repeat(60));
             }
         }
     }
-    Ok(())
 }


### PR DESCRIPTION
## Summary
- Replace `expect()` with `AuthConfig` enum that caches `HeaderValue` at construction, eliminating panic path
- Add HTTP timeouts (10s connect, 30s request) to auth detection and `BugzillaClient`
- Replace `eprintln!` with `tracing` (`info` for detection, `debug` for probe failures, `warn` for non-HTTPS URLs)
- Add `active_server_named()` to `Config`, eliminating redundant double-lookup in all command handlers
- Add `[lints.clippy]` config to `Cargo.toml` enforcing pedantic + panic prevention rules
- Add 5 wiremock tests for auth detection: header success, query-param fallback, both fail, cached result, missing server
- Fix all pre-existing pedantic clippy warnings exposed by new lints

## Test plan
- [x] `cargo test` — 5 new auth tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)