### PR TITLE
fix(config): use XDG_CONFIG_HOME instead of platform config dir

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -40,8 +40,13 @@ pub struct ServerConfig {
 
 impl Config {
     pub fn path() -> Result<PathBuf> {
-        let config_dir = dirs::config_dir()
-            .ok_or_else(|| BzrError::config("cannot determine config directory"))?;
+        let config_dir = if let Ok(val) = std::env::var("XDG_CONFIG_HOME") {
+            PathBuf::from(val)
+        } else {
+            let home = dirs::home_dir()
+                .ok_or_else(|| BzrError::config("cannot determine home directory"))?;
+            home.join(".config")
+        };
         Ok(config_dir.join("bzr").join("config.toml"))
     }
 


### PR DESCRIPTION
## Summary
- `dirs::config_dir()` returns `~/Library/Application Support/` on macOS instead of `~/.config/`, causing the config file to be written to an unexpected location
- Config path now respects `$XDG_CONFIG_HOME` if set, otherwise falls back to `~/.config/`, matching the convention used by `gh` and most CLI tools

## Test plan
- [ ] Run `bzr config set-server` and verify file is created at `~/.config/bzr/config.toml`
- [ ] Set `XDG_CONFIG_HOME=/tmp/test-xdg` and verify config is created at `/tmp/test-xdg/bzr/config.toml`
- [ ] Verify `cargo test` and `cargo clippy -- -D warnings` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)