### PR TITLE
fix(auth): fall back to valid_login for older Bugzilla servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Requires Rust 1.70+.
 ## Quick Start
 
 ```bash
-# Configure a Bugzilla server
+# Configure a Bugzilla server (add --email for Bugzilla 5.0 or earlier)
 bzr config set-server myserver --url https://bugzilla.example.com --api-key YOUR_API_KEY
 
 # List open bugs in a product
@@ -66,7 +66,7 @@ bzr [--server <NAME>] [--output table|json]
 │   ├── download <ATTACHMENT_ID> [-o <FILE>]
 │   └── upload <BUG_ID> <FILE> [--summary <S>] [--content-type <MIME>]
 └── config
-    ├── set-server <NAME> --url <URL> --api-key <KEY>
+    ├── set-server <NAME> --url <URL> --api-key <KEY> [--email <EMAIL>]
     ├── set-default <NAME>
     └── show
 ```
@@ -232,9 +232,11 @@ Configuration is stored in `~/.config/bzr/config.toml`. Multiple servers can be 
 Add or update a named server configuration.
 
 ```bash
-bzr config set-server redhat --url https://bugzilla.redhat.com --api-key abc123
+bzr config set-server redhat --url https://bugzilla.redhat.com --api-key abc123 --email you@redhat.com
 bzr config set-server mozilla --url https://bugzilla.mozilla.org --api-key xyz789
 ```
+
+The `--email` flag is required for older Bugzilla servers (5.0 and earlier) that don't support the `/rest/whoami` endpoint. It is used during auth detection via `/rest/valid_login`.
 
 The first server added is automatically set as the default.
 
@@ -279,6 +281,7 @@ default_server = "redhat"
 [servers.redhat]
 url = "https://bugzilla.redhat.com"
 api_key = "your-api-key-here"
+email = "you@redhat.com"
 
 [servers.mozilla]
 url = "https://bugzilla.mozilla.org"
@@ -287,7 +290,11 @@ api_key = "another-api-key"
 
 ## Authentication
 
-`bzr` authenticates using Bugzilla API keys sent via the `X-BUGZILLA-API-KEY` HTTP header. To generate an API key:
+`bzr` authenticates using Bugzilla API keys. On first use, it auto-detects whether your server supports header-based auth (`X-BUGZILLA-API-KEY`) or query parameter auth (`Bugzilla_api_key`), and caches the result.
+
+For servers running Bugzilla 5.0 or earlier, provide your `--email` when configuring, as auth detection uses the `/rest/valid_login` endpoint which requires it.
+
+To generate an API key:
 
 1. Log in to your Bugzilla instance
 2. Go to **Preferences > API Keys**

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -28,6 +28,7 @@ pub async fn resolve_auth_method(config: &mut Config, server_name: &str) -> Resu
 
     let url = srv.url.clone();
     let api_key = srv.api_key.clone();
+    let email = srv.email.clone();
 
     let http = reqwest::Client::builder()
         .connect_timeout(CONNECT_TIMEOUT)
@@ -35,7 +36,7 @@ pub async fn resolve_auth_method(config: &mut Config, server_name: &str) -> Resu
         .build()
         .map_err(|e| BzrError::Other(format!("failed to build HTTP client: {e}")))?;
 
-    let method = detect_auth_method(&http, &url, &api_key).await?;
+    let method = detect_auth_method(&http, &url, &api_key, email.as_deref()).await?;
 
     tracing::info!(server = server_name, %method, "detected auth method");
 
@@ -53,6 +54,7 @@ async fn detect_auth_method(
     http: &reqwest::Client,
     base_url: &str,
     api_key: &str,
+    email: Option<&str>,
 ) -> Result<AuthMethod> {
     let base = base_url.trim_end_matches('/');
 
@@ -63,48 +65,198 @@ async fn detect_auth_method(
         );
     }
 
-    let whoami_url = format!("{base}/rest/whoami");
-
-    // Probe 1: header-based auth
     let key_val = HeaderValue::from_str(api_key)
         .map_err(|_| BzrError::config("invalid API key characters"))?;
-    let resp = http
-        .get(&whoami_url)
-        .header("X-BUGZILLA-API-KEY", key_val)
+
+    // Try whoami endpoint first (Bugzilla 5.1+)
+    let whoami = try_whoami(http, base, api_key, &key_val).await;
+    match whoami {
+        WhoamiOutcome::Authenticated(method) => return Ok(method),
+        WhoamiOutcome::NotFound => {
+            tracing::info!("falling back to rest/valid_login for older Bugzilla");
+        }
+        WhoamiOutcome::Failed => {}
+    }
+
+    // Fall back to valid_login endpoint (Bugzilla 5.0+, requires email)
+    if let Some(login) = email {
+        if let Some(method) = try_valid_login(http, base, api_key, &key_val, login).await {
+            return Ok(method);
+        }
+    }
+
+    let hint = match whoami {
+        WhoamiOutcome::NotFound if email.is_none() => {
+            "auth detection failed: rest/whoami not available and no \
+             --email provided for rest/valid_login fallback. \
+             Re-run `bzr config set-server` with --email your@email."
+        }
+        WhoamiOutcome::NotFound => {
+            "auth detection failed: rest/valid_login did not confirm \
+             your credentials. Check your API key and email address."
+        }
+        _ => {
+            "auth detection failed: could not authenticate with the \
+             server. Check your API key and server URL."
+        }
+    };
+    Err(BzrError::Other(hint.into()))
+}
+
+enum WhoamiOutcome {
+    Authenticated(AuthMethod),
+    NotFound,
+    Failed,
+}
+
+async fn try_whoami(
+    http: &reqwest::Client,
+    base: &str,
+    api_key: &str,
+    key_header: &HeaderValue,
+) -> WhoamiOutcome {
+    let url = format!("{base}/rest/whoami");
+
+    // Probe: header-based auth
+    let resp = match http
+        .get(&url)
+        .header("X-BUGZILLA-API-KEY", key_header.clone())
         .send()
-        .await?;
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!("whoami request failed: {e}");
+            return WhoamiOutcome::Failed;
+        }
+    };
 
     if resp.status().is_success() {
-        let body: WhoAmIResponse = resp.json().await?;
-        if body.id > 0 {
-            return Ok(AuthMethod::Header);
+        if let Ok(body) = resp.json::<WhoAmIResponse>().await {
+            if body.id > 0 {
+                return WhoamiOutcome::Authenticated(AuthMethod::Header);
+            }
         }
+    } else if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        tracing::debug!("rest/whoami not available on this server");
+        return WhoamiOutcome::NotFound;
     } else {
         tracing::debug!(status = %resp.status(), "header auth probe failed");
     }
 
-    // Probe 2: query-param auth
-    let resp = http
-        .get(&whoami_url)
+    // Probe: query-param auth
+    let resp = match http
+        .get(&url)
         .query(&[("Bugzilla_api_key", api_key)])
         .send()
-        .await?;
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!("whoami query-param request failed: {e}");
+            return WhoamiOutcome::Failed;
+        }
+    };
 
     if resp.status().is_success() {
-        let body: WhoAmIResponse = resp.json().await?;
-        if body.id > 0 {
-            return Ok(AuthMethod::QueryParam);
+        if let Ok(body) = resp.json::<WhoAmIResponse>().await {
+            if body.id > 0 {
+                return WhoamiOutcome::Authenticated(AuthMethod::QueryParam);
+            }
         }
+    } else if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        tracing::debug!("rest/whoami not available on this server");
+        return WhoamiOutcome::NotFound;
     } else {
         tracing::debug!(status = %resp.status(), "query param auth probe failed");
     }
 
-    Err(BzrError::Other(
-        "auth detection failed: neither header nor query param auth \
-         returned a valid user from rest/whoami. Check your API key \
-         and server URL."
-            .into(),
-    ))
+    WhoamiOutcome::Failed
+}
+
+#[derive(Deserialize)]
+struct ValidLoginResponse {
+    #[serde(default)]
+    result: ValidLoginResult,
+}
+
+/// Bugzilla returns `{"result": true}` (bool) or `{"result": 1}` (integer)
+/// depending on version. Accept both.
+#[derive(Deserialize, Default)]
+#[serde(from = "serde_json::Value")]
+struct ValidLoginResult(bool);
+
+impl From<serde_json::Value> for ValidLoginResult {
+    fn from(v: serde_json::Value) -> Self {
+        match v {
+            serde_json::Value::Bool(b) => Self(b),
+            serde_json::Value::Number(n) => Self(n.as_u64() == Some(1)),
+            _ => Self(false),
+        }
+    }
+}
+
+async fn try_valid_login(
+    http: &reqwest::Client,
+    base: &str,
+    api_key: &str,
+    key_header: &HeaderValue,
+    login: &str,
+) -> Option<AuthMethod> {
+    let url = format!("{base}/rest/valid_login");
+
+    // Probe: header-based auth
+    if let Some(method) = probe_valid_login(
+        http,
+        &url,
+        &[("login", login)],
+        Some(key_header),
+        AuthMethod::Header,
+    )
+    .await
+    {
+        return Some(method);
+    }
+
+    // Probe: query-param auth
+    if let Some(method) = probe_valid_login(
+        http,
+        &url,
+        &[("login", login), ("Bugzilla_api_key", api_key)],
+        None,
+        AuthMethod::QueryParam,
+    )
+    .await
+    {
+        return Some(method);
+    }
+
+    tracing::debug!("valid_login probes both failed");
+    None
+}
+
+async fn probe_valid_login(
+    http: &reqwest::Client,
+    url: &str,
+    query: &[(&str, &str)],
+    key_header: Option<&HeaderValue>,
+    method: AuthMethod,
+) -> Option<AuthMethod> {
+    let mut req = http.get(url).query(query);
+    if let Some(hdr) = key_header {
+        req = req.header("X-BUGZILLA-API-KEY", hdr.clone());
+    }
+    let resp = req.send().await.ok()?;
+    if !resp.status().is_success() {
+        tracing::debug!(status = %resp.status(), %method, "valid_login probe failed");
+        return None;
+    }
+    let body: ValidLoginResponse = resp.json().await.ok()?;
+    if body.result.0 {
+        Some(method)
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -133,7 +285,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let result = detect_auth_method(&test_client(), &server.uri(), "test-key")
+        let result = detect_auth_method(&test_client(), &server.uri(), "test-key", None)
             .await
             .unwrap();
         assert_eq!(result, AuthMethod::Header);
@@ -157,14 +309,85 @@ mod tests {
             .mount(&server)
             .await;
 
-        let result = detect_auth_method(&test_client(), &server.uri(), "test-key")
+        let result = detect_auth_method(&test_client(), &server.uri(), "test-key", None)
             .await
             .unwrap();
         assert_eq!(result, AuthMethod::QueryParam);
     }
 
     #[tokio::test]
-    async fn both_methods_fail() {
+    async fn whoami_404_falls_back_to_valid_login_header() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/whoami"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/valid_login"))
+            .and(query_param("login", "user@example.com"))
+            .and(header("X-BUGZILLA-API-KEY", "test-key"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": true})),
+            )
+            .mount(&server)
+            .await;
+
+        let result = detect_auth_method(
+            &test_client(),
+            &server.uri(),
+            "test-key",
+            Some("user@example.com"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result, AuthMethod::Header);
+    }
+
+    #[tokio::test]
+    async fn whoami_404_falls_back_to_valid_login_query_param() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/whoami"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/valid_login"))
+            .and(header("X-BUGZILLA-API-KEY", "test-key"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": false})),
+            )
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/valid_login"))
+            .and(query_param("login", "user@example.com"))
+            .and(query_param("Bugzilla_api_key", "test-key"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": true})),
+            )
+            .mount(&server)
+            .await;
+
+        let result = detect_auth_method(
+            &test_client(),
+            &server.uri(),
+            "test-key",
+            Some("user@example.com"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result, AuthMethod::QueryParam);
+    }
+
+    #[tokio::test]
+    async fn whoami_401_no_email_gives_api_key_error() {
         let server = MockServer::start().await;
 
         Mock::given(method("GET"))
@@ -173,7 +396,90 @@ mod tests {
             .mount(&server)
             .await;
 
-        let result = detect_auth_method(&test_client(), &server.uri(), "test-key").await;
+        let result = detect_auth_method(&test_client(), &server.uri(), "test-key", None).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Check your API key"),
+            "should mention API key, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn whoami_404_no_email_suggests_email_flag() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/whoami"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let result = detect_auth_method(&test_client(), &server.uri(), "test-key", None).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("--email"),
+            "should suggest --email flag, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn valid_login_accepts_integer_result() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/whoami"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/valid_login"))
+            .and(query_param("login", "user@example.com"))
+            .and(header("X-BUGZILLA-API-KEY", "test-key"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": 1})),
+            )
+            .mount(&server)
+            .await;
+
+        let result = detect_auth_method(
+            &test_client(),
+            &server.uri(),
+            "test-key",
+            Some("user@example.com"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result, AuthMethod::Header);
+    }
+
+    #[tokio::test]
+    async fn both_methods_fail_with_email() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/whoami"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/valid_login"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": false})),
+            )
+            .mount(&server)
+            .await;
+
+        let result = detect_auth_method(
+            &test_client(),
+            &server.uri(),
+            "test-key",
+            Some("bad@example.com"),
+        )
+        .await;
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -190,6 +496,7 @@ mod tests {
             crate::config::ServerConfig {
                 url: "https://example.com".into(),
                 api_key: "key".into(),
+                email: None,
                 auth_method: Some(AuthMethod::Header),
             },
         );

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -186,6 +186,9 @@ pub enum ConfigAction {
         /// API key
         #[arg(long)]
         api_key: String,
+        /// Login email (required for older Bugzilla servers)
+        #[arg(long)]
+        email: Option<String>,
     },
     /// Set the default server
     SetDefault {

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -5,13 +5,19 @@ use crate::error::Result;
 #[expect(clippy::print_stdout)]
 pub fn execute(action: &ConfigAction) -> Result<()> {
     match action {
-        ConfigAction::SetServer { name, url, api_key } => {
+        ConfigAction::SetServer {
+            name,
+            url,
+            api_key,
+            email,
+        } => {
             let mut config = Config::load()?;
             config.servers.insert(
                 name.clone(),
                 ServerConfig {
                     url: url.clone(),
                     api_key: api_key.clone(),
+                    email: email.clone(),
                     auth_method: None,
                 },
             );
@@ -57,6 +63,9 @@ pub fn execute(action: &ConfigAction) -> Result<()> {
                     };
                     println!("\n[{name}]");
                     println!("  URL:     {}", srv.url);
+                    if let Some(ref email) = srv.email {
+                        println!("  Email:   {email}");
+                    }
                     println!("  API Key: {masked_key}");
                     println!("  Auth:    {auth_display}");
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,8 @@ pub struct ServerConfig {
     pub url: String,
     pub api_key: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_method: Option<AuthMethod>,
 }
 


### PR DESCRIPTION
## Summary

- Bugzilla 5.0 servers return 404 for `/rest/whoami`, breaking auth detection. This adds a fallback to `/rest/valid_login` using an optional `--email` flag on `config set-server`.
- Distinguishes "endpoint missing" (404) from "bad API key" (401) via `WhoamiOutcome` enum, producing accurate error messages for each case.
- Accepts both boolean (`true`) and integer (`1`) `valid_login` responses for cross-version compatibility.

## Test plan

- [x] 10 unit tests pass covering: whoami success, whoami fallback to query param, whoami 404 → valid_login (header and query param), integer valid_login response, 404 with no email (suggests `--email`), 401 with no email (suggests checking API key), both methods fail with email, cached auth, missing server
- [ ] Manual test against Bugzilla 5.0 server with `--email` flag
- [ ] Verify existing config files without `email` field still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)