### PR TITLE
fix(client): handle Bugzilla error responses with 200 status

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -247,26 +247,43 @@ impl BugzillaClient {
 
     async fn send(&self, builder: RequestBuilder) -> Result<reqwest::Response> {
         let resp = builder.send().await?;
-        let url = resp.url();
-        let safe_url = format!("{}{}", url.origin().ascii_serialization(), url.path());
-        tracing::debug!(url = safe_url, status = %resp.status(), "API response");
+        tracing::debug!(
+            url = Self::safe_url(resp.url()),
+            status = %resp.status(),
+            "API response"
+        );
         self.check_error(resp).await
+    }
+
+    fn safe_url(url: &reqwest::Url) -> String {
+        format!("{}{}", url.origin().ascii_serialization(), url.path())
     }
 
     async fn parse_json<T: serde::de::DeserializeOwned>(
         &self,
         resp: reqwest::Response,
     ) -> Result<T> {
-        let url = resp.url().to_string();
+        let safe_url = Self::safe_url(resp.url());
         let body = resp.text().await?;
+
+        // Check for Bugzilla error responses that arrive with 200 status
+        if let Ok(err) = serde_json::from_str::<ErrorResponse>(&body) {
+            if err.error {
+                return Err(BzrError::Api {
+                    code: err.code,
+                    message: err.message.unwrap_or_else(|| "unknown API error".into()),
+                });
+            }
+        }
+
         serde_json::from_str(&body).map_err(|e| {
             tracing::debug!(
-                %url,
+                url = safe_url,
                 error = %e,
                 body_preview = &body[..body.len().min(512)],
                 "JSON deserialization failed"
             );
-            BzrError::Other(format!("failed to parse response from {url}: {e}"))
+            BzrError::Other(format!("failed to parse response from {safe_url}: {e}"))
         })
     }
 


### PR DESCRIPTION
## Summary

- Bugzilla can return HTTP 200 with an error payload (`"error": true`), e.g., server-side Perl exceptions (code 100500). Previously `check_error` only caught 4xx/5xx, so these produced confusing "missing field `bugs`" deserialization errors.
- `parse_json()` now checks for Bugzilla error payloads before attempting struct deserialization, returning a proper `BzrError::Api` with the server's error code and message.
- Extract `safe_url()` helper to consistently redact query params from logged URLs in both `send()` and `parse_json()`.

## Test plan

- [x] `cargo test` — all 12 tests pass
- [x] `cargo clippy` — clean
- [ ] Manual: `bzr -vvv bug view <id>` against a server that returns a 200-with-error now shows the API error message instead of a deserialization error

🤖 Generated with [Claude Code](https://claude.com/claude-code)