### PR TITLE
fix(auth,client): handle network errors and mixed error/data responses

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -141,17 +141,20 @@ async fn try_whoami(
         }
     };
 
-    if resp.status().is_success() {
-        if let Ok(body) = resp.json::<WhoAmIResponse>().await {
-            if body.id > 0 {
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    tracing::trace!(probe = "whoami/header", %status, body, "auth probe response");
+    if status.is_success() {
+        if let Ok(parsed) = serde_json::from_str::<WhoAmIResponse>(&body) {
+            if parsed.id > 0 {
                 return WhoamiOutcome::Authenticated(AuthMethod::Header);
             }
         }
-    } else if resp.status() == reqwest::StatusCode::NOT_FOUND {
+    } else if status == reqwest::StatusCode::NOT_FOUND {
         tracing::debug!("rest/whoami not available on this server");
         return WhoamiOutcome::NotFound;
     } else {
-        tracing::debug!(status = %resp.status(), "header auth probe failed");
+        tracing::debug!(%status, "header auth probe failed");
     }
 
     // Probe: query-param auth
@@ -168,17 +171,20 @@ async fn try_whoami(
         }
     };
 
-    if resp.status().is_success() {
-        if let Ok(body) = resp.json::<WhoAmIResponse>().await {
-            if body.id > 0 {
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    tracing::trace!(probe = "whoami/query_param", %status, body, "auth probe response");
+    if status.is_success() {
+        if let Ok(parsed) = serde_json::from_str::<WhoAmIResponse>(&body) {
+            if parsed.id > 0 {
                 return WhoamiOutcome::Authenticated(AuthMethod::QueryParam);
             }
         }
-    } else if resp.status() == reqwest::StatusCode::NOT_FOUND {
+    } else if status == reqwest::StatusCode::NOT_FOUND {
         tracing::debug!("rest/whoami not available on this server");
         return WhoamiOutcome::NotFound;
     } else {
-        tracing::debug!(status = %resp.status(), "query param auth probe failed");
+        tracing::debug!(%status, "query param auth probe failed");
     }
 
     WhoamiOutcome::AuthRejected
@@ -257,14 +263,18 @@ async fn probe_valid_login(
         req = req.header("X-BUGZILLA-API-KEY", hdr.clone());
     }
     let resp = req.send().await.ok()?;
-    if !resp.status().is_success() {
-        tracing::debug!(status = %resp.status(), %method, "valid_login probe failed");
+    let status = resp.status();
+    if !status.is_success() {
+        tracing::debug!(%status, %method, "valid_login probe failed");
         return None;
     }
-    let body: ValidLoginResponse = resp.json().await.ok()?;
-    if body.result.0 {
+    let body_text = resp.text().await.ok()?;
+    tracing::trace!(probe = "valid_login", %method, body = body_text, "auth probe response");
+    let parsed: ValidLoginResponse = serde_json::from_str(&body_text).ok()?;
+    if parsed.result.0 {
         Some(method)
     } else {
+        tracing::debug!(%method, "valid_login returned false");
         None
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -643,22 +643,34 @@ impl BugzillaClient {
         let safe_url = Self::safe_url(resp.url());
         let body = resp.text().await?;
 
+        tracing::trace!(
+            url = safe_url,
+            body = &body[..body.len().min(2048)],
+            "response body"
+        );
+
         // Check for Bugzilla error responses that arrive with 200 status.
         // Some servers (e.g. IBM LTC Bugzilla) include error fields alongside
         // valid data — only treat the error as fatal when the response doesn't
         // also contain real data (indicated by common Bugzilla result keys).
         if let Ok(err) = serde_json::from_str::<ErrorResponse>(&body) {
-            if err.error && !Self::has_data_fields(&body) {
-                return Err(BzrError::Api {
-                    code: err.code,
-                    message: err.message.unwrap_or_else(|| "unknown API error".into()),
-                });
-            }
             if err.error {
-                tracing::warn!(
+                let has_data = Self::has_data_fields(&body);
+                tracing::debug!(
                     url = safe_url,
                     code = err.code,
                     message = err.message.as_deref().unwrap_or("unknown"),
+                    has_data,
+                    "error payload in 200 response"
+                );
+                if !has_data {
+                    return Err(BzrError::Api {
+                        code: err.code,
+                        message: err.message.unwrap_or_else(|| "unknown API error".into()),
+                    });
+                }
+                tracing::warn!(
+                    url = safe_url,
                     "server returned error alongside data; using data"
                 );
             }
@@ -679,12 +691,11 @@ impl BugzillaClient {
         if response.status().is_client_error() || response.status().is_server_error() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            let preview = if body.len() > 512 {
-                &body[..512]
-            } else {
-                &body
-            };
-            tracing::debug!(%status, body = preview, "API error response");
+            tracing::debug!(
+                %status,
+                body = &body[..body.len().min(512)],
+                "API error response"
+            );
             if let Ok(err) = serde_json::from_str::<ErrorResponse>(&body) {
                 if err.error {
                     return Err(BzrError::Api {


### PR DESCRIPTION
## Summary

- **Default to header auth on network errors** — when the server is unreachable during auth detection (timeout, TLS, VPN down), default to header auth with a warning instead of failing with a misleading "Check your API key" message
- **Tolerate mixed error/data responses** — some Bugzilla servers with extensions (e.g. IBM LTC MirrorTool) return 200 responses containing both error fields and valid data. Previously `parse_json` failed on any error payload even when a usable `bugs` array was present. Now checks for known data keys before treating the error as fatal.
- **Fix flaky tracing tests** — replace `logged_url_contains_path` and `send_does_not_log_query_param_api_key` with direct `safe_url()` unit tests. The originals used `set_default` which is thread-local, causing intermittent failures under tokio's multi-threaded runtime.
- Improved error diagnostics: full reqwest error cause chain in logs, `WhoamiOutcome` enum distinguishes network errors from auth rejections

## Test plan

- [x] `network_error_defaults_to_header` — unreachable server returns header auth default
- [x] `api_error_with_200_and_data_returns_data` — mixed error+data response returns the data
- [x] `api_error_with_200_status` — error-only 200 responses still raise errors
- [x] `safe_url_strips_query_params` / `safe_url_preserves_path` — deterministic replacements for flaky tracing tests
- [x] All `*_forbidden` tests still fail correctly (error-only, no data keys)
- [x] 84 tests pass, clippy clean
- [ ] Manual test on IBM LTC Bugzilla: `bzr bug view 216138` should return bug data despite MirrorTool error