### PR TITLE
fix(client): retry with alternate auth on 401

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -641,9 +641,7 @@ impl BugzillaClient {
                     status = %retried.status(),
                     "auth fallback response"
                 );
-                if !retried.status().is_client_error()
-                    && !retried.status().is_server_error()
-                {
+                if !retried.status().is_client_error() && !retried.status().is_server_error() {
                     return Ok(retried);
                 }
                 tracing::debug!("auth fallback also failed, returning original 401");
@@ -654,9 +652,7 @@ impl BugzillaClient {
 
     fn apply_alternate_auth(&self, builder: RequestBuilder) -> RequestBuilder {
         match &self.auth {
-            AuthConfig::Header(_) => {
-                builder.query(&[("Bugzilla_api_key", &self.api_key)])
-            }
+            AuthConfig::Header(_) => builder.query(&[("Bugzilla_api_key", &self.api_key)]),
             AuthConfig::QueryParam(_) => {
                 let value = HeaderValue::from_str(&self.api_key)
                     .unwrap_or_else(|_| HeaderValue::from_static(""));


### PR DESCRIPTION
## Summary

- Add auth fallback in `BugzillaClient::send()`: on a 401 response, automatically retry with the alternate auth method (header↔query param)
- Store raw API key in `BugzillaClient` so alternate auth can be constructed at retry time
- If the retry also fails, the original 401 error is returned unchanged

Some Bugzilla servers accept one auth method for most endpoints but reject it for specific ones (e.g. `rest/user?match=`), returning 401. The cached auth method is determined once at setup and never re-evaluated, so users see a confusing "must log in" error even though their API key is valid.

## Test plan

- [x] `cargo test` — all 89 tests pass (4 new auth fallback tests)
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: `bzr user search "alice" -vvv` against a server that rejects header auth on `rest/user` — should show fallback debug log and succeed