### PR TITLE
fix(client): fall back to search endpoint on error 100500

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2045,10 +2045,7 @@ mod tests {
             .await;
 
         let client = test_client(&mock.uri());
-        let bug = client
-            .get_bug_with_fields("99", None, None)
-            .await
-            .unwrap();
+        let bug = client.get_bug_with_fields("99", None, None).await.unwrap();
         assert_eq!(bug.id, 99);
         assert_eq!(bug.summary, "fallback bug");
     }


### PR DESCRIPTION
## Summary

- When `get_bug_with_fields` (used by `bug view`) receives error 100500 from the direct endpoint (`/rest/bug/ID`), retries via the search endpoint (`/rest/bug?id=ID`)
- Some Bugzilla extensions only hook into the direct lookup path and crash there; the search endpoint uses a different server code path that bypasses the extension
- Builds on #23 which added default `include_fields` for bug queries

## Test plan

- [ ] `cargo test` passes (96 tests, including new `get_bug_with_fields_falls_back_on_100500`)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `bug view <id>` works for bugs that trigger server extension errors
- [ ] `bug view <id>` still works normally for bugs without extension issues