### PR TITLE
fix(client): replace nightly integer_sign_cast with stable as casts

### DIFF
--- a/src/xmlrpc_client.rs
+++ b/src/xmlrpc_client.rs
@@ -86,11 +86,7 @@ impl XmlRpcClient {
         }
         if !params.id.is_empty() {
             #[expect(clippy::cast_possible_wrap, reason = "bug IDs fit in i64")]
-            let ids: Vec<Value> = params
-                .id
-                .iter()
-                .map(|id| Value::Int(*id as i64))
-                .collect();
+            let ids: Vec<Value> = params.id.iter().map(|id| Value::Int(*id as i64)).collect();
             rpc_params.insert("ids".into(), Value::Array(ids));
         }
         if let Some(limit) = params.limit {


### PR DESCRIPTION
## Summary
- Replace unstable `cast_signed()`/`cast_unsigned()` methods in `xmlrpc_client.rs` with stable `as` casts
- Add `#[expect]` attributes for clippy's `cast_possible_wrap` and `cast_sign_loss` pedantic lints
- Fixes build failure on stable Rust < 1.87 where `integer_sign_cast` is not yet stabilized

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` passes (133 tests)