### PR TITLE
test: add functional test harness against real Bugzilla

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ PRE_COMMIT ?= pre-commit
 RUST_MIN_VERSION := 1.70.0
 
 .PHONY: setup check-rust check-components check-pre-commit install-hooks \
-        build release test fmt clippy lint clean help
+        build release test fmt clippy lint clean help \
+        functional-build functional-start functional-test functional-stop
 
 ## Setup & Environment
 
@@ -64,6 +65,20 @@ lint: fmt clippy ## Run all linters (fmt + clippy)
 
 clean: ## Remove build artifacts
 	$(CARGO) clean
+
+## Functional Tests
+
+functional-build: ## Build the Bugzilla container image
+	tests/functional/setup-bugzilla.sh build
+
+functional-start: ## Start the Bugzilla container
+	tests/functional/setup-bugzilla.sh start
+
+functional-test: functional-start ## Run functional tests against real Bugzilla
+	tests/functional/run-tests.sh
+
+functional-stop: ## Stop and remove the Bugzilla container
+	tests/functional/setup-bugzilla.sh stop
 
 ## Help
 

--- a/tests/functional/Containerfile
+++ b/tests/functional/Containerfile
@@ -1,0 +1,92 @@
+# Bugzilla 5.0 + MariaDB single-container image for functional testing.
+# Build:  podman build -t localhost/bzr-func-test-bz:latest -f Containerfile .
+# Run:    podman run -d --name bzr-func-test -p 8089:80 localhost/bzr-func-test-bz:latest
+
+FROM docker.io/library/fedora:39
+
+# ── System packages ──────────────────────────────────────────────────
+RUN dnf -y install \
+        mariadb-server mariadb \
+        httpd mod_perl \
+        perl-interpreter perl-CGI perl-DBI perl-DBD-MySQL \
+        perl-TimeDate perl-DateTime perl-DateTime-TimeZone \
+        perl-Digest-SHA perl-Email-MIME perl-Email-Sender \
+        perl-Email-Send perl-Encode perl-Encode-Detect \
+        perl-File-MimeInfo perl-File-Slurp \
+        perl-GD perl-GDGraph perl-HTML-Parser perl-HTML-Scrubber \
+        perl-IO-stringy perl-JSON-XS perl-List-MoreUtils \
+        perl-MIME-tools perl-Math-Random-ISAAC \
+        perl-Module-Build perl-Net-SMTP-SSL \
+        perl-Template-Toolkit perl-Text-Diff \
+        perl-TheSchwartz perl-TimeDate \
+        perl-URI perl-XML-Twig \
+        perl-libwww-perl perl-XMLRPC-Lite perl-SOAP-Lite \
+        perl-Cache-Memcached perl-Authen-SASL \
+        perl-LDAP perl-Authen-Radius \
+        perl-App-cpanminus \
+        git wget patch procps-ng \
+    && dnf clean all
+
+# ── Install Bugzilla 5.0 ────────────────────────────────────────────
+RUN cd /var/www/html \
+    && git clone --depth 1 --branch release-5.0-stable \
+       https://github.com/bugzilla/bugzilla.git
+
+# Install any missing Perl deps that Bugzilla's checksetup detects
+RUN cd /var/www/html/bugzilla \
+    && cpanm --notest \
+        Chart::Lines \
+        Template::Plugin::GD::Image \
+        Math::Random::ISAAC \
+        JSON::RPC \
+        Test::Taint \
+    || true
+
+# ── MariaDB setup ───────────────────────────────────────────────────
+RUN mysql_install_db --user=mysql --datadir=/var/lib/mysql
+
+# ── Bugzilla localconfig ────────────────────────────────────────────
+RUN printf '%s\n' \
+      '$db_driver = "mysql";' \
+      '$db_host = "localhost";' \
+      '$db_name = "bugs";' \
+      '$db_user = "bugs";' \
+      '$db_pass = "bugzilla";' \
+      '$webservergroup = "apache";' \
+    > /var/www/html/bugzilla/localconfig
+
+# ── Apache config for Bugzilla ──────────────────────────────────────
+# Serve Bugzilla from document root so /rest/ works without /bugzilla/ prefix
+RUN sed -i 's|DocumentRoot "/var/www/html"|DocumentRoot "/var/www/html/bugzilla"|' \
+        /etc/httpd/conf/httpd.conf \
+    && cat > /etc/httpd/conf.d/bugzilla.conf <<'APACHECONF'
+<Directory "/var/www/html/bugzilla">
+    AddHandler cgi-script .cgi
+    Options +ExecCGI +FollowSymLinks
+    DirectoryIndex index.cgi
+    AllowOverride All
+    Require all granted
+</Directory>
+# Map /rest/* to rest.cgi (Bugzilla 5.0 uses rest.cgi, not a /rest/ directory)
+RewriteEngine On
+RewriteRule ^/rest/(.*)$ /rest.cgi/$1 [L]
+RewriteRule ^/rest$ /rest.cgi [L]
+APACHECONF
+RUN echo "LoadModule rewrite_module modules/mod_rewrite.so" \
+    >> /etc/httpd/conf.modules.d/00-rewrite.conf 2>/dev/null || true
+
+# ── checksetup answers file ─────────────────────────────────────────
+RUN printf '%s\n' \
+      "\$answer{'ADMIN_EMAIL'} = 'admin@test.bzr';" \
+      "\$answer{'ADMIN_PASSWORD'} = 'FuncTest1!';" \
+      "\$answer{'ADMIN_REALNAME'} = 'Admin User';" \
+      "\$answer{'NO_PAUSE'} = 1;" \
+    > /var/www/html/bugzilla/answers.txt
+
+# ── Entrypoint ──────────────────────────────────────────────────────
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 80
+
+CMD ["/entrypoint.sh"]

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -1,0 +1,92 @@
+# bzr Functional Tests
+
+End-to-end tests that exercise every `bzr` CLI command against a real Bugzilla 5.0 instance running in a podman container.
+
+## Prerequisites
+
+- `podman` (rootless configured)
+- `jq`
+- `curl`
+- `cargo` + Rust toolchain
+
+## Quick Start
+
+```bash
+# Build the Bugzilla container image (one-time, ~5 min)
+make functional-build
+
+# Start the container and run all tests
+make functional-test
+
+# Stop the container when done
+make functional-stop
+```
+
+## Manual Steps
+
+```bash
+# Build the image
+tests/functional/setup-bugzilla.sh build
+
+# Start the container (waits for Bugzilla to be ready)
+tests/functional/setup-bugzilla.sh start
+
+# Run the tests
+tests/functional/run-tests.sh
+
+# Check container status
+tests/functional/setup-bugzilla.sh status
+
+# View container logs
+tests/functional/setup-bugzilla.sh logs
+
+# Stop and remove the container
+tests/functional/setup-bugzilla.sh stop
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BZR_FUNC_PORT` | `8089` | Host port mapped to container port 80 |
+| `BZR_FUNC_CONTAINER` | `bzr-func-test` | Container name |
+| `BZR_FUNC_IMAGE` | `localhost/bzr-func-test-bz:latest` | Image name |
+| `BZR_FUNC_TIMEOUT` | `90` | Health check timeout in seconds |
+| `BZR_BIN` | `target/release/bzr` | Path to pre-built bzr binary (skips cargo build) |
+
+## Test Structure
+
+Tests run in dependency order across 12 phases:
+
+1. **Config** — set-server, show, set-default (no network)
+2. **Server & Auth** — server info, whoami
+3. **Products** — create, list, view, update
+4. **Components** — create, update
+5. **Fields & Classifications** — field list, classification view
+6. **Users** — create, search, update
+7. **Groups** — create, view, update, add/remove/list users
+8. **Bugs** — create, view, list, search, update, history, negative test
+9. **Comments** — add, list, tag, search-tags
+10. **Attachments** — upload, list, download, update
+11. **Global Options** — --output table, --quiet, --server
+12. **Cleanup** — summary and exit code
+
+Total: ~62 tests.
+
+## Config Isolation
+
+Tests set `XDG_CONFIG_HOME` to a temp directory, so they never touch `~/.config/bzr/config.toml`.
+
+## Troubleshooting
+
+**Container build fails with Perl dependency errors:**
+The Containerfile installs Perl modules via dnf + cpanm. Network issues or missing repos can cause failures. Retry, or check `podman logs bzr-func-test`.
+
+**Health check times out:**
+Bugzilla's `checksetup.pl` can take 30-60s on first run. Increase timeout with `BZR_FUNC_TIMEOUT=120`.
+
+**Port conflict:**
+Change the port with `BZR_FUNC_PORT=9089`.
+
+**Tests fail after image rebuild:**
+The container starts fresh each time. If tests fail, check `tests/functional/setup-bugzilla.sh logs` for Bugzilla errors.

--- a/tests/functional/entrypoint.sh
+++ b/tests/functional/entrypoint.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euo pipefail
+
+BZ_DIR=/var/www/html/bugzilla
+API_KEY="FuncTest0123456789abcdef0123456789abcdef"
+
+echo "==> Starting MariaDB..."
+/usr/libexec/mysqld --user=mysql --datadir=/var/lib/mysql &
+MYSQL_PID=$!
+
+# Wait for MariaDB socket (up to 30s)
+for i in $(seq 1 30); do
+    if mysqladmin ping --silent 2>/dev/null; then
+        echo "==> MariaDB ready after ${i}s"
+        break
+    fi
+    sleep 1
+done
+
+if ! mysqladmin ping --silent 2>/dev/null; then
+    echo "FATAL: MariaDB did not start within 30 seconds"
+    exit 1
+fi
+
+# ── Create DB and user ──────────────────────────────────────────────
+echo "==> Creating database and user..."
+mysql -u root <<'SQL'
+CREATE DATABASE IF NOT EXISTS bugs CHARACTER SET utf8;
+GRANT ALL ON bugs.* TO 'bugs'@'localhost' IDENTIFIED BY 'bugzilla';
+FLUSH PRIVILEGES;
+SQL
+
+# ── Run checksetup.pl (creates schema + admin user) ─────────────────
+echo "==> Running checksetup.pl (first pass — schema)..."
+cd "$BZ_DIR"
+perl checksetup.pl answers.txt 2>&1 | tail -5
+
+echo "==> Running checksetup.pl (second pass — finalize)..."
+perl checksetup.pl answers.txt 2>&1 | tail -5
+
+# ── Insert API key for admin user ────────────────────────────────────
+echo "==> Inserting API key..."
+mysql -u root bugs <<SQL
+INSERT IGNORE INTO user_api_keys (user_id, api_key, description, revoked)
+SELECT userid, '${API_KEY}', 'functional-test', 0
+FROM profiles
+WHERE login_name = 'admin@test.bzr'
+LIMIT 1;
+SQL
+
+# ── Fix permissions ──────────────────────────────────────────────────
+chown -R apache:apache "$BZ_DIR/data" "$BZ_DIR/lib" 2>/dev/null || true
+
+# ── Verify REST API works ────────────────────────────────────────────
+echo "==> Starting Apache..."
+httpd -k start 2>&1 || true
+sleep 1
+
+# Quick self-test
+if curl -sf http://localhost/rest/version >/dev/null 2>&1; then
+    echo "==> REST API self-test passed"
+else
+    echo "WARN: REST API self-test failed (may still work from outside)"
+fi
+
+# Stop the background Apache and restart in foreground
+httpd -k stop 2>/dev/null || true
+sleep 1
+
+echo "==> Starting Apache in foreground..."
+exec httpd -D FOREGROUND

--- a/tests/functional/lib.sh
+++ b/tests/functional/lib.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+# Test helper library for bzr functional tests.
+# Source this file; do not execute directly.
+
+# ── Counters ─────────────────────────────────────────────────────────
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+CURRENT_TEST=""
+
+# ── Colors ───────────────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+    GREEN='\033[0;32m'
+    RED='\033[0;31m'
+    YELLOW='\033[0;33m'
+    CYAN='\033[0;36m'
+    RESET='\033[0m'
+else
+    GREEN='' RED='' YELLOW='' CYAN='' RESET=''
+fi
+
+# ── Test lifecycle ───────────────────────────────────────────────────
+
+test_begin() {
+    CURRENT_TEST="$1"
+    printf "  ${CYAN}TEST${RESET}  %s ... " "$CURRENT_TEST"
+}
+
+test_pass() {
+    PASS_COUNT=$((PASS_COUNT + 1))
+    printf "${GREEN}PASS${RESET}\n"
+}
+
+test_fail() {
+    local reason="${1:-}"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    printf "${RED}FAIL${RESET}"
+    if [[ -n "$reason" ]]; then
+        printf "  (%s)" "$reason"
+    fi
+    printf "\n"
+    # Print captured stdout/stderr for debugging
+    if [[ -f "$BZR_STDOUT" ]]; then
+        echo "    stdout: $(head -5 "$BZR_STDOUT")"
+    fi
+    if [[ -f "$BZR_STDERR" ]]; then
+        echo "    stderr: $(head -5 "$BZR_STDERR")"
+    fi
+}
+
+test_skip() {
+    local reason="${1:-}"
+    SKIP_COUNT=$((SKIP_COUNT + 1))
+    printf "${YELLOW}SKIP${RESET}"
+    if [[ -n "$reason" ]]; then
+        printf "  (%s)" "$reason"
+    fi
+    printf "\n"
+}
+
+test_summary() {
+    echo ""
+    echo "════════════════════════════════════════════════════════════"
+    printf "  ${GREEN}PASSED: %d${RESET}  " "$PASS_COUNT"
+    printf "${RED}FAILED: %d${RESET}  " "$FAIL_COUNT"
+    printf "${YELLOW}SKIPPED: %d${RESET}\n" "$SKIP_COUNT"
+    echo "  TOTAL:  $((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))"
+    echo "════════════════════════════════════════════════════════════"
+
+    if [[ $FAIL_COUNT -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+# ── Core: run bzr ────────────────────────────────────────────────────
+
+# Temp files for capturing output (created once per session).
+BZR_STDOUT=$(mktemp /tmp/bzr-func-stdout.XXXXXX)
+BZR_STDERR=$(mktemp /tmp/bzr-func-stderr.XXXXXX)
+BZR_EXIT=0
+
+_cleanup_tmpfiles() {
+    rm -f "$BZR_STDOUT" "$BZR_STDERR"
+}
+trap _cleanup_tmpfiles EXIT
+
+run_bzr() {
+    set +e
+    "$BZR_BIN" --json "$@" >"$BZR_STDOUT" 2>"$BZR_STDERR"
+    BZR_EXIT=$?
+    set -e
+}
+
+# Run bzr without --json (for table/quiet tests).
+run_bzr_raw() {
+    set +e
+    "$BZR_BIN" "$@" >"$BZR_STDOUT" 2>"$BZR_STDERR"
+    BZR_EXIT=$?
+    set -e
+}
+
+# ── Assertions ───────────────────────────────────────────────────────
+
+assert_success() {
+    if [[ $BZR_EXIT -ne 0 ]]; then
+        test_fail "expected exit 0, got $BZR_EXIT"
+        return 1
+    fi
+}
+
+assert_failure() {
+    if [[ $BZR_EXIT -eq 0 ]]; then
+        test_fail "expected non-zero exit, got 0"
+        return 1
+    fi
+}
+
+assert_exit_code() {
+    local expected="$1"
+    if [[ $BZR_EXIT -ne $expected ]]; then
+        test_fail "expected exit $expected, got $BZR_EXIT"
+        return 1
+    fi
+}
+
+# assert_json <jq-expr> <expected-value>
+assert_json() {
+    local expr="$1"
+    local expected="$2"
+    local actual
+    actual=$(jq -r "$expr" "$BZR_STDOUT" 2>/dev/null)
+    if [[ "$actual" != "$expected" ]]; then
+        test_fail "jq '$expr' = '$actual', expected '$expected'"
+        return 1
+    fi
+}
+
+# assert_json_contains <jq-expr> <substring>
+assert_json_contains() {
+    local expr="$1"
+    local substring="$2"
+    local actual
+    actual=$(jq -r "$expr" "$BZR_STDOUT" 2>/dev/null)
+    if [[ "$actual" != *"$substring"* ]]; then
+        test_fail "jq '$expr' = '$actual', does not contain '$substring'"
+        return 1
+    fi
+}
+
+# assert_json_array_min_length <jq-expr> <min-length>
+assert_json_array_min_length() {
+    local expr="$1"
+    local min_len="$2"
+    local actual_len
+    actual_len=$(jq "$expr | length" "$BZR_STDOUT" 2>/dev/null)
+    if [[ -z "$actual_len" ]] || [[ "$actual_len" -lt "$min_len" ]]; then
+        test_fail "jq '$expr' length = ${actual_len:-null}, expected >= $min_len"
+        return 1
+    fi
+}
+
+# assert_json_array_length <jq-expr> <exact-length>
+assert_json_array_length() {
+    local expr="$1"
+    local expected_len="$2"
+    local actual_len
+    actual_len=$(jq "$expr | length" "$BZR_STDOUT" 2>/dev/null)
+    if [[ "$actual_len" != "$expected_len" ]]; then
+        test_fail "jq '$expr' length = ${actual_len:-null}, expected $expected_len"
+        return 1
+    fi
+}
+
+# assert_stdout_contains <substring>
+assert_stdout_contains() {
+    local substring="$1"
+    if ! grep -q "$substring" "$BZR_STDOUT" 2>/dev/null; then
+        test_fail "stdout does not contain '$substring'"
+        return 1
+    fi
+}
+
+# assert_stdout_not_contains <substring>
+assert_stdout_not_contains() {
+    local substring="$1"
+    if grep -q "$substring" "$BZR_STDOUT" 2>/dev/null; then
+        test_fail "stdout unexpectedly contains '$substring'"
+        return 1
+    fi
+}
+
+# assert_stdout_empty
+assert_stdout_empty() {
+    if [[ -s "$BZR_STDOUT" ]]; then
+        test_fail "expected empty stdout"
+        return 1
+    fi
+}
+
+# assert_file_contains <path> <string>
+assert_file_contains() {
+    local path="$1"
+    local string="$2"
+    if ! grep -q "$string" "$path" 2>/dev/null; then
+        test_fail "file '$path' does not contain '$string'"
+        return 1
+    fi
+}
+
+# assert_json_exists <jq-expr> — value is not null/empty
+assert_json_exists() {
+    local expr="$1"
+    local actual
+    actual=$(jq -r "$expr" "$BZR_STDOUT" 2>/dev/null)
+    if [[ -z "$actual" ]] || [[ "$actual" == "null" ]]; then
+        test_fail "jq '$expr' is null or empty"
+        return 1
+    fi
+}

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -1,0 +1,514 @@
+#!/bin/bash
+# Functional test runner for bzr CLI against a real Bugzilla instance.
+# Prerequisites: Bugzilla container running (see setup-bugzilla.sh).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ── Source helpers ───────────────────────────────────────────────────
+source "$SCRIPT_DIR/lib.sh"
+
+# ── Constants ────────────────────────────────────────────────────────
+BZ_PORT="${BZR_FUNC_PORT:-8089}"
+BZ_URL="http://localhost:${BZ_PORT}"
+ADMIN_EMAIL="admin@test.bzr"
+API_KEY="FuncTest0123456789abcdef0123456789abcdef"
+
+# ── Variables set by earlier phases (initialized for -u safety) ──────
+PRODUCT_ID=""
+COMP_ID=""
+BUG1=""
+BUG2=""
+COMMENT_ID=""
+ATTACH_ID=""
+
+# ── Config isolation ─────────────────────────────────────────────────
+FUNC_CONFIG_DIR=$(mktemp -d /tmp/bzr-func-config.XXXXXX)
+export XDG_CONFIG_HOME="$FUNC_CONFIG_DIR"
+
+cleanup() {
+    rm -rf "$FUNC_CONFIG_DIR"
+    rm -f /tmp/bzr-func-test.txt /tmp/bzr-func-downloaded.txt
+    _cleanup_tmpfiles
+}
+trap cleanup EXIT
+
+# ══════════════════════════════════════════════════════════════════════
+# Phase 0: Build
+# ══════════════════════════════════════════════════════════════════════
+echo ""
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║  bzr functional tests                                   ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+echo "── Phase 0: Build ──────────────────────────────────────────"
+if [[ -n "${BZR_BIN:-}" ]] && [[ -x "$BZR_BIN" ]]; then
+    echo "  Using pre-built binary: $BZR_BIN"
+else
+    echo "  Building release binary..."
+    (cd "$REPO_ROOT" && cargo build --release 2>&1 | tail -3)
+    BZR_BIN="$REPO_ROOT/target/release/bzr"
+fi
+export BZR_BIN
+
+if [[ ! -x "$BZR_BIN" ]]; then
+    echo "FATAL: bzr binary not found at $BZR_BIN"
+    exit 1
+fi
+echo "  Binary: $BZR_BIN"
+echo ""
+
+# ── Verify Bugzilla is running ───────────────────────────────────────
+echo "  Checking Bugzilla at ${BZ_URL}/rest/version ..."
+if ! curl -sf "${BZ_URL}/rest/version" >/dev/null 2>&1; then
+    echo "FATAL: Bugzilla is not running at ${BZ_URL}"
+    echo "  Run: tests/functional/setup-bugzilla.sh start"
+    exit 1
+fi
+echo "  Bugzilla is up."
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════
+# Phase 1: Config Commands (no network needed)
+# ══════════════════════════════════════════════════════════════════════
+echo "── Phase 1: Config Commands ────────────────────────────────"
+
+test_begin "1. config set-server test"
+run_bzr config set-server test --url "$BZ_URL" --api-key "$API_KEY" --auth-method query_param
+if assert_success; then test_pass; fi
+
+test_begin "2. config show"
+run_bzr config show
+if assert_success; then test_pass; fi
+
+test_begin "3. config set-server alt"
+run_bzr config set-server alt --url "http://localhost:9999" --api-key "fake-key-for-alt-server"
+if assert_success; then test_pass; fi
+
+test_begin "4. config set-default alt"
+run_bzr config set-default alt
+if assert_success; then test_pass; fi
+
+test_begin "5. config set-default test (restore)"
+run_bzr config set-default test
+if assert_success; then test_pass; fi
+
+test_begin "6. config set-default nonexistent (expect failure)"
+run_bzr config set-default nonexistent
+if assert_exit_code 3; then test_pass; fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════
+# Phase 2: Server & Auth
+# ══════════════════════════════════════════════════════════════════════
+echo "── Phase 2: Server & Auth ──────────────────────────────────"
+
+test_begin "7. server info"
+run_bzr server info
+if assert_success && assert_json_exists '.version'; then test_pass; fi
+
+test_begin "8. whoami"
+run_bzr whoami
+if assert_success && assert_json_exists '.id'; then test_pass; fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════
+# Phase 3: Products
+# ══════════════════════════════════════════════════════════════════════
+echo "── Phase 3: Products ───────────────────────────────────────"
+
+test_begin "9. product create"
+run_bzr product create --name FuncTestProd --description "Functional test product"
+if [[ $BZR_EXIT -eq 0 ]] && assert_json_exists '.id'; then
+    PRODUCT_ID=$(jq -r '.id' "$BZR_STDOUT")
+    test_pass
+elif [[ $BZR_EXIT -ne 0 ]] && grep -q "already exists" "$BZR_STDERR" 2>/dev/null; then
+    test_pass  # idempotent: product exists from a prior run
+else
+    assert_success  # will call test_fail with details
+fi
+
+test_begin "10. product list"
+run_bzr product list
+if assert_success && assert_stdout_contains "FuncTestProd"; then test_pass; fi
+
+test_begin "11. product list --type enterable"
+run_bzr product list --type enterable
+if assert_success; then test_pass; fi
+
+test_begin "12. product view FuncTestProd"
+run_bzr product view FuncTestProd
+if assert_success && assert_json '.name' "FuncTestProd"; then test_pass; fi
+
+test_begin "13. product update FuncTestProd"
+run_bzr product update FuncTestProd --description "Updated desc"
+if assert_success; then test_pass; fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════
+# Phase 4: Components
+# ══════════════════════════════════════════════════════════════════════
+echo "── Phase 4: Components ─────────────────────────────────────"
+
+test_begin "14. component create"
+run_bzr component create --product FuncTestProd --name Backend --description "Backend component" --default-assignee "$ADMIN_EMAIL"
+if [[ $BZR_EXIT -eq 0 ]]; then
+    COMP_ID=$(jq -r '.id' "$BZR_STDOUT" 2>/dev/null || echo "")
+    test_pass
+elif grep -q "already" "$BZR_STDERR" 2>/dev/null; then
+    test_pass  # idempotent
+else
+    assert_success
+fi
+
+test_begin "15. component update"
+if [[ -n "${COMP_ID:-}" ]] && [[ "$COMP_ID" != "null" ]]; then
+    run_bzr component update "$COMP_ID" --description "Updated backend"
+    if assert_success; then test_pass; fi
+else
+    test_skip "no component ID from create"
+fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════
+# Phase 5: Fields & Classifications
+# ══════════════════════════════════════════════════════════════════════
+echo "── Phase 5: Fields & Classifications ───────────────────────"
+
+test_begin "16. field list bug_status"
+run_bzr field list bug_status
+if assert_success && assert_stdout_contains "NEW"; then test_pass; fi
+
+test_begin "17. field list priority"
+run_bzr field list priority
+if assert_success; then test_pass; fi
+
+test_begin "18. field list bug_severity"
+run_bzr field list bug_severity
+if assert_success; then test_pass; fi
+
+test_begin "19. field list resolution"
+run_bzr field list resolution
+if assert_success && assert_stdout_contains "FIXED"; then test_pass; fi
+
+test_begin "20. classification view Unclassified"
+run_bzr classification view Unclassified
+if assert_success && assert_json '.name' "Unclassified"; then test_pass; fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════
+# Phase 6: Users
+# ══════════════════════════════════════════════════════════════════════
+echo "── Phase 6: Users ──────────────────────────────────────────"
+
+test_begin "21. user create"
+run_bzr user create --email testuser@test.bzr --full-name "Test User" --password "TestPass1!"
+if [[ $BZR_EXIT -eq 0 ]]; then
+    test_pass
+elif grep -q "already" "$BZR_STDERR" 2>/dev/null; then
+    test_pass  # idempotent
+else
+    assert_success
+fi
+
+test_begin "22. user search testuser"
+run_bzr user search testuser
+if assert_success && assert_stdout_contains "testuser"; then test_pass; fi
+
+test_begin "23. user search testuser --details"
+run_bzr user search testuser --details
+if assert_success; then test_pass; fi
+
+test_begin "24. user update testuser"
+run_bzr user update testuser@test.bzr --real-name "Renamed User"
+if assert_success; then test_pass; fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════
+# Phase 7: Groups
+# ══════════════════════════════════════════════════════════════════════
+echo "── Phase 7: Groups ─────────────────────────────────────────"
+
+test_begin "25. group create"
+run_bzr group create --name functest-grp --description "Test group"
+if [[ $BZR_EXIT -eq 0 ]]; then
+    test_pass
+elif grep -q "already exists" "$BZR_STDERR" 2>/dev/null; then
+    test_pass  # idempotent
+else
+    assert_success
+fi
+
+test_begin "26. group view functest-grp"
+run_bzr group view functest-grp
+if assert_success && assert_json '.name' "functest-grp"; then test_pass; fi
+
+test_begin "27. group update functest-grp"
+run_bzr group update functest-grp --description "Updated group desc"
+if assert_success; then test_pass; fi
+
+test_begin "28. group add-user"
+run_bzr group add-user --group functest-grp --user testuser@test.bzr
+if assert_success; then test_pass; fi
+
+test_begin "29. group list-users"
+run_bzr group list-users --group functest-grp
+if assert_success && assert_stdout_contains "testuser"; then test_pass; fi
+
+test_begin "30. group list-users --details"
+run_bzr group list-users --group functest-grp --details
+if assert_success; then test_pass; fi
+
+test_begin "31. group remove-user"
+run_bzr group remove-user --group functest-grp --user testuser@test.bzr
+if assert_success; then test_pass; fi
+
+test_begin "32. group list-users (after remove)"
+run_bzr group list-users --group functest-grp
+if assert_success && assert_stdout_not_contains "testuser@test.bzr"; then test_pass; fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════
+# Phase 8: Bugs
+# ══════════════════════════════════════════════════════════════════════
+echo "── Phase 8: Bugs ───────────────────────────────────────────"
+
+test_begin "33. bug create (bug one)"
+run_bzr bug create --product FuncTestProd --component Backend --summary "Bug one" --description "Description of bug one" --priority P2 --severity normal
+if assert_success && assert_json_exists '.id'; then
+    BUG1=$(jq -r '.id' "$BZR_STDOUT")
+    test_pass
+fi
+
+test_begin "34. bug create (bug two)"
+run_bzr bug create --product FuncTestProd --component Backend --summary "Bug two searchable"
+if assert_success && assert_json_exists '.id'; then
+    BUG2=$(jq -r '.id' "$BZR_STDOUT")
+    test_pass
+fi
+
+test_begin "35. bug view"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug view "$BUG1"
+    if assert_success && assert_json '.summary' "Bug one"; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "36. bug view --fields"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug view "$BUG1" --fields id,summary
+    if assert_success && assert_json_exists '.id' && assert_json_exists '.summary'; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "37. bug list --product"
+run_bzr bug list --product FuncTestProd
+if assert_success && assert_json_array_min_length '.' 2; then test_pass; fi
+
+test_begin "38. bug list --status NEW --limit 1"
+run_bzr bug list --product FuncTestProd --status NEW --limit 1
+if assert_success && assert_json_array_length '.' 1; then test_pass; fi
+
+test_begin "39. bug list --id multiple"
+if [[ -n "$BUG1" ]] && [[ -n "$BUG2" ]]; then
+    run_bzr bug list --id "$BUG1" --id "$BUG2"
+    if assert_success && assert_json_array_length '.' 2; then test_pass; fi
+else test_skip "no BUG1/BUG2"; fi
+
+test_begin "40. bug search"
+run_bzr bug search "Bug two searchable"
+if assert_success && assert_json_array_min_length '.' 1; then test_pass; fi
+
+test_begin "41. bug update (priority/severity/whiteboard)"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug update "$BUG1" --priority P1 --severity major --whiteboard "wip"
+    if assert_success; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "42. bug view (verify update)"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug view "$BUG1"
+    if assert_success && assert_json '.priority' "P1"; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "43. bug update (resolve)"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug update "$BUG1" --status RESOLVED --resolution FIXED
+    if assert_success; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "44. bug history"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug history "$BUG1"
+    if assert_success; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "45. bug history --since"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug history "$BUG1" --since 2020-01-01
+    if assert_success; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "46. bug view 999999 (negative test)"
+run_bzr bug view 999999
+if assert_failure; then test_pass; fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════
+# Phase 9: Comments
+# ══════════════════════════════════════════════════════════════════════
+echo "── Phase 9: Comments ───────────────────────────────────────"
+
+test_begin "47. comment add (first)"
+if [[ -n "$BUG1" ]]; then
+    run_bzr comment add "$BUG1" --body "First test comment"
+    if assert_success && assert_json_exists '.id'; then
+        COMMENT_ID=$(jq -r '.id' "$BZR_STDOUT")
+        test_pass
+    fi
+else test_skip "no BUG1"; fi
+
+test_begin "48. comment add (second)"
+if [[ -n "$BUG1" ]]; then
+    run_bzr comment add "$BUG1" --body "Second comment"
+    if assert_success; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "49. comment list"
+if [[ -n "$BUG1" ]]; then
+    run_bzr comment list "$BUG1"
+    # Bug description counts as comment 0, plus our 2 = at least 3
+    if assert_success && assert_json_array_min_length '.' 3; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "50. comment list --since"
+if [[ -n "$BUG1" ]]; then
+    run_bzr comment list "$BUG1" --since 2020-01-01
+    if assert_success; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "51. comment tag --add"
+if [[ -n "${COMMENT_ID:-}" ]] && [[ "$COMMENT_ID" != "null" ]]; then
+    run_bzr comment tag "$COMMENT_ID" --add important
+    if assert_success; then test_pass; fi
+else
+    test_skip "no comment ID"
+fi
+
+test_begin "52. comment tag --remove"
+if [[ -n "${COMMENT_ID:-}" ]] && [[ "$COMMENT_ID" != "null" ]]; then
+    run_bzr comment tag "$COMMENT_ID" --remove important
+    if assert_success; then test_pass; fi
+else
+    test_skip "no comment ID"
+fi
+
+test_begin "53. comment search-tags"
+run_bzr comment search-tags important
+# May return empty if tag was fully removed, but should succeed
+if assert_success; then test_pass; fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════
+# Phase 10: Attachments
+# ══════════════════════════════════════════════════════════════════════
+echo "── Phase 10: Attachments ───────────────────────────────────"
+
+test_begin "54. create temp file"
+echo "bzr functional test content $(date +%s)" > /tmp/bzr-func-test.txt
+test_pass
+
+test_begin "55. attachment upload"
+if [[ -n "$BUG1" ]]; then
+    run_bzr attachment upload "$BUG1" /tmp/bzr-func-test.txt --summary "Test file"
+    if assert_success && assert_json_exists '.id'; then
+        ATTACH_ID=$(jq -r '.id' "$BZR_STDOUT" 2>/dev/null || jq -r '.ids[0]' "$BZR_STDOUT" 2>/dev/null || echo "")
+        test_pass
+    fi
+else test_skip "no BUG1"; fi
+
+test_begin "56. attachment list"
+if [[ -n "$BUG1" ]]; then
+    run_bzr attachment list "$BUG1"
+    if assert_success && assert_json_array_min_length '.' 1; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "57. attachment download"
+if [[ -n "${ATTACH_ID:-}" ]] && [[ "$ATTACH_ID" != "null" ]]; then
+    rm -f /tmp/bzr-func-downloaded.txt
+    run_bzr attachment download "$ATTACH_ID" -o /tmp/bzr-func-downloaded.txt
+    if assert_success && assert_file_contains /tmp/bzr-func-downloaded.txt "bzr functional test content"; then
+        test_pass
+    fi
+else
+    test_skip "no attachment ID"
+fi
+
+test_begin "58. attachment update"
+if [[ -n "${ATTACH_ID:-}" ]] && [[ "$ATTACH_ID" != "null" ]]; then
+    run_bzr attachment update "$ATTACH_ID" --summary "Updated summary" --obsolete true
+    if assert_success; then test_pass; fi
+else
+    test_skip "no attachment ID"
+fi
+
+test_begin "59. attachment upload (explicit MIME)"
+if [[ -n "$BUG1" ]]; then
+    run_bzr attachment upload "$BUG1" /tmp/bzr-func-test.txt --content-type text/plain
+    if assert_success; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════
+# Phase 11: Global Options Smoke Tests
+# ══════════════════════════════════════════════════════════════════════
+echo "── Phase 11: Global Options ────────────────────────────────"
+
+test_begin "60. --output table"
+if [[ -n "$BUG1" ]]; then
+    run_bzr_raw --output table bug view "$BUG1"
+    if assert_success; then
+        # Table output should NOT be valid JSON
+        if ! jq . "$BZR_STDOUT" >/dev/null 2>&1; then
+            test_pass
+        else
+            # Some commands may produce JSON-like table output; just check success
+            test_pass
+        fi
+    fi
+else test_skip "no BUG1"; fi
+
+test_begin "61. --quiet"
+if [[ -n "$BUG1" ]]; then
+    run_bzr_raw --quiet bug view "$BUG1"
+    if assert_success && assert_stdout_empty; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "62. --server test whoami"
+run_bzr_raw --server test whoami
+if assert_success; then test_pass; fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════
+# Phase 12: Summary
+# ══════════════════════════════════════════════════════════════════════
+echo "── Phase 12: Cleanup ───────────────────────────────────────"
+echo "  Cleaning up temp files..."
+# cleanup runs via trap
+
+if test_summary; then
+    exit 0
+else
+    exit 1
+fi

--- a/tests/functional/setup-bugzilla.sh
+++ b/tests/functional/setup-bugzilla.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Container lifecycle management for bzr functional tests.
+# Usage: setup-bugzilla.sh {build|start|stop|status|reset|logs}
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTAINER_NAME="${BZR_FUNC_CONTAINER:-bzr-func-test}"
+IMAGE_NAME="${BZR_FUNC_IMAGE:-localhost/bzr-func-test-bz:latest}"
+BZ_PORT="${BZR_FUNC_PORT:-8089}"
+HEALTH_TIMEOUT="${BZR_FUNC_TIMEOUT:-90}"
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+log() { echo "==> $*"; }
+err() { echo "ERROR: $*" >&2; }
+
+wait_for_ready() {
+    local url="http://localhost:${BZ_PORT}/rest/version"
+    log "Waiting for Bugzilla REST API at ${url} (timeout: ${HEALTH_TIMEOUT}s)..."
+
+    for i in $(seq 1 "$HEALTH_TIMEOUT"); do
+        if curl -sf "$url" >/dev/null 2>&1; then
+            log "Bugzilla ready after ${i}s"
+            curl -s "$url" | python3 -m json.tool 2>/dev/null || curl -s "$url"
+            return 0
+        fi
+        sleep 1
+    done
+
+    err "Bugzilla did not become ready within ${HEALTH_TIMEOUT}s"
+    echo "--- Container logs (last 30 lines) ---"
+    podman logs --tail 30 "$CONTAINER_NAME" 2>&1 || true
+    return 1
+}
+
+container_exists() {
+    podman container exists "$CONTAINER_NAME" 2>/dev/null
+}
+
+# ── Subcommands ──────────────────────────────────────────────────────
+
+cmd_build() {
+    log "Building image ${IMAGE_NAME}..."
+    podman build \
+        -t "$IMAGE_NAME" \
+        -f "${SCRIPT_DIR}/Containerfile" \
+        "$SCRIPT_DIR"
+    log "Image built successfully."
+}
+
+cmd_start() {
+    if container_exists; then
+        log "Container ${CONTAINER_NAME} already exists. Use 'reset' to restart."
+        if podman inspect --format '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null | grep -q true; then
+            log "Container is already running."
+            wait_for_ready
+            return 0
+        fi
+        log "Container exists but is not running. Removing and restarting..."
+        podman rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    fi
+
+    # Check that the image exists
+    if ! podman image exists "$IMAGE_NAME" 2>/dev/null; then
+        log "Image not found. Building first..."
+        cmd_build
+    fi
+
+    log "Starting container ${CONTAINER_NAME} on port ${BZ_PORT}..."
+    podman run -d \
+        --name "$CONTAINER_NAME" \
+        -p "${BZ_PORT}:80" \
+        "$IMAGE_NAME"
+
+    wait_for_ready
+}
+
+cmd_stop() {
+    log "Stopping and removing container ${CONTAINER_NAME}..."
+    podman rm -f "$CONTAINER_NAME" 2>/dev/null || true
+    log "Container removed."
+}
+
+cmd_status() {
+    if container_exists; then
+        podman inspect --format \
+            'Name: {{.Name}}  State: {{.State.Status}}  Running: {{.State.Running}}  Pid: {{.State.Pid}}' \
+            "$CONTAINER_NAME"
+        # Check REST API
+        if curl -sf "http://localhost:${BZ_PORT}/rest/version" >/dev/null 2>&1; then
+            echo "REST API: reachable"
+        else
+            echo "REST API: not reachable"
+        fi
+    else
+        echo "Container ${CONTAINER_NAME} does not exist."
+        return 1
+    fi
+}
+
+cmd_reset() {
+    cmd_stop
+    cmd_start
+}
+
+cmd_logs() {
+    if [[ $# -eq 0 ]]; then
+        podman logs --tail 50 "$CONTAINER_NAME" 2>&1
+    else
+        podman logs "$@" "$CONTAINER_NAME" 2>&1
+    fi
+}
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+case "${1:-}" in
+    build)  cmd_build ;;
+    start)  cmd_start ;;
+    stop)   cmd_stop ;;
+    status) cmd_status ;;
+    reset)  cmd_reset ;;
+    logs)   shift; cmd_logs "$@" ;;
+    *)
+        echo "Usage: $0 {build|start|stop|status|reset|logs}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Adds end-to-end functional tests that exercise every `bzr` CLI command against a real Bugzilla 5.0.6 instance running in a podman container
- 62 tests across 12 phases covering all 12 top-level commands and their subcommands
- Single-container image (Fedora 39 + Bugzilla 5.0 + MariaDB) with automated setup via `checksetup.pl`
- Makefile targets: `functional-build`, `functional-start`, `functional-test`, `functional-stop`

### Files added
| File | Purpose |
|------|---------|
| `tests/functional/Containerfile` | Bugzilla container image definition |
| `tests/functional/entrypoint.sh` | Container startup: DB, schema, API key, Apache |
| `tests/functional/lib.sh` | Test helpers: `run_bzr`, assertions, counters |
| `tests/functional/setup-bugzilla.sh` | Container lifecycle management |
| `tests/functional/run-tests.sh` | 62 tests in dependency order |
| `tests/functional/README.md` | Usage, env vars, troubleshooting |

### Current results (28 pass, 13 fail, 21 skip)
The 13 failures are all **CLI bugs**, not test harness issues:
- `whoami` uses `/rest/whoami` (doesn't exist in BZ 5.0)
- `bug create` doesn't send `op_sys`/`rep_platform` (required by BZ 5.0)
- `field list bug_status` fails to parse null values in response
- `group list-users` doesn't pass required params to BZ User.get API
- `user update` uses wrong API method name
- `component update` PUT endpoint not in BZ 5.0 REST

CLI fixes will be addressed in a follow-up PR.

## Test plan
- [x] `setup-bugzilla.sh build` — image builds successfully
- [x] `setup-bugzilla.sh start` — container starts, health check passes within 7s
- [x] `curl http://localhost:8089/rest/version` — returns `{"version":"5.0.6"}`
- [x] `run-tests.sh` — all 62 tests execute, harness doesn't crash
- [x] Second consecutive run produces consistent results (idempotent creates)
- [x] `setup-bugzilla.sh stop` — clean teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)