### PR TITLE
feat: multi-platform release workflow and v0.1.0 polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,26 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release
+
+  cross-check:
+    name: Cross-check ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-unknown-linux-gnu
+          - powerpc64le-unknown-linux-gnu
+          - s390x-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+      - name: Install cross
+        run: cargo install cross --locked
+      - name: Check
+        run: cross check --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,122 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            use_cross: false
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            use_cross: true
+            archive: tar.gz
+          - target: powerpc64le-unknown-linux-gnu
+            os: ubuntu-latest
+            use_cross: true
+            archive: tar.gz
+          - target: s390x-unknown-linux-gnu
+            os: ubuntu-latest
+            use_cross: true
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-13
+            use_cross: false
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-14
+            use_cross: false
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            use_cross: false
+            archive: zip
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.use_cross
+        run: cargo install cross --locked
+
+      - name: Build
+        run: |
+          if [ "${{ matrix.use_cross }}" = "true" ]; then
+            cross build --release --locked --target ${{ matrix.target }}
+          else
+            cargo build --release --locked --target ${{ matrix.target }}
+          fi
+        shell: bash
+
+      - name: Package (unix)
+        if: matrix.archive == 'tar.gz'
+        run: |
+          STAGING="bzr-${{ github.ref_name }}-${{ matrix.target }}"
+          mkdir "$STAGING"
+          cp "target/${{ matrix.target }}/release/bzr" "$STAGING/"
+          cp LICENSE README.md "$STAGING/"
+          tar czf "$STAGING.tar.gz" "$STAGING"
+        shell: bash
+
+      - name: Package (windows)
+        if: matrix.archive == 'zip'
+        run: |
+          $STAGING = "bzr-${{ github.ref_name }}-${{ matrix.target }}"
+          New-Item -ItemType Directory -Path $STAGING
+          Copy-Item "target\${{ matrix.target }}\release\bzr.exe" "$STAGING\"
+          Copy-Item LICENSE, README.md "$STAGING\"
+          Compress-Archive -Path "$STAGING\*" -DestinationPath "$STAGING.zip"
+        shell: pwsh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bzr-${{ matrix.target }}
+          path: bzr-${{ github.ref_name }}-${{ matrix.target }}.*
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PRERELEASE=""
+          if [[ "${{ github.ref_name }}" == *-* ]]; then
+            PRERELEASE="--prerelease"
+          fi
+          gh release create "${{ github.ref_name }}" \
+            --title "bzr ${{ github.ref_name }}" \
+            --generate-notes \
+            $PRERELEASE \
+            artifacts/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - Unreleased
+## [0.1.0] - 2026-03-21
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ A command-line interface for Bugzilla servers, written in Rust. Inspired by the 
 
 ## Installation
 
+### Pre-built binaries
+
+Download the latest release for your platform from
+[GitHub Releases](https://github.com/randomparity/bzr/releases/latest).
+
+Available platforms: Linux (x86_64, aarch64, ppc64le, s390x), macOS (x86_64, Apple Silicon), Windows (x86_64).
+
+### From source
+
 ```bash
 cargo install --path .
 ```

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -66,6 +66,7 @@ For installation and quick start, see [README.md](../README.md).
 | 8 | Response deserialization error |
 | 9 | Authentication error |
 | 10 | Data integrity error (e.g. missing attachment data) |
+| 11 | Batch partial failure (some operations succeeded, some failed) |
 
 *Exit code 2 is also produced by clap for invalid or missing arguments before bzr's error handling runs.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,9 +77,9 @@ async fn main() -> ExitCode {
     ExitCode::SUCCESS
 }
 
-/// Convert a `BzrError` exit code (1-10) to a `std::process::ExitCode`.
+/// Convert a `BzrError` exit code (1-11) to a `std::process::ExitCode`.
 fn exit_code(e: &BzrError) -> ExitCode {
-    // All BzrError exit codes are in the range 1..=10.
+    // All BzrError exit codes are in the range 1..=11.
     ExitCode::from(u8::try_from(e.exit_code()).unwrap_or(1))
 }
 


### PR DESCRIPTION
## Summary

- Add GitHub Actions release workflow (`release.yml`) triggered on `v*` tag push, building binaries for 7 platform targets:
  - Linux: x86_64 (native), aarch64, ppc64le, s390x (via cross-rs)
  - macOS: x86_64 (Intel), aarch64 (Apple Silicon)
  - Windows: x86_64
- Add `cross-check` CI job to verify compilation on aarch64/ppc64le/s390x during PRs
- Fix missing exit code 11 (batch partial failure) in `docs/bzr-cli.md` and `src/main.rs` comment
- Set CHANGELOG release date to 2026-03-21
- Add pre-built binary installation instructions to README

## Test plan

- [ ] CI passes (fmt, clippy, test, build, cross-check jobs)
- [ ] After merge, push `v0.1.0-rc1` tag to test release workflow end-to-end
- [ ] Verify all 7 platform builds succeed and GitHub Release is created
- [ ] Download ppc64le and s390x binaries and verify ELF headers with `file`
- [ ] Delete RC release, then tag `v0.1.0` for the real release

🤖 Generated with [Claude Code](https://claude.com/claude-code)