### PR TITLE
fix: update GitHub Actions versions and drop x86_64 macOS target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -24,7 +24,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -35,7 +35,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
@@ -44,7 +44,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release
@@ -60,7 +60,7 @@ jobs:
           - powerpc64le-unknown-linux-gnu
           - s390x-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,6 @@ jobs:
             os: ubuntu-latest
             use_cross: true
             archive: tar.gz
-          - target: x86_64-apple-darwin
-            os: macos-13
-            use_cross: false
-            archive: tar.gz
           - target: aarch64-apple-darwin
             os: macos-14
             use_cross: false
@@ -47,7 +43,7 @@ jobs:
             use_cross: false
             archive: zip
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -90,7 +86,7 @@ jobs:
           Compress-Archive -Path "$STAGING\*" -DestinationPath "$STAGING.zip"
         shell: pwsh
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: bzr-${{ matrix.target }}
           path: bzr-${{ github.ref_name }}-${{ matrix.target }}.*
@@ -100,9 +96,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
## Summary
- Upgrade to Node.js 24-compatible action versions: checkout v6, upload-artifact v7, download-artifact v8
- Remove x86_64-apple-darwin build target (macos-13 runners no longer available)
- Updates both CI and Release workflows

## Test plan
- [ ] CI workflow passes on this PR
- [ ] Verify release workflow builds all 6 targets on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)