### PR TITLE
test(functional): add explicit returns to shell helpers

### DIFF
--- a/tests/functional/keyring-test.sh
+++ b/tests/functional/keyring-test.sh
@@ -25,6 +25,7 @@ cleanup() {
       ./target/debug/bzr config unset-keyring "$SERVER_NAME" 2>/dev/null || true
   fi
   rm -rf "$TMP_CONFIG_HOME"
+  return 0
 }
 trap cleanup EXIT
 

--- a/tests/functional/lib.sh
+++ b/tests/functional/lib.sh
@@ -12,6 +12,7 @@ bz_version_num() {
         bz53) echo 530 ;;
         *)    echo 0 ;;
     esac
+    return 0
 }
 
 # Skip test if version is below minimum. Usage: require_version 520 "reason"
@@ -47,11 +48,13 @@ fi
 test_begin() {
     CURRENT_TEST="$1"
     printf "  ${CYAN}TEST${RESET}  %s ... " "$CURRENT_TEST"
+    return 0
 }
 
 test_pass() {
     PASS_COUNT=$((PASS_COUNT + 1))
     printf "${GREEN}PASS${RESET}\n"
+    return 0
 }
 
 test_fail() {
@@ -69,6 +72,7 @@ test_fail() {
     if [[ -f "$BZR_STDERR" ]]; then
         echo "    stderr: $(head -5 "$BZR_STDERR")"
     fi
+    return 0
 }
 
 test_skip() {
@@ -79,6 +83,7 @@ test_skip() {
         printf "  (%s)" "$reason"
     fi
     printf "\n"
+    return 0
 }
 
 test_summary() {
@@ -105,6 +110,7 @@ BZR_EXIT=0
 
 _cleanup_tmpfiles() {
     rm -f "$BZR_STDOUT" "$BZR_STDERR"
+    return 0
 }
 trap _cleanup_tmpfiles EXIT
 
@@ -113,6 +119,7 @@ run_bzr() {
     "$BZR_BIN" --json "$@" >"$BZR_STDOUT" 2>"$BZR_STDERR"
     BZR_EXIT=$?
     set -e
+    return 0
 }
 
 # Run bzr without --json (for table/quiet tests).
@@ -121,6 +128,7 @@ run_bzr_raw() {
     "$BZR_BIN" "$@" >"$BZR_STDOUT" 2>"$BZR_STDERR"
     BZR_EXIT=$?
     set -e
+    return 0
 }
 
 # ── Assertions ───────────────────────────────────────────────────────

--- a/tests/functional/run-all-versions.sh
+++ b/tests/functional/run-all-versions.sh
@@ -11,6 +11,7 @@ cleanup_all() {
     for ver in "${VERSIONS[@]}"; do
         BZR_BZ_VERSION="$ver" "$SCRIPT_DIR/setup-bugzilla.sh" stop 2>/dev/null || true
     done
+    return 0
 }
 trap cleanup_all EXIT
 

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -42,6 +42,7 @@ cleanup() {
     rm -rf "$FUNC_CONFIG_DIR"
     rm -f /tmp/bzr-func-test.txt /tmp/bzr-func-downloaded.txt
     _cleanup_tmpfiles
+    return 0
 }
 trap cleanup EXIT
 

--- a/tests/functional/setup-bugzilla.sh
+++ b/tests/functional/setup-bugzilla.sh
@@ -33,8 +33,8 @@ HEALTH_TIMEOUT="${BZR_FUNC_TIMEOUT:-$DEFAULT_TIMEOUT}"
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
-log() { echo "==> [$BZ_VERSION] $*"; }
-err() { echo "ERROR: [$BZ_VERSION] $*" >&2; }
+log() { echo "==> [$BZ_VERSION] $*"; return 0; }
+err() { echo "ERROR: [$BZ_VERSION] $*" >&2; return 0; }
 
 wait_for_ready() {
     local url="http://127.0.0.1:${BZ_PORT}/rest/version"
@@ -57,6 +57,7 @@ wait_for_ready() {
 
 container_exists() {
     $CONTAINER_RT container inspect "$CONTAINER_NAME" >/dev/null 2>&1
+    return $?
 }
 
 # ── Subcommands ──────────────────────────────────────────────────────
@@ -74,6 +75,7 @@ cmd_build() {
         -f "$containerfile" \
         "$context"
     log "Image built successfully."
+    return 0
 }
 
 cmd_start() {
@@ -107,6 +109,7 @@ cmd_stop() {
     log "Stopping and removing container ${CONTAINER_NAME}..."
     $CONTAINER_RT rm -f "$CONTAINER_NAME" 2>/dev/null || true
     log "Container removed."
+    return 0
 }
 
 cmd_status() {
@@ -129,6 +132,7 @@ cmd_status() {
 cmd_reset() {
     cmd_stop
     cmd_start
+    return 0
 }
 
 cmd_logs() {
@@ -137,6 +141,7 @@ cmd_logs() {
     else
         $CONTAINER_RT logs "$@" "$CONTAINER_NAME" 2>&1
     fi
+    return 0
 }
 
 # ── Main ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Resolves all 18 SonarCloud `shelldre:S7682` findings ("Add an explicit return statement at the end of the function") in `tests/functional/*.sh`.

## Changes

- `tests/functional/lib.sh` — added explicit `return 0` to `bz_version_num`, `test_begin`, `test_pass`, `test_fail`, `test_skip`, `_cleanup_tmpfiles`, `run_bzr`, `run_bzr_raw`.
- `tests/functional/setup-bugzilla.sh` — added explicit `return 0` to `log`, `err`, `cmd_build`, `cmd_stop`, `cmd_reset`, `cmd_logs`; added `return $?` to `container_exists` (used as a boolean predicate, so its real exit code must propagate).
- `tests/functional/keyring-test.sh` — `cleanup` (trap handler).
- `tests/functional/run-all-versions.sh` — `cleanup_all` (trap handler).
- `tests/functional/run-tests.sh` — `cleanup` (trap handler).

Without an explicit terminal `return`, each function's exit status was incidentally whatever its last command produced — exactly what the rule warns against.

## Testing

- `bash -n` syntax check on all 5 modified files: clean.
- Pre-push `cargo test --workspace`: 556 unit tests + 43 integration tests pass.
- Pre-commit `cargo fmt --check` + `cargo clippy -- -D warnings`: clean.
- No behavioral change — every added `return 0` either follows a command that already returns 0 under normal flow, or sits behind a `set -e`/early-return guard.

## Notes

- `container_exists` deliberately uses `return $?` rather than `return 0` because callers branch on its truth value (`if container_exists; then …`).
- SonarCloud rescan should clear all 18 issues.
