### PR TITLE
chore: unbreak main (rustls-webpki advisory + clippy lint)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ target/
 
 # Superpowers
 docs/superpowers/
+
+# Git worktrees
+.worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1784,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -60,7 +60,7 @@ pub async fn execute(
             let att_id = client.upload_attachment(&upload_params).await?;
             output::print_result(
                 &UploadResult::new(att_id, *bug_id, size),
-                &format!("Uploaded attachment #{att_id} to bug #{bug_id} ({size} bytes)",),
+                &format!("Uploaded attachment #{att_id} to bug #{bug_id} ({size} bytes)"),
                 format,
             );
         }

--- a/src/output/bug.rs
+++ b/src/output/bug.rs
@@ -87,7 +87,7 @@ pub fn print_history(history: &[HistoryEntry], format: OutputFormat) {
                     .attachment_id
                     .map(|id| format!(" [attachment #{id}]"))
                     .unwrap_or_default();
-                println!("  {}{attachment_suffix}:", change.field_name.bold(),);
+                println!("  {}{attachment_suffix}:", change.field_name.bold());
                 if !change.removed.is_empty() {
                     println!("    - {}", change.removed.red());
                 }


### PR DESCRIPTION
## Summary

Clears the three pre-existing CI failures currently blocking Dependabot PRs #84 (clap 4.5.61) and #85 (tokio 1.52.1):

1. `cargo update -p rustls-webpki` past 0.103.13 to clear RUSTSEC-2026-0104 (reachable panic in CRL parsing) and the related name-constraints advisory. Lockfile-only.
2. Drop two `clippy::unnecessary_trailing_comma` errors at `src/commands/attachment.rs:63` and `src/output/bug.rs:90` (new lint in Rust 1.95.0).

## Testing

- `cargo deny check advisories` — passes
- `cargo clippy --all-targets --all-features -- -D warnings` — passes
- `cargo fmt --check` — passes
- `cargo test` — passes (43 tests)

## Follow-up

After this lands, comment `@dependabot rebase` on #84 and #85 so they pick up the new lockfile and re-run CI against a clean tree.