### PR TITLE
ci: skip SonarQube on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,10 @@ jobs:
         run: cargo check --locked --target aarch64-pc-windows-msvc
   sonarqube:
     name: SonarQube
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    # Skip on forked PRs and Dependabot PRs (neither has access to SONAR_TOKEN).
+    if: |
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+      && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Dependabot PRs run with the read-only `GITHUB_TOKEN` and have no access to repository secrets. Today the SonarQube job runs on Dependabot PRs but `secrets.SONAR_TOKEN` resolves to empty, and the scanner exits with `Project not found`. This is the only red check on PRs #84 (clap) and #85 (tokio) right now.

Add `github.actor != 'dependabot[bot]'` to the SonarQube job's `if:` condition so it skips cleanly on Dependabot PRs, matching the existing fork-skip behavior. Skipped jobs do not block merge gates; the scan still runs on every push to \`main\` and on human-authored PRs.

## Testing

- \`actionlint .github/workflows/ci.yml\` — passes
- The change is condition-only; behavior on \`main\` and human-authored PRs is unchanged