### PR TITLE
feat: add --from-url to execute and save Bugzilla GUI queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ colored = "3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 percent-encoding = "2"
+url = "2"
 quick-xml = "0.39"
 # Optional: used only by test-helpers feature
 wiremock = { version = ">=0.6, <0.6.5", optional = true }

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -222,7 +222,7 @@ bzr bug search "kernel panic"
 bzr bug search "component:NetworkManager priority:high" --limit 10
 bzr bug search "memory leak" --fields id,summary
 bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW"
-bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?..." --save-as "my-query"
+bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW" --save-as "my-query"
 ```
 
 `--from-url` and the positional `<QUERY>` argument are mutually exclusive.
@@ -230,9 +230,9 @@ bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?..." --save-
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
 | `<QUERY>` | No* | | Search query (quicksearch syntax) |
-| `--from-url <URL>` | No* | | Execute a search from a Bugzilla buglist.cgi URL. Recognized parameters (product, component, status, etc.) are mapped to structured fields; unrecognized parameters (boolean charts, field-change filters) are passed through to the REST API verbatim. Mutually exclusive with `<QUERY>`. |
+| `--from-url <URL>` | No* | | Execute a search from a Bugzilla buglist.cgi URL. Recognized parameters (product, component, status, etc.) are mapped to structured fields; unrecognized parameters (boolean charts, field-change filters) are passed through to the REST API verbatim. |
 | `--save-as <NAME>` | No | | Save this URL query with the given name for future reuse. Requires `--from-url`. |
-| `--limit <N>` | No | 50 | Max results |
+| `--limit <N>` | No | 50 | Max results. When `--from-url` is used, the URL's own limit parameter takes precedence unless overridden here. |
 | `--fields <F>` | No | | Only return these fields (comma-separated) |
 | `--exclude-fields <F>` | No | | Exclude these fields (comma-separated) |
 
@@ -1055,7 +1055,7 @@ bzr query save crashes --search "crash in tab" --limit 10
 bzr query save my-p1 --assignee me@example.com --priority P1 --status NEW --status ASSIGNED
 
 # Import a query from a Bugzilla URL
-bzr query save my-query --from-url "https://bugzilla.example.com/buglist.cgi?..."
+bzr query save my-query --from-url "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW"
 ```
 
 `--from-url` and manual filter flags (`--search`, `--product`, `--component`, etc.) are mutually exclusive.
@@ -1078,6 +1078,8 @@ bzr query save my-query --from-url "https://bugzilla.example.com/buglist.cgi?...
 
 At least one filter must be set. Use either `--from-url` or one or more manual filter flags.
 
+When `--from-url` is used, `--limit`, `--fields`, and `--exclude-fields` may still be provided and will be stored with the saved query as overrides.
+
 Agent note: saved queries are useful for agents because they turn multi-flag searches into stable named workflows. Pair them with `bzr --json query run <name>` for deterministic reuse.
 
 ### `bzr query list`
@@ -1095,6 +1097,10 @@ Show details of a saved query.
 ```bash
 bzr query show firefox-new
 ```
+
+For URL-sourced queries (saved with `--from-url`), the output also includes the
+original source URL, the associated server name, and a count of raw passthrough
+parameters. In JSON format, the full list of raw parameters is included.
 
 ### `bzr query delete`
 
@@ -1128,7 +1134,7 @@ bzr query run my-query --server other-server --limit 50
 | `--limit <N>` | No | Override the saved limit |
 | `--fields <F>` | No | Only return these fields (comma-separated) |
 | `--exclude-fields <F>` | No | Exclude these fields (comma-separated) |
-| `--server <NAME>` | No | Override the server to run the query against. By default, uses the server associated with the saved query (if URL-sourced), or the default server. |
+| `--server <NAME>` | No | Override the server to run the query against. Takes precedence over the server stored in the saved query. The global `--server` flag takes precedence over this flag. |
 
 ---
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -84,7 +84,7 @@ bzr [--server <NAME>] [--output table|json] [--json] [--no-color] [--quiet] [--a
 │   │        [--creator <C>...] [--priority <P>...] [--severity <S>...] [--id <ID>...]
 │   │        [--alias <A>] [--limit <N>] [--fields <F>] [--exclude-fields <F>]
 │   ├── view <ID> [--fields <F>] [--exclude-fields <F>]
-│   ├── search <QUERY> [--limit <N>] [--fields <F>] [--exclude-fields <F>]
+│   ├── search [<QUERY>] [--from-url <URL>] [--save-as <NAME>] [--limit <N>] [--fields <F>] [--exclude-fields <F>]
 │   ├── history <ID> [--since <DATE>]
 │   ├── my [--created] [--cc] [--all] [--status <S>...] [--limit <N>]
 │   │       [--fields <F>] [--exclude-fields <F>]
@@ -153,13 +153,13 @@ bzr [--server <NAME>] [--output table|json] [--json] [--no-color] [--quiet] [--a
 │   ├── show <NAME>
 │   └── delete <NAME>
 └── query
-    ├── save <NAME> [--product <P>...] [--component <C>...] [--status <S>...] [--assignee <A>...]
-    │               [--creator <C>...] [--priority <P>...] [--severity <S>...] [--search <Q>]
-    │               [--limit <N>] [--fields <F>] [--exclude-fields <F>]
+    ├── save <NAME> (--from-url <URL> | [--product <P>...] [--component <C>...] [--status <S>...]
+    │               [--assignee <A>...] [--creator <C>...] [--priority <P>...] [--severity <S>...]
+    │               [--search <Q>]) [--limit <N>] [--fields <F>] [--exclude-fields <F>]
     ├── list
     ├── show <NAME>
     ├── delete <NAME>
-    └── run <NAME> [--limit <N>] [--fields <F>] [--exclude-fields <F>]
+    └── run <NAME> [--limit <N>] [--fields <F>] [--exclude-fields <F>] [--server <NAME>]
 ```
 
 ---
@@ -215,20 +215,28 @@ bzr bug view my-alias --fields id,summary,assigned_to
 
 ### `bzr bug search`
 
-Full-text search using Bugzilla's quicksearch syntax.
+Full-text search using Bugzilla's quicksearch syntax, or execute a search from a Bugzilla buglist.cgi URL.
 
 ```bash
 bzr bug search "kernel panic"
 bzr bug search "component:NetworkManager priority:high" --limit 10
 bzr bug search "memory leak" --fields id,summary
+bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW"
+bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?..." --save-as "my-query"
 ```
+
+`--from-url` and the positional `<QUERY>` argument are mutually exclusive.
 
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
-| `<QUERY>` | Yes | | Search query |
+| `<QUERY>` | No* | | Search query (quicksearch syntax) |
+| `--from-url <URL>` | No* | | Execute a search from a Bugzilla buglist.cgi URL. Recognized parameters (product, component, status, etc.) are mapped to structured fields; unrecognized parameters (boolean charts, field-change filters) are passed through to the REST API verbatim. Mutually exclusive with `<QUERY>`. |
+| `--save-as <NAME>` | No | | Save this URL query with the given name for future reuse. Requires `--from-url`. |
 | `--limit <N>` | No | 50 | Max results |
 | `--fields <F>` | No | | Only return these fields (comma-separated) |
 | `--exclude-fields <F>` | No | | Exclude these fields (comma-separated) |
+
+*One of `<QUERY>` or `--from-url` must be provided.
 
 ### `bzr bug history`
 
@@ -1045,24 +1053,30 @@ bzr query save crashes --search "crash in tab" --limit 10
 
 # Save with multiple filters
 bzr query save my-p1 --assignee me@example.com --priority P1 --status NEW --status ASSIGNED
+
+# Import a query from a Bugzilla URL
+bzr query save my-query --from-url "https://bugzilla.example.com/buglist.cgi?..."
 ```
+
+`--from-url` and manual filter flags (`--search`, `--product`, `--component`, etc.) are mutually exclusive.
 
 | Option | Required | Description |
 |--------|----------|-------------|
 | `<NAME>` | Yes | Query name |
-| `--product <P>` | No | Filter by product name (repeatable; prefix with `!` to exclude) |
-| `--component <C>` | No | Filter by component name (repeatable; prefix with `!` to exclude) |
-| `--status <S>` | No | Filter by status (repeatable; prefix with `!` to exclude) |
-| `--assignee <A>` | No | Filter by assignee email (repeatable; prefix with `!` to exclude) |
-| `--creator <C>` | No | Filter by bug creator email (repeatable; prefix with `!` to exclude) |
-| `--priority <P>` | No | Filter by priority (repeatable; prefix with `!` to exclude) |
-| `--severity <S>` | No | Filter by severity (repeatable; prefix with `!` to exclude) |
-| `--search <Q>` | No | Free-text search query |
+| `--from-url <URL>` | No* | Import query from a Bugzilla buglist.cgi URL. Mutually exclusive with manual filter flags (`--search`, `--product`, `--component`, etc.). |
+| `--product <P>` | No* | Filter by product name (repeatable; prefix with `!` to exclude) |
+| `--component <C>` | No* | Filter by component name (repeatable; prefix with `!` to exclude) |
+| `--status <S>` | No* | Filter by status (repeatable; prefix with `!` to exclude) |
+| `--assignee <A>` | No* | Filter by assignee email (repeatable; prefix with `!` to exclude) |
+| `--creator <C>` | No* | Filter by bug creator email (repeatable; prefix with `!` to exclude) |
+| `--priority <P>` | No* | Filter by priority (repeatable; prefix with `!` to exclude) |
+| `--severity <S>` | No* | Filter by severity (repeatable; prefix with `!` to exclude) |
+| `--search <Q>` | No* | Free-text search query |
 | `--limit <N>` | No | Max results |
 | `--fields <F>` | No | Only return these fields when the query runs (comma-separated) |
 | `--exclude-fields <F>` | No | Exclude these fields when the query runs (comma-separated) |
 
-At least one filter must be set.
+At least one filter must be set. Use either `--from-url` or one or more manual filter flags.
 
 Agent note: saved queries are useful for agents because they turn multi-flag searches into stable named workflows. Pair them with `bzr --json query run <name>` for deterministic reuse.
 
@@ -1092,7 +1106,7 @@ bzr query delete firefox-new
 
 ### `bzr query run`
 
-Execute a saved query. Supports runtime overrides for limit, fields, and exclude-fields.
+Execute a saved query. Supports runtime overrides for limit, fields, exclude-fields, and server.
 
 ```bash
 # Run a saved query
@@ -1103,6 +1117,9 @@ bzr query run firefox-new --limit 10
 
 # Run with field selection
 bzr query run firefox-new --fields id,summary,status
+
+# Run against a different server
+bzr query run my-query --server other-server --limit 50
 ```
 
 | Option | Required | Description |
@@ -1111,6 +1128,7 @@ bzr query run firefox-new --fields id,summary,status
 | `--limit <N>` | No | Override the saved limit |
 | `--fields <F>` | No | Only return these fields (comma-separated) |
 | `--exclude-fields <F>` | No | Exclude these fields (comma-separated) |
+| `--server <NAME>` | No | Override the server to run the query against. By default, uses the server associated with the saved query (if URL-sourced), or the default server. |
 
 ---
 

--- a/docs/plans/2026-04-27-from-url-saved-queries.md
+++ b/docs/plans/2026-04-27-from-url-saved-queries.md
@@ -1,0 +1,1638 @@
+# `--from-url` and Saved Query Enhancement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to pass Bugzilla GUI URLs to `bzr` via `--from-url`, execute them, and optionally save them as named queries for reuse.
+
+**Architecture:** A new `url_parser` module parses `buglist.cgi` URLs into the existing `SavedQuery` struct (extended with `source_url`, `server`, and `raw_params` fields). Raw boolean chart parameters pass through to the REST API verbatim. CLI changes add `--from-url`/`--save-as` to `bug search` and `--from-url` to `query save`.
+
+**Tech Stack:** Rust, clap (CLI), url crate (parsing), reqwest (HTTP), wiremock (testing), serde/TOML (config)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `Cargo.toml` | Modify | Add `url` as direct dependency |
+| `src/types/bug.rs` | Modify | Extend `QueryKind`, `SavedQuery`, `SearchParams` with new fields |
+| `src/types/mod.rs` | Modify | Re-export new items if needed |
+| `src/url_parser.rs` | Create | Parse `buglist.cgi` URLs into `SavedQuery` |
+| `src/lib.rs` | Modify | Add `pub mod url_parser` |
+| `src/client/bug.rs` | Modify | Add `append_raw_params`, call it in `search_bugs_rest`, force REST for raw params |
+| `src/cli/bug.rs` | Modify | Add `--from-url` and `--save-as` to `Search` variant |
+| `src/cli/query.rs` | Modify | Add `--from-url` to `Save`, `--server` to `Run` |
+| `src/commands/bug.rs` | Modify | Handle `--from-url` path in `handle_search` |
+| `src/commands/query.rs` | Modify | Handle `--from-url` in `handle_save`, pass raw params in `handle_run`, use server override |
+| `src/output/query.rs` | Modify | Display `source_url`, `server`, raw param count in `query show` |
+| `docs/bzr-cli.md` | Modify | Document new flags |
+
+---
+
+### Task 1: Add `url` dependency
+
+**Files:**
+- Modify: `Cargo.toml`
+
+- [ ] **Step 1: Add the `url` crate to `[dependencies]`**
+
+In `Cargo.toml`, add under `[dependencies]`:
+
+```toml
+url = "2"
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo check`
+Expected: compiles with no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "feat: add url crate as direct dependency for URL parsing"
+```
+
+---
+
+### Task 2: Extend data model — `QueryKind`, `SavedQuery`, `SearchParams`
+
+**Files:**
+- Modify: `src/types/bug.rs:242-312`
+
+- [ ] **Step 1: Write tests for new `QueryKind::Url` variant**
+
+Add to the existing `#[cfg(test)] mod tests` block at the bottom of `src/types/bug.rs` (alongside the existing `saved_query_*` tests):
+
+```rust
+#[test]
+fn query_kind_url_serializes() {
+    let json = serde_json::to_string(&QueryKind::Url).unwrap();
+    assert_eq!(json, r#""url""#);
+}
+
+#[test]
+fn query_kind_url_deserializes() {
+    let kind: QueryKind = serde_json::from_str(r#""url""#).unwrap();
+    assert_eq!(kind, QueryKind::Url);
+}
+
+#[test]
+fn saved_query_with_url_fields_roundtrips() {
+    let query = SavedQuery {
+        kind: QueryKind::Url,
+        source_url: Some("https://bugzilla.example.com/buglist.cgi?product=Firefox".into()),
+        server: Some("example".into()),
+        raw_params: vec![
+            ("f1".into(), "qa_contact".into()),
+            ("o1".into(), "changedfrom".into()),
+            ("v1".into(), "user@example.com".into()),
+        ],
+        product: vec!["Firefox".into()],
+        ..SavedQuery::default()
+    };
+    let json = serde_json::to_string(&query).unwrap();
+    let roundtripped: SavedQuery = serde_json::from_str(&json).unwrap();
+    assert_eq!(roundtripped.kind, QueryKind::Url);
+    assert_eq!(
+        roundtripped.source_url.as_deref(),
+        Some("https://bugzilla.example.com/buglist.cgi?product=Firefox")
+    );
+    assert_eq!(roundtripped.server.as_deref(), Some("example"));
+    assert_eq!(roundtripped.raw_params.len(), 3);
+    assert_eq!(roundtripped.raw_params[0], ("f1".into(), "qa_contact".into()));
+    assert_eq!(roundtripped.product, vec!["Firefox"]);
+}
+
+#[test]
+fn saved_query_without_url_fields_omits_them_in_json() {
+    let query = SavedQuery {
+        kind: QueryKind::List,
+        product: vec!["Firefox".into()],
+        ..SavedQuery::default()
+    };
+    let json = serde_json::to_string(&query).unwrap();
+    assert!(!json.contains("source_url"));
+    assert!(!json.contains("server"));
+    assert!(!json.contains("raw_params"));
+}
+
+#[test]
+fn saved_query_url_kind_to_search_params_includes_raw_params() {
+    let query = SavedQuery {
+        kind: QueryKind::Url,
+        product: vec!["Firefox".into()],
+        raw_params: vec![
+            ("f1".into(), "qa_contact".into()),
+            ("o1".into(), "changedfrom".into()),
+        ],
+        limit: Some(100),
+        ..SavedQuery::default()
+    };
+    let params = query.to_search_params();
+    assert_eq!(params.product, vec!["Firefox"]);
+    assert_eq!(params.limit, Some(100));
+    assert_eq!(params.raw_params.len(), 2);
+    assert_eq!(params.raw_params[0], ("f1".into(), "qa_contact".into()));
+}
+
+#[test]
+fn saved_query_url_kind_has_filters_with_only_raw_params() {
+    let query = SavedQuery {
+        kind: QueryKind::Url,
+        raw_params: vec![("f1".into(), "qa_contact".into())],
+        ..SavedQuery::default()
+    };
+    assert!(query.has_filters());
+}
+
+#[test]
+fn search_params_has_filters_with_raw_params() {
+    let params = SearchParams {
+        raw_params: vec![("f1".into(), "qa_contact".into())],
+        ..Default::default()
+    };
+    assert!(params.has_filters());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib types::bug::tests::query_kind_url -- --no-capture 2>&1 | head -20`
+Expected: compilation errors (fields/variant don't exist yet)
+
+- [ ] **Step 3: Add `Url` variant to `QueryKind`**
+
+In `src/types/bug.rs`, add the variant to the `QueryKind` enum (after `Search`):
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum QueryKind {
+    #[default]
+    List,
+    Search,
+    /// Query imported from a Bugzilla URL (may contain raw passthrough params)
+    Url,
+}
+```
+
+- [ ] **Step 4: Add new fields to `SavedQuery`**
+
+In `src/types/bug.rs`, add these fields to the `SavedQuery` struct after `exclude_fields`:
+
+```rust
+    /// The original Bugzilla URL this query was parsed from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+    /// Server name (from config) this query is associated with.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server: Option<String>,
+    /// Raw query parameters not mapped to structured fields.
+    /// Passed through verbatim to the Bugzilla REST API.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
+```
+
+- [ ] **Step 5: Add `raw_params` field to `SearchParams`**
+
+In `src/types/bug.rs`, add this field to `SearchParams` after `exclude_fields`:
+
+```rust
+    /// Raw query parameters passed through verbatim to the REST API.
+    /// Used for URL-imported queries with boolean chart params.
+    pub raw_params: Vec<(String, String)>,
+```
+
+- [ ] **Step 6: Update `SavedQuery::to_search_params` to include `raw_params`**
+
+In the `to_search_params` method, add `raw_params` to the constructed `SearchParams`:
+
+```rust
+    pub fn to_search_params(&self) -> SearchParams {
+        SearchParams {
+            product: self.product.clone(),
+            component: self.component.clone(),
+            status: self.status.clone(),
+            assigned_to: self.assignee.clone(),
+            creator: self.creator.clone(),
+            priority: self.priority.clone(),
+            severity: self.severity.clone(),
+            quicksearch: self.quicksearch.clone(),
+            limit: self.limit,
+            include_fields: self.fields.clone(),
+            exclude_fields: self.exclude_fields.clone(),
+            raw_params: self.raw_params.clone(),
+            ..Default::default()
+        }
+    }
+```
+
+- [ ] **Step 7: Update `SavedQuery::has_filters` to check `raw_params`**
+
+Add `|| !self.raw_params.is_empty()` to the condition chain in `has_filters()`.
+
+- [ ] **Step 8: Update `SearchParams::has_filters` to check `raw_params`**
+
+Add `|| !self.raw_params.is_empty()` to the condition chain in `has_filters()`.
+
+- [ ] **Step 9: Update `output/query.rs` — add `Url` arm to match expressions**
+
+In `src/output/query.rs`, find the two `match q.kind` / `match view.query.kind` expressions and add:
+
+```rust
+QueryKind::Url => "url",
+```
+
+- [ ] **Step 10: Run all tests**
+
+Run: `cargo test`
+Expected: all tests pass (including the new ones and existing ones that were unaffected by `..Default::default()`)
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/types/bug.rs src/output/query.rs
+git commit -m "feat: extend SavedQuery and SearchParams with raw_params, source_url, server fields"
+```
+
+---
+
+### Task 3: Create URL parser module
+
+**Files:**
+- Create: `src/url_parser.rs`
+- Modify: `src/lib.rs:21` (add module declaration)
+
+- [ ] **Step 1: Create `src/url_parser.rs` with tests first**
+
+Create the file with the module doc, imports, the public function signature that returns `Err` (to make tests compile but fail), and the test module:
+
+```rust
+//! Parse Bugzilla `buglist.cgi` URLs into `SavedQuery` structs.
+
+use url::Url;
+
+use crate::config::Config;
+use crate::error::{BzrError, Result};
+use crate::types::{QueryKind, SavedQuery};
+
+/// Parameters ignored during URL parsing (display/session metadata).
+const IGNORED_PARAMS: &[&str] = &["columnlist", "list_id", "query_format"];
+
+/// Parameters extracted as the suggested query name, not stored as filters.
+const NAME_PARAMS: &[&str] = &["known_name", "query_based_on"];
+
+/// Maps Bugzilla URL parameter names to `SavedQuery` vec field names.
+/// Each entry is (url_param, field_name) where field_name matches
+/// the `SavedQuery` struct field.
+const RECOGNIZED_VEC_PARAMS: &[(&str, &str)] = &[
+    ("product", "product"),
+    ("component", "component"),
+    ("bug_status", "status"),
+    ("assigned_to", "assignee"),
+    ("reporter", "creator"),
+    ("priority", "priority"),
+    ("bug_severity", "severity"),
+];
+
+/// Result of parsing a Bugzilla URL.
+pub struct ParsedUrl {
+    /// The parsed query ready for storage.
+    pub query: SavedQuery,
+    /// Suggested name extracted from `known_name`/`query_based_on` params.
+    pub suggested_name: Option<String>,
+}
+
+/// Parse a Bugzilla `buglist.cgi` URL into a `SavedQuery`.
+///
+/// Recognized parameters are mapped to structured `SavedQuery` fields.
+/// Unrecognized parameters are stored in `raw_params` for verbatim
+/// passthrough to the REST API. Display/session params are ignored.
+///
+/// The `config` is used to match the URL hostname against configured
+/// servers.
+pub fn parse_bugzilla_url(url_str: &str, config: &Config) -> Result<ParsedUrl> {
+    let url = Url::parse(url_str)
+        .map_err(|e| BzrError::InputValidation(format!("invalid URL: {e}")))?;
+
+    // Verify this is a buglist.cgi URL
+    if !url.path().contains("buglist.cgi") {
+        return Err(BzrError::InputValidation(
+            "URL must be a Bugzilla buglist.cgi URL".into(),
+        ));
+    }
+
+    // Match hostname against configured servers
+    let url_host = url
+        .host_str()
+        .ok_or_else(|| BzrError::InputValidation("URL has no hostname".into()))?;
+
+    let server = find_server_by_hostname(config, url_host);
+    if server.is_none() && config.default_server.is_none() {
+        return Err(BzrError::config(format!(
+            "URL hostname '{url_host}' does not match any configured server \
+             and no default server is set. Run `bzr config set-server` first."
+        )));
+    }
+    if server.is_none() {
+        tracing::warn!(
+            "URL hostname '{url_host}' does not match any configured server; \
+             using default server"
+        );
+    }
+
+    let mut query = SavedQuery {
+        kind: QueryKind::Url,
+        source_url: Some(url_str.to_string()),
+        server: server.map(String::from),
+        ..SavedQuery::default()
+    };
+
+    let mut suggested_name: Option<String> = None;
+
+    for (key, value) in url.query_pairs() {
+        let key = key.as_ref();
+        let value = value.as_ref();
+
+        // Skip ignored params
+        if IGNORED_PARAMS.contains(&key) {
+            continue;
+        }
+
+        // Extract suggested name
+        if NAME_PARAMS.contains(&key) {
+            if suggested_name.is_none() && !value.is_empty() {
+                suggested_name = Some(value.to_string());
+            }
+            continue;
+        }
+
+        // Handle limit
+        if key == "limit" {
+            if let Ok(n) = value.parse::<u32>() {
+                query.limit = Some(n);
+            }
+            continue;
+        }
+
+        // Check recognized vec params
+        if let Some(&(_, field_name)) = RECOGNIZED_VEC_PARAMS
+            .iter()
+            .find(|&&(url_key, _)| url_key == key)
+        {
+            let target = match field_name {
+                "product" => &mut query.product,
+                "component" => &mut query.component,
+                "status" => &mut query.status,
+                "assignee" => &mut query.assignee,
+                "creator" => &mut query.creator,
+                "priority" => &mut query.priority,
+                "severity" => &mut query.severity,
+                _ => unreachable!(),
+            };
+            target.push(value.to_string());
+            continue;
+        }
+
+        // Everything else -> raw_params
+        query.raw_params.push((key.to_string(), value.to_string()));
+    }
+
+    Ok(ParsedUrl {
+        query,
+        suggested_name,
+    })
+}
+
+/// Find a configured server whose URL hostname matches the given hostname.
+fn find_server_by_hostname<'a>(config: &'a Config, hostname: &str) -> Option<&'a str> {
+    for (name, srv) in &config.servers {
+        if let Ok(srv_url) = Url::parse(&srv.url) {
+            if srv_url.host_str() == Some(hostname) {
+                return Some(name.as_str());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, ServerConfig};
+    use std::collections::HashMap;
+
+    fn make_config(server_url: &str) -> Config {
+        let mut servers = HashMap::new();
+        servers.insert(
+            "test".into(),
+            ServerConfig {
+                url: server_url.into(),
+                api_key: None,
+                api_key_env: None,
+                api_key_keyring: None,
+                email: None,
+                auth_method: None,
+                api_mode: None,
+                server_version: None,
+                tls_insecure: false,
+            },
+        );
+        Config {
+            default_server: Some("test".into()),
+            servers,
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn parse_simple_url_with_recognized_params() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi?\
+            product=Firefox&product=Thunderbird&bug_status=NEW&limit=50";
+
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        assert_eq!(parsed.query.kind, QueryKind::Url);
+        assert_eq!(parsed.query.product, vec!["Firefox", "Thunderbird"]);
+        assert_eq!(parsed.query.status, vec!["NEW"]);
+        assert_eq!(parsed.query.limit, Some(50));
+        assert!(parsed.query.raw_params.is_empty());
+        assert_eq!(parsed.query.server.as_deref(), Some("test"));
+        assert!(parsed.query.source_url.is_some());
+    }
+
+    #[test]
+    fn parse_complex_boolean_chart_url() {
+        let config = make_config("https://bugzilla.linux.ibm.com");
+        let url = "https://bugzilla.linux.ibm.com/buglist.cgi?\
+            chfield=qa_contact&chfieldfrom=-1w&chfieldto=Now&\
+            classification=BugsAgainstDistros&\
+            f1=qa_contact&o1=changedfrom&v1=user%40example.com&\
+            known_name=my%20saved%20search&query_format=advanced&\
+            list_id=12345&columnlist=qa_contact%2Cproduct";
+
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        assert_eq!(parsed.query.kind, QueryKind::Url);
+        assert!(parsed.query.product.is_empty());
+
+        // Boolean chart and chfield params should be in raw_params
+        let raw_keys: Vec<&str> = parsed
+            .query
+            .raw_params
+            .iter()
+            .map(|(k, _)| k.as_str())
+            .collect();
+        assert!(raw_keys.contains(&"f1"));
+        assert!(raw_keys.contains(&"o1"));
+        assert!(raw_keys.contains(&"v1"));
+        assert!(raw_keys.contains(&"chfield"));
+        assert!(raw_keys.contains(&"chfieldfrom"));
+        assert!(raw_keys.contains(&"classification"));
+
+        // Ignored params should not appear
+        assert!(!raw_keys.contains(&"columnlist"));
+        assert!(!raw_keys.contains(&"list_id"));
+        assert!(!raw_keys.contains(&"query_format"));
+
+        // URL-decoded value
+        let v1 = parsed
+            .query
+            .raw_params
+            .iter()
+            .find(|(k, _)| k == "v1")
+            .unwrap();
+        assert_eq!(v1.1, "user@example.com");
+
+        // Suggested name extracted and decoded
+        assert_eq!(parsed.suggested_name.as_deref(), Some("my saved search"));
+    }
+
+    #[test]
+    fn parse_url_without_buglist_cgi_errors() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/show_bug.cgi?id=123";
+        let result = parse_bugzilla_url(url, &config);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("buglist.cgi"));
+    }
+
+    #[test]
+    fn parse_malformed_url_errors() {
+        let config = make_config("https://bugzilla.example.com");
+        let result = parse_bugzilla_url("not a url", &config);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("invalid URL"));
+    }
+
+    #[test]
+    fn parse_url_hostname_matches_configured_server() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi?product=Test";
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        assert_eq!(parsed.query.server.as_deref(), Some("test"));
+    }
+
+    #[test]
+    fn parse_url_hostname_no_match_uses_default() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://other.example.com/buglist.cgi?product=Test";
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        // No match, but default server exists so server is None (will use default)
+        assert!(parsed.query.server.is_none());
+    }
+
+    #[test]
+    fn parse_url_hostname_no_match_no_default_errors() {
+        let config = Config {
+            default_server: None,
+            servers: HashMap::new(),
+            ..Config::default()
+        };
+        let url = "https://other.example.com/buglist.cgi?product=Test";
+        let result = parse_bugzilla_url(url, &config);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("does not match"));
+    }
+
+    #[test]
+    fn parse_url_repeated_product_params_accumulate() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi?\
+            product=Firefox&product=Thunderbird&product=Core";
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        assert_eq!(
+            parsed.query.product,
+            vec!["Firefox", "Thunderbird", "Core"]
+        );
+    }
+
+    #[test]
+    fn parse_url_decodes_percent_encoded_values() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi?\
+            product=PPC64%20Development&assigned_to=user%40example.com";
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        assert_eq!(parsed.query.product, vec!["PPC64 Development"]);
+        assert_eq!(parsed.query.assignee, vec!["user@example.com"]);
+    }
+
+    #[test]
+    fn parse_url_all_recognized_fields() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi?\
+            product=Firefox&component=General&bug_status=NEW&\
+            assigned_to=dev%40test.com&reporter=creator%40test.com&\
+            priority=P1&bug_severity=critical&limit=25";
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        assert_eq!(parsed.query.product, vec!["Firefox"]);
+        assert_eq!(parsed.query.component, vec!["General"]);
+        assert_eq!(parsed.query.status, vec!["NEW"]);
+        assert_eq!(parsed.query.assignee, vec!["dev@test.com"]);
+        assert_eq!(parsed.query.creator, vec!["creator@test.com"]);
+        assert_eq!(parsed.query.priority, vec!["P1"]);
+        assert_eq!(parsed.query.severity, vec!["critical"]);
+        assert_eq!(parsed.query.limit, Some(25));
+        assert!(parsed.query.raw_params.is_empty());
+    }
+
+    #[test]
+    fn parse_url_only_raw_params() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi?\
+            f1=qa_contact&o1=changedfrom&v1=user%40example.com";
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        assert!(parsed.query.product.is_empty());
+        assert_eq!(parsed.query.raw_params.len(), 3);
+        assert!(parsed.query.has_filters());
+    }
+
+    #[test]
+    fn find_server_by_hostname_matches() {
+        let config = make_config("https://bugzilla.example.com");
+        assert_eq!(
+            find_server_by_hostname(&config, "bugzilla.example.com"),
+            Some("test")
+        );
+    }
+
+    #[test]
+    fn find_server_by_hostname_no_match() {
+        let config = make_config("https://bugzilla.example.com");
+        assert_eq!(find_server_by_hostname(&config, "other.example.com"), None);
+    }
+}
+```
+
+- [ ] **Step 2: Add module declaration to `src/lib.rs`**
+
+In `src/lib.rs`, add after the `pub mod types;` line:
+
+```rust
+pub mod url_parser;
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cargo test url_parser`
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/url_parser.rs src/lib.rs
+git commit -m "feat: add url_parser module to parse buglist.cgi URLs into SavedQuery"
+```
+
+---
+
+### Task 4: Wire raw params into client
+
+**Files:**
+- Modify: `src/client/bug.rs:98-190`
+
+- [ ] **Step 1: Write test for `append_raw_params`**
+
+Add to the existing `#[cfg(test)] mod tests` in `src/client/bug.rs`:
+
+```rust
+#[test]
+fn append_raw_params_empty_is_noop() {
+    let client = reqwest::Client::new();
+    let builder = client.get("https://example.com/rest/bug");
+    let result = super::append_raw_params(builder, &[]);
+    // If it compiles and doesn't panic, the noop case works.
+    // We verify the full behavior via the wiremock integration test below.
+    let _ = result;
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib client::bug::tests::append_raw_params_empty -- --no-capture`
+Expected: compilation error (function doesn't exist yet)
+
+- [ ] **Step 3: Implement `append_raw_params`**
+
+In `src/client/bug.rs`, add this function after `append_option_params` (around line 119):
+
+```rust
+/// Appends raw key-value parameters to the request builder verbatim.
+/// Used for URL-imported queries with boolean chart params that
+/// `bzr` does not natively model.
+fn append_raw_params(
+    mut builder: reqwest::RequestBuilder,
+    raw_params: &[(String, String)],
+) -> reqwest::RequestBuilder {
+    for (key, value) in raw_params {
+        builder = builder.query(&[(key, value)]);
+    }
+    builder
+}
+```
+
+- [ ] **Step 4: Call `append_raw_params` in `search_bugs_rest`**
+
+In the `search_bugs_rest` method, add the call after `append_option_params` and the `id` loop, but before the `include_fields` default check:
+
+```rust
+    async fn search_bugs_rest(&self, params: &SearchParams) -> Result<Vec<Bug>> {
+        let mut req_builder = self.http.get(self.url("bug"));
+        req_builder = append_multi_value_params(req_builder, params);
+        req_builder = append_negated_params(req_builder, params);
+        req_builder = append_option_params(req_builder, params);
+
+        for id in &params.id {
+            req_builder = req_builder.query(&[("id", id)]);
+        }
+
+        // Append raw passthrough params (from URL-imported queries)
+        req_builder = append_raw_params(req_builder, &params.raw_params);
+
+        if params.include_fields.is_none() {
+            req_builder = req_builder.query(&[("include_fields", BUG_DEFAULT_FIELDS)]);
+        }
+        let req = self.apply_auth(req_builder);
+        let resp = self.send(req).await?;
+        let data: BugListResponse = self.parse_json(resp).await?;
+        Ok(data.bugs)
+    }
+```
+
+- [ ] **Step 5: Force REST mode when raw params are present**
+
+In the `search_bugs` method, add a check at the top:
+
+```rust
+    pub async fn search_bugs(&self, params: &SearchParams) -> Result<Vec<Bug>> {
+        tracing::debug!(?params, %self.api_mode, "search parameters");
+
+        // Raw params (boolean charts from URLs) only work with REST.
+        if !params.raw_params.is_empty() && self.api_mode != ApiMode::Rest {
+            tracing::warn!(
+                "query contains raw URL parameters that require REST API; \
+                 ignoring configured {} mode",
+                self.api_mode
+            );
+            return self.search_bugs_rest(params).await;
+        }
+
+        match self.api_mode {
+            // ... existing match arms unchanged ...
+        }
+    }
+```
+
+- [ ] **Step 6: Run all tests**
+
+Run: `cargo test`
+Expected: all tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/client/bug.rs
+git commit -m "feat: add raw_params passthrough in search_bugs_rest, force REST when present"
+```
+
+---
+
+### Task 5: CLI changes — `bug search --from-url --save-as`
+
+**Files:**
+- Modify: `src/cli/bug.rs:55-68`
+
+- [ ] **Step 1: Modify the `Search` variant in `BugAction`**
+
+Replace the current `Search` variant with:
+
+```rust
+    /// Search bugs by text query or Bugzilla URL
+    Search {
+        /// Search query (mutually exclusive with --from-url)
+        #[arg(conflicts_with = "from_url")]
+        query: Option<String>,
+        /// Execute a search from a Bugzilla buglist.cgi URL
+        #[arg(long)]
+        from_url: Option<String>,
+        /// Save this URL query with the given name for future reuse (requires --from-url)
+        #[arg(long, requires = "from_url")]
+        save_as: Option<String>,
+        /// Max number of results
+        #[arg(long, default_value = "50")]
+        limit: u32,
+        /// Only return these fields (comma-separated)
+        #[arg(long)]
+        fields: Option<String>,
+        /// Exclude these fields (comma-separated)
+        #[arg(long)]
+        exclude_fields: Option<String>,
+    },
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo check`
+Expected: compilation errors in `commands/bug.rs` where `handle_search` destructures the old `Search` variant. This is expected — we fix it in Task 7.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/bug.rs
+git commit -m "feat: add --from-url and --save-as flags to bug search CLI"
+```
+
+---
+
+### Task 6: CLI changes — `query save --from-url`, `query run --server`
+
+**Files:**
+- Modify: `src/cli/query.rs`
+
+- [ ] **Step 1: Add `--from-url` to `Save` and `--server` to `Run`**
+
+Replace the full `QueryAction` enum:
+
+```rust
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum QueryAction {
+    /// Save a named query
+    Save {
+        /// Query name
+        name: String,
+        /// Import query from a Bugzilla buglist.cgi URL (mutually exclusive with filter flags)
+        #[arg(long, conflicts_with_all = ["search", "product", "component", "status", "assignee", "creator", "priority", "severity"])]
+        from_url: Option<String>,
+        /// Free-text search (creates a "search" kind query)
+        #[arg(long)]
+        search: Option<String>,
+        /// Filter by product (repeatable for OR; prefix with ! to exclude)
+        #[arg(long)]
+        product: Vec<String>,
+        /// Filter by component (repeatable for OR; prefix with ! to exclude)
+        #[arg(long)]
+        component: Vec<String>,
+        /// Filter by status (repeatable for OR; prefix with ! to exclude)
+        #[arg(long)]
+        status: Vec<String>,
+        /// Filter by assignee (repeatable for OR; prefix with ! to exclude)
+        #[arg(long)]
+        assignee: Vec<String>,
+        /// Filter by creator (repeatable for OR; prefix with ! to exclude)
+        #[arg(long)]
+        creator: Vec<String>,
+        /// Filter by priority (repeatable for OR; prefix with ! to exclude)
+        #[arg(long)]
+        priority: Vec<String>,
+        /// Filter by severity (repeatable for OR; prefix with ! to exclude)
+        #[arg(long)]
+        severity: Vec<String>,
+        /// Max number of results
+        #[arg(long)]
+        limit: Option<u32>,
+        /// Only return these fields (comma-separated)
+        #[arg(long)]
+        fields: Option<String>,
+        /// Exclude these fields (comma-separated)
+        #[arg(long)]
+        exclude_fields: Option<String>,
+    },
+    /// List all saved queries
+    List,
+    /// Show details of a saved query
+    Show {
+        /// Query name
+        name: String,
+    },
+    /// Delete a saved query
+    Delete {
+        /// Query name
+        name: String,
+    },
+    /// Run a saved query
+    Run {
+        /// Query name
+        name: String,
+        /// Override the saved limit
+        #[arg(long)]
+        limit: Option<u32>,
+        /// Override the saved fields selection
+        #[arg(long)]
+        fields: Option<String>,
+        /// Override the saved exclude-fields selection
+        #[arg(long)]
+        exclude_fields: Option<String>,
+        /// Override the server to run against
+        #[arg(long)]
+        server: Option<String>,
+    },
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo check`
+Expected: compilation errors in `commands/query.rs` where `handle_save` and `handle_run` destructure the old variants. Expected — we fix in Task 8.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/query.rs
+git commit -m "feat: add --from-url to query save and --server to query run CLI"
+```
+
+---
+
+### Task 7: Command handler — `bug search --from-url`
+
+**Files:**
+- Modify: `src/commands/bug.rs:115-140`
+
+- [ ] **Step 1: Write test for `--from-url` execution**
+
+Add to the existing test module in `src/commands/bug.rs`:
+
+```rust
+#[tokio::test]
+async fn handle_search_from_url_executes() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("product", "TestProduct"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "bugs": [{"id": 1, "summary": "Test bug", "status": "NEW",
+                          "product": "TestProduct", "component": "General"}]
+            })),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let server_url = mock.uri();
+    let url = format!(
+        "{}/buglist.cgi?product=TestProduct&limit=10",
+        server_url
+    );
+    let action = BugAction::Search {
+        query: None,
+        from_url: Some(url),
+        save_as: None,
+        limit: 50,
+        fields: None,
+        exclude_fields: None,
+    };
+
+    let (result, output) = capture_stdout(
+        super::execute(&action, None, OutputFormat::Json, None),
+    )
+    .await;
+    assert!(result.is_ok(), "from-url search failed: {result:?}");
+    let parsed: serde_json::Value = extract_json(&output);
+    assert_eq!(parsed[0]["id"], 1);
+}
+
+#[tokio::test]
+async fn handle_search_from_url_saves_query() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"bugs": []})),
+        )
+        .mount(&mock)
+        .await;
+
+    let server_url = mock.uri();
+    let url = format!(
+        "{}/buglist.cgi?product=TestProduct&known_name=my-query",
+        server_url
+    );
+    let action = BugAction::Search {
+        query: None,
+        from_url: Some(url),
+        save_as: Some("my-query".into()),
+        limit: 50,
+        fields: None,
+        exclude_fields: None,
+    };
+
+    let (result, _output) = capture_stdout(
+        super::execute(&action, None, OutputFormat::Json, None),
+    )
+    .await;
+    assert!(result.is_ok(), "from-url save failed: {result:?}");
+
+    // Verify query was saved to config
+    let config = crate::config::Config::load().unwrap();
+    let saved = config.queries.get("my-query").unwrap();
+    assert_eq!(saved.kind, crate::types::QueryKind::Url);
+    assert_eq!(saved.product, vec!["TestProduct"]);
+    assert!(saved.source_url.is_some());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib commands::bug::tests::handle_search_from_url -- --no-capture 2>&1 | head -20`
+Expected: compilation errors (the `handle_search` function doesn't handle the new fields yet)
+
+- [ ] **Step 3: Update `handle_search` to support `--from-url`**
+
+Replace the `handle_search` function in `src/commands/bug.rs`:
+
+```rust
+async fn handle_search(
+    client: &BugzillaClient,
+    action: &BugAction,
+    format: OutputFormat,
+) -> Result<()> {
+    let BugAction::Search {
+        query,
+        from_url,
+        save_as,
+        limit,
+        fields,
+        exclude_fields,
+    } = action
+    else {
+        unreachable!()
+    };
+
+    let params = if let Some(url_str) = from_url {
+        let config = crate::config::Config::load()?;
+        let parsed = crate::url_parser::parse_bugzilla_url(url_str, &config)?;
+
+        // Save if requested
+        if let Some(name) = save_as {
+            let mut config = config;
+            let is_update = config.queries.contains_key(name.as_str());
+            config.queries.insert(name.clone(), parsed.query.clone());
+            config.save()?;
+            let verb = if is_update { "Updated" } else { "Saved" };
+            tracing::info!("{verb} query '{name}'");
+        }
+
+        let mut params = parsed.query.to_search_params();
+        // CLI overrides
+        if *limit != 50 {
+            params.limit = Some(*limit);
+        } else if params.limit.is_none() {
+            params.limit = Some(*limit);
+        }
+        if let Some(f) = fields {
+            params.include_fields = Some(f.clone());
+        }
+        if let Some(ef) = exclude_fields {
+            params.exclude_fields = Some(ef.clone());
+        }
+        params
+    } else {
+        let query_str = query.as_deref().ok_or_else(|| {
+            crate::error::BzrError::InputValidation(
+                "either a search query or --from-url is required".into(),
+            )
+        })?;
+        SearchParams {
+            quicksearch: Some(query_str.to_string()),
+            limit: Some(*limit),
+            include_fields: fields.clone(),
+            exclude_fields: exclude_fields.clone(),
+            ..Default::default()
+        }
+    };
+
+    let bugs = client.search_bugs(&params).await?;
+    output::print_bugs(&bugs, format);
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --lib commands::bug::tests::handle_search`
+Expected: all search tests pass
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cargo test`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/bug.rs
+git commit -m "feat: handle --from-url in bug search command"
+```
+
+---
+
+### Task 8: Command handler — `query save --from-url`, `query run --server`
+
+**Files:**
+- Modify: `src/commands/query.rs`
+
+- [ ] **Step 1: Write test for `query save --from-url`**
+
+Add to the test module in `src/commands/query.rs`:
+
+```rust
+#[tokio::test]
+async fn query_save_from_url() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    let server_url = mock.uri();
+    let url = format!(
+        "{}/buglist.cgi?product=TestProduct&f1=qa_contact&o1=changedfrom&v1=user%40example.com",
+        server_url
+    );
+    let action = QueryAction::Save {
+        name: "url-query".into(),
+        from_url: Some(url),
+        search: None,
+        product: vec![],
+        component: vec![],
+        status: vec![],
+        assignee: vec![],
+        creator: vec![],
+        priority: vec![],
+        severity: vec![],
+        limit: None,
+        fields: None,
+        exclude_fields: None,
+    };
+    let (result, _output) =
+        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    assert!(result.is_ok(), "query save --from-url failed: {result:?}");
+
+    let config = Config::load().unwrap();
+    let saved = &config.queries["url-query"];
+    assert_eq!(saved.kind, crate::types::QueryKind::Url);
+    assert_eq!(saved.product, vec!["TestProduct"]);
+    assert!(!saved.raw_params.is_empty());
+    assert!(saved.source_url.is_some());
+}
+
+#[tokio::test]
+async fn query_run_with_server_override() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    // Save a query with server association
+    let save_action = save_action("server-test");
+    let (result, _) =
+        capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
+    assert!(result.is_ok());
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"bugs": []})),
+        )
+        .mount(&mock)
+        .await;
+
+    // Run with --server override (uses the test server from setup_test_env)
+    let run_action = QueryAction::Run {
+        name: "server-test".into(),
+        limit: None,
+        fields: None,
+        exclude_fields: None,
+        server: Some("test".into()),
+    };
+    let (result, _) =
+        capture_stdout(super::execute(&run_action, Some("test"), OutputFormat::Json, None)).await;
+    assert!(result.is_ok(), "query run with server override failed: {result:?}");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib commands::query::tests::query_save_from_url -- --no-capture 2>&1 | head -20`
+Expected: compilation error (destructuring doesn't include `from_url`)
+
+- [ ] **Step 3: Update `handle_save` to support `--from-url`**
+
+Replace the `handle_save` function:
+
+```rust
+fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
+    let QueryAction::Save {
+        name,
+        from_url,
+        search,
+        product,
+        component,
+        status,
+        assignee,
+        creator,
+        priority,
+        severity,
+        limit,
+        fields,
+        exclude_fields,
+    } = action
+    else {
+        unreachable!()
+    };
+
+    let query = if let Some(url_str) = from_url {
+        let config = Config::load()?;
+        let parsed = crate::url_parser::parse_bugzilla_url(url_str, &config)?;
+        let mut query = parsed.query;
+        // Apply any explicit overrides
+        if let Some(limit) = limit {
+            query.limit = Some(*limit);
+        }
+        if let Some(f) = fields {
+            query.fields = Some(f.clone());
+        }
+        if let Some(ef) = exclude_fields {
+            query.exclude_fields = Some(ef.clone());
+        }
+        query
+    } else {
+        let kind = if search.is_some() {
+            QueryKind::Search
+        } else {
+            QueryKind::List
+        };
+
+        SavedQuery {
+            kind,
+            product: product.clone(),
+            component: component.clone(),
+            status: status.clone(),
+            assignee: assignee.clone(),
+            creator: creator.clone(),
+            priority: priority.clone(),
+            severity: severity.clone(),
+            quicksearch: search.clone(),
+            limit: *limit,
+            fields: fields.clone(),
+            exclude_fields: exclude_fields.clone(),
+            ..SavedQuery::default()
+        }
+    };
+
+    if !query.has_filters() {
+        return Err(BzrError::InputValidation(
+            "query must have at least one filter set".into(),
+        ));
+    }
+
+    let mut config = Config::load()?;
+    let is_update = config.queries.contains_key(name.as_str());
+    config.queries.insert(name.clone(), query);
+    config.save()?;
+
+    let verb = if is_update { "Updated" } else { "Saved" };
+    output::print_query_saved(name, verb, format);
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Update `handle_run` to support `--server` override**
+
+Replace the `handle_run` function:
+
+```rust
+async fn handle_run(
+    action: &QueryAction,
+    server: Option<&str>,
+    format: OutputFormat,
+    api: Option<crate::types::ApiMode>,
+) -> Result<()> {
+    let QueryAction::Run {
+        name,
+        limit,
+        fields,
+        exclude_fields,
+        server: server_override,
+    } = action
+    else {
+        unreachable!()
+    };
+
+    let config = Config::load()?;
+    let query = config
+        .queries
+        .get(name.as_str())
+        .ok_or_else(|| BzrError::config(format!("query '{name}' not found")))?;
+
+    let mut params = query.to_search_params();
+
+    // Apply runtime overrides
+    if let Some(limit) = limit {
+        params.limit = Some(*limit);
+    }
+    if let Some(fields) = fields {
+        params.include_fields = Some(fields.clone());
+    }
+    if let Some(exclude_fields) = exclude_fields {
+        params.exclude_fields = Some(exclude_fields.clone());
+    }
+
+    // Server resolution: CLI --server > query run --server > saved server > default
+    let effective_server = server
+        .or(server_override.as_deref())
+        .or(query.server.as_deref());
+
+    let client = super::shared::connect_and_configure(effective_server, api).await?;
+    let bugs = client.search_bugs(&params).await?;
+    output::print_bugs(&bugs, format);
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Update the `save_action` test helper to include `from_url`**
+
+In the test module, update the `save_action` helper:
+
+```rust
+fn save_action(name: &str) -> QueryAction {
+    QueryAction::Save {
+        name: name.into(),
+        from_url: None,
+        search: None,
+        product: vec!["Firefox".into()],
+        component: vec![],
+        status: vec!["NEW".into()],
+        assignee: vec![],
+        creator: vec![],
+        priority: vec![],
+        severity: vec![],
+        limit: Some(25),
+        fields: None,
+        exclude_fields: None,
+    }
+}
+```
+
+- [ ] **Step 6: Update all existing `QueryAction::Save` test constructions**
+
+In the test module, every manual `QueryAction::Save { .. }` construction must include `from_url: None`. Update these tests:
+- `query_save_search_kind`
+- `query_save_requires_filter`
+- `query_run_executes_saved_query`
+- `query_run_with_limit_override`
+- `query_save_existing_entry_reports_updated` (both the save and the update action)
+- `query_delete_removes_saved_query`
+- `query_run_applies_field_overrides`
+
+- [ ] **Step 7: Update all existing `QueryAction::Run` test constructions**
+
+Every manual `QueryAction::Run { .. }` construction must include `server: None`. Update these tests:
+- `query_run_executes_saved_query`
+- `query_run_with_limit_override`
+- `query_run_applies_field_overrides`
+- `query_run_unknown_errors`
+
+- [ ] **Step 8: Run tests**
+
+Run: `cargo test --lib commands::query`
+Expected: all query command tests pass
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `cargo test`
+Expected: all tests pass
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/commands/query.rs
+git commit -m "feat: handle --from-url in query save, --server override in query run"
+```
+
+---
+
+### Task 9: Enhanced `query show` output for URL queries
+
+**Files:**
+- Modify: `src/output/query.rs:59-89`
+
+- [ ] **Step 1: Write test for URL query display**
+
+Add to the test module in `src/output/query.rs`:
+
+```rust
+fn make_url_query() -> SavedQuery {
+    SavedQuery {
+        kind: QueryKind::Url,
+        source_url: Some("https://bugzilla.example.com/buglist.cgi?product=Firefox&f1=qa_contact".into()),
+        server: Some("example".into()),
+        product: vec!["Firefox".into()],
+        raw_params: vec![
+            ("f1".into(), "qa_contact".into()),
+            ("o1".into(), "changedfrom".into()),
+        ],
+        limit: Some(100),
+        ..SavedQuery::default()
+    }
+}
+
+#[test]
+fn query_detail_json_includes_url_fields() {
+    #[derive(serde::Serialize)]
+    struct QueryView<'a> {
+        name: &'a str,
+        #[serde(flatten)]
+        query: &'a SavedQuery,
+    }
+    let query = make_url_query();
+    let view = QueryView {
+        name: "url-q",
+        query: &query,
+    };
+    let json = serde_json::to_string_pretty(&view).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["kind"], "url");
+    assert_eq!(
+        parsed["source_url"],
+        "https://bugzilla.example.com/buglist.cgi?product=Firefox&f1=qa_contact"
+    );
+    assert_eq!(parsed["server"], "example");
+    assert_eq!(parsed["raw_params"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn query_summary_line_renders_url_query() {
+    let line = query_summary_line("url-q", &make_url_query());
+    assert!(line.starts_with("url-q (kind=url"));
+    assert!(line.contains("product=Firefox"));
+    assert!(line.contains("2 raw params"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn print_query_detail_table_renders_url_fields() {
+    let _lock = crate::ENV_LOCK.lock().await;
+    let query = make_url_query();
+
+    let ((), output) = crate::test_helpers::capture_stdout(async {
+        print_query_detail("url-q", &query, OutputFormat::Table);
+    })
+    .await;
+
+    assert!(output.contains("Source URL"));
+    assert!(output.contains("bugzilla.example.com"));
+    assert!(output.contains("Server"));
+    assert!(output.contains("example"));
+    assert!(output.contains("Raw params"));
+    assert!(output.contains("2"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib output::query::tests::query_summary_line_renders_url -- --no-capture`
+Expected: fails (no "raw params" in output yet)
+
+- [ ] **Step 3: Update `query_summary_line` for URL queries**
+
+In `src/output/query.rs`, update the `query_summary_line` function:
+
+```rust
+fn query_summary_line(name: &str, q: &SavedQuery) -> String {
+    let kind_label = match q.kind {
+        QueryKind::List => "list",
+        QueryKind::Search => "search",
+        QueryKind::Url => "url",
+    };
+    let mut parts = vec![format!("kind={kind_label}")];
+    if !q.product.is_empty() {
+        parts.push(format!("product={}", q.product.join(",")));
+    }
+    if !q.status.is_empty() {
+        parts.push(format!("status={}", q.status.join(",")));
+    }
+    if let Some(qs) = &q.quicksearch {
+        parts.push(format!("search=\"{qs}\""));
+    }
+    if let Some(limit) = q.limit {
+        parts.push(format!("limit={limit}"));
+    }
+    if !q.raw_params.is_empty() {
+        parts.push(format!("{} raw params", q.raw_params.len()));
+    }
+    format!("{name} ({})", parts.join(", "))
+}
+```
+
+- [ ] **Step 4: Update `print_query_detail` for URL queries**
+
+In `src/output/query.rs`, update the table rendering in `print_query_detail`:
+
+```rust
+pub fn print_query_detail(name: &str, query: &SavedQuery, format: OutputFormat) {
+    #[derive(serde::Serialize)]
+    struct QueryView<'a> {
+        name: &'a str,
+        #[serde(flatten)]
+        query: &'a SavedQuery,
+    }
+
+    let view = QueryView { name, query };
+    print_formatted(&view, format, |view| {
+        let kind_label = match view.query.kind {
+            QueryKind::List => "list",
+            QueryKind::Search => "search",
+            QueryKind::Url => "url",
+        };
+        print_field("Name", view.name);
+        print_field("Kind", kind_label);
+        print_optional_field("Source URL", view.query.source_url.as_deref());
+        print_optional_field("Server", view.query.server.as_deref());
+        print_list_field("Product", &view.query.product);
+        print_list_field("Component", &view.query.component);
+        print_list_field("Status", &view.query.status);
+        print_list_field("Assignee", &view.query.assignee);
+        print_list_field("Creator", &view.query.creator);
+        print_list_field("Priority", &view.query.priority);
+        print_list_field("Severity", &view.query.severity);
+        print_optional_field("Search", view.query.quicksearch.as_deref());
+        if let Some(limit) = view.query.limit {
+            print_field("Limit", &limit.to_string());
+        }
+        print_optional_field("Fields", view.query.fields.as_deref());
+        print_optional_field("Exclude", view.query.exclude_fields.as_deref());
+        if !view.query.raw_params.is_empty() {
+            print_field("Raw params", &view.query.raw_params.len().to_string());
+        }
+    });
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test --lib output::query`
+Expected: all output query tests pass
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `cargo test`
+Expected: all tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/output/query.rs
+git commit -m "feat: display source_url, server, and raw_params in query show output"
+```
+
+---
+
+### Task 10: Fix integration tests and dispatch tests
+
+**Files:**
+- Modify: `tests/integration.rs` (if any query-related tests exist)
+- Modify: `src/lib.rs` (dispatch test for query save uses old CLI parse)
+
+- [ ] **Step 1: Check for integration test breakage**
+
+Run: `cargo test --test integration 2>&1 | head -40`
+Expected: may show compilation errors if integration tests construct `QueryAction` variants
+
+- [ ] **Step 2: Fix any broken integration test constructions**
+
+If integration tests construct `QueryAction::Save` or `QueryAction::Run` directly, add the new fields (`from_url: None`, `server: None`). If they parse CLI strings via `Cli::try_parse_from`, they should be fine.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `cargo test`
+Expected: all tests pass
+
+- [ ] **Step 4: Run clippy**
+
+Run: `cargo clippy --all-targets --all-features -- -D warnings`
+Expected: no warnings
+
+- [ ] **Step 5: Run fmt check**
+
+Run: `cargo fmt --check`
+Expected: no formatting issues
+
+- [ ] **Step 6: Commit (if any changes were needed)**
+
+```bash
+git add -A
+git commit -m "fix: update integration tests for new QueryAction fields"
+```
+
+---
+
+### Task 11: Update CLI documentation
+
+**Files:**
+- Modify: `docs/bzr-cli.md`
+
+- [ ] **Step 1: Add `--from-url` and `--save-as` to the `bug search` section**
+
+Find the `bug search` section in `docs/bzr-cli.md` and add documentation for:
+- `--from-url <URL>` — Execute a search from a Bugzilla buglist.cgi URL
+- `--save-as <NAME>` — Save this URL query for future reuse (requires `--from-url`)
+
+Include example:
+
+```
+bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW"
+bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?..." --save-as "my-query"
+```
+
+- [ ] **Step 2: Add `--from-url` to the `query save` section**
+
+Document: `--from-url <URL>` — Import query from a Bugzilla URL (mutually exclusive with filter flags)
+
+Include example:
+
+```
+bzr query save my-query --from-url "https://bugzilla.example.com/buglist.cgi?..."
+```
+
+- [ ] **Step 3: Add `--server` to the `query run` section**
+
+Document: `--server <NAME>` — Override the server to run the query against
+
+Include example:
+
+```
+bzr query run my-query --server other-server --limit 50
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/bzr-cli.md
+git commit -m "docs: document --from-url, --save-as, and --server flags"
+```

--- a/docs/specs/2026-04-27-from-url-saved-queries-design.md
+++ b/docs/specs/2026-04-27-from-url-saved-queries-design.md
@@ -1,0 +1,217 @@
+# Design: `--from-url` and Saved Query Enhancement
+
+**Date:** 2026-04-27
+**Status:** Draft
+
+## Problem
+
+Bugzilla's GUI lets users build complex advanced queries with boolean charts, field-change tracking, and multi-field conditions. These queries are shareable as URLs but cannot be used from the `bzr` CLI. Users must manually translate URL parameters into CLI flags, which is impractical for advanced queries.
+
+## Goals
+
+1. Accept a Bugzilla `buglist.cgi` URL via `--from-url` and execute the query directly.
+2. Optionally save the parsed query as a named template for future reuse via `--save-as`.
+3. Allow runtime overrides (limit, fields, server) when running saved queries.
+4. Preserve the full fidelity of the original URL, including boolean chart parameters that `bzr` does not natively model.
+
+## Non-Goals
+
+- Generating Bugzilla GUI URLs from CLI queries (reverse direction).
+- Parsing or validating boolean chart logic (we pass it through verbatim).
+- XML-RPC support for URL-sourced queries (boolean charts are a REST/CGI concept).
+
+## Design
+
+### Data Model
+
+Extend `SavedQuery` with three new fields:
+
+```rust
+pub struct SavedQuery {
+    // ... existing fields (kind, product, component, status, etc.) ...
+
+    /// The original Bugzilla URL this query was parsed from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+
+    /// Server name (from config) this query is associated with.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server: Option<String>,
+
+    /// Raw query parameters not mapped to structured fields.
+    /// Passed through verbatim to the Bugzilla REST API.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
+}
+```
+
+Add a new `QueryKind::Url` variant to indicate URL-sourced queries.
+
+Extend `SearchParams` with a `raw_params: Vec<(String, String)>` field (defaults to empty, so existing callers are unaffected).
+
+### URL Parsing
+
+New module: `src/url_parser.rs`
+
+**Entry point:** `parse_bugzilla_url(url: &str, config: &Config) -> Result<SavedQuery>`
+
+**Steps:**
+
+1. Parse and validate the URL using the `url` crate (transitive dep via `reqwest`).
+2. Verify the path contains `buglist.cgi`; reject other pages.
+3. Match the hostname against configured `ServerConfig` URLs to populate `server`.
+4. Iterate query parameters, classifying each:
+
+**Recognized parameters mapped to structured fields:**
+
+| URL parameter | `SavedQuery` field |
+|---|---|
+| `product` | `product` (vec, may repeat) |
+| `component` | `component` (vec) |
+| `bug_status` | `status` (vec) |
+| `assigned_to` | `assignee` (vec) |
+| `reporter` | `creator` (vec) |
+| `priority` | `priority` (vec) |
+| `bug_severity` | `severity` (vec) |
+| `limit` | `limit` |
+
+**Ignored parameters (display/session metadata):**
+
+| URL parameter | Reason |
+|---|---|
+| `columnlist` | Display preference, not a filter |
+| `list_id` | Session-specific |
+| `query_format` | Always "advanced" for these URLs |
+
+**Name extraction:**
+
+`known_name` and `query_based_on` are extracted as a suggested default name for `--save-as` when the user doesn't provide one explicitly.
+
+**Everything else goes to `raw_params`:**
+
+Boolean chart params (`f1`, `o1`, `v1`, `j3`, `OP`, `CP`), `chfield*` params, `classification`, and any other unrecognized keys are stored as ordered `(key, value)` pairs.
+
+**Server matching:**
+
+Compare the URL hostname against each `ServerConfig.url` hostname. If exactly one matches, associate the query with that server name. If none match but a default server is configured, leave `server` as `None` (the default server will be used at runtime) and warn that the URL hostname didn't match any configured server. If none match and no default server is configured, return an error advising the user to configure the server first.
+
+### CLI Changes
+
+#### `bug search` -- add `--from-url` and `--save-as`
+
+```
+bzr bug search --from-url "https://..." --save-as "my-query"
+bzr bug search --from-url "https://..."
+```
+
+- `--from-url` is mutually exclusive with the positional `query` argument (enforced by clap).
+- When present, parses the URL, builds `SearchParams` + raw params, and executes.
+- `--save-as` optionally persists to config before executing.
+- `--save-as` requires `--from-url`.
+
+#### `query save` -- add `--from-url`
+
+```
+bzr query save --from-url "https://..." --name "my-query"
+```
+
+Saves without executing. Mutually exclusive with the existing manual filter flags.
+
+#### `query run` -- add `--server` override
+
+```
+bzr query run "my-query" --server other-server --limit 50
+```
+
+Existing `--limit`, `--fields`, `--exclude-fields` overrides continue to work. New `--server` flag overrides the stored server association.
+
+#### `query show` -- enhanced display for URL queries
+
+For URL-sourced queries, displays the original URL, recognized parsed fields, and a count of raw passthrough parameters. JSON format includes all raw params.
+
+### Execution Flow
+
+**`bug search --from-url`:**
+
+1. Parse URL via `url_parser::parse_bugzilla_url()`.
+2. If `--save-as` present, persist `SavedQuery` to config.
+3. Convert recognized fields to `SearchParams` via `to_search_params()`.
+4. Copy `raw_params` from `SavedQuery` into `SearchParams.raw_params`.
+5. Apply CLI overrides (`--limit`, `--fields`, etc.).
+6. Resolve server: CLI `--server` > parsed server > default server.
+7. Execute via `search_bugs()`.
+
+**`query run`:**
+
+1. Load `SavedQuery` from config.
+2. Convert to `SearchParams` (including `raw_params`).
+3. Apply runtime overrides.
+4. Resolve server: CLI `--server` > saved server > default server.
+5. Execute via `search_bugs()`.
+
+**Raw params in the client:**
+
+New function in `client/bug.rs`:
+
+```rust
+fn append_raw_params(
+    mut builder: reqwest::RequestBuilder,
+    raw_params: &[(String, String)],
+) -> reqwest::RequestBuilder {
+    for (key, value) in raw_params {
+        builder = builder.query(&[(key, value)]);
+    }
+    builder
+}
+```
+
+Called in `search_bugs_rest()` after `append_option_params` and before `apply_auth`.
+
+**XML-RPC interaction:** When `raw_params` is non-empty and `api_mode` is `XmlRpc` or `Hybrid`, force REST mode and log a warning. Boolean chart params are a REST/CGI concept with no XML-RPC equivalent.
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `src/url_parser.rs` | **New.** URL parsing logic. |
+| `src/types/bug.rs` | Add `source_url`, `server`, `raw_params` to `SavedQuery`. Add `QueryKind::Url`. Add `raw_params` to `SearchParams`. |
+| `src/cli/bug.rs` | Add `--from-url` and `--save-as` to `Search` variant. |
+| `src/cli/query.rs` | Add `--from-url` to `Save`. Add `--server` to `Run`. |
+| `src/commands/bug.rs` | Handle `--from-url` in `handle_search`. |
+| `src/commands/query.rs` | Handle `--from-url` in `handle_save`. Pass `raw_params` through in `handle_run`. |
+| `src/client/bug.rs` | Add `append_raw_params`. Call it in `search_bugs_rest`. Force REST when raw params present. |
+| `src/output/query.rs` | Display `source_url` and raw param count in `query show`. |
+| `src/lib.rs` | Add `mod url_parser`. |
+| `docs/bzr-cli.md` | Document new flags. |
+
+### Testing
+
+**Unit tests (`url_parser.rs`):**
+- Simple URL with product/status/limit: recognized fields populated, no raw params.
+- Complex boolean chart URL (from the motivating example): `classification` and `f1/o1/v1` etc. in `raw_params`, `known_name` extracted.
+- URL without `buglist.cgi` path: error.
+- Malformed URL: error.
+- Server hostname matching: match, no match (warn), not configured (error).
+- Repeated params (multiple `product=`): accumulate into vec.
+- URL-decoded values: `%20` becomes space, etc.
+
+**Unit tests (`client/bug.rs`):**
+- `append_raw_params` with empty vec: no change.
+- `append_raw_params` with boolean chart params: params appear in request.
+- `search_bugs_rest` with non-empty `raw_params`: wiremock verifies HTTP request.
+
+**Integration tests (`commands/query.rs`):**
+- `query save --from-url` parses and persists; `query show` displays original URL and raw params.
+- `query run` on URL-sourced query sends raw params to server (wiremock).
+- `query run` with `--limit` override replaces saved limit.
+- `query run` with `--server` override targets different server.
+
+**Integration tests (`commands/bug.rs`):**
+- `bug search --from-url` executes parsed query (wiremock verifies params).
+- `bug search --from-url --save-as` both executes and saves.
+- `--save-as` name defaults to `known_name` from URL when not provided.
+- `--from-url` mutually exclusive with positional query (clap enforces).
+
+**Edge cases:**
+- URL with only boolean chart params (nothing recognized): works, everything in `raw_params`.
+- Non-empty `raw_params` forces REST when `api_mode` is Hybrid/XmlRpc: warning logged.

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -52,10 +52,17 @@ pub enum BugAction {
         #[arg(long)]
         exclude_fields: Option<String>,
     },
-    /// Search bugs by text query
+    /// Search bugs by text query or Bugzilla URL
     Search {
-        /// Search query
-        query: String,
+        /// Search query (mutually exclusive with --from-url)
+        #[arg(conflicts_with = "from_url")]
+        query: Option<String>,
+        /// Execute a search from a Bugzilla buglist.cgi URL
+        #[arg(long)]
+        from_url: Option<String>,
+        /// Save this URL query with the given name for future reuse (requires --from-url)
+        #[arg(long, requires = "from_url")]
+        save_as: Option<String>,
         /// Max number of results
         #[arg(long, default_value = "50")]
         limit: u32,

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -63,9 +63,9 @@ pub enum BugAction {
         /// Save this URL query with the given name for future reuse (requires --from-url)
         #[arg(long, requires = "from_url")]
         save_as: Option<String>,
-        /// Max number of results
-        #[arg(long, default_value = "50")]
-        limit: u32,
+        /// Max number of results (default: 50)
+        #[arg(long)]
+        limit: Option<u32>,
         /// Only return these fields (comma-separated)
         #[arg(long)]
         fields: Option<String>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -244,7 +244,7 @@ mod tests {
                 action: BugAction::Search { query, limit, .. },
             } => {
                 assert_eq!(query.as_deref(), Some("crash"));
-                assert_eq!(limit, 50);
+                assert_eq!(limit, None);
             }
             _ => panic!("expected Bug Search"),
         }
@@ -256,7 +256,7 @@ mod tests {
         match cli.command {
             Commands::Bug {
                 action: BugAction::Search { limit, .. },
-            } => assert_eq!(limit, 10),
+            } => assert_eq!(limit, Some(10)),
             _ => panic!("expected Bug Search"),
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -243,7 +243,7 @@ mod tests {
             Commands::Bug {
                 action: BugAction::Search { query, limit, .. },
             } => {
-                assert_eq!(query, "crash");
+                assert_eq!(query.as_deref(), Some("crash"));
                 assert_eq!(limit, 50);
             }
             _ => panic!("expected Bug Search"),

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -6,6 +6,9 @@ pub enum QueryAction {
     Save {
         /// Query name
         name: String,
+        /// Import query from a Bugzilla buglist.cgi URL (mutually exclusive with filter flags)
+        #[arg(long, conflicts_with_all = ["search", "product", "component", "status", "assignee", "creator", "priority", "severity"])]
+        from_url: Option<String>,
         /// Free-text search (creates a "search" kind query)
         #[arg(long)]
         search: Option<String>,
@@ -65,5 +68,8 @@ pub enum QueryAction {
         /// Override the saved exclude-fields selection
         #[arg(long)]
         exclude_fields: Option<String>,
+        /// Override the server to run against
+        #[arg(long)]
+        server: Option<String>,
     },
 }

--- a/src/client/bug.rs
+++ b/src/client/bug.rs
@@ -835,6 +835,7 @@ mod tests {
             quicksearch: Some("qs-term".into()),
             include_fields: Some("id,summary".into()),
             exclude_fields: Some("cc".into()),
+            ..Default::default()
         };
         let bugs = client.search_bugs(&params).await.unwrap();
         assert_eq!(bugs.len(), 1);

--- a/src/client/bug.rs
+++ b/src/client/bug.rs
@@ -118,6 +118,19 @@ fn append_option_params(
     builder
 }
 
+/// Appends raw key-value parameters to the request builder verbatim.
+/// Used for URL-imported queries with boolean chart params that
+/// `bzr` does not natively model.
+fn append_raw_params(
+    mut builder: reqwest::RequestBuilder,
+    raw_params: &[(String, String)],
+) -> reqwest::RequestBuilder {
+    for (key, value) in raw_params {
+        builder = builder.query(&[(key, value)]);
+    }
+    builder
+}
+
 impl BugzillaClient {
     pub async fn get_bug_history_since(
         &self,
@@ -139,6 +152,15 @@ impl BugzillaClient {
     }
 
     pub async fn search_bugs(&self, params: &SearchParams) -> Result<Vec<Bug>> {
+        // Raw params (boolean charts from URLs) only work with REST.
+        if !params.raw_params.is_empty() && self.api_mode != ApiMode::Rest {
+            tracing::warn!(
+                "query contains raw URL parameters that require REST API; \
+                 ignoring configured {} mode",
+                self.api_mode
+            );
+            return self.search_bugs_rest(params).await;
+        }
         tracing::debug!(?params, %self.api_mode, "search parameters");
         match self.api_mode {
             ApiMode::Rest => self.search_bugs_rest(params).await,
@@ -180,6 +202,10 @@ impl BugzillaClient {
         for id in &params.id {
             req_builder = req_builder.query(&[("id", id)]);
         }
+
+        // Append raw passthrough params (from URL-imported queries)
+        req_builder = append_raw_params(req_builder, &params.raw_params);
+
         if params.include_fields.is_none() {
             req_builder = req_builder.query(&[("include_fields", BUG_DEFAULT_FIELDS)]);
         }
@@ -698,6 +724,14 @@ mod tests {
             err.to_string().contains("Invalid API key"),
             "should propagate auth error, got: {err}"
         );
+    }
+
+    #[test]
+    fn append_raw_params_empty_is_noop() {
+        let client = reqwest::Client::new();
+        let builder = client.get("https://example.com/rest/bug");
+        let result = super::append_raw_params(builder, &[]);
+        let _ = result;
     }
 
     #[test]

--- a/src/client/bug.rs
+++ b/src/client/bug.rs
@@ -122,13 +122,13 @@ fn append_option_params(
 /// Used for URL-imported queries with boolean chart params that
 /// `bzr` does not natively model.
 fn append_raw_params(
-    mut builder: reqwest::RequestBuilder,
+    builder: reqwest::RequestBuilder,
     raw_params: &[(String, String)],
 ) -> reqwest::RequestBuilder {
-    for (key, value) in raw_params {
-        builder = builder.query(&[(key, value)]);
+    if raw_params.is_empty() {
+        return builder;
     }
-    builder
+    builder.query(raw_params)
 }
 
 impl BugzillaClient {
@@ -203,7 +203,6 @@ impl BugzillaClient {
             req_builder = req_builder.query(&[("id", id)]);
         }
 
-        // Append raw passthrough params (from URL-imported queries)
         req_builder = append_raw_params(req_builder, &params.raw_params);
 
         if params.include_fields.is_none() {
@@ -724,14 +723,6 @@ mod tests {
             err.to_string().contains("Invalid API key"),
             "should propagate auth error, got: {err}"
         );
-    }
-
-    #[test]
-    fn append_raw_params_empty_is_noop() {
-        let client = reqwest::Client::new();
-        let builder = client.get("https://example.com/rest/bug");
-        let result = super::append_raw_params(builder, &[]);
-        let _ = result;
     }
 
     #[test]

--- a/src/client/bug.rs
+++ b/src/client/bug.rs
@@ -152,6 +152,7 @@ impl BugzillaClient {
     }
 
     pub async fn search_bugs(&self, params: &SearchParams) -> Result<Vec<Bug>> {
+        tracing::debug!(?params, %self.api_mode, "search parameters");
         // Raw params (boolean charts from URLs) only work with REST.
         if !params.raw_params.is_empty() && self.api_mode != ApiMode::Rest {
             tracing::warn!(
@@ -161,7 +162,6 @@ impl BugzillaClient {
             );
             return self.search_bugs_rest(params).await;
         }
-        tracing::debug!(?params, %self.api_mode, "search parameters");
         match self.api_mode {
             ApiMode::Rest => self.search_bugs_rest(params).await,
             ApiMode::XmlRpc => self.xmlrpc_client()?.search_bugs(params).await,

--- a/src/client/bug.rs
+++ b/src/client/bug.rs
@@ -125,9 +125,6 @@ fn append_raw_params(
     builder: reqwest::RequestBuilder,
     raw_params: &[(String, String)],
 ) -> reqwest::RequestBuilder {
-    if raw_params.is_empty() {
-        return builder;
-    }
     builder.query(raw_params)
 }
 
@@ -203,6 +200,10 @@ impl BugzillaClient {
             req_builder = req_builder.query(&[("id", id)]);
         }
 
+        // Note: raw_params and append_negated_params both use fN/oN/vN indices.
+        // Index collision cannot occur because URL-parsed queries store boolean
+        // chart params in raw_params (not as negated structured filters), and
+        // there is no CLI path that combines negated filters with raw params.
         req_builder = append_raw_params(req_builder, &params.raw_params);
 
         if params.include_fields.is_none() {

--- a/src/commands/bug.rs
+++ b/src/commands/bug.rs
@@ -119,6 +119,8 @@ async fn handle_search(
 ) -> Result<()> {
     let BugAction::Search {
         query,
+        from_url,
+        save_as,
         limit,
         fields,
         exclude_fields,
@@ -127,13 +129,45 @@ async fn handle_search(
         unreachable!()
     };
 
-    let params = SearchParams {
-        quicksearch: Some(query.clone()),
-        limit: Some(*limit),
-        include_fields: fields.clone(),
-        exclude_fields: exclude_fields.clone(),
-        ..Default::default()
+    let params = if let Some(url_str) = from_url {
+        let config = crate::config::Config::load()?;
+        let parsed = crate::url_parser::parse_bugzilla_url(url_str, &config)?;
+
+        if let Some(name) = save_as {
+            let mut config = config;
+            let is_update = config.queries.contains_key(name.as_str());
+            config.queries.insert(name.clone(), parsed.query.clone());
+            config.save()?;
+            let verb = if is_update { "Updated" } else { "Saved" };
+            tracing::info!("{verb} query '{name}'");
+        }
+
+        let mut params = parsed.query.to_search_params();
+        if *limit != 50 || params.limit.is_none() {
+            params.limit = Some(*limit);
+        }
+        if let Some(f) = fields {
+            params.include_fields = Some(f.clone());
+        }
+        if let Some(ef) = exclude_fields {
+            params.exclude_fields = Some(ef.clone());
+        }
+        params
+    } else {
+        let query_str = query.as_deref().ok_or_else(|| {
+            crate::error::BzrError::InputValidation(
+                "either a search query or --from-url is required".into(),
+            )
+        })?;
+        SearchParams {
+            quicksearch: Some(query_str.to_string()),
+            limit: Some(*limit),
+            include_fields: fields.clone(),
+            exclude_fields: exclude_fields.clone(),
+            ..Default::default()
+        }
     };
+
     let bugs = client.search_bugs(&params).await?;
     output::print_bugs(&bugs, format);
     Ok(())
@@ -511,11 +545,11 @@ async fn handle_update(
 #[cfg(test)]
 #[expect(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, ResponseTemplate};
 
     use crate::cli::BugAction;
-    use crate::test_helpers::{capture_stdout, setup_test_env};
+    use crate::test_helpers::{capture_stdout, extract_json, setup_test_env};
     use crate::types::OutputFormat;
 
     #[tokio::test]
@@ -1076,5 +1110,70 @@ mod tests {
         let (result, _output) =
             capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
         assert!(result.is_ok(), "bug clone --no-comment failed: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn handle_search_from_url_executes() {
+        let (_lock, mock, _tmp) = setup_test_env().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .and(query_param("product", "TestProduct"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "bugs": [{"id": 1, "summary": "Test bug", "status": "NEW",
+                          "product": "TestProduct", "component": "General"}]
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let server_url = mock.uri();
+        let url = format!("{server_url}/buglist.cgi?product=TestProduct&limit=10");
+        let action = BugAction::Search {
+            query: None,
+            from_url: Some(url),
+            save_as: None,
+            limit: 50,
+            fields: None,
+            exclude_fields: None,
+        };
+
+        let (result, output) =
+            capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+        assert!(result.is_ok(), "from-url search failed: {result:?}");
+        let parsed: serde_json::Value = extract_json(&output);
+        assert_eq!(parsed[0]["id"], 1);
+    }
+
+    #[tokio::test]
+    async fn handle_search_from_url_saves_query() {
+        let (_lock, mock, _tmp) = setup_test_env().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+            .mount(&mock)
+            .await;
+
+        let server_url = mock.uri();
+        let url = format!("{server_url}/buglist.cgi?product=TestProduct&known_name=my-query");
+        let action = BugAction::Search {
+            query: None,
+            from_url: Some(url),
+            save_as: Some("my-query".into()),
+            limit: 50,
+            fields: None,
+            exclude_fields: None,
+        };
+
+        let (result, _output) =
+            capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+        assert!(result.is_ok(), "from-url save failed: {result:?}");
+
+        let config = crate::config::Config::load().unwrap();
+        let saved = config.queries.get("my-query").unwrap();
+        assert_eq!(saved.kind, crate::types::QueryKind::Url);
+        assert_eq!(saved.product, vec!["TestProduct"]);
+        assert!(saved.source_url.is_some());
     }
 }

--- a/src/commands/bug.rs
+++ b/src/commands/bug.rs
@@ -1122,6 +1122,17 @@ mod tests {
         assert!(result.is_ok(), "bug clone --no-comment failed: {result:?}");
     }
 
+    fn from_url_action(url: String, save_as: Option<String>) -> BugAction {
+        BugAction::Search {
+            query: None,
+            from_url: Some(url),
+            save_as,
+            limit: None,
+            fields: None,
+            exclude_fields: None,
+        }
+    }
+
     #[tokio::test]
     async fn handle_search_from_url_executes() {
         let (_lock, mock, _tmp) = setup_test_env().await;
@@ -1139,14 +1150,7 @@ mod tests {
 
         let server_url = mock.uri();
         let url = format!("{server_url}/buglist.cgi?product=TestProduct&limit=10");
-        let action = BugAction::Search {
-            query: None,
-            from_url: Some(url),
-            save_as: None,
-            limit: None,
-            fields: None,
-            exclude_fields: None,
-        };
+        let action = from_url_action(url, None);
 
         let (result, output) =
             capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
@@ -1175,14 +1179,7 @@ mod tests {
         let url = format!(
             "{server_url}/buglist.cgi?product=TestProduct&f1=qa_contact&o1=changedfrom&v1=user%40example.com"
         );
-        let action = BugAction::Search {
-            query: None,
-            from_url: Some(url),
-            save_as: None,
-            limit: None,
-            fields: None,
-            exclude_fields: None,
-        };
+        let action = from_url_action(url, None);
 
         let (result, _) =
             capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
@@ -1204,14 +1201,7 @@ mod tests {
 
         let server_url = mock.uri();
         let url = format!("{server_url}/buglist.cgi?product=TestProduct&known_name=my-query");
-        let action = BugAction::Search {
-            query: None,
-            from_url: Some(url),
-            save_as: Some("my-query".into()),
-            limit: None,
-            fields: None,
-            exclude_fields: None,
-        };
+        let action = from_url_action(url, Some("my-query".into()));
 
         let (result, _output) =
             capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;

--- a/src/commands/bug.rs
+++ b/src/commands/bug.rs
@@ -19,7 +19,7 @@ pub async fn execute(
         BugAction::List { .. } => handle_list(&client, action, format).await,
         BugAction::View { .. } => handle_view(&client, action, format).await,
         BugAction::History { .. } => handle_history(&client, action, format).await,
-        BugAction::Search { .. } => handle_search(&client, action, format).await,
+        BugAction::Search { .. } => handle_search(action, server, format, api).await,
         BugAction::My { .. } => handle_my(&client, action, format).await,
         BugAction::Create { .. } => handle_create(&client, action, format).await,
         BugAction::Clone { .. } => handle_clone(&client, action, format).await,
@@ -113,9 +113,10 @@ async fn handle_history(
 }
 
 async fn handle_search(
-    client: &BugzillaClient,
     action: &BugAction,
+    server: Option<&str>,
     format: OutputFormat,
+    api: Option<ApiMode>,
 ) -> Result<()> {
     let BugAction::Search {
         query,
@@ -129,7 +130,7 @@ async fn handle_search(
         unreachable!()
     };
 
-    let params = if let Some(url_str) = from_url {
+    let (client, params) = if let Some(url_str) = from_url {
         let config = crate::config::Config::load()?;
         let parsed = crate::url_parser::parse_bugzilla_url(url_str, &config)?;
 
@@ -142,9 +143,14 @@ async fn handle_search(
             tracing::info!("{verb} query '{name}'");
         }
 
+        let effective_server = server.or(parsed.query.server.as_deref());
+        let client = super::shared::connect_and_configure(effective_server, api).await?;
+
         let mut params = parsed.query.to_search_params();
-        if *limit != 50 || params.limit.is_none() {
-            params.limit = Some(*limit);
+        if let Some(l) = limit {
+            params.limit = Some(*l);
+        } else if params.limit.is_none() {
+            params.limit = Some(50);
         }
         if let Some(f) = fields {
             params.include_fields = Some(f.clone());
@@ -152,20 +158,22 @@ async fn handle_search(
         if let Some(ef) = exclude_fields {
             params.exclude_fields = Some(ef.clone());
         }
-        params
+        (client, params)
     } else {
         let query_str = query.as_deref().ok_or_else(|| {
             crate::error::BzrError::InputValidation(
                 "either a search query or --from-url is required".into(),
             )
         })?;
-        SearchParams {
+        let client = super::shared::connect_and_configure(server, api).await?;
+        let params = SearchParams {
             quicksearch: Some(query_str.to_string()),
-            limit: Some(*limit),
+            limit: Some(limit.unwrap_or(50)),
             include_fields: fields.clone(),
             exclude_fields: exclude_fields.clone(),
             ..Default::default()
-        }
+        };
+        (client, params)
     };
 
     let bugs = client.search_bugs(&params).await?;
@@ -1133,7 +1141,7 @@ mod tests {
             query: None,
             from_url: Some(url),
             save_as: None,
-            limit: 50,
+            limit: None,
             fields: None,
             exclude_fields: None,
         };
@@ -1161,7 +1169,7 @@ mod tests {
             query: None,
             from_url: Some(url),
             save_as: Some("my-query".into()),
-            limit: 50,
+            limit: None,
             fields: None,
             exclude_fields: None,
         };

--- a/src/commands/bug.rs
+++ b/src/commands/bug.rs
@@ -140,24 +140,17 @@ async fn handle_search(
             config.queries.insert(name.clone(), parsed.query.clone());
             config.save()?;
             let verb = if is_update { "Updated" } else { "Saved" };
-            tracing::info!("{verb} query '{name}'");
+            crate::output::print_query_saved(name, verb, format);
         }
 
         let effective_server = server.or(parsed.query.server.as_deref());
         let client = super::shared::connect_and_configure(effective_server, api).await?;
 
         let mut params = parsed.query.to_search_params();
-        if let Some(l) = limit {
-            params.limit = Some(*l);
-        } else if params.limit.is_none() {
+        if params.limit.is_none() && limit.is_none() {
             params.limit = Some(50);
         }
-        if let Some(f) = fields {
-            params.include_fields = Some(f.clone());
-        }
-        if let Some(ef) = exclude_fields {
-            params.exclude_fields = Some(ef.clone());
-        }
+        params.apply_overrides(*limit, fields.as_deref(), exclude_fields.as_deref());
         (client, params)
     } else {
         let query_str = query.as_deref().ok_or_else(|| {

--- a/src/commands/bug.rs
+++ b/src/commands/bug.rs
@@ -1154,6 +1154,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_search_from_url_passes_raw_params() {
+        let (_lock, mock, _tmp) = setup_test_env().await;
+
+        // Wiremock matcher verifying raw params appear in the request
+        Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .and(query_param("product", "TestProduct"))
+            .and(query_param("f1", "qa_contact"))
+            .and(query_param("o1", "changedfrom"))
+            .and(query_param("v1", "user@example.com"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let server_url = mock.uri();
+        let url = format!(
+            "{server_url}/buglist.cgi?product=TestProduct&f1=qa_contact&o1=changedfrom&v1=user%40example.com"
+        );
+        let action = BugAction::Search {
+            query: None,
+            from_url: Some(url),
+            save_as: None,
+            limit: None,
+            fields: None,
+            exclude_fields: None,
+        };
+
+        let (result, _) =
+            capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+        assert!(
+            result.is_ok(),
+            "from-url with raw params failed: {result:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn handle_search_from_url_saves_query() {
         let (_lock, mock, _tmp) = setup_test_env().await;
 

--- a/src/commands/bug.rs
+++ b/src/commands/bug.rs
@@ -112,6 +112,8 @@ async fn handle_history(
     Ok(())
 }
 
+/// Handles bug search — builds its own client (unlike other handlers) because
+/// `--from-url` may resolve a different server from the URL hostname.
 async fn handle_search(
     action: &BugAction,
     server: Option<&str>,
@@ -130,18 +132,9 @@ async fn handle_search(
         unreachable!()
     };
 
-    let (client, params) = if let Some(url_str) = from_url {
+    let (client, params, save_info) = if let Some(url_str) = from_url {
         let config = crate::config::Config::load()?;
         let parsed = crate::url_parser::parse_bugzilla_url(url_str, &config)?;
-
-        if let Some(name) = save_as {
-            let mut config = config;
-            let is_update = config.queries.contains_key(name.as_str());
-            config.queries.insert(name.clone(), parsed.query.clone());
-            config.save()?;
-            let verb = if is_update { "Updated" } else { "Saved" };
-            crate::output::print_query_saved(name, verb, format);
-        }
 
         let effective_server = server.or(parsed.query.server.as_deref());
         let client = super::shared::connect_and_configure(effective_server, api).await?;
@@ -151,7 +144,12 @@ async fn handle_search(
             params.limit = Some(50);
         }
         params.apply_overrides(*limit, fields.as_deref(), exclude_fields.as_deref());
-        (client, params)
+
+        // Defer saving until after search succeeds
+        let save_info = save_as
+            .as_ref()
+            .map(|name| (name.clone(), parsed.query.clone()));
+        (client, params, save_info)
     } else {
         let query_str = query.as_deref().ok_or_else(|| {
             crate::error::BzrError::InputValidation(
@@ -166,11 +164,22 @@ async fn handle_search(
             exclude_fields: exclude_fields.clone(),
             ..Default::default()
         };
-        (client, params)
+        (client, params, None)
     };
 
     let bugs = client.search_bugs(&params).await?;
     output::print_bugs(&bugs, format);
+
+    // Save query to config after successful search
+    if let Some((name, query)) = save_info {
+        let mut config = crate::config::Config::load()?;
+        let is_update = config.queries.contains_key(name.as_str());
+        config.queries.insert(name.clone(), query);
+        config.save()?;
+        let verb = if is_update { "Updated" } else { "Saved" };
+        crate::output::print_query_saved(&name, verb, format);
+    }
+
     Ok(())
 }
 

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -27,6 +27,7 @@ pub async fn execute(
 fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
     let QueryAction::Save {
         name,
+        from_url,
         search,
         product,
         component,
@@ -43,26 +44,41 @@ fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
         unreachable!()
     };
 
-    let kind = if search.is_some() {
-        QueryKind::Search
+    let query = if let Some(url_str) = from_url {
+        let config = Config::load()?;
+        let parsed = crate::url_parser::parse_bugzilla_url(url_str, &config)?;
+        let mut query = parsed.query;
+        if let Some(limit) = limit {
+            query.limit = Some(*limit);
+        }
+        if let Some(f) = fields {
+            query.fields = Some(f.clone());
+        }
+        if let Some(ef) = exclude_fields {
+            query.exclude_fields = Some(ef.clone());
+        }
+        query
     } else {
-        QueryKind::List
-    };
-
-    let query = SavedQuery {
-        kind,
-        product: product.clone(),
-        component: component.clone(),
-        status: status.clone(),
-        assignee: assignee.clone(),
-        creator: creator.clone(),
-        priority: priority.clone(),
-        severity: severity.clone(),
-        quicksearch: search.clone(),
-        limit: *limit,
-        fields: fields.clone(),
-        exclude_fields: exclude_fields.clone(),
-        ..Default::default()
+        let kind = if search.is_some() {
+            QueryKind::Search
+        } else {
+            QueryKind::List
+        };
+        SavedQuery {
+            kind,
+            product: product.clone(),
+            component: component.clone(),
+            status: status.clone(),
+            assignee: assignee.clone(),
+            creator: creator.clone(),
+            priority: priority.clone(),
+            severity: severity.clone(),
+            quicksearch: search.clone(),
+            limit: *limit,
+            fields: fields.clone(),
+            exclude_fields: exclude_fields.clone(),
+            ..SavedQuery::default()
+        }
     };
 
     if !query.has_filters() {
@@ -125,6 +141,7 @@ async fn handle_run(
         limit,
         fields,
         exclude_fields,
+        server: server_override,
     } = action
     else {
         unreachable!()
@@ -138,7 +155,6 @@ async fn handle_run(
 
     let mut params = query.to_search_params();
 
-    // Apply runtime overrides
     if let Some(limit) = limit {
         params.limit = Some(*limit);
     }
@@ -149,7 +165,12 @@ async fn handle_run(
         params.exclude_fields = Some(exclude_fields.clone());
     }
 
-    let client = super::shared::connect_and_configure(server, api).await?;
+    // Server resolution: CLI --server > query run --server > saved server > default
+    let effective_server = server
+        .or(server_override.as_deref())
+        .or(query.server.as_deref());
+
+    let client = super::shared::connect_and_configure(effective_server, api).await?;
     let bugs = client.search_bugs(&params).await?;
     output::print_bugs(&bugs, format);
     Ok(())
@@ -168,6 +189,7 @@ mod tests {
     fn save_action(name: &str) -> QueryAction {
         QueryAction::Save {
             name: name.into(),
+            from_url: None,
             search: None,
             product: vec!["Firefox".into()],
             component: vec![],
@@ -209,6 +231,7 @@ mod tests {
 
         let action = QueryAction::Save {
             name: "crashes".into(),
+            from_url: None,
             search: Some("crash in tab".into()),
             product: vec![],
             component: vec![],
@@ -242,6 +265,7 @@ mod tests {
 
         let action = QueryAction::Save {
             name: "empty".into(),
+            from_url: None,
             search: None,
             product: vec![],
             component: vec![],
@@ -296,6 +320,7 @@ mod tests {
         // First, save a query
         let save_action = QueryAction::Save {
             name: "run-test".into(),
+            from_url: None,
             search: None,
             product: vec!["TestProduct".into()],
             component: vec![],
@@ -333,6 +358,7 @@ mod tests {
             limit: None,
             fields: None,
             exclude_fields: None,
+            server: None,
         };
         let (result, output) =
             capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
@@ -348,6 +374,7 @@ mod tests {
 
         let save_action = QueryAction::Save {
             name: "override-test".into(),
+            from_url: None,
             search: None,
             product: vec!["TestProduct".into()],
             component: vec![],
@@ -377,6 +404,7 @@ mod tests {
             limit: Some(5),
             fields: None,
             exclude_fields: None,
+            server: None,
         };
         let (result, _) =
             capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
@@ -389,6 +417,7 @@ mod tests {
 
         let save_action = QueryAction::Save {
             name: "existing".into(),
+            from_url: None,
             search: None,
             product: vec!["Firefox".into()],
             component: vec![],
@@ -407,6 +436,7 @@ mod tests {
 
         let update_action = QueryAction::Save {
             name: "existing".into(),
+            from_url: None,
             search: Some("updated".into()),
             product: vec![],
             component: vec![],
@@ -445,6 +475,7 @@ mod tests {
 
         let save_action = QueryAction::Save {
             name: "delete-me".into(),
+            from_url: None,
             search: None,
             product: vec!["Firefox".into()],
             component: vec![],
@@ -490,6 +521,7 @@ mod tests {
 
         let save_action = QueryAction::Save {
             name: "fields-test".into(),
+            from_url: None,
             search: None,
             product: vec!["TestProduct".into()],
             component: vec![],
@@ -520,6 +552,7 @@ mod tests {
             limit: None,
             fields: Some("id,summary".into()),
             exclude_fields: Some("comments".into()),
+            server: None,
         };
         let (result, _) =
             capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
@@ -535,6 +568,7 @@ mod tests {
             limit: None,
             fields: None,
             exclude_fields: None,
+            server: None,
         };
         let result = super::execute(&action, None, OutputFormat::Json, None).await;
         assert!(result.is_err(), "running unknown query should fail");
@@ -591,5 +625,40 @@ mod tests {
         .unwrap_err();
 
         assert!(err.to_string().contains("query 'missing' not found"));
+    }
+
+    #[tokio::test]
+    async fn query_save_from_url() {
+        let (_lock, mock, _tmp) = setup_test_env().await;
+
+        let server_url = mock.uri();
+        let url = format!(
+            "{server_url}/buglist.cgi?product=TestProduct&f1=qa_contact&o1=changedfrom&v1=user%40example.com"
+        );
+        let action = QueryAction::Save {
+            name: "url-query".into(),
+            from_url: Some(url),
+            search: None,
+            product: vec![],
+            component: vec![],
+            status: vec![],
+            assignee: vec![],
+            creator: vec![],
+            priority: vec![],
+            severity: vec![],
+            limit: None,
+            fields: None,
+            exclude_fields: None,
+        };
+        let (result, _output) =
+            capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+        assert!(result.is_ok(), "query save --from-url failed: {result:?}");
+
+        let config = Config::load().unwrap();
+        let saved = &config.queries["url-query"];
+        assert_eq!(saved.kind, crate::types::QueryKind::Url);
+        assert_eq!(saved.product, vec!["TestProduct"]);
+        assert!(!saved.raw_params.is_empty());
+        assert!(saved.source_url.is_some());
     }
 }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -628,6 +628,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn query_run_with_server_override() {
+        let (_lock, mock, _tmp) = setup_test_env().await;
+
+        // Save a query first
+        let save_action = save_action("server-test");
+        let (result, _) =
+            capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
+        assert!(result.is_ok());
+
+        Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+            .mount(&mock)
+            .await;
+
+        // Run with --server override
+        let run_action = QueryAction::Run {
+            name: "server-test".into(),
+            limit: None,
+            fields: None,
+            exclude_fields: None,
+            server: Some("test".into()),
+        };
+        let (result, _) = capture_stdout(super::execute(
+            &run_action,
+            Some("test"),
+            OutputFormat::Json,
+            None,
+        ))
+        .await;
+        assert!(
+            result.is_ok(),
+            "query run with server override failed: {result:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn query_save_from_url() {
         let (_lock, mock, _tmp) = setup_test_env().await;
 

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -62,6 +62,7 @@ fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
         limit: *limit,
         fields: fields.clone(),
         exclude_fields: exclude_fields.clone(),
+        ..Default::default()
     };
 
     if !query.has_filters() {

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -44,7 +44,7 @@ fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
         unreachable!()
     };
 
-    let query = if let Some(url_str) = from_url {
+    let (query, preloaded_config) = if let Some(url_str) = from_url {
         let config = Config::load()?;
         let parsed = crate::url_parser::parse_bugzilla_url(url_str, &config)?;
         let mut query = parsed.query;
@@ -57,14 +57,14 @@ fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
         if let Some(ef) = exclude_fields {
             query.exclude_fields = Some(ef.clone());
         }
-        query
+        (query, Some(config))
     } else {
         let kind = if search.is_some() {
             QueryKind::Search
         } else {
             QueryKind::List
         };
-        SavedQuery {
+        let query = SavedQuery {
             kind,
             product: product.clone(),
             component: component.clone(),
@@ -78,7 +78,8 @@ fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
             fields: fields.clone(),
             exclude_fields: exclude_fields.clone(),
             ..SavedQuery::default()
-        }
+        };
+        (query, None)
     };
 
     if !query.has_filters() {
@@ -87,7 +88,10 @@ fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
         ));
     }
 
-    let mut config = Config::load()?;
+    let mut config = match preloaded_config {
+        Some(c) => c,
+        None => Config::load()?,
+    };
     let is_update = config.queries.contains_key(name.as_str());
     config.queries.insert(name.clone(), query);
     config.save()?;
@@ -154,16 +158,7 @@ async fn handle_run(
         .ok_or_else(|| BzrError::config(format!("query '{name}' not found")))?;
 
     let mut params = query.to_search_params();
-
-    if let Some(limit) = limit {
-        params.limit = Some(*limit);
-    }
-    if let Some(fields) = fields {
-        params.include_fields = Some(fields.clone());
-    }
-    if let Some(exclude_fields) = exclude_fields {
-        params.exclude_fields = Some(exclude_fields.clone());
-    }
+    params.apply_overrides(*limit, fields.as_deref(), exclude_fields.as_deref());
 
     // Server resolution: CLI --server > query run --server > saved server > default
     let effective_server = server

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -199,6 +199,25 @@ mod tests {
         }
     }
 
+    /// Build a Save action for a single-product query with no status filters.
+    fn product_save_action(name: &str, product: &str, limit: u32) -> QueryAction {
+        QueryAction::Save {
+            name: name.into(),
+            from_url: None,
+            search: None,
+            product: vec![product.into()],
+            component: vec![],
+            status: vec![],
+            assignee: vec![],
+            creator: vec![],
+            priority: vec![],
+            severity: vec![],
+            limit: Some(limit),
+            fields: None,
+            exclude_fields: None,
+        }
+    }
+
     fn empty_save_action(name: &str, search: Option<String>) -> QueryAction {
         QueryAction::Save {
             name: name.into(),
@@ -270,21 +289,7 @@ mod tests {
     async fn query_save_search_kind() {
         let (_lock, _mock, _tmp) = setup_test_env().await;
 
-        let action = QueryAction::Save {
-            name: "crashes".into(),
-            from_url: None,
-            search: Some("crash in tab".into()),
-            product: vec![],
-            component: vec![],
-            status: vec![],
-            assignee: vec![],
-            creator: vec![],
-            priority: vec![],
-            severity: vec![],
-            limit: Some(10),
-            fields: None,
-            exclude_fields: None,
-        };
+        let action = empty_save_action("crashes", Some("crash in tab".into()));
         let (result, _output) =
             capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
         assert!(result.is_ok(), "query save failed: {result:?}");
@@ -345,21 +350,7 @@ mod tests {
         let (_lock, mock, _tmp) = setup_test_env().await;
 
         // First, save a query
-        let save_action = QueryAction::Save {
-            name: "run-test".into(),
-            from_url: None,
-            search: None,
-            product: vec!["TestProduct".into()],
-            component: vec![],
-            status: vec![],
-            assignee: vec![],
-            creator: vec![],
-            priority: vec![],
-            severity: vec![],
-            limit: Some(10),
-            fields: None,
-            exclude_fields: None,
-        };
+        let save_action = product_save_action("run-test", "TestProduct", 10);
         let (result, _) =
             capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
         assert!(result.is_ok(), "query save failed: {result:?}");
@@ -393,21 +384,7 @@ mod tests {
     async fn query_run_with_limit_override() {
         let (_lock, mock, _tmp) = setup_test_env().await;
 
-        let save_action = QueryAction::Save {
-            name: "override-test".into(),
-            from_url: None,
-            search: None,
-            product: vec!["TestProduct".into()],
-            component: vec![],
-            status: vec![],
-            assignee: vec![],
-            creator: vec![],
-            priority: vec![],
-            severity: vec![],
-            limit: Some(100),
-            fields: None,
-            exclude_fields: None,
-        };
+        let save_action = product_save_action("override-test", "TestProduct", 100);
         let (result, _) =
             capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
         assert!(result.is_ok());
@@ -494,21 +471,7 @@ mod tests {
     async fn query_delete_removes_saved_query() {
         let (_lock, _mock, _tmp) = setup_test_env().await;
 
-        let save_action = QueryAction::Save {
-            name: "delete-me".into(),
-            from_url: None,
-            search: None,
-            product: vec!["Firefox".into()],
-            component: vec![],
-            status: vec![],
-            assignee: vec![],
-            creator: vec![],
-            priority: vec![],
-            severity: vec![],
-            limit: Some(1),
-            fields: None,
-            exclude_fields: None,
-        };
+        let save_action = product_save_action("delete-me", "Firefox", 1);
         let (result, _) =
             capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
         assert!(result.is_ok());

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -199,6 +199,52 @@ mod tests {
         }
     }
 
+    fn empty_save_action(name: &str, search: Option<String>) -> QueryAction {
+        QueryAction::Save {
+            name: name.into(),
+            from_url: None,
+            search,
+            product: vec![],
+            component: vec![],
+            status: vec![],
+            assignee: vec![],
+            creator: vec![],
+            priority: vec![],
+            severity: vec![],
+            limit: None,
+            fields: None,
+            exclude_fields: None,
+        }
+    }
+
+    fn url_save_action(name: &str, url: String) -> QueryAction {
+        QueryAction::Save {
+            name: name.into(),
+            from_url: Some(url),
+            search: None,
+            product: vec![],
+            component: vec![],
+            status: vec![],
+            assignee: vec![],
+            creator: vec![],
+            priority: vec![],
+            severity: vec![],
+            limit: None,
+            fields: None,
+            exclude_fields: None,
+        }
+    }
+
+    fn run_action(name: &str) -> QueryAction {
+        QueryAction::Run {
+            name: name.into(),
+            limit: None,
+            fields: None,
+            exclude_fields: None,
+            server: None,
+        }
+    }
+
     #[tokio::test]
     async fn query_save_and_show() {
         let (_lock, _mock, _tmp) = setup_test_env().await;
@@ -258,21 +304,7 @@ mod tests {
     async fn query_save_requires_filter() {
         let (_lock, _mock, _tmp) = setup_test_env().await;
 
-        let action = QueryAction::Save {
-            name: "empty".into(),
-            from_url: None,
-            search: None,
-            product: vec![],
-            component: vec![],
-            status: vec![],
-            assignee: vec![],
-            creator: vec![],
-            priority: vec![],
-            severity: vec![],
-            limit: None,
-            fields: None,
-            exclude_fields: None,
-        };
+        let action = empty_save_action("empty", None);
         let result = super::execute(&action, None, OutputFormat::Json, None).await;
         assert!(result.is_err(), "saving empty query should fail");
         let err = result.unwrap_err().to_string();
@@ -348,13 +380,7 @@ mod tests {
             .await;
 
         // Run the saved query
-        let run_action = QueryAction::Run {
-            name: "run-test".into(),
-            limit: None,
-            fields: None,
-            exclude_fields: None,
-            server: None,
-        };
+        let run_action = run_action("run-test");
         let (result, output) =
             capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
         assert!(result.is_ok(), "query run failed: {result:?}");
@@ -558,13 +584,7 @@ mod tests {
     async fn query_run_unknown_errors() {
         let (_lock, _mock, _tmp) = setup_test_env().await;
 
-        let action = QueryAction::Run {
-            name: "nonexistent".into(),
-            limit: None,
-            fields: None,
-            exclude_fields: None,
-            server: None,
-        };
+        let action = run_action("nonexistent");
         let result = super::execute(&action, None, OutputFormat::Json, None).await;
         assert!(result.is_err(), "running unknown query should fail");
         let err = result.unwrap_err().to_string();
@@ -667,21 +687,7 @@ mod tests {
         let url = format!(
             "{server_url}/buglist.cgi?product=TestProduct&f1=qa_contact&o1=changedfrom&v1=user%40example.com"
         );
-        let action = QueryAction::Save {
-            name: "url-query".into(),
-            from_url: Some(url),
-            search: None,
-            product: vec![],
-            component: vec![],
-            status: vec![],
-            assignee: vec![],
-            creator: vec![],
-            priority: vec![],
-            severity: vec![],
-            limit: None,
-            fields: None,
-            exclude_fields: None,
-        };
+        let action = url_save_action("url-query", url);
         let (result, _output) =
             capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
         assert!(result.is_ok(), "query save --from-url failed: {result:?}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub(crate) mod http;
 #[expect(clippy::print_stdout, clippy::expect_used)]
 pub(crate) mod output;
 pub mod types;
-pub mod url_parser;
+pub(crate) mod url_parser;
 pub(crate) mod xmlrpc;
 
 /// Dispatch a parsed CLI to the appropriate command handler.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub(crate) mod http;
 #[expect(clippy::print_stdout, clippy::expect_used)]
 pub(crate) mod output;
 pub mod types;
+pub mod url_parser;
 pub(crate) mod xmlrpc;
 
 /// Dispatch a parsed CLI to the appropriate command handler.

--- a/src/output/query.rs
+++ b/src/output/query.rs
@@ -6,17 +6,20 @@ use super::formatting::{
     print_field, print_formatted, print_json, print_list_field, print_optional_field,
 };
 
+fn kind_label(kind: &QueryKind) -> &'static str {
+    match kind {
+        QueryKind::List => "list",
+        QueryKind::Search => "search",
+        QueryKind::Url => "url",
+    }
+}
+
 fn query_saved_message(name: &str, verb: &str) -> String {
     format!("{verb} query '{name}'")
 }
 
 fn query_summary_line(name: &str, q: &SavedQuery) -> String {
-    let kind_label = match q.kind {
-        QueryKind::List => "list",
-        QueryKind::Search => "search",
-        QueryKind::Url => "url",
-    };
-    let mut parts = vec![format!("kind={kind_label}")];
+    let mut parts = vec![format!("kind={}", kind_label(&q.kind))];
     if !q.product.is_empty() {
         parts.push(format!("product={}", q.product.join(",")));
     }
@@ -70,13 +73,8 @@ pub fn print_query_detail(name: &str, query: &SavedQuery, format: OutputFormat) 
 
     let view = QueryView { name, query };
     print_formatted(&view, format, |view| {
-        let kind_label = match view.query.kind {
-            QueryKind::List => "list",
-            QueryKind::Search => "search",
-            QueryKind::Url => "url",
-        };
         print_field("Name", view.name);
-        print_field("Kind", kind_label);
+        print_field("Kind", kind_label(&view.query.kind));
         print_optional_field("Source URL", view.query.source_url.as_deref());
         print_optional_field("Server", view.query.server.as_deref());
         print_list_field("Product", &view.query.product);

--- a/src/output/query.rs
+++ b/src/output/query.rs
@@ -29,6 +29,9 @@ fn query_summary_line(name: &str, q: &SavedQuery) -> String {
     if let Some(limit) = q.limit {
         parts.push(format!("limit={limit}"));
     }
+    if !q.raw_params.is_empty() {
+        parts.push(format!("{} raw params", q.raw_params.len()));
+    }
     format!("{name} ({})", parts.join(", "))
 }
 
@@ -74,6 +77,8 @@ pub fn print_query_detail(name: &str, query: &SavedQuery, format: OutputFormat) 
         };
         print_field("Name", view.name);
         print_field("Kind", kind_label);
+        print_optional_field("Source URL", view.query.source_url.as_deref());
+        print_optional_field("Server", view.query.server.as_deref());
         print_list_field("Product", &view.query.product);
         print_list_field("Component", &view.query.component);
         print_list_field("Status", &view.query.status);
@@ -87,6 +92,9 @@ pub fn print_query_detail(name: &str, query: &SavedQuery, format: OutputFormat) 
         }
         print_optional_field("Fields", view.query.fields.as_deref());
         print_optional_field("Exclude", view.query.exclude_fields.as_deref());
+        if !view.query.raw_params.is_empty() {
+            print_field("Raw params", &view.query.raw_params.len().to_string());
+        }
     });
 }
 
@@ -94,6 +102,23 @@ pub fn print_query_detail(name: &str, query: &SavedQuery, format: OutputFormat) 
 #[expect(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    fn make_url_query() -> SavedQuery {
+        SavedQuery {
+            kind: QueryKind::Url,
+            source_url: Some(
+                "https://bugzilla.example.com/buglist.cgi?product=Firefox&f1=qa_contact".into(),
+            ),
+            server: Some("example".into()),
+            product: vec!["Firefox".into()],
+            raw_params: vec![
+                ("f1".into(), "qa_contact".into()),
+                ("o1".into(), "changedfrom".into()),
+            ],
+            limit: Some(100),
+            ..SavedQuery::default()
+        }
+    }
 
     fn make_list_query() -> SavedQuery {
         SavedQuery {
@@ -209,6 +234,57 @@ mod tests {
         assert!(output.contains("id,summary"));
         assert!(output.contains("Exclude"));
         assert!(output.contains("comments"));
+    }
+
+    #[test]
+    fn query_detail_json_includes_url_fields() {
+        #[derive(serde::Serialize)]
+        struct QueryView<'a> {
+            name: &'a str,
+            #[serde(flatten)]
+            query: &'a SavedQuery,
+        }
+        let query = make_url_query();
+        let view = QueryView {
+            name: "url-q",
+            query: &query,
+        };
+        let json = serde_json::to_string_pretty(&view).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["kind"], "url");
+        assert_eq!(
+            parsed["source_url"],
+            "https://bugzilla.example.com/buglist.cgi?product=Firefox&f1=qa_contact"
+        );
+        assert_eq!(parsed["server"], "example");
+        assert_eq!(parsed["raw_params"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn query_summary_line_renders_url_query() {
+        let line = query_summary_line("url-q", &make_url_query());
+        assert!(line.starts_with("url-q (kind=url"));
+        assert!(line.contains("product=Firefox"));
+        assert!(line.contains("2 raw params"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn print_query_detail_table_renders_url_fields() {
+        let _lock = crate::ENV_LOCK.lock().await;
+        let query = make_url_query();
+
+        let ((), output) = crate::test_helpers::capture_stdout(async {
+            print_query_detail("url-q", &query, OutputFormat::Table);
+        })
+        .await;
+
+        assert!(output.contains("Source URL"));
+        assert!(output.contains("bugzilla.example.com"));
+        assert!(output.contains("Server"));
+        assert!(output.contains("example"));
+        assert!(output.contains("Raw params"));
+        assert!(output.contains('2'));
     }
 
     #[cfg(unix)]

--- a/src/output/query.rs
+++ b/src/output/query.rs
@@ -14,6 +14,7 @@ fn query_summary_line(name: &str, q: &SavedQuery) -> String {
     let kind_label = match q.kind {
         QueryKind::List => "list",
         QueryKind::Search => "search",
+        QueryKind::Url => "url",
     };
     let mut parts = vec![format!("kind={kind_label}")];
     if !q.product.is_empty() {
@@ -69,6 +70,7 @@ pub fn print_query_detail(name: &str, query: &SavedQuery, format: OutputFormat) 
         let kind_label = match view.query.kind {
             QueryKind::List => "list",
             QueryKind::Search => "search",
+            QueryKind::Url => "url",
         };
         print_field("Name", view.name);
         print_field("Kind", kind_label);

--- a/src/output/query.rs
+++ b/src/output/query.rs
@@ -101,6 +101,14 @@ pub fn print_query_detail(name: &str, query: &SavedQuery, format: OutputFormat) 
 mod tests {
     use super::*;
 
+    /// Shared test helper — mirrors the `QueryView` in `print_query_detail` for JSON assertions.
+    #[derive(serde::Serialize)]
+    struct QueryView<'a> {
+        name: &'a str,
+        #[serde(flatten)]
+        query: &'a SavedQuery,
+    }
+
     fn make_url_query() -> SavedQuery {
         SavedQuery {
             kind: QueryKind::Url,
@@ -161,12 +169,6 @@ mod tests {
 
     #[test]
     fn query_detail_json_with_flatten() {
-        #[derive(serde::Serialize)]
-        struct QueryView<'a> {
-            name: &'a str,
-            #[serde(flatten)]
-            query: &'a SavedQuery,
-        }
         let query = make_list_query();
         let view = QueryView {
             name: "test-q",
@@ -236,12 +238,6 @@ mod tests {
 
     #[test]
     fn query_detail_json_includes_url_fields() {
-        #[derive(serde::Serialize)]
-        struct QueryView<'a> {
-            name: &'a str,
-            #[serde(flatten)]
-            query: &'a SavedQuery,
-        }
         let query = make_url_query();
         let view = QueryView {
             name: "url-q",

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -78,6 +78,24 @@ pub struct SearchParams {
 }
 
 impl SearchParams {
+    /// Apply optional runtime overrides for limit, fields, and `exclude_fields`.
+    pub fn apply_overrides(
+        &mut self,
+        limit: Option<u32>,
+        fields: Option<&str>,
+        exclude_fields: Option<&str>,
+    ) {
+        if let Some(l) = limit {
+            self.limit = Some(l);
+        }
+        if let Some(f) = fields {
+            self.include_fields = Some(f.to_string());
+        }
+        if let Some(ef) = exclude_fields {
+            self.exclude_fields = Some(ef.to_string());
+        }
+    }
+
     /// Returns true if any filter fields are set (product, component, etc.).
     ///
     /// Used by hybrid mode to decide whether an empty REST result warrants

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -544,6 +544,13 @@ mod tests {
         assert!(query.has_filters());
     }
 
+    fn sample_raw_params() -> Vec<(String, String)> {
+        vec![
+            ("f1".into(), "qa_contact".into()),
+            ("o1".into(), "changedfrom".into()),
+        ]
+    }
+
     #[test]
     fn query_kind_url_serializes() {
         let json = serde_json::to_string(&QueryKind::Url).unwrap();
@@ -604,10 +611,7 @@ mod tests {
         let query = SavedQuery {
             kind: QueryKind::Url,
             product: vec!["Firefox".into()],
-            raw_params: vec![
-                ("f1".into(), "qa_contact".into()),
-                ("o1".into(), "changedfrom".into()),
-            ],
+            raw_params: sample_raw_params(),
             limit: Some(100),
             ..SavedQuery::default()
         };

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -72,6 +72,9 @@ pub struct SearchParams {
     pub quicksearch: Option<String>,
     pub include_fields: Option<String>,
     pub exclude_fields: Option<String>,
+    /// Raw query parameters passed through verbatim to the REST API.
+    /// Used for URL-imported queries with boolean chart params.
+    pub raw_params: Vec<(String, String)>,
 }
 
 impl SearchParams {
@@ -96,6 +99,7 @@ impl SearchParams {
             || !self.id.is_empty()
             || self.summary.is_some()
             || self.quicksearch.is_some()
+            || !self.raw_params.is_empty()
     }
 }
 
@@ -248,6 +252,8 @@ pub enum QueryKind {
     List,
     /// Free-text quicksearch query
     Search,
+    /// Query imported from a Bugzilla URL (may contain raw passthrough params)
+    Url,
 }
 
 /// A reusable bug query stored in the config file.
@@ -277,6 +283,16 @@ pub struct SavedQuery {
     pub fields: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exclude_fields: Option<String>,
+    /// The original Bugzilla URL this query was parsed from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+    /// Server name (from config) this query is associated with.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server: Option<String>,
+    /// Raw query parameters not mapped to structured fields.
+    /// Passed through verbatim to the Bugzilla REST API.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 impl SavedQuery {
@@ -294,6 +310,7 @@ impl SavedQuery {
             limit: self.limit,
             include_fields: self.fields.clone(),
             exclude_fields: self.exclude_fields.clone(),
+            raw_params: self.raw_params.clone(),
             ..Default::default()
         }
     }
@@ -308,6 +325,7 @@ impl SavedQuery {
             || !self.priority.is_empty()
             || !self.severity.is_empty()
             || self.quicksearch.is_some()
+            || !self.raw_params.is_empty()
     }
 }
 
@@ -424,6 +442,9 @@ mod tests {
             limit: Some(25),
             fields: None,
             exclude_fields: None,
+            source_url: None,
+            server: None,
+            raw_params: vec![],
         };
         let json = serde_json::to_string(&query).unwrap();
         let roundtripped: SavedQuery = serde_json::from_str(&json).unwrap();
@@ -503,5 +524,98 @@ mod tests {
             ..SavedQuery::default()
         };
         assert!(query.has_filters());
+    }
+
+    #[test]
+    fn query_kind_url_serializes() {
+        let json = serde_json::to_string(&QueryKind::Url).unwrap();
+        assert_eq!(json, r#""url""#);
+    }
+
+    #[test]
+    fn query_kind_url_deserializes() {
+        let kind: QueryKind = serde_json::from_str(r#""url""#).unwrap();
+        assert_eq!(kind, QueryKind::Url);
+    }
+
+    #[test]
+    fn saved_query_with_url_fields_roundtrips() {
+        let query = SavedQuery {
+            kind: QueryKind::Url,
+            source_url: Some("https://bugzilla.example.com/buglist.cgi?product=Firefox".into()),
+            server: Some("example".into()),
+            raw_params: vec![
+                ("f1".into(), "qa_contact".into()),
+                ("o1".into(), "changedfrom".into()),
+                ("v1".into(), "user@example.com".into()),
+            ],
+            product: vec!["Firefox".into()],
+            ..SavedQuery::default()
+        };
+        let json = serde_json::to_string(&query).unwrap();
+        let roundtripped: SavedQuery = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtripped.kind, QueryKind::Url);
+        assert_eq!(
+            roundtripped.source_url.as_deref(),
+            Some("https://bugzilla.example.com/buglist.cgi?product=Firefox")
+        );
+        assert_eq!(roundtripped.server.as_deref(), Some("example"));
+        assert_eq!(roundtripped.raw_params.len(), 3);
+        assert_eq!(
+            roundtripped.raw_params[0],
+            ("f1".into(), "qa_contact".into())
+        );
+        assert_eq!(roundtripped.product, vec!["Firefox"]);
+    }
+
+    #[test]
+    fn saved_query_without_url_fields_omits_them_in_json() {
+        let query = SavedQuery {
+            kind: QueryKind::List,
+            product: vec!["Firefox".into()],
+            ..SavedQuery::default()
+        };
+        let json = serde_json::to_string(&query).unwrap();
+        assert!(!json.contains("source_url"));
+        assert!(!json.contains("\"server\""));
+        assert!(!json.contains("raw_params"));
+    }
+
+    #[test]
+    fn saved_query_url_kind_to_search_params_includes_raw_params() {
+        let query = SavedQuery {
+            kind: QueryKind::Url,
+            product: vec!["Firefox".into()],
+            raw_params: vec![
+                ("f1".into(), "qa_contact".into()),
+                ("o1".into(), "changedfrom".into()),
+            ],
+            limit: Some(100),
+            ..SavedQuery::default()
+        };
+        let params = query.to_search_params();
+        assert_eq!(params.product, vec!["Firefox"]);
+        assert_eq!(params.limit, Some(100));
+        assert_eq!(params.raw_params.len(), 2);
+        assert_eq!(params.raw_params[0], ("f1".into(), "qa_contact".into()));
+    }
+
+    #[test]
+    fn saved_query_url_kind_has_filters_with_only_raw_params() {
+        let query = SavedQuery {
+            kind: QueryKind::Url,
+            raw_params: vec![("f1".into(), "qa_contact".into())],
+            ..SavedQuery::default()
+        };
+        assert!(query.has_filters());
+    }
+
+    #[test]
+    fn search_params_has_filters_with_raw_params() {
+        let params = SearchParams {
+            raw_params: vec![("f1".into(), "qa_contact".into())],
+            ..Default::default()
+        };
+        assert!(params.has_filters());
     }
 }

--- a/src/url_parser.rs
+++ b/src/url_parser.rs
@@ -175,6 +175,27 @@ mod tests {
         parse_bugzilla_url(&url, &config).unwrap()
     }
 
+    /// Extract `raw_params` keys as a vec for assertions.
+    fn raw_keys(parsed: &ParsedUrl) -> Vec<&str> {
+        parsed
+            .query
+            .raw_params
+            .iter()
+            .map(|(k, _)| k.as_str())
+            .collect()
+    }
+
+    /// Find a raw param value by key.
+    fn raw_value<'a>(parsed: &'a ParsedUrl, key: &str) -> &'a str {
+        parsed
+            .query
+            .raw_params
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+            .unwrap()
+    }
+
     #[test]
     fn parse_simple_url_with_recognized_params() {
         let parsed = parse_test_url("product=Firefox&product=Thunderbird&bug_status=NEW&limit=50");
@@ -201,12 +222,7 @@ mod tests {
         );
 
         // Ignored params must not appear in raw_params
-        let keys: Vec<&str> = parsed
-            .query
-            .raw_params
-            .iter()
-            .map(|(k, _)| k.as_str())
-            .collect();
+        let keys = raw_keys(&parsed);
         assert!(!keys.contains(&"query_format"));
         assert!(!keys.contains(&"list_id"));
         assert!(!keys.contains(&"columnlist"));
@@ -221,23 +237,8 @@ mod tests {
         assert!(keys.contains(&"classification"));
 
         // URL-decoded values
-        let v1 = parsed
-            .query
-            .raw_params
-            .iter()
-            .find(|(k, _)| k == "v1")
-            .map(|(_, v)| v.as_str())
-            .unwrap();
-        assert_eq!(v1, "PDF Viewer");
-
-        let chfield = parsed
-            .query
-            .raw_params
-            .iter()
-            .find(|(k, _)| k == "chfield")
-            .map(|(_, v)| v.as_str())
-            .unwrap();
-        assert_eq!(chfield, "[Bug creation]");
+        assert_eq!(raw_value(&parsed, "v1"), "PDF Viewer");
+        assert_eq!(raw_value(&parsed, "chfield"), "[Bug creation]");
     }
 
     #[test]
@@ -371,12 +372,7 @@ mod tests {
         );
 
         // API key must not appear in raw_params
-        let keys: Vec<&str> = parsed
-            .query
-            .raw_params
-            .iter()
-            .map(|(k, _)| k.as_str())
-            .collect();
+        let keys = raw_keys(&parsed);
         assert!(!keys.contains(&"Bugzilla_api_key"));
         assert!(!keys.contains(&"bugzilla_api_key"));
 
@@ -418,12 +414,7 @@ mod tests {
         assert!(!source.contains("abc"));
         assert!(!source.contains("def"));
 
-        let keys: Vec<&str> = parsed
-            .query
-            .raw_params
-            .iter()
-            .map(|(k, _)| k.as_str())
-            .collect();
+        let keys = raw_keys(&parsed);
         assert!(
             keys.is_empty()
                 || !keys

--- a/src/url_parser.rs
+++ b/src/url_parser.rs
@@ -1,0 +1,377 @@
+//! Parse Bugzilla `buglist.cgi` URLs into `SavedQuery` structs.
+
+use url::Url;
+
+use crate::config::Config;
+use crate::error::{BzrError, Result};
+use crate::types::{QueryKind, SavedQuery};
+
+/// Parameters ignored during URL parsing (display/session metadata).
+const IGNORED_PARAMS: &[&str] = &["columnlist", "list_id", "query_format"];
+
+/// Parameters extracted as the suggested query name, not stored as filters.
+const NAME_PARAMS: &[&str] = &["known_name", "query_based_on"];
+
+/// Maps Bugzilla URL parameter names to `SavedQuery` vec field names.
+const RECOGNIZED_VEC_PARAMS: &[(&str, &str)] = &[
+    ("product", "product"),
+    ("component", "component"),
+    ("bug_status", "status"),
+    ("assigned_to", "assignee"),
+    ("reporter", "creator"),
+    ("priority", "priority"),
+    ("bug_severity", "severity"),
+];
+
+/// Result of parsing a Bugzilla URL.
+#[derive(Debug)]
+pub struct ParsedUrl {
+    pub query: SavedQuery,
+    pub suggested_name: Option<String>,
+}
+
+/// Parse a Bugzilla `buglist.cgi` URL into a `SavedQuery`.
+///
+/// Recognized parameters are mapped to structured `SavedQuery` fields.
+/// Unrecognized parameters are stored in `raw_params` for verbatim
+/// passthrough to the REST API. Display/session params are ignored.
+pub fn parse_bugzilla_url(url_str: &str, config: &Config) -> Result<ParsedUrl> {
+    let url =
+        Url::parse(url_str).map_err(|e| BzrError::InputValidation(format!("invalid URL: {e}")))?;
+
+    if !url.path().contains("buglist.cgi") {
+        return Err(BzrError::InputValidation(
+            "URL must be a Bugzilla buglist.cgi URL".into(),
+        ));
+    }
+
+    let url_host = url
+        .host_str()
+        .ok_or_else(|| BzrError::InputValidation("URL has no hostname".into()))?;
+
+    let server = find_server_by_hostname(config, url_host);
+    if server.is_none() && config.default_server.is_none() {
+        return Err(BzrError::config(format!(
+            "URL hostname '{url_host}' does not match any configured server \
+             and no default server is set. Run `bzr config set-server` first."
+        )));
+    }
+    if server.is_none() {
+        tracing::warn!(
+            "URL hostname '{url_host}' does not match any configured server; \
+             using default server"
+        );
+    }
+
+    let mut query = SavedQuery {
+        kind: QueryKind::Url,
+        source_url: Some(url_str.to_string()),
+        server: server.map(String::from),
+        ..SavedQuery::default()
+    };
+
+    let mut suggested_name: Option<String> = None;
+
+    for (key, value) in url.query_pairs() {
+        let key = key.as_ref();
+        let value = value.as_ref();
+
+        if IGNORED_PARAMS.contains(&key) {
+            continue;
+        }
+
+        if NAME_PARAMS.contains(&key) {
+            if suggested_name.is_none() && !value.is_empty() {
+                suggested_name = Some(value.to_string());
+            }
+            continue;
+        }
+
+        if key == "limit" {
+            if let Ok(n) = value.parse::<u32>() {
+                query.limit = Some(n);
+            }
+            continue;
+        }
+
+        if let Some(&(_, field_name)) = RECOGNIZED_VEC_PARAMS
+            .iter()
+            .find(|&&(url_key, _)| url_key == key)
+        {
+            let target = match field_name {
+                "product" => &mut query.product,
+                "component" => &mut query.component,
+                "status" => &mut query.status,
+                "assignee" => &mut query.assignee,
+                "creator" => &mut query.creator,
+                "priority" => &mut query.priority,
+                "severity" => &mut query.severity,
+                _ => unreachable!(),
+            };
+            target.push(value.to_string());
+            continue;
+        }
+
+        query.raw_params.push((key.to_string(), value.to_string()));
+    }
+
+    Ok(ParsedUrl {
+        query,
+        suggested_name,
+    })
+}
+
+fn find_server_by_hostname<'a>(config: &'a Config, hostname: &str) -> Option<&'a str> {
+    for (name, srv) in &config.servers {
+        if let Ok(srv_url) = Url::parse(&srv.url) {
+            if srv_url.host_str() == Some(hostname) {
+                return Some(name.as_str());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::config::{Config, ServerConfig};
+
+    fn make_server_config(server_url: &str) -> ServerConfig {
+        ServerConfig {
+            url: server_url.into(),
+            api_key: None,
+            api_key_env: None,
+            api_key_keyring: None,
+            email: None,
+            auth_method: None,
+            api_mode: None,
+            server_version: None,
+            tls_insecure: false,
+        }
+    }
+
+    fn make_config(server_url: &str) -> Config {
+        let mut servers = HashMap::new();
+        servers.insert("test".to_string(), make_server_config(server_url));
+        Config {
+            default_server: Some("test".to_string()),
+            servers,
+            templates: HashMap::new(),
+            queries: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn parse_simple_url_with_recognized_params() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi\
+            ?product=Firefox&product=Thunderbird&bug_status=NEW&limit=50";
+
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        assert_eq!(parsed.query.product, vec!["Firefox", "Thunderbird"]);
+        assert_eq!(parsed.query.status, vec!["NEW"]);
+        assert_eq!(parsed.query.limit, Some(50));
+        assert!(parsed.query.raw_params.is_empty());
+        assert_eq!(parsed.query.server.as_deref(), Some("test"));
+    }
+
+    #[test]
+    fn parse_complex_boolean_chart_url() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi\
+            ?known_name=My+Query\
+            &query_format=advanced\
+            &list_id=12345\
+            &columnlist=bug_id%2Csummary\
+            &chfield=%5BBug+creation%5D\
+            &chfieldfrom=-7d\
+            &classification=Client+Software\
+            &f1=component\
+            &o1=equals\
+            &v1=PDF+Viewer";
+
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+
+        assert_eq!(parsed.suggested_name.as_deref(), Some("My Query"));
+
+        // Ignored params must not appear in raw_params
+        let keys: Vec<&str> = parsed
+            .query
+            .raw_params
+            .iter()
+            .map(|(k, _)| k.as_str())
+            .collect();
+        assert!(!keys.contains(&"query_format"));
+        assert!(!keys.contains(&"list_id"));
+        assert!(!keys.contains(&"columnlist"));
+        assert!(!keys.contains(&"known_name"));
+
+        // Boolean chart params must be in raw_params
+        assert!(keys.contains(&"f1"));
+        assert!(keys.contains(&"o1"));
+        assert!(keys.contains(&"v1"));
+        assert!(keys.contains(&"chfield"));
+        assert!(keys.contains(&"chfieldfrom"));
+        assert!(keys.contains(&"classification"));
+
+        // URL-decoded values
+        let v1 = parsed
+            .query
+            .raw_params
+            .iter()
+            .find(|(k, _)| k == "v1")
+            .map(|(_, v)| v.as_str())
+            .unwrap();
+        assert_eq!(v1, "PDF Viewer");
+
+        let chfield = parsed
+            .query
+            .raw_params
+            .iter()
+            .find(|(k, _)| k == "chfield")
+            .map(|(_, v)| v.as_str())
+            .unwrap();
+        assert_eq!(chfield, "[Bug creation]");
+    }
+
+    #[test]
+    fn parse_url_without_buglist_cgi_errors() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/show_bug.cgi?id=12345";
+
+        let err = parse_bugzilla_url(url, &config).unwrap_err();
+        assert!(
+            err.to_string().contains("buglist.cgi"),
+            "error should mention buglist.cgi: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_malformed_url_errors() {
+        let config = make_config("https://bugzilla.example.com");
+
+        let err = parse_bugzilla_url("not a url", &config).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid URL"),
+            "error should mention invalid URL: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_url_hostname_matches_configured_server() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW";
+
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        assert_eq!(parsed.query.server.as_deref(), Some("test"));
+    }
+
+    #[test]
+    fn parse_url_hostname_no_match_uses_default() {
+        let config = make_config("https://other.example.com");
+        // Config has "test" server at other.example.com, with default_server = "test"
+        // URL hostname (bugzilla.example.com) won't match
+        let url = "https://bugzilla.example.com/buglist.cgi?product=Firefox";
+
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        // No hostname match → server field is None (will use default at query time)
+        assert!(parsed.query.server.is_none());
+    }
+
+    #[test]
+    fn parse_url_hostname_no_match_no_default_errors() {
+        let config = Config {
+            default_server: None,
+            servers: HashMap::new(),
+            templates: HashMap::new(),
+            queries: HashMap::new(),
+        };
+        let url = "https://bugzilla.example.com/buglist.cgi?product=Firefox";
+
+        let err = parse_bugzilla_url(url, &config).unwrap_err();
+        assert!(
+            err.to_string().contains("does not match"),
+            "error should mention does not match: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_url_repeated_product_params_accumulate() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi\
+            ?product=Firefox&product=Thunderbird&product=SeaMonkey";
+
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        assert_eq!(
+            parsed.query.product,
+            vec!["Firefox", "Thunderbird", "SeaMonkey"]
+        );
+    }
+
+    #[test]
+    fn parse_url_decodes_percent_encoded_values() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi\
+            ?product=PPC64%20Development\
+            &assigned_to=user%40example.com";
+
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        assert_eq!(parsed.query.product, vec!["PPC64 Development"]);
+        assert_eq!(parsed.query.assignee, vec!["user@example.com"]);
+    }
+
+    #[test]
+    fn parse_url_all_recognized_fields() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi\
+            ?product=Firefox\
+            &component=General\
+            &bug_status=NEW\
+            &assigned_to=dev@example.com\
+            &reporter=reporter@example.com\
+            &priority=P1\
+            &bug_severity=major\
+            &limit=100";
+
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        assert_eq!(parsed.query.product, vec!["Firefox"]);
+        assert_eq!(parsed.query.component, vec!["General"]);
+        assert_eq!(parsed.query.status, vec!["NEW"]);
+        assert_eq!(parsed.query.assignee, vec!["dev@example.com"]);
+        assert_eq!(parsed.query.creator, vec!["reporter@example.com"]);
+        assert_eq!(parsed.query.priority, vec!["P1"]);
+        assert_eq!(parsed.query.severity, vec!["major"]);
+        assert_eq!(parsed.query.limit, Some(100));
+        assert!(parsed.query.raw_params.is_empty());
+    }
+
+    #[test]
+    fn parse_url_only_raw_params() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi\
+            ?f1=component&o1=equals&v1=PDF+Viewer";
+
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        assert!(parsed.query.product.is_empty());
+        assert_eq!(parsed.query.raw_params.len(), 3);
+        assert!(parsed.query.has_filters());
+    }
+
+    #[test]
+    fn find_server_by_hostname_matches() {
+        let config = make_config("https://bugzilla.example.com");
+        let result = find_server_by_hostname(&config, "bugzilla.example.com");
+        assert_eq!(result, Some("test"));
+    }
+
+    #[test]
+    fn find_server_by_hostname_no_match() {
+        let config = make_config("https://bugzilla.example.com");
+        let result = find_server_by_hostname(&config, "other.example.com");
+        assert!(result.is_none());
+    }
+}

--- a/src/url_parser.rs
+++ b/src/url_parser.rs
@@ -6,28 +6,38 @@ use crate::config::Config;
 use crate::error::{BzrError, Result};
 use crate::types::{QueryKind, SavedQuery};
 
+/// Parameters containing credentials that must not be stored or forwarded.
+const CREDENTIAL_PARAMS: &[&str] = &["bugzilla_api_key", "token", "api_key"];
+
 /// Parameters ignored during URL parsing (display/session metadata).
-const IGNORED_PARAMS: &[&str] = &["columnlist", "list_id", "query_format"];
-
-/// Parameters extracted as the suggested query name, not stored as filters.
-const NAME_PARAMS: &[&str] = &["known_name", "query_based_on"];
-
-/// Maps Bugzilla URL parameter names to `SavedQuery` vec field names.
-const RECOGNIZED_VEC_PARAMS: &[(&str, &str)] = &[
-    ("product", "product"),
-    ("component", "component"),
-    ("bug_status", "status"),
-    ("assigned_to", "assignee"),
-    ("reporter", "creator"),
-    ("priority", "priority"),
-    ("bug_severity", "severity"),
+const IGNORED_PARAMS: &[&str] = &[
+    "columnlist",
+    "list_id",
+    "query_format",
+    "known_name",
+    "query_based_on",
 ];
 
 /// Result of parsing a Bugzilla URL.
 #[derive(Debug)]
 pub struct ParsedUrl {
     pub query: SavedQuery,
-    pub suggested_name: Option<String>,
+}
+
+/// Strip credential query parameters from a URL, returning the sanitized string.
+fn sanitize_url(url: &Url) -> String {
+    let mut sanitized = url.clone();
+    let pairs: Vec<(String, String)> = sanitized
+        .query_pairs()
+        .filter(|(k, _)| !CREDENTIAL_PARAMS.contains(&k.to_ascii_lowercase().as_str()))
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect();
+    if pairs.is_empty() {
+        sanitized.set_query(None);
+    } else {
+        sanitized.query_pairs_mut().clear().extend_pairs(pairs);
+    }
+    sanitized.to_string()
 }
 
 /// Parse a Bugzilla `buglist.cgi` URL into a `SavedQuery`.
@@ -35,6 +45,7 @@ pub struct ParsedUrl {
 /// Recognized parameters are mapped to structured `SavedQuery` fields.
 /// Unrecognized parameters are stored in `raw_params` for verbatim
 /// passthrough to the REST API. Display/session params are ignored.
+/// Credential parameters are stripped from both `source_url` and `raw_params`.
 pub fn parse_bugzilla_url(url_str: &str, config: &Config) -> Result<ParsedUrl> {
     let url =
         Url::parse(url_str).map_err(|e| BzrError::InputValidation(format!("invalid URL: {e}")))?;
@@ -65,25 +76,16 @@ pub fn parse_bugzilla_url(url_str: &str, config: &Config) -> Result<ParsedUrl> {
 
     let mut query = SavedQuery {
         kind: QueryKind::Url,
-        source_url: Some(url_str.to_string()),
+        source_url: Some(sanitize_url(&url)),
         server: server.map(String::from),
         ..SavedQuery::default()
     };
-
-    let mut suggested_name: Option<String> = None;
 
     for (key, value) in url.query_pairs() {
         let key = key.as_ref();
         let value = value.as_ref();
 
         if IGNORED_PARAMS.contains(&key) {
-            continue;
-        }
-
-        if NAME_PARAMS.contains(&key) {
-            if suggested_name.is_none() && !value.is_empty() {
-                suggested_name = Some(value.to_string());
-            }
             continue;
         }
 
@@ -94,31 +96,32 @@ pub fn parse_bugzilla_url(url_str: &str, config: &Config) -> Result<ParsedUrl> {
             continue;
         }
 
-        if let Some(&(_, field_name)) = RECOGNIZED_VEC_PARAMS
-            .iter()
-            .find(|&&(url_key, _)| url_key == key)
-        {
-            let target = match field_name {
-                "product" => &mut query.product,
-                "component" => &mut query.component,
-                "status" => &mut query.status,
-                "assignee" => &mut query.assignee,
-                "creator" => &mut query.creator,
-                "priority" => &mut query.priority,
-                "severity" => &mut query.severity,
-                _ => unreachable!(),
-            };
+        // Recognized vec fields — map Bugzilla URL param names to SavedQuery fields
+        let target = match key {
+            "product" => Some(&mut query.product),
+            "component" => Some(&mut query.component),
+            "bug_status" => Some(&mut query.status),
+            "assigned_to" => Some(&mut query.assignee),
+            "reporter" => Some(&mut query.creator),
+            "priority" => Some(&mut query.priority),
+            "bug_severity" => Some(&mut query.severity),
+            _ => None,
+        };
+        if let Some(target) = target {
             target.push(value.to_string());
+            continue;
+        }
+
+        // Strip credential params — never store or forward these
+        if CREDENTIAL_PARAMS.contains(&key.to_ascii_lowercase().as_str()) {
+            tracing::warn!("stripping credential parameter '{key}' from URL");
             continue;
         }
 
         query.raw_params.push((key.to_string(), value.to_string()));
     }
 
-    Ok(ParsedUrl {
-        query,
-        suggested_name,
-    })
+    Ok(ParsedUrl { query })
 }
 
 fn find_server_by_hostname<'a>(config: &'a Config, hostname: &str) -> Option<&'a str> {
@@ -195,8 +198,6 @@ mod tests {
             &v1=PDF+Viewer";
 
         let parsed = parse_bugzilla_url(url, &config).unwrap();
-
-        assert_eq!(parsed.suggested_name.as_deref(), Some("My Query"));
 
         // Ignored params must not appear in raw_params
         let keys: Vec<&str> = parsed
@@ -373,5 +374,80 @@ mod tests {
         let config = make_config("https://bugzilla.example.com");
         let result = find_server_by_hostname(&config, "other.example.com");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_url_strips_api_key_from_raw_params() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi?\
+            product=Firefox&Bugzilla_api_key=secret123&f1=component&o1=equals&v1=General";
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+
+        // API key must not appear in raw_params
+        let keys: Vec<&str> = parsed
+            .query
+            .raw_params
+            .iter()
+            .map(|(k, _)| k.as_str())
+            .collect();
+        assert!(!keys.contains(&"Bugzilla_api_key"));
+        assert!(!keys.contains(&"bugzilla_api_key"));
+
+        // Other raw params should still be present
+        assert!(keys.contains(&"f1"));
+        assert!(keys.contains(&"o1"));
+        assert!(keys.contains(&"v1"));
+
+        // Product should be recognized normally
+        assert_eq!(parsed.query.product, vec!["Firefox"]);
+    }
+
+    #[test]
+    fn parse_url_strips_credentials_from_source_url() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi?\
+            product=Firefox&Bugzilla_api_key=secret123&token=abc";
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+
+        let source = parsed.query.source_url.as_deref().unwrap();
+        assert!(
+            !source.contains("secret123"),
+            "API key leaked into source_url: {source}"
+        );
+        assert!(
+            !source.contains("abc"),
+            "token leaked into source_url: {source}"
+        );
+        assert!(
+            source.contains("product=Firefox"),
+            "non-credential params should remain: {source}"
+        );
+    }
+
+    #[test]
+    fn parse_url_strips_credentials_case_insensitive() {
+        let config = make_config("https://bugzilla.example.com");
+        let url = "https://bugzilla.example.com/buglist.cgi?\
+            product=Firefox&BUGZILLA_API_KEY=secret&Token=abc&api_key=def";
+        let parsed = parse_bugzilla_url(url, &config).unwrap();
+
+        let source = parsed.query.source_url.as_deref().unwrap();
+        assert!(!source.contains("secret"));
+        assert!(!source.contains("abc"));
+        assert!(!source.contains("def"));
+
+        let keys: Vec<&str> = parsed
+            .query
+            .raw_params
+            .iter()
+            .map(|(k, _)| k.as_str())
+            .collect();
+        assert!(
+            keys.is_empty()
+                || !keys
+                    .iter()
+                    .any(|k| k.to_ascii_lowercase().contains("key")
+                        || k.eq_ignore_ascii_case("token"))
+        );
     }
 }

--- a/src/url_parser.rs
+++ b/src/url_parser.rs
@@ -168,13 +168,16 @@ mod tests {
         }
     }
 
+    /// Parse a buglist.cgi URL with the standard test config (bugzilla.example.com).
+    fn parse_test_url(query: &str) -> ParsedUrl {
+        let config = make_config("https://bugzilla.example.com");
+        let url = format!("https://bugzilla.example.com/buglist.cgi?{query}");
+        parse_bugzilla_url(&url, &config).unwrap()
+    }
+
     #[test]
     fn parse_simple_url_with_recognized_params() {
-        let config = make_config("https://bugzilla.example.com");
-        let url = "https://bugzilla.example.com/buglist.cgi\
-            ?product=Firefox&product=Thunderbird&bug_status=NEW&limit=50";
-
-        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        let parsed = parse_test_url("product=Firefox&product=Thunderbird&bug_status=NEW&limit=50");
         assert_eq!(parsed.query.product, vec!["Firefox", "Thunderbird"]);
         assert_eq!(parsed.query.status, vec!["NEW"]);
         assert_eq!(parsed.query.limit, Some(50));
@@ -184,9 +187,8 @@ mod tests {
 
     #[test]
     fn parse_complex_boolean_chart_url() {
-        let config = make_config("https://bugzilla.example.com");
-        let url = "https://bugzilla.example.com/buglist.cgi\
-            ?known_name=My+Query\
+        let parsed = parse_test_url(
+            "known_name=My+Query\
             &query_format=advanced\
             &list_id=12345\
             &columnlist=bug_id%2Csummary\
@@ -195,9 +197,8 @@ mod tests {
             &classification=Client+Software\
             &f1=component\
             &o1=equals\
-            &v1=PDF+Viewer";
-
-        let parsed = parse_bugzilla_url(url, &config).unwrap();
+            &v1=PDF+Viewer",
+        );
 
         // Ignored params must not appear in raw_params
         let keys: Vec<&str> = parsed
@@ -242,9 +243,11 @@ mod tests {
     #[test]
     fn parse_url_without_buglist_cgi_errors() {
         let config = make_config("https://bugzilla.example.com");
-        let url = "https://bugzilla.example.com/show_bug.cgi?id=12345";
-
-        let err = parse_bugzilla_url(url, &config).unwrap_err();
+        let err = parse_bugzilla_url(
+            "https://bugzilla.example.com/show_bug.cgi?id=12345",
+            &config,
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("buglist.cgi"),
             "error should mention buglist.cgi: {err}"
@@ -254,7 +257,6 @@ mod tests {
     #[test]
     fn parse_malformed_url_errors() {
         let config = make_config("https://bugzilla.example.com");
-
         let err = parse_bugzilla_url("not a url", &config).unwrap_err();
         assert!(
             err.to_string().contains("invalid URL"),
@@ -264,10 +266,7 @@ mod tests {
 
     #[test]
     fn parse_url_hostname_matches_configured_server() {
-        let config = make_config("https://bugzilla.example.com");
-        let url = "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW";
-
-        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        let parsed = parse_test_url("product=Firefox&bug_status=NEW");
         assert_eq!(parsed.query.server.as_deref(), Some("test"));
     }
 
@@ -276,9 +275,11 @@ mod tests {
         let config = make_config("https://other.example.com");
         // Config has "test" server at other.example.com, with default_server = "test"
         // URL hostname (bugzilla.example.com) won't match
-        let url = "https://bugzilla.example.com/buglist.cgi?product=Firefox";
-
-        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        let parsed = parse_bugzilla_url(
+            "https://bugzilla.example.com/buglist.cgi?product=Firefox",
+            &config,
+        )
+        .unwrap();
         // No hostname match → server field is None (will use default at query time)
         assert!(parsed.query.server.is_none());
     }
@@ -291,9 +292,11 @@ mod tests {
             templates: HashMap::new(),
             queries: HashMap::new(),
         };
-        let url = "https://bugzilla.example.com/buglist.cgi?product=Firefox";
-
-        let err = parse_bugzilla_url(url, &config).unwrap_err();
+        let err = parse_bugzilla_url(
+            "https://bugzilla.example.com/buglist.cgi?product=Firefox",
+            &config,
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("does not match"),
             "error should mention does not match: {err}"
@@ -302,11 +305,7 @@ mod tests {
 
     #[test]
     fn parse_url_repeated_product_params_accumulate() {
-        let config = make_config("https://bugzilla.example.com");
-        let url = "https://bugzilla.example.com/buglist.cgi\
-            ?product=Firefox&product=Thunderbird&product=SeaMonkey";
-
-        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        let parsed = parse_test_url("product=Firefox&product=Thunderbird&product=SeaMonkey");
         assert_eq!(
             parsed.query.product,
             vec!["Firefox", "Thunderbird", "SeaMonkey"]
@@ -315,30 +314,23 @@ mod tests {
 
     #[test]
     fn parse_url_decodes_percent_encoded_values() {
-        let config = make_config("https://bugzilla.example.com");
-        let url = "https://bugzilla.example.com/buglist.cgi\
-            ?product=PPC64%20Development\
-            &assigned_to=user%40example.com";
-
-        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        let parsed = parse_test_url("product=PPC64%20Development&assigned_to=user%40example.com");
         assert_eq!(parsed.query.product, vec!["PPC64 Development"]);
         assert_eq!(parsed.query.assignee, vec!["user@example.com"]);
     }
 
     #[test]
     fn parse_url_all_recognized_fields() {
-        let config = make_config("https://bugzilla.example.com");
-        let url = "https://bugzilla.example.com/buglist.cgi\
-            ?product=Firefox\
+        let parsed = parse_test_url(
+            "product=Firefox\
             &component=General\
             &bug_status=NEW\
             &assigned_to=dev@example.com\
             &reporter=reporter@example.com\
             &priority=P1\
             &bug_severity=major\
-            &limit=100";
-
-        let parsed = parse_bugzilla_url(url, &config).unwrap();
+            &limit=100",
+        );
         assert_eq!(parsed.query.product, vec!["Firefox"]);
         assert_eq!(parsed.query.component, vec!["General"]);
         assert_eq!(parsed.query.status, vec!["NEW"]);
@@ -352,11 +344,7 @@ mod tests {
 
     #[test]
     fn parse_url_only_raw_params() {
-        let config = make_config("https://bugzilla.example.com");
-        let url = "https://bugzilla.example.com/buglist.cgi\
-            ?f1=component&o1=equals&v1=PDF+Viewer";
-
-        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        let parsed = parse_test_url("f1=component&o1=equals&v1=PDF+Viewer");
         assert!(parsed.query.product.is_empty());
         assert_eq!(parsed.query.raw_params.len(), 3);
         assert!(parsed.query.has_filters());
@@ -378,10 +366,9 @@ mod tests {
 
     #[test]
     fn parse_url_strips_api_key_from_raw_params() {
-        let config = make_config("https://bugzilla.example.com");
-        let url = "https://bugzilla.example.com/buglist.cgi?\
-            product=Firefox&Bugzilla_api_key=secret123&f1=component&o1=equals&v1=General";
-        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        let parsed = parse_test_url(
+            "product=Firefox&Bugzilla_api_key=secret123&f1=component&o1=equals&v1=General",
+        );
 
         // API key must not appear in raw_params
         let keys: Vec<&str> = parsed
@@ -404,10 +391,7 @@ mod tests {
 
     #[test]
     fn parse_url_strips_credentials_from_source_url() {
-        let config = make_config("https://bugzilla.example.com");
-        let url = "https://bugzilla.example.com/buglist.cgi?\
-            product=Firefox&Bugzilla_api_key=secret123&token=abc";
-        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        let parsed = parse_test_url("product=Firefox&Bugzilla_api_key=secret123&token=abc");
 
         let source = parsed.query.source_url.as_deref().unwrap();
         assert!(
@@ -426,10 +410,8 @@ mod tests {
 
     #[test]
     fn parse_url_strips_credentials_case_insensitive() {
-        let config = make_config("https://bugzilla.example.com");
-        let url = "https://bugzilla.example.com/buglist.cgi?\
-            product=Firefox&BUGZILLA_API_KEY=secret&Token=abc&api_key=def";
-        let parsed = parse_bugzilla_url(url, &config).unwrap();
+        let parsed =
+            parse_test_url("product=Firefox&BUGZILLA_API_KEY=secret&Token=abc&api_key=def");
 
         let source = parsed.query.source_url.as_deref().unwrap();
         assert!(!source.contains("secret"));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -117,7 +117,7 @@ async fn bug_search_integration() {
         query: Some("crash".to_string()),
         from_url: None,
         save_as: None,
-        limit: 50,
+        limit: None,
         fields: None,
         exclude_fields: None,
     };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -114,7 +114,9 @@ async fn bug_search_integration() {
         .await;
 
     let action = bzr::cli::BugAction::Search {
-        query: "crash".to_string(),
+        query: Some("crash".to_string()),
+        from_url: None,
+        save_as: None,
         limit: 50,
         fields: None,
         exclude_fields: None,


### PR DESCRIPTION
## Summary

- Add `--from-url` flag to `bug search` and `query save` to parse Bugzilla `buglist.cgi` URLs directly from the CLI
- Add `--save-as` on `bug search` to save URL queries for future reuse in one command
- Add `--server` override on `query run` for running saved queries against a different server
- New `url_parser` module maps recognized URL params (product, status, etc.) to structured fields; unrecognized params (boolean charts, field-change filters) pass through to the REST API verbatim
- Credential parameters (`Bugzilla_api_key`, `token`, `api_key`) are stripped from stored URLs and raw params
- Enhanced `query show` output displays source URL, server, and raw param count for URL-sourced queries

## Test plan

- [ ] 644 tests pass (`cargo test`), clippy clean, fmt clean
- [ ] Verify `bzr bug search --from-url "<buglist.cgi URL>"` executes the query
- [ ] Verify `bzr bug search --from-url "<url>" --save-as "name"` saves after successful search
- [ ] Verify `bzr query save name --from-url "<url>"` saves without executing
- [ ] Verify `bzr query run name --server <other>` overrides the stored server
- [ ] Verify `bzr query show name` displays source URL and raw param count for URL queries
- [ ] Verify URLs containing `Bugzilla_api_key=` do not leak credentials into config
- [ ] Verify `--from-url` is mutually exclusive with the positional query argument
- [ ] Verify `--save-as` requires `--from-url`

## Related issues

- #88 — Unify field-mapping tables (deferred refactor)
- #89 — Add consuming `into_search_params` (deferred optimization)
- #90 — Migrate output/query.rs from `println!` (pre-existing)
- #91 — Boolean chart index collision guard (deferred safety)
- #92 — Auto-suggest save name from URL's `known_name` (future enhancement)
- #93 — Strengthen server override test (test improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)