### PR TITLE
Post-merge cleanup: unified field mappings, collision guard, known_name auto-suggest

### DIFF
--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -84,7 +84,7 @@ bzr [--server <NAME>] [--output table|json] [--json] [--no-color] [--quiet] [--a
 │   │        [--creator <C>...] [--priority <P>...] [--severity <S>...] [--id <ID>...]
 │   │        [--alias <A>] [--limit <N>] [--fields <F>] [--exclude-fields <F>]
 │   ├── view <ID> [--fields <F>] [--exclude-fields <F>]
-│   ├── search [<QUERY>] [--from-url <URL>] [--save-as <NAME>] [--limit <N>] [--fields <F>] [--exclude-fields <F>]
+│   ├── search [<QUERY>] [--from-url <URL>] [--save-as [NAME]] [--limit <N>] [--fields <F>] [--exclude-fields <F>]
 │   ├── history <ID> [--since <DATE>]
 │   ├── my [--created] [--cc] [--all] [--status <S>...] [--limit <N>]
 │   │       [--fields <F>] [--exclude-fields <F>]
@@ -223,6 +223,7 @@ bzr bug search "component:NetworkManager priority:high" --limit 10
 bzr bug search "memory leak" --fields id,summary
 bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW"
 bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW" --save-as "my-query"
+bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?known_name=my%20search&product=Firefox" --save-as
 ```
 
 `--from-url` and the positional `<QUERY>` argument are mutually exclusive.
@@ -231,7 +232,7 @@ bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?product=Fire
 |--------|----------|---------|-------------|
 | `<QUERY>` | No* | | Search query (quicksearch syntax) |
 | `--from-url <URL>` | No* | | Execute a search from a Bugzilla buglist.cgi URL. Recognized parameters (product, component, status, etc.) are mapped to structured fields; unrecognized parameters (boolean charts, field-change filters) are passed through to the REST API verbatim. |
-| `--save-as <NAME>` | No | | Save this URL query with the given name for future reuse. Requires `--from-url`. |
+| `--save-as [NAME]` | No | | Save this URL query for future reuse. If `NAME` is omitted, uses the URL's `known_name` parameter as the query name. Requires `--from-url`. |
 | `--limit <N>` | No | 50 | Max results. When `--from-url` is used, the URL's own limit parameter takes precedence unless overridden here. |
 | `--fields <F>` | No | | Only return these fields (comma-separated) |
 | `--exclude-fields <F>` | No | | Exclude these fields (comma-separated) |

--- a/docs/plans/2026-04-27-post-merge-cleanup.md
+++ b/docs/plans/2026-04-27-post-merge-cleanup.md
@@ -1,0 +1,1091 @@
+# Post-Merge Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Address 6 deferred review items from the `--from-url` PR (#88-#93) in a single cleanup PR.
+
+**Architecture:** All changes build on the `feature/from-url-saved-queries` branch. Task 1 introduces a unified field-mapping table that Tasks 2, 3, and 4 depend on. Tasks 5-7 are independent.
+
+**Tech Stack:** Rust, clap, wiremock, tokio
+
+**Base branch:** `feature/from-url-saved-queries` (must be merged to `main` first, or this work branches from it)
+
+---
+
+## File Map
+
+| File | Action | Tasks |
+|------|--------|-------|
+| `src/types/bug.rs` | Modify | 1, 2, 3 |
+| `src/types/mod.rs` | Modify | 1 |
+| `src/client/bug.rs` | Modify | 1, 4 |
+| `src/url_parser.rs` | Modify | 1, 7 |
+| `src/output/query.rs` | Modify | 5 |
+| `src/commands/query.rs` | Modify | 3, 6 |
+| `src/commands/bug.rs` | Modify | 3, 7 |
+| `src/cli/bug.rs` | Modify | 7 |
+
+---
+
+### Task 1: Unify Field-Mapping Tables (#88)
+
+**Files:**
+- Modify: `src/types/bug.rs` (add `FieldMapping`, `FIELD_MAPPINGS`, accessor methods; remove `BOOLEAN_CHART_FIELD_NAMES`)
+- Modify: `src/types/mod.rs` (update exports)
+- Modify: `src/client/bug.rs` (rewrite `append_multi_value_params` and `append_negated_params` to use `FIELD_MAPPINGS`)
+- Modify: `src/url_parser.rs` (rewrite field matching to use `FIELD_MAPPINGS`)
+
+- [ ] **Step 1: Write tests for `FieldMapping` and accessor methods**
+
+Add to the `#[cfg(test)] mod tests` block in `src/types/bug.rs`:
+
+```rust
+#[test]
+fn field_mappings_covers_all_search_params_vec_fields() {
+    // Verify that every FIELD_MAPPINGS entry resolves to a real field
+    let params = SearchParams::default();
+    for mapping in FIELD_MAPPINGS {
+        let field = params.get_field(mapping.struct_field);
+        assert!(field.is_empty(), "default field should be empty: {}", mapping.struct_field);
+    }
+}
+
+#[test]
+fn field_mappings_has_expected_count() {
+    assert_eq!(FIELD_MAPPINGS.len(), 7);
+}
+
+#[test]
+fn field_mappings_url_param_lookup() {
+    let status = FIELD_MAPPINGS.iter().find(|m| m.url_param == "bug_status");
+    assert!(status.is_some());
+    assert_eq!(status.unwrap().struct_field, "status");
+    assert_eq!(status.unwrap().internal_name, "bug_status");
+}
+
+#[test]
+fn field_mappings_internal_name_for_creator() {
+    let creator = FIELD_MAPPINGS.iter().find(|m| m.struct_field == "creator");
+    assert!(creator.is_some());
+    assert_eq!(creator.unwrap().internal_name, "reporter");
+}
+
+#[test]
+fn search_params_get_field_returns_correct_data() {
+    let params = SearchParams {
+        product: vec!["Firefox".into()],
+        status: vec!["NEW".into(), "ASSIGNED".into()],
+        ..Default::default()
+    };
+    assert_eq!(params.get_field("product"), &["Firefox"]);
+    assert_eq!(params.get_field("status"), &["NEW", "ASSIGNED"]);
+    assert!(params.get_field("creator").is_empty());
+}
+
+#[test]
+#[should_panic(expected = "unknown field")]
+fn search_params_get_field_panics_on_unknown() {
+    let params = SearchParams::default();
+    params.get_field("nonexistent");
+}
+
+#[test]
+fn saved_query_get_field_mut_returns_correct_fields() {
+    let mut query = SavedQuery::default();
+    query.get_field_mut("assigned_to").unwrap().push("dev@example.com".into());
+    assert_eq!(query.assignee, vec!["dev@example.com"]);
+
+    query.get_field_mut("status").unwrap().push("NEW".into());
+    assert_eq!(query.status, vec!["NEW"]);
+}
+
+#[test]
+fn saved_query_get_field_mut_returns_none_for_unknown() {
+    let mut query = SavedQuery::default();
+    assert!(query.get_field_mut("nonexistent").is_none());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib types::bug::tests::field_mappings`
+Expected: compilation errors — `FIELD_MAPPINGS`, `get_field`, `get_field_mut` don't exist yet.
+
+- [ ] **Step 3: Implement `FieldMapping`, `FIELD_MAPPINGS`, and accessor methods**
+
+In `src/types/bug.rs`, replace `BOOLEAN_CHART_FIELD_NAMES` (lines 142-150 on feature branch) with:
+
+```rust
+/// Maps a filterable field across all naming contexts.
+pub struct FieldMapping {
+    /// Name on `SearchParams` / `SavedQuery` (e.g. "status").
+    /// Also used as the REST API query parameter.
+    pub struct_field: &'static str,
+    /// `buglist.cgi` URL parameter name (e.g. "bug_status").
+    pub url_param: &'static str,
+    /// Bugzilla internal name for boolean charts (e.g. "bug_status").
+    pub internal_name: &'static str,
+}
+
+/// Canonical field-mapping table for the 7 multi-value filter fields.
+///
+/// Single source of truth consumed by:
+/// - `client/bug.rs` (`append_multi_value_params`, `append_negated_params`)
+/// - `url_parser.rs` (URL param to struct field mapping)
+/// - Any code needing boolean chart internal names
+pub const FIELD_MAPPINGS: &[FieldMapping] = &[
+    FieldMapping { struct_field: "product",     url_param: "product",      internal_name: "product" },
+    FieldMapping { struct_field: "component",   url_param: "component",    internal_name: "component" },
+    FieldMapping { struct_field: "status",      url_param: "bug_status",   internal_name: "bug_status" },
+    FieldMapping { struct_field: "assigned_to", url_param: "assigned_to",  internal_name: "assigned_to" },
+    FieldMapping { struct_field: "creator",     url_param: "reporter",     internal_name: "reporter" },
+    FieldMapping { struct_field: "priority",    url_param: "priority",     internal_name: "priority" },
+    FieldMapping { struct_field: "severity",    url_param: "bug_severity", internal_name: "bug_severity" },
+];
+```
+
+Add to `impl SearchParams` (after `apply_overrides`):
+
+```rust
+/// Get a reference to a multi-value filter field by its struct_field name.
+///
+/// # Panics
+/// Panics if `name` is not a recognized field in `FIELD_MAPPINGS`.
+pub fn get_field(&self, name: &str) -> &[String] {
+    match name {
+        "product" => &self.product,
+        "component" => &self.component,
+        "status" => &self.status,
+        "assigned_to" => &self.assigned_to,
+        "creator" => &self.creator,
+        "priority" => &self.priority,
+        "severity" => &self.severity,
+        _ => panic!("unknown field: {name}"),
+    }
+}
+```
+
+Add to `impl SavedQuery` (after `has_filters`):
+
+```rust
+/// Get a mutable reference to a multi-value filter field by struct_field name.
+///
+/// Uses `FIELD_MAPPINGS` struct_field names. Note that `assigned_to` maps to
+/// `self.assignee` (the `SavedQuery` uses a friendlier name for TOML config).
+///
+/// Returns `None` for unrecognized field names.
+pub fn get_field_mut(&mut self, name: &str) -> Option<&mut Vec<String>> {
+    match name {
+        "product" => Some(&mut self.product),
+        "component" => Some(&mut self.component),
+        "status" => Some(&mut self.status),
+        "assigned_to" => Some(&mut self.assignee),
+        "creator" => Some(&mut self.creator),
+        "priority" => Some(&mut self.priority),
+        "severity" => Some(&mut self.severity),
+        _ => None,
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib types::bug::tests::field_mappings && cargo test --lib types::bug::tests::search_params_get_field && cargo test --lib types::bug::tests::saved_query_get_field`
+Expected: all pass.
+
+- [ ] **Step 5: Update `src/types/mod.rs` exports**
+
+Replace the `BOOLEAN_CHART_FIELD_NAMES` export with `FIELD_MAPPINGS` and `FieldMapping`:
+
+In the `pub use bug::{...}` block (line 11-13 on feature branch), change:
+```rust
+    BOOLEAN_CHART_FIELD_NAMES,
+```
+to:
+```rust
+    FIELD_MAPPINGS, FieldMapping,
+```
+
+- [ ] **Step 6: Rewrite `append_multi_value_params` in `src/client/bug.rs`**
+
+Replace the current function (lines 34-54) with:
+
+```rust
+fn append_multi_value_params(
+    mut builder: reqwest::RequestBuilder,
+    params: &SearchParams,
+) -> reqwest::RequestBuilder {
+    for mapping in FIELD_MAPPINGS {
+        let (positive, _) = partition_filters(params.get_field(mapping.struct_field));
+        for v in positive {
+            builder = builder.query(&[(mapping.struct_field, v)]);
+        }
+    }
+    builder
+}
+```
+
+- [ ] **Step 7: Rewrite `append_negated_params` in `src/client/bug.rs`**
+
+Replace the current function (lines 64-93) with:
+
+```rust
+fn append_negated_params(
+    mut builder: reqwest::RequestBuilder,
+    params: &SearchParams,
+) -> reqwest::RequestBuilder {
+    let mut idx = 1u32;
+    for mapping in FIELD_MAPPINGS {
+        let (_, negated) = partition_filters(params.get_field(mapping.struct_field));
+        for v in negated {
+            let f_key = format!("f{idx}");
+            let o_key = format!("o{idx}");
+            let v_key = format!("v{idx}");
+            builder = builder.query(&[
+                (&f_key, mapping.internal_name),
+                (&o_key, "notequals"),
+                (&v_key, v),
+            ]);
+            idx += 1;
+        }
+    }
+    builder
+}
+```
+
+Update the import at the top of `src/client/bug.rs` (line 6-7): replace `BOOLEAN_CHART_FIELD_NAMES` with `FIELD_MAPPINGS`:
+
+```rust
+    partition_filters, ApiMode, Bug, CreateBugParams, HistoryEntry, SearchParams, UpdateBugParams,
+    FIELD_MAPPINGS,
+```
+
+- [ ] **Step 8: Rewrite URL parser field matching in `src/url_parser.rs`**
+
+Replace the inline match block (lines ~100-113 on feature branch) with a `FIELD_MAPPINGS` lookup:
+
+```rust
+        // Recognized vec fields — map Bugzilla URL param names to SavedQuery fields
+        if let Some(mapping) = FIELD_MAPPINGS.iter().find(|m| m.url_param == key) {
+            if let Some(target) = query.get_field_mut(mapping.struct_field) {
+                target.push(value.to_string());
+                continue;
+            }
+        }
+```
+
+Add the import at the top of `src/url_parser.rs`:
+
+```rust
+use crate::types::FIELD_MAPPINGS;
+```
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `cargo test && cargo clippy --all-targets --all-features -- -D warnings`
+Expected: all pass, no warnings.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/types/bug.rs src/types/mod.rs src/client/bug.rs src/url_parser.rs
+git commit -m "refactor: unify field-mapping tables into FIELD_MAPPINGS (#88)"
+```
+
+---
+
+### Task 2: Add `into_search_params` (#89)
+
+**Files:**
+- Modify: `src/types/bug.rs` (add `into_search_params`)
+- Modify: `src/commands/query.rs` (use `into_search_params` in `handle_run`)
+- Modify: `src/commands/bug.rs` (use `into_search_params` in `handle_search`)
+
+- [ ] **Step 1: Write test for `into_search_params`**
+
+Add to the `#[cfg(test)] mod tests` block in `src/types/bug.rs`:
+
+```rust
+#[test]
+fn into_search_params_moves_fields() {
+    let query = SavedQuery {
+        kind: QueryKind::List,
+        product: vec!["Firefox".into()],
+        component: vec!["General".into()],
+        status: vec!["NEW".into()],
+        assignee: vec!["dev@example.com".into()],
+        creator: vec!["reporter@example.com".into()],
+        priority: vec!["P1".into()],
+        severity: vec!["critical".into()],
+        quicksearch: Some("crash".into()),
+        limit: Some(25),
+        fields: Some("id,summary".into()),
+        exclude_fields: Some("comments".into()),
+        raw_params: vec![("f1".into(), "qa_contact".into())],
+        ..Default::default()
+    };
+    let params = query.into_search_params();
+    assert_eq!(params.product, vec!["Firefox"]);
+    assert_eq!(params.component, vec!["General"]);
+    assert_eq!(params.status, vec!["NEW"]);
+    assert_eq!(params.assigned_to, vec!["dev@example.com"]);
+    assert_eq!(params.creator, vec!["reporter@example.com"]);
+    assert_eq!(params.priority, vec!["P1"]);
+    assert_eq!(params.severity, vec!["critical"]);
+    assert_eq!(params.quicksearch, Some("crash".into()));
+    assert_eq!(params.limit, Some(25));
+    assert_eq!(params.include_fields, Some("id,summary".into()));
+    assert_eq!(params.exclude_fields, Some("comments".into()));
+    assert_eq!(params.raw_params, vec![("f1".into(), "qa_contact".into())]);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib types::bug::tests::into_search_params_moves_fields`
+Expected: compilation error — `into_search_params` not defined.
+
+- [ ] **Step 3: Implement `into_search_params`**
+
+Add to `impl SavedQuery` in `src/types/bug.rs`, right after `to_search_params`:
+
+```rust
+/// Consuming variant of `to_search_params` — moves fields instead of cloning.
+/// Use when the `SavedQuery` is owned and not needed after conversion.
+pub fn into_search_params(self) -> SearchParams {
+    SearchParams {
+        product: self.product,
+        component: self.component,
+        status: self.status,
+        assigned_to: self.assignee,
+        creator: self.creator,
+        priority: self.priority,
+        severity: self.severity,
+        quicksearch: self.quicksearch,
+        limit: self.limit,
+        include_fields: self.fields,
+        exclude_fields: self.exclude_fields,
+        raw_params: self.raw_params,
+        ..Default::default()
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib types::bug::tests::into_search_params_moves_fields`
+Expected: PASS.
+
+- [ ] **Step 5: Update `handle_search` in `src/commands/bug.rs`**
+
+`handle_run` is handled in Task 3 (requires restructuring to extract server first).
+
+For `handle_search` in `src/commands/bug.rs`, the `parsed.query` is owned. Change (around line 142):
+
+```rust
+        let mut params = parsed.query.to_search_params();
+```
+
+to:
+
+```rust
+        let save_query = if save_as.is_some() {
+            Some(parsed.query.clone())
+        } else {
+            None
+        };
+        let mut params = parsed.query.into_search_params();
+```
+
+And update the `save_info` construction (around line 149) to use `save_query`:
+
+```rust
+        let save_info = save_as
+            .as_ref()
+            .zip(save_query)
+            .map(|(name, query)| (name.clone(), query));
+```
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `cargo test && cargo clippy --all-targets --all-features -- -D warnings`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/types/bug.rs src/commands/bug.rs
+git commit -m "perf: add into_search_params to avoid cloning (#89)"
+```
+
+---
+
+### Task 3: Use `into_search_params` in `handle_run` (#89 continued)
+
+**Files:**
+- Modify: `src/commands/query.rs` (restructure `handle_run` to use `into_search_params`)
+
+- [ ] **Step 1: Restructure `handle_run` to extract server then consume the query**
+
+The query is borrowed from `config.queries`. Since `into_search_params` consumes `self`, extract the server string before consuming. Replace the body of `handle_run` (from the `Config::load()` call onward) with:
+
+```rust
+    let config = Config::load()?;
+    let saved = config
+        .queries
+        .get(name.as_str())
+        .ok_or_else(|| BzrError::config(format!("query '{name}' not found")))?;
+
+    // Extract server before consuming the query
+    let saved_server = saved.server.clone();
+    let effective_server = server
+        .or(server_override.as_deref())
+        .or(saved_server.as_deref());
+
+    let mut params = saved.clone().into_search_params();
+    params.apply_overrides(*limit, fields.as_deref(), exclude_fields.as_deref());
+
+    let client = super::shared::connect_and_configure(effective_server, api).await?;
+    let bugs = client.search_bugs(&params).await?;
+    output::print_bugs(&bugs, format);
+    Ok(())
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cargo test && cargo clippy --all-targets --all-features -- -D warnings`
+Expected: all pass. The existing `query_run_executes_saved_query` and other run tests validate correctness.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/commands/query.rs
+git commit -m "perf: use into_search_params in handle_run (#89)"
+```
+
+---
+
+### Task 4: Guard Against Boolean Chart Index Collision (#91)
+
+**Files:**
+- Modify: `src/client/bug.rs` (add validation in `search_bugs_rest`)
+
+- [ ] **Step 1: Write tests for the collision guard**
+
+Add to the `#[cfg(test)] mod tests` block in `src/client/bug.rs`:
+
+```rust
+#[test]
+fn has_negated_filters_detects_negation() {
+    let params = SearchParams {
+        status: vec!["!CLOSED".into()],
+        ..Default::default()
+    };
+    assert!(super::has_negated_filters(&params));
+}
+
+#[test]
+fn has_negated_filters_false_for_positive_only() {
+    let params = SearchParams {
+        status: vec!["NEW".into()],
+        ..Default::default()
+    };
+    assert!(!super::has_negated_filters(&params));
+}
+
+#[test]
+fn has_raw_boolean_chart_params_detects_f1() {
+    let params = SearchParams {
+        raw_params: vec![
+            ("f1".into(), "qa_contact".into()),
+            ("o1".into(), "equals".into()),
+            ("v1".into(), "user@example.com".into()),
+        ],
+        ..Default::default()
+    };
+    assert!(super::has_raw_boolean_chart_params(&params));
+}
+
+#[test]
+fn has_raw_boolean_chart_params_false_for_non_chart() {
+    let params = SearchParams {
+        raw_params: vec![("product".into(), "Firefox".into())],
+        ..Default::default()
+    };
+    assert!(!super::has_raw_boolean_chart_params(&params));
+}
+
+#[test]
+fn has_raw_boolean_chart_params_false_for_empty() {
+    let params = SearchParams::default();
+    assert!(!super::has_raw_boolean_chart_params(&params));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib client::bug::tests::has_negated`
+Expected: compilation error — functions don't exist.
+
+- [ ] **Step 3: Implement the detection helpers**
+
+Add above `search_bugs_rest` in `src/client/bug.rs`:
+
+```rust
+/// Returns true if any multi-value filter field contains negated values (prefixed with `!`).
+fn has_negated_filters(params: &SearchParams) -> bool {
+    FIELD_MAPPINGS.iter().any(|m| {
+        params
+            .get_field(m.struct_field)
+            .iter()
+            .any(|v| v.starts_with('!'))
+    })
+}
+
+/// Returns true if `raw_params` contains boolean chart parameters (`fN`, `oN`, `vN`
+/// where N is a positive integer).
+fn has_raw_boolean_chart_params(params: &SearchParams) -> bool {
+    params.raw_params.iter().any(|(k, _)| {
+        k.len() >= 2
+            && k.as_bytes()[0].is_ascii_lowercase()
+            && matches!(k.as_bytes()[0], b'f' | b'o' | b'v')
+            && k[1..].parse::<u32>().is_ok()
+    })
+}
+```
+
+- [ ] **Step 4: Run helper tests to verify they pass**
+
+Run: `cargo test --lib client::bug::tests::has_negated && cargo test --lib client::bug::tests::has_raw_boolean`
+Expected: all pass.
+
+- [ ] **Step 5: Add the validation to `search_bugs_rest`**
+
+In `search_bugs_rest`, replace the comment block (around lines 203-207 on feature branch):
+
+```rust
+        // Note: raw_params and append_negated_params both use fN/oN/vN indices.
+        // Index collision cannot occur because URL-parsed queries store boolean
+        // chart params in raw_params (not as negated structured filters), and
+        // there is no CLI path that combines negated filters with raw params.
+        req_builder = append_raw_params(req_builder, &params.raw_params);
+```
+
+with:
+
+```rust
+        if has_negated_filters(params) && has_raw_boolean_chart_params(params) {
+            return Err(crate::error::BzrError::InputValidation(
+                "cannot combine negated filters (e.g. --status '!CLOSED') with a \
+                 URL-imported query containing boolean chart parameters; the chart \
+                 indices would collide"
+                    .into(),
+            ));
+        }
+        req_builder = append_raw_params(req_builder, &params.raw_params);
+```
+
+- [ ] **Step 6: Write integration test for the collision error**
+
+Add to the tests in `src/client/bug.rs`:
+
+```rust
+#[tokio::test]
+async fn search_bugs_rejects_negated_plus_raw_boolean_chart() {
+    let mock = wiremock::MockServer::start().await;
+    let client = crate::client::BugzillaClient::new(
+        &mock.uri(),
+        None,
+        crate::types::ApiMode::Rest,
+    );
+    let params = SearchParams {
+        status: vec!["!CLOSED".into()],
+        raw_params: vec![
+            ("f1".into(), "qa_contact".into()),
+            ("o1".into(), "equals".into()),
+            ("v1".into(), "user@example.com".into()),
+        ],
+        ..Default::default()
+    };
+    let result = client.search_bugs(&params).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("cannot combine negated filters"),
+        "unexpected error: {err}"
+    );
+}
+```
+
+- [ ] **Step 7: Run all tests**
+
+Run: `cargo test && cargo clippy --all-targets --all-features -- -D warnings`
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/client/bug.rs
+git commit -m "fix: guard against boolean chart index collision (#91)"
+```
+
+---
+
+### Task 5: Migrate `output/query.rs` from `println!` to `writeln!` (#90)
+
+**Files:**
+- Modify: `src/output/query.rs`
+
+- [ ] **Step 1: Replace `println!` with `writeln!` in `print_query_saved`**
+
+Add import at the top of `src/output/query.rs`:
+
+```rust
+use std::io::{self, Write as _};
+```
+
+In `print_query_saved`, replace:
+
+```rust
+        OutputFormat::Table => {
+            println!("{}", query_saved_message(name, verb));
+        }
+```
+
+with:
+
+```rust
+        OutputFormat::Table => {
+            let _ = writeln!(io::stdout(), "{}", query_saved_message(name, verb));
+        }
+```
+
+- [ ] **Step 2: Replace `println!` in `print_query_list`**
+
+In `print_query_list`, replace:
+
+```rust
+        if queries.is_empty() {
+            println!("No saved queries configured.");
+            return;
+        }
+```
+
+with:
+
+```rust
+        if queries.is_empty() {
+            let _ = writeln!(io::stdout(), "No saved queries configured.");
+            return;
+        }
+```
+
+And replace:
+
+```rust
+            println!("{}", query_summary_line(name, &queries[name]));
+```
+
+with:
+
+```rust
+            let _ = writeln!(io::stdout(), "{}", query_summary_line(name, &queries[name]));
+```
+
+- [ ] **Step 3: Remove any `#[expect(clippy::print_stdout)]` attributes**
+
+Check if these functions have `#[expect(clippy::print_stdout)]` annotations and remove them if present.
+
+- [ ] **Step 4: Run tests and clippy**
+
+Run: `cargo test && cargo clippy --all-targets --all-features -- -D warnings`
+Expected: all pass. The existing `capture_stdout` tests should continue to work (and may actually capture output better now).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/output/query.rs
+git commit -m "fix: migrate output/query.rs from println to writeln (#90)"
+```
+
+---
+
+### Task 6: Strengthen Server Override Test (#93)
+
+**Files:**
+- Modify: `src/commands/query.rs` (rewrite `query_run_with_server_override` test)
+
+- [ ] **Step 1: Rewrite the test**
+
+Replace the `query_run_with_server_override` test (around line 609 on feature branch) with:
+
+```rust
+    #[tokio::test]
+    async fn query_run_with_server_override() {
+        let (_lock, mock, _tmp) = setup_test_env().await;
+
+        // Save a query that records a different server than the mock
+        let save_action = save_action("server-test");
+        let (result, _) =
+            capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
+        assert!(result.is_ok());
+
+        // Patch the saved query to have a different server
+        let mut config = Config::load().unwrap();
+        let query = config.queries.get_mut("server-test").unwrap();
+        query.server = Some("other-server".into());
+        config.save().unwrap();
+
+        // Mount a mock that expects exactly 1 request
+        let mock_guard = Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})),
+            )
+            .expect(1)
+            .mount_as_scoped(&mock)
+            .await;
+
+        // Run with --server override pointing to the mock server ("test")
+        let run_action = QueryAction::Run {
+            name: "server-test".into(),
+            limit: None,
+            fields: None,
+            exclude_fields: None,
+            server: Some("test".into()),
+        };
+        let (result, _) = capture_stdout(super::execute(
+            &run_action,
+            None,
+            OutputFormat::Json,
+            None,
+        ))
+        .await;
+        assert!(
+            result.is_ok(),
+            "query run with server override failed: {result:?}"
+        );
+
+        // Drop the scoped mock to trigger the expect(1) assertion
+        drop(mock_guard);
+    }
+```
+
+Key changes from the original:
+1. The saved query now has `server: Some("other-server")` — a server that doesn't exist as a mock.
+2. The `--server` override uses `"test"` which points to the wiremock server.
+3. The global server param is `None` (not `Some("test")`), so only the action-level override can route to the mock.
+4. `.expect(1)` verifies the mock was actually hit.
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test --lib commands::query::tests::query_run_with_server_override`
+Expected: PASS. The override should route to "test" (the mock), not "other-server".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/commands/query.rs
+git commit -m "test: strengthen server override test to verify precedence (#93)"
+```
+
+---
+
+### Task 7: Auto-Suggest Save Name from URL's `known_name` (#92)
+
+**Files:**
+- Modify: `src/url_parser.rs` (extract `known_name`, add `suggested_name` to `ParsedUrl`)
+- Modify: `src/cli/bug.rs` (make `--save-as` optional argument)
+- Modify: `src/commands/bug.rs` (use `suggested_name` when `--save-as` has no explicit name)
+
+- [ ] **Step 1: Write tests for `suggested_name` extraction**
+
+Add to the `#[cfg(test)] mod tests` block in `src/url_parser.rs`:
+
+```rust
+#[test]
+fn parses_known_name_into_suggested_name() {
+    let config = test_config();
+    let result = parse_bugzilla_url(
+        "https://bugzilla.example.com/buglist.cgi?product=Firefox&known_name=my%20saved%20search",
+        &config,
+    )
+    .unwrap();
+    assert_eq!(
+        result.suggested_name,
+        Some("my saved search".into())
+    );
+}
+
+#[test]
+fn prefers_known_name_over_query_based_on() {
+    let config = test_config();
+    let result = parse_bugzilla_url(
+        "https://bugzilla.example.com/buglist.cgi?product=Firefox&known_name=preferred&query_based_on=ancestor",
+        &config,
+    )
+    .unwrap();
+    assert_eq!(
+        result.suggested_name,
+        Some("preferred".into())
+    );
+}
+
+#[test]
+fn falls_back_to_query_based_on() {
+    let config = test_config();
+    let result = parse_bugzilla_url(
+        "https://bugzilla.example.com/buglist.cgi?product=Firefox&query_based_on=ancestor%20query",
+        &config,
+    )
+    .unwrap();
+    assert_eq!(
+        result.suggested_name,
+        Some("ancestor query".into())
+    );
+}
+
+#[test]
+fn no_suggested_name_when_absent() {
+    let config = test_config();
+    let result = parse_bugzilla_url(
+        "https://bugzilla.example.com/buglist.cgi?product=Firefox",
+        &config,
+    )
+    .unwrap();
+    assert!(result.suggested_name.is_none());
+}
+
+#[test]
+fn empty_known_name_ignored() {
+    let config = test_config();
+    let result = parse_bugzilla_url(
+        "https://bugzilla.example.com/buglist.cgi?product=Firefox&known_name=",
+        &config,
+    )
+    .unwrap();
+    assert!(result.suggested_name.is_none());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib url_parser::tests::parses_known_name`
+Expected: failure — `suggested_name` field doesn't exist on `ParsedUrl`.
+
+- [ ] **Step 3: Implement `suggested_name` extraction**
+
+In `src/url_parser.rs`, update `IGNORED_PARAMS` to remove `known_name` and `query_based_on`:
+
+```rust
+const IGNORED_PARAMS: &[&str] = &["columnlist", "list_id", "query_format"];
+```
+
+Update `ParsedUrl` struct:
+
+```rust
+#[derive(Debug)]
+pub struct ParsedUrl {
+    pub query: SavedQuery,
+    /// Suggested name extracted from URL's `known_name` or `query_based_on` param.
+    pub suggested_name: Option<String>,
+}
+```
+
+In `parse_bugzilla_url`, add tracking variables before the `for` loop:
+
+```rust
+    let mut known_name: Option<String> = None;
+    let mut query_based_on: Option<String> = None;
+```
+
+In the `for` loop, add handling before the credential check:
+
+```rust
+        if key == "known_name" {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                known_name = Some(trimmed.to_string());
+            }
+            continue;
+        }
+
+        if key == "query_based_on" {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                query_based_on = Some(trimmed.to_string());
+            }
+            continue;
+        }
+```
+
+Update the return to include `suggested_name`:
+
+```rust
+    Ok(ParsedUrl {
+        query,
+        suggested_name: known_name.or(query_based_on),
+    })
+```
+
+- [ ] **Step 4: Run url_parser tests to verify they pass**
+
+Run: `cargo test --lib url_parser::tests`
+Expected: all pass.
+
+- [ ] **Step 5: Make `--save-as` accept an optional name**
+
+In `src/cli/bug.rs`, change the `save_as` field (around line 64-65):
+
+```rust
+        #[arg(long, requires = "from_url")]
+        save_as: Option<String>,
+```
+
+to:
+
+```rust
+        /// Save this URL query for future reuse. Optionally provide a name;
+        /// if omitted, uses the URL's known_name parameter.
+        #[arg(long, requires = "from_url", num_args = 0..=1, default_missing_value = "")]
+        save_as: Option<String>,
+```
+
+- [ ] **Step 6: Update `handle_search` to use `suggested_name`**
+
+In `src/commands/bug.rs`, update the `save_info` construction (around line 149) to handle the empty-string sentinel:
+
+Replace:
+
+```rust
+        let save_info = save_as
+            .as_ref()
+            .map(|name| (name.clone(), parsed.query.clone()));
+```
+
+(Or the version from Task 2 if already modified.)
+
+With:
+
+```rust
+        let save_info = if let Some(raw_name) = save_as {
+            let name = if raw_name.is_empty() {
+                parsed.suggested_name.ok_or_else(|| {
+                    crate::error::BzrError::InputValidation(
+                        "no name provided for --save-as and URL has no known_name; \
+                         specify a name explicitly: --save-as <name>"
+                            .into(),
+                    )
+                })?
+            } else {
+                raw_name.clone()
+            };
+            Some((name, parsed.query.clone()))
+        } else {
+            None
+        };
+```
+
+Note: if Task 2 changed this code to use `into_search_params`, adapt accordingly — clone the query for `save_info` before consuming it.
+
+- [ ] **Step 7: Write integration tests**
+
+Add to the tests in `src/commands/bug.rs`:
+
+```rust
+#[tokio::test]
+async fn handle_search_from_url_auto_names_from_known_name() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})),
+        )
+        .mount(&mock)
+        .await;
+
+    let server_url = mock.uri();
+    let url = format!(
+        "{server_url}/buglist.cgi?product=TestProduct&known_name=my%20saved%20search"
+    );
+    // --save-as with no name (empty string sentinel)
+    let action = BugAction::Search {
+        query: None,
+        from_url: Some(url),
+        save_as: Some(String::new()),
+        limit: None,
+        fields: None,
+        exclude_fields: None,
+    };
+    let (result, _output) =
+        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    assert!(result.is_ok(), "auto-name from known_name failed: {result:?}");
+
+    let config = Config::load().unwrap();
+    assert!(
+        config.queries.contains_key("my saved search"),
+        "query should be saved as 'my saved search'"
+    );
+}
+
+#[tokio::test]
+async fn handle_search_save_as_no_name_no_known_name_errors() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let action = BugAction::Search {
+        query: None,
+        from_url: Some("https://bugzilla.example.com/buglist.cgi?product=Firefox".into()),
+        save_as: Some(String::new()),
+        limit: None,
+        fields: None,
+        exclude_fields: None,
+    };
+    let (result, _output) =
+        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("no name provided for --save-as"),
+        "unexpected error: {err}"
+    );
+}
+```
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `cargo test && cargo clippy --all-targets --all-features -- -D warnings`
+Expected: all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/url_parser.rs src/cli/bug.rs src/commands/bug.rs
+git commit -m "feat: auto-suggest save name from URL's known_name (#92)"
+```
+
+---
+
+### Task 8: Final Verification
+
+- [ ] **Step 1: Run full test suite and lints**
+
+```bash
+cargo test && cargo clippy --all-targets --all-features -- -D warnings && cargo fmt --check
+```
+
+Expected: all pass, no warnings, no formatting issues.
+
+- [ ] **Step 2: Verify all issues are addressed**
+
+Confirm each issue:
+- #88: `BOOLEAN_CHART_FIELD_NAMES` removed, `FIELD_MAPPINGS` used everywhere
+- #89: `into_search_params` exists and is used in owning call sites
+- #90: No `println!` in `output/query.rs`
+- #91: `search_bugs_rest` rejects negated + raw boolean chart collision
+- #92: `--save-as` without a name auto-fills from `known_name`
+- #93: Server override test verifies a different saved server is overridden
+
+- [ ] **Step 3: Update CLI docs if needed**
+
+If `docs/bzr-cli.md` documents `--save-as`, update it to mention the optional name behavior.

--- a/docs/specs/2026-04-27-post-merge-cleanup-design.md
+++ b/docs/specs/2026-04-27-post-merge-cleanup-design.md
@@ -1,0 +1,240 @@
+# Post-Merge Cleanup: from-url Review Items
+
+Addresses issues #88-#93, all deferred from the `--from-url` / saved query PR review.
+
+## Issue #88: Unify Field-Mapping Tables
+
+### Problem
+
+The same 7 Bugzilla field mappings are duplicated in 3 locations with slightly different representations:
+
+1. `url_parser.rs` — URL param name to `SavedQuery` field name (inline match arms)
+2. `types/bug.rs` — `BOOLEAN_CHART_FIELD_NAMES` (`SearchParams` field to Bugzilla internal name)
+3. `client/bug.rs` — `append_multi_value_params` + `append_negated_params` (inline field arrays)
+
+Adding a new filterable field requires editing all 3, with no compile-time enforcement.
+
+### Design
+
+Define a single canonical table in `types/bug.rs`:
+
+```rust
+/// Each entry maps a filterable field across all naming contexts:
+/// - `struct_field`: name on `SearchParams` (e.g. "status") — also used as the
+///   REST API query parameter since Bugzilla accepts both short and long forms
+/// - `url_param`: `buglist.cgi` URL parameter name (e.g. "bug_status")
+/// - `internal_name`: Bugzilla internal name for boolean charts (e.g. "bug_status")
+///
+/// `url_param` and `internal_name` happen to be identical for all current fields.
+/// They're kept separate because the URL format and boolean chart format are
+/// different API surfaces that could diverge.
+pub struct FieldMapping {
+    pub struct_field: &'static str,
+    pub url_param: &'static str,
+    pub internal_name: &'static str,
+}
+
+pub const FIELD_MAPPINGS: &[FieldMapping] = &[
+    FieldMapping { struct_field: "product",     url_param: "product",      internal_name: "product" },
+    FieldMapping { struct_field: "component",   url_param: "component",    internal_name: "component" },
+    FieldMapping { struct_field: "status",      url_param: "bug_status",   internal_name: "bug_status" },
+    FieldMapping { struct_field: "assigned_to", url_param: "assigned_to",  internal_name: "assigned_to" },
+    FieldMapping { struct_field: "creator",     url_param: "reporter",     internal_name: "reporter" },
+    FieldMapping { struct_field: "priority",    url_param: "priority",     internal_name: "priority" },
+    FieldMapping { struct_field: "severity",    url_param: "bug_severity", internal_name: "bug_severity" },
+];
+```
+
+**Consumers updated:**
+
+- `client/bug.rs`: `append_multi_value_params` iterates `FIELD_MAPPINGS`, using `struct_field` as the REST param name and `get_field` for the values. `append_negated_params` uses `internal_name` for boolean chart field names.
+- `url_parser.rs`: Replace the inline match with a lookup into `FIELD_MAPPINGS` by `url_param`. Map to `SavedQuery` field via `struct_field` and `get_field_mut`.
+- `types/bug.rs`: Remove `BOOLEAN_CHART_FIELD_NAMES`; callers use `FIELD_MAPPINGS[i].internal_name` instead.
+- `types/mod.rs`: Export `FIELD_MAPPINGS` and `FieldMapping` instead of `BOOLEAN_CHART_FIELD_NAMES`.
+
+**Field accessor helper** — both `SearchParams` and `SavedQuery` need a way to get a `&[String]` / `&mut Vec<String>` by struct_field name. Add methods:
+
+```rust
+impl SearchParams {
+    /// Get a reference to a multi-value filter field by its struct_field name.
+    pub fn get_field(&self, name: &str) -> &[String] { ... }
+}
+
+impl SavedQuery {
+    /// Get a mutable reference to a multi-value filter field by name.
+    pub fn get_field_mut(&mut self, name: &str) -> Option<&mut Vec<String>> { ... }
+}
+```
+
+These use a match internally (7 arms) which is a single source of truth for the struct-to-field binding. The match arms map directly to `FIELD_MAPPINGS` entries.
+
+### Note on `assigned_to` vs `assignee`
+
+`SearchParams` uses `assigned_to` (matching the REST API param name), while `SavedQuery` uses `assignee` (a friendlier name for TOML config). The `FIELD_MAPPINGS` table uses `assigned_to` as the `struct_field` name since that's what `SearchParams` uses. `SavedQuery` handles the mapping in its `get_field_mut` method (maps `"assigned_to"` to `self.assignee`).
+
+## Issue #89: Add `into_search_params`
+
+### Problem
+
+`SavedQuery::to_search_params()` clones all 7 `Vec<String>` fields plus `raw_params`. Callers that own the `SavedQuery` discard it after conversion, making the clones unnecessary.
+
+### Design
+
+Add a consuming variant:
+
+```rust
+impl SavedQuery {
+    pub fn into_search_params(self) -> SearchParams {
+        SearchParams {
+            product: self.product,
+            component: self.component,
+            status: self.status,
+            assigned_to: self.assignee,
+            creator: self.creator,
+            priority: self.priority,
+            severity: self.severity,
+            quicksearch: self.quicksearch,
+            limit: self.limit,
+            include_fields: self.fields,
+            exclude_fields: self.exclude_fields,
+            raw_params: self.raw_params,
+            ..Default::default()
+        }
+    }
+}
+```
+
+Update call sites that own the `SavedQuery`:
+- `commands/query.rs::handle_run` — owns the query after loading from config
+- `commands/bug.rs::handle_search` (if applicable) — owns the query after URL parsing
+
+Keep borrowing `to_search_params(&self)` for call sites that borrow from config.
+
+## Issue #90: Migrate `output/query.rs` from `println!` to `writeln!`
+
+### Problem
+
+3 `println!` call sites in `output/query.rs` violate the project convention and break `capture_stdout` tests.
+
+### Design
+
+Replace each `println!(...)` with `let _ = writeln!(io::stdout(), ...);` in:
+- `print_query_saved` (line 40)
+- `print_query_list` (lines 48, 54)
+
+Add `use std::io::{self, Write};` import. Remove any `#[expect(clippy::print_stdout)]` attributes that exist on these functions.
+
+## Issue #91: Guard Against Boolean Chart Index Collision
+
+### Problem
+
+`append_negated_params` generates `fN/oN/vN` starting at index 1. URL-imported `raw_params` may also contain `f1/o1/v1`. If both are present, Bugzilla silently uses whichever appears last.
+
+Currently impossible (no CLI path combines both), but will silently corrupt queries if the surface area grows.
+
+### Design
+
+Add a validation check in `search_bugs_rest` (or `search_bugs`, before dispatching):
+
+```rust
+fn has_negated_filters(params: &SearchParams) -> bool {
+    FIELD_MAPPINGS.iter().any(|m| {
+        let values = params.get_field(m.struct_field);
+        values.iter().any(|v| v.starts_with('!'))
+    })
+}
+
+fn has_raw_boolean_chart_params(params: &SearchParams) -> bool {
+    params.raw_params.iter().any(|(k, _)| {
+        k.len() >= 2
+            && (k.starts_with('f') || k.starts_with('o') || k.starts_with('v'))
+            && k[1..].parse::<u32>().is_ok()
+    })
+}
+```
+
+In `search_bugs_rest`, before appending params:
+
+```rust
+if has_negated_filters(params) && has_raw_boolean_chart_params(params) {
+    return Err(BzrError::InputValidation(
+        "cannot combine negated filters (e.g. --status '!CLOSED') with a URL-imported \
+         query containing boolean chart parameters; the chart indices would collide. \
+         Use either negated filters or the raw URL query, not both.".into()
+    ));
+}
+```
+
+### Tests
+
+- Test that a `SearchParams` with both negated status and raw `f1/o1/v1` returns `InputValidation` error.
+- Test that negated-only and raw-only each work without error.
+
+## Issue #92: Auto-Suggest Save Name from URL's `known_name`
+
+### Problem
+
+Bugzilla URLs often contain `known_name=<saved search name>`. This was designed to be extracted but removed as dead code during review.
+
+### Design
+
+**URL parser changes:**
+- Move `known_name` from `IGNORED_PARAMS` to active extraction.
+- Add `suggested_name: Option<String>` to `ParsedUrl` struct.
+- Extract: prefer `known_name` over `query_based_on`. URL-decode the value.
+
+**CLI changes:**
+- Make `--save-as` accept an optional name: `--save-as [NAME]` (clap `num_args = 0..=1`, `default_missing_value = ""`).
+- When `--save-as` is used without a name (empty string sentinel):
+  - If `ParsedUrl::suggested_name` is `Some`, use that as the name.
+  - Otherwise, return `InputValidation` error: "no name provided for --save-as and URL has no known_name; specify a name explicitly".
+- When `--save-as <name>` is used with an explicit name, ignore `suggested_name`.
+- `known_name` values may contain spaces and special characters; validate that the resulting name is non-empty after trimming.
+
+**Output:**
+- When auto-using `suggested_name`, print: `Saved query '<name>' (name from URL's known_name)`.
+
+### Tests
+
+- URL with `known_name=my%20search` populates `suggested_name`.
+- `--save-as` without a name + URL with `known_name` uses the suggested name.
+- `--save-as` without a name + URL without `known_name` returns error.
+- `--save-as explicit-name` ignores `known_name`.
+
+## Issue #93: Strengthen Server Override Test
+
+### Problem
+
+`query_run_with_server_override` saves a query and runs it with the same server as both the saved server and the override, so it doesn't test that the override takes precedence.
+
+### Design
+
+Rewrite the test:
+1. Save a query with `server: Some("other-server")` in the `SavedQuery`.
+2. Run with `server: Some("test")` (the wiremock server).
+3. Assert the wiremock mock received exactly 1 request (`.expect(1)`).
+4. This proves the override was used instead of `"other-server"`.
+
+The test should manually insert the query into config (with `server: Some("other-server")`) rather than using the save action, to avoid needing a second wiremock server for `"other-server"`.
+
+## Implementation Order
+
+1. **#88** — Unify field mappings (foundational; touches types, client, url_parser)
+2. **#89** — Add `into_search_params` (uses the unified table)
+3. **#91** — Boolean chart collision guard (uses `FIELD_MAPPINGS` + `get_field`)
+4. **#90** — Migrate println to writeln (independent, small)
+5. **#93** — Strengthen server override test (independent, test-only)
+6. **#92** — Auto-suggest save name (independent, touches url_parser + CLI)
+
+Items 4-6 are independent and can be done in any order or in parallel.
+
+## Testing Strategy
+
+All changes should have unit tests. Issues #91 and #93 are specifically about adding/improving tests. The existing test suite must continue to pass after each change.
+
+Run after each issue:
+```bash
+cargo test
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+```

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -60,8 +60,9 @@ pub enum BugAction {
         /// Execute a search from a Bugzilla buglist.cgi URL
         #[arg(long)]
         from_url: Option<String>,
-        /// Save this URL query with the given name for future reuse (requires --from-url)
-        #[arg(long, requires = "from_url")]
+        /// Save this URL query for future reuse. Optionally provide a name;
+        /// if omitted, uses the URL's `known_name` parameter.
+        #[arg(long, requires = "from_url", num_args = 0..=1, default_missing_value = "")]
         save_as: Option<String>,
         /// Max number of results (default: 50)
         #[arg(long)]

--- a/src/client/bug.rs
+++ b/src/client/bug.rs
@@ -4,7 +4,7 @@ use super::BugzillaClient;
 use crate::error::{BzrError, Result, BUGZILLA_INTERNAL_ERROR};
 use crate::types::{
     partition_filters, ApiMode, Bug, CreateBugParams, HistoryEntry, SearchParams, UpdateBugParams,
-    BOOLEAN_CHART_FIELD_NAMES,
+    FIELD_MAPPINGS,
 };
 
 /// Default fields requested for Bug queries. Matches the fields in [`Bug`] and
@@ -35,19 +35,10 @@ fn append_multi_value_params(
     mut builder: reqwest::RequestBuilder,
     params: &SearchParams,
 ) -> reqwest::RequestBuilder {
-    let fields: &[(&str, &[String])] = &[
-        ("product", &params.product),
-        ("component", &params.component),
-        ("status", &params.status),
-        ("assigned_to", &params.assigned_to),
-        ("creator", &params.creator),
-        ("priority", &params.priority),
-        ("severity", &params.severity),
-    ];
-    for &(key, values) in fields {
-        let (positive, _) = partition_filters(values);
+    for mapping in FIELD_MAPPINGS {
+        let (positive, _) = partition_filters(params.get_field(mapping.struct_field));
         for v in positive {
-            builder = builder.query(&[(key, v)]);
+            builder = builder.query(&[(mapping.struct_field, v)]);
         }
     }
     builder
@@ -65,27 +56,18 @@ fn append_negated_params(
     mut builder: reqwest::RequestBuilder,
     params: &SearchParams,
 ) -> reqwest::RequestBuilder {
-    let fields: &[(&str, &[String])] = &[
-        ("product", &params.product),
-        ("component", &params.component),
-        ("status", &params.status),
-        ("assigned_to", &params.assigned_to),
-        ("creator", &params.creator),
-        ("priority", &params.priority),
-        ("severity", &params.severity),
-    ];
     let mut idx = 1u32;
-    for &(field_name, values) in fields {
-        let (_, negated) = partition_filters(values);
-        let chart_field = BOOLEAN_CHART_FIELD_NAMES
-            .iter()
-            .find(|&&(k, _)| k == field_name)
-            .map_or(field_name, |&(_, v)| v);
+    for mapping in FIELD_MAPPINGS {
+        let (_, negated) = partition_filters(params.get_field(mapping.struct_field));
         for v in negated {
             let f_key = format!("f{idx}");
             let o_key = format!("o{idx}");
             let v_key = format!("v{idx}");
-            builder = builder.query(&[(&f_key, chart_field), (&o_key, "notequals"), (&v_key, v)]);
+            builder = builder.query(&[
+                (&f_key, mapping.internal_name),
+                (&o_key, "notequals"),
+                (&v_key, v),
+            ]);
             idx += 1;
         }
     }

--- a/src/client/bug.rs
+++ b/src/client/bug.rs
@@ -100,6 +100,26 @@ fn append_option_params(
     builder
 }
 
+/// Returns true if any multi-value filter field contains negated values (prefixed with `!`).
+fn has_negated_filters(params: &SearchParams) -> bool {
+    FIELD_MAPPINGS.iter().any(|m| {
+        params
+            .get_field(m.struct_field)
+            .iter()
+            .any(|v| v.starts_with('!'))
+    })
+}
+
+/// Returns true if `raw_params` contains boolean chart parameters (`fN`, `oN`, `vN`
+/// where N is a positive integer).
+fn has_raw_boolean_chart_params(params: &SearchParams) -> bool {
+    params.raw_params.iter().any(|(k, _)| {
+        k.len() >= 2
+            && matches!(k.as_bytes()[0], b'f' | b'o' | b'v')
+            && k[1..].parse::<u32>().is_ok()
+    })
+}
+
 /// Appends raw key-value parameters to the request builder verbatim.
 /// Used for URL-imported queries with boolean chart params that
 /// `bzr` does not natively model.
@@ -182,10 +202,14 @@ impl BugzillaClient {
             req_builder = req_builder.query(&[("id", id)]);
         }
 
-        // Note: raw_params and append_negated_params both use fN/oN/vN indices.
-        // Index collision cannot occur because URL-parsed queries store boolean
-        // chart params in raw_params (not as negated structured filters), and
-        // there is no CLI path that combines negated filters with raw params.
+        if has_negated_filters(params) && has_raw_boolean_chart_params(params) {
+            return Err(crate::error::BzrError::InputValidation(
+                "cannot combine negated filters (e.g. --status '!CLOSED') with a \
+                 URL-imported query containing boolean chart parameters; the chart \
+                 indices would collide"
+                    .into(),
+            ));
+        }
         req_builder = append_raw_params(req_builder, &params.raw_params);
 
         if params.include_fields.is_none() {
@@ -709,6 +733,52 @@ mod tests {
     }
 
     #[test]
+    fn has_negated_filters_detects_negation() {
+        let params = SearchParams {
+            status: vec!["!CLOSED".into()],
+            ..Default::default()
+        };
+        assert!(super::has_negated_filters(&params));
+    }
+
+    #[test]
+    fn has_negated_filters_false_for_positive_only() {
+        let params = SearchParams {
+            status: vec!["NEW".into()],
+            ..Default::default()
+        };
+        assert!(!super::has_negated_filters(&params));
+    }
+
+    #[test]
+    fn has_raw_boolean_chart_params_detects_f1() {
+        let params = SearchParams {
+            raw_params: vec![
+                ("f1".into(), "qa_contact".into()),
+                ("o1".into(), "equals".into()),
+                ("v1".into(), "user@example.com".into()),
+            ],
+            ..Default::default()
+        };
+        assert!(super::has_raw_boolean_chart_params(&params));
+    }
+
+    #[test]
+    fn has_raw_boolean_chart_params_false_for_non_chart() {
+        let params = SearchParams {
+            raw_params: vec![("product".into(), "Firefox".into())],
+            ..Default::default()
+        };
+        assert!(!super::has_raw_boolean_chart_params(&params));
+    }
+
+    #[test]
+    fn has_raw_boolean_chart_params_false_for_empty() {
+        let params = SearchParams::default();
+        assert!(!super::has_raw_boolean_chart_params(&params));
+    }
+
+    #[test]
     fn search_params_has_filters() {
         let empty = SearchParams::default();
         assert!(!empty.has_filters());
@@ -797,6 +867,28 @@ mod tests {
         };
         let bugs = client.search_bugs(&params).await.unwrap();
         assert_eq!(bugs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn search_bugs_rejects_negated_plus_raw_boolean_chart() {
+        let mock = MockServer::start().await;
+        let client = test_client(&mock.uri());
+        let params = SearchParams {
+            status: vec!["!CLOSED".into()],
+            raw_params: vec![
+                ("f1".into(), "qa_contact".into()),
+                ("o1".into(), "equals".into()),
+                ("v1".into(), "user@example.com".into()),
+            ],
+            ..Default::default()
+        };
+        let result = client.search_bugs(&params).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("cannot combine negated filters"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/src/client/bug.rs
+++ b/src/client/bug.rs
@@ -116,7 +116,7 @@ fn has_raw_boolean_chart_params(params: &SearchParams) -> bool {
     params.raw_params.iter().any(|(k, _)| {
         k.len() >= 2
             && matches!(k.as_bytes()[0], b'f' | b'o' | b'v')
-            && k[1..].parse::<u32>().is_ok()
+            && k[1..].parse::<u32>().is_ok_and(|n| n >= 1)
     })
 }
 
@@ -186,22 +186,6 @@ impl BugzillaClient {
     }
 
     async fn search_bugs_rest(&self, params: &SearchParams) -> Result<Vec<Bug>> {
-        let mut req_builder = self.http.get(self.url("bug"));
-
-        // Append multi-value positive filters as repeated query params
-        // (e.g. &status=NEW&status=ASSIGNED) for OR semantics.
-        req_builder = append_multi_value_params(req_builder, params);
-
-        // Append negated filters as boolean chart fN/oN/vN triples.
-        req_builder = append_negated_params(req_builder, params);
-
-        // Append single-value Option fields and limit.
-        req_builder = append_option_params(req_builder, params);
-
-        for id in &params.id {
-            req_builder = req_builder.query(&[("id", id)]);
-        }
-
         if has_negated_filters(params) && has_raw_boolean_chart_params(params) {
             return Err(crate::error::BzrError::InputValidation(
                 "cannot combine negated filters (e.g. --status '!CLOSED') with a \
@@ -210,6 +194,16 @@ impl BugzillaClient {
                     .into(),
             ));
         }
+
+        let mut req_builder = self.http.get(self.url("bug"));
+        req_builder = append_multi_value_params(req_builder, params);
+        req_builder = append_negated_params(req_builder, params);
+        req_builder = append_option_params(req_builder, params);
+
+        for id in &params.id {
+            req_builder = req_builder.query(&[("id", id)]);
+        }
+
         req_builder = append_raw_params(req_builder, &params.raw_params);
 
         if params.include_fields.is_none() {

--- a/src/commands/bug.rs
+++ b/src/commands/bug.rs
@@ -1239,14 +1239,7 @@ mod tests {
         let server_url = mock.uri();
         let url =
             format!("{server_url}/buglist.cgi?product=TestProduct&known_name=my%20saved%20search");
-        let action = BugAction::Search {
-            query: None,
-            from_url: Some(url),
-            save_as: Some(String::new()),
-            limit: None,
-            fields: None,
-            exclude_fields: None,
-        };
+        let action = from_url_action(url, Some(String::new()));
         let (result, _output) =
             capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
         assert!(
@@ -1265,14 +1258,10 @@ mod tests {
     async fn handle_search_save_as_no_name_no_known_name_errors() {
         let (_lock, _mock, _tmp) = setup_test_env().await;
 
-        let action = BugAction::Search {
-            query: None,
-            from_url: Some("https://bugzilla.example.com/buglist.cgi?product=Firefox".into()),
-            save_as: Some(String::new()),
-            limit: None,
-            fields: None,
-            exclude_fields: None,
-        };
+        let action = from_url_action(
+            "https://bugzilla.example.com/buglist.cgi?product=Firefox".into(),
+            Some(String::new()),
+        );
         let (result, _output) =
             capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
         assert!(result.is_err());

--- a/src/commands/bug.rs
+++ b/src/commands/bug.rs
@@ -139,7 +139,12 @@ async fn handle_search(
         let effective_server = server.or(parsed.query.server.as_deref());
         let client = super::shared::connect_and_configure(effective_server, api).await?;
 
-        let mut params = parsed.query.to_search_params();
+        let save_query = if save_as.is_some() {
+            Some(parsed.query.clone())
+        } else {
+            None
+        };
+        let mut params = parsed.query.into_search_params();
         if params.limit.is_none() && limit.is_none() {
             params.limit = Some(50);
         }
@@ -148,7 +153,8 @@ async fn handle_search(
         // Defer saving until after search succeeds
         let save_info = save_as
             .as_ref()
-            .map(|name| (name.clone(), parsed.query.clone()));
+            .zip(save_query)
+            .map(|(name, query)| (name.clone(), query));
         (client, params, save_info)
     } else {
         let query_str = query.as_deref().ok_or_else(|| {

--- a/src/commands/bug.rs
+++ b/src/commands/bug.rs
@@ -139,22 +139,28 @@ async fn handle_search(
         let effective_server = server.or(parsed.query.server.as_deref());
         let client = super::shared::connect_and_configure(effective_server, api).await?;
 
-        let save_query = if save_as.is_some() {
-            Some(parsed.query.clone())
+        let save_info = if let Some(raw_name) = save_as {
+            let name = if raw_name.is_empty() {
+                parsed.suggested_name.ok_or_else(|| {
+                    crate::error::BzrError::InputValidation(
+                        "no name provided for --save-as and URL has no known_name; \
+                         specify a name explicitly: --save-as <name>"
+                            .into(),
+                    )
+                })?
+            } else {
+                raw_name.clone()
+            };
+            Some((name, parsed.query.clone()))
         } else {
             None
         };
+
         let mut params = parsed.query.into_search_params();
         if params.limit.is_none() && limit.is_none() {
             params.limit = Some(50);
         }
         params.apply_overrides(*limit, fields.as_deref(), exclude_fields.as_deref());
-
-        // Defer saving until after search succeeds
-        let save_info = save_as
-            .as_ref()
-            .zip(save_query)
-            .map(|(name, query)| (name.clone(), query));
         (client, params, save_info)
     } else {
         let query_str = query.as_deref().ok_or_else(|| {
@@ -1218,5 +1224,62 @@ mod tests {
         assert_eq!(saved.kind, crate::types::QueryKind::Url);
         assert_eq!(saved.product, vec!["TestProduct"]);
         assert!(saved.source_url.is_some());
+    }
+
+    #[tokio::test]
+    async fn handle_search_from_url_auto_names_from_known_name() {
+        let (_lock, mock, _tmp) = setup_test_env().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+            .mount(&mock)
+            .await;
+
+        let server_url = mock.uri();
+        let url =
+            format!("{server_url}/buglist.cgi?product=TestProduct&known_name=my%20saved%20search");
+        let action = BugAction::Search {
+            query: None,
+            from_url: Some(url),
+            save_as: Some(String::new()),
+            limit: None,
+            fields: None,
+            exclude_fields: None,
+        };
+        let (result, _output) =
+            capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+        assert!(
+            result.is_ok(),
+            "auto-name from known_name failed: {result:?}"
+        );
+
+        let config = crate::config::Config::load().unwrap();
+        assert!(
+            config.queries.contains_key("my saved search"),
+            "query should be saved as 'my saved search'"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_search_save_as_no_name_no_known_name_errors() {
+        let (_lock, _mock, _tmp) = setup_test_env().await;
+
+        let action = BugAction::Search {
+            query: None,
+            from_url: Some("https://bugzilla.example.com/buglist.cgi?product=Firefox".into()),
+            save_as: Some(String::new()),
+            limit: None,
+            fields: None,
+            exclude_fields: None,
+        };
+        let (result, _output) =
+            capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("no name provided for --save-as"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -157,13 +157,11 @@ async fn handle_run(
         .get(name.as_str())
         .ok_or_else(|| BzrError::config(format!("query '{name}' not found")))?;
 
-    // Extract server before consuming the query
-    let saved_server = saved.server.clone();
     let effective_server = server
         .or(server_override.as_deref())
-        .or(saved_server.as_deref());
+        .or(saved.server.as_deref());
 
-    let mut params = saved.clone().into_search_params();
+    let mut params = saved.to_search_params();
     params.apply_overrides(*limit, fields.as_deref(), exclude_fields.as_deref());
 
     let client = super::shared::connect_and_configure(effective_server, api).await?;

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -610,19 +610,27 @@ mod tests {
     async fn query_run_with_server_override() {
         let (_lock, mock, _tmp) = setup_test_env().await;
 
-        // Save a query first
+        // Save a query that records a different server than the mock
         let save_action = save_action("server-test");
         let (result, _) =
             capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
         assert!(result.is_ok());
 
-        Mock::given(method("GET"))
+        // Patch the saved query to have a different server
+        let mut config = Config::load().unwrap();
+        let query = config.queries.get_mut("server-test").unwrap();
+        query.server = Some("other-server".into());
+        config.save().unwrap();
+
+        // Mount a mock that expects exactly 1 request
+        let mock_guard = Mock::given(method("GET"))
             .and(path("/rest/bug"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
-            .mount(&mock)
+            .expect(1)
+            .mount_as_scoped(&mock)
             .await;
 
-        // Run with --server override
+        // Run with --server override pointing to the mock server ("test")
         let run_action = QueryAction::Run {
             name: "server-test".into(),
             limit: None,
@@ -630,17 +638,15 @@ mod tests {
             exclude_fields: None,
             server: Some("test".into()),
         };
-        let (result, _) = capture_stdout(super::execute(
-            &run_action,
-            Some("test"),
-            OutputFormat::Json,
-            None,
-        ))
-        .await;
+        let (result, _) =
+            capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
         assert!(
             result.is_ok(),
             "query run with server override failed: {result:?}"
         );
+
+        // Drop the scoped mock to trigger the expect(1) assertion
+        drop(mock_guard);
     }
 
     #[tokio::test]

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -152,18 +152,19 @@ async fn handle_run(
     };
 
     let config = Config::load()?;
-    let query = config
+    let saved = config
         .queries
         .get(name.as_str())
         .ok_or_else(|| BzrError::config(format!("query '{name}' not found")))?;
 
-    let mut params = query.to_search_params();
-    params.apply_overrides(*limit, fields.as_deref(), exclude_fields.as_deref());
-
-    // Server resolution: CLI --server > query run --server > saved server > default
+    // Extract server before consuming the query
+    let saved_server = saved.server.clone();
     let effective_server = server
         .or(server_override.as_deref())
-        .or(query.server.as_deref());
+        .or(saved_server.as_deref());
+
+    let mut params = saved.clone().into_search_params();
+    params.apply_overrides(*limit, fields.as_deref(), exclude_fields.as_deref());
 
     let client = super::shared::connect_and_configure(effective_server, api).await?;
     let bugs = client.search_bugs(&params).await?;

--- a/src/output/query.rs
+++ b/src/output/query.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io::{self, Write as _};
 
 use crate::types::{OutputFormat, QueryKind, SavedQuery};
 
@@ -44,7 +45,7 @@ pub fn print_query_saved(name: &str, verb: &str, format: OutputFormat) {
             print_json(&serde_json::json!({"name": name, "action": verb.to_lowercase()}));
         }
         OutputFormat::Table => {
-            println!("{}", query_saved_message(name, verb));
+            let _ = writeln!(io::stdout(), "{}", query_saved_message(name, verb));
         }
     }
 }
@@ -52,13 +53,13 @@ pub fn print_query_saved(name: &str, verb: &str, format: OutputFormat) {
 pub fn print_query_list(queries: &HashMap<String, SavedQuery>, format: OutputFormat) {
     print_formatted(queries, format, |queries| {
         if queries.is_empty() {
-            println!("No saved queries configured.");
+            let _ = writeln!(io::stdout(), "No saved queries configured.");
             return;
         }
         let mut names: Vec<&str> = queries.keys().map(String::as_str).collect();
         names.sort_unstable();
         for name in names {
-            println!("{}", query_summary_line(name, &queries[name]));
+            let _ = writeln!(io::stdout(), "{}", query_summary_line(name, &queries[name]));
         }
     });
 }

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -371,27 +371,12 @@ pub struct SavedQuery {
 }
 
 impl SavedQuery {
-    /// Convert this saved query into `SearchParams` for the Bugzilla client.
+    /// Convert this saved query into `SearchParams` by cloning.
     pub fn to_search_params(&self) -> SearchParams {
-        SearchParams {
-            product: self.product.clone(),
-            component: self.component.clone(),
-            status: self.status.clone(),
-            assigned_to: self.assignee.clone(),
-            creator: self.creator.clone(),
-            priority: self.priority.clone(),
-            severity: self.severity.clone(),
-            quicksearch: self.quicksearch.clone(),
-            limit: self.limit,
-            include_fields: self.fields.clone(),
-            exclude_fields: self.exclude_fields.clone(),
-            raw_params: self.raw_params.clone(),
-            ..Default::default()
-        }
+        self.clone().into_search_params()
     }
 
-    /// Consuming variant of `to_search_params` — moves fields instead of cloning.
-    /// Use when the `SavedQuery` is owned and not needed after conversion.
+    /// Convert this saved query into `SearchParams`, consuming `self`.
     pub fn into_search_params(self) -> SearchParams {
         SearchParams {
             product: self.product,

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -2,6 +2,19 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use super::common::FlagUpdate;
 
+/// Generates a match expression mapping `FIELD_MAPPINGS` `struct_field` names
+/// to struct fields. Used by `SearchParams::get_field` and
+/// `SavedQuery::get_field_mut` to keep both in sync with a single definition.
+macro_rules! match_field {
+    ($name:expr, $self:expr, $wrap:ident, $default:expr,
+     { $($field:literal => $member:ident),+ $(,)? }) => {
+        match $name {
+            $($field => $wrap!($self.$member),)+
+            _ => $default,
+        }
+    };
+}
+
 /// Deserialize a string that may be null into an empty string.
 fn deserialize_null_string<'de, D: Deserializer<'de>>(d: D) -> Result<String, D::Error> {
     Option::<String>::deserialize(d).map(Option::unwrap_or_default)
@@ -102,18 +115,21 @@ impl SearchParams {
     ///
     /// Panics if `name` is not one of the 7 known field names in
     /// `FIELD_MAPPINGS`. Only called with compile-time-known names.
-    #[expect(clippy::panic, reason = "only called with FIELD_MAPPINGS keys")]
     pub fn get_field(&self, name: &str) -> &[String] {
-        match name {
-            "product" => &self.product,
-            "component" => &self.component,
-            "status" => &self.status,
-            "assigned_to" => &self.assigned_to,
-            "creator" => &self.creator,
-            "priority" => &self.priority,
-            "severity" => &self.severity,
-            _ => panic!("unknown field: {name}"),
+        macro_rules! as_ref {
+            ($e:expr) => {
+                &$e
+            };
         }
+        match_field!(name, self, as_ref, panic!("unknown field: {name}"), {
+            "product" => product,
+            "component" => component,
+            "status" => status,
+            "assigned_to" => assigned_to,
+            "creator" => creator,
+            "priority" => priority,
+            "severity" => severity,
+        })
     }
 
     /// Returns true if any filter fields are set (product, component, etc.).
@@ -398,16 +414,20 @@ impl SavedQuery {
     /// Access a multi-value filter field mutably by its `struct_field` name.
     /// Maps `assigned_to` to `self.assignee` (TOML-friendly name).
     pub fn get_field_mut(&mut self, name: &str) -> Option<&mut Vec<String>> {
-        match name {
-            "product" => Some(&mut self.product),
-            "component" => Some(&mut self.component),
-            "status" => Some(&mut self.status),
-            "assigned_to" => Some(&mut self.assignee),
-            "creator" => Some(&mut self.creator),
-            "priority" => Some(&mut self.priority),
-            "severity" => Some(&mut self.severity),
-            _ => None,
+        macro_rules! some_mut {
+            ($e:expr) => {
+                Some(&mut $e)
+            };
         }
+        match_field!(name, self, some_mut, None, {
+            "product" => product,
+            "component" => component,
+            "status" => status,
+            "assigned_to" => assignee,
+            "creator" => creator,
+            "priority" => priority,
+            "severity" => severity,
+        })
     }
 
     /// Returns true if the query has any meaningful filters set.

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -390,6 +390,26 @@ impl SavedQuery {
         }
     }
 
+    /// Consuming variant of `to_search_params` — moves fields instead of cloning.
+    /// Use when the `SavedQuery` is owned and not needed after conversion.
+    pub fn into_search_params(self) -> SearchParams {
+        SearchParams {
+            product: self.product,
+            component: self.component,
+            status: self.status,
+            assigned_to: self.assignee,
+            creator: self.creator,
+            priority: self.priority,
+            severity: self.severity,
+            quicksearch: self.quicksearch,
+            limit: self.limit,
+            include_fields: self.fields,
+            exclude_fields: self.exclude_fields,
+            raw_params: self.raw_params,
+            ..Default::default()
+        }
+    }
+
     /// Access a multi-value filter field mutably by its `struct_field` name.
     /// Maps `assigned_to` to `self.assignee` (TOML-friendly name).
     pub fn get_field_mut(&mut self, name: &str) -> Option<&mut Vec<String>> {
@@ -782,5 +802,38 @@ mod tests {
     fn saved_query_get_field_mut_returns_none_for_unknown() {
         let mut query = SavedQuery::default();
         assert!(query.get_field_mut("nonexistent").is_none());
+    }
+
+    #[test]
+    fn into_search_params_moves_fields() {
+        let query = SavedQuery {
+            kind: QueryKind::List,
+            product: vec!["Firefox".into()],
+            component: vec!["General".into()],
+            status: vec!["NEW".into()],
+            assignee: vec!["dev@example.com".into()],
+            creator: vec!["reporter@example.com".into()],
+            priority: vec!["P1".into()],
+            severity: vec!["critical".into()],
+            quicksearch: Some("crash".into()),
+            limit: Some(25),
+            fields: Some("id,summary".into()),
+            exclude_fields: Some("comments".into()),
+            raw_params: vec![("f1".into(), "qa_contact".into())],
+            ..Default::default()
+        };
+        let params = query.into_search_params();
+        assert_eq!(params.product, vec!["Firefox"]);
+        assert_eq!(params.component, vec!["General"]);
+        assert_eq!(params.status, vec!["NEW"]);
+        assert_eq!(params.assigned_to, vec!["dev@example.com"]);
+        assert_eq!(params.creator, vec!["reporter@example.com"]);
+        assert_eq!(params.priority, vec!["P1"]);
+        assert_eq!(params.severity, vec!["critical"]);
+        assert_eq!(params.quicksearch, Some("crash".into()));
+        assert_eq!(params.limit, Some(25));
+        assert_eq!(params.include_fields, Some("id,summary".into()));
+        assert_eq!(params.exclude_fields, Some("comments".into()));
+        assert_eq!(params.raw_params, vec![("f1".into(), "qa_contact".into())]);
     }
 }

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -96,6 +96,26 @@ impl SearchParams {
         }
     }
 
+    /// Access a multi-value filter field by its `struct_field` name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name` is not one of the 7 known field names in
+    /// `FIELD_MAPPINGS`. Only called with compile-time-known names.
+    #[expect(clippy::panic, reason = "only called with FIELD_MAPPINGS keys")]
+    pub fn get_field(&self, name: &str) -> &[String] {
+        match name {
+            "product" => &self.product,
+            "component" => &self.component,
+            "status" => &self.status,
+            "assigned_to" => &self.assigned_to,
+            "creator" => &self.creator,
+            "priority" => &self.priority,
+            "severity" => &self.severity,
+            _ => panic!("unknown field: {name}"),
+        }
+    }
+
     /// Returns true if any filter fields are set (product, component, etc.).
     ///
     /// Used by hybrid mode to decide whether an empty REST result warrants
@@ -136,17 +156,54 @@ pub fn partition_filters(values: &[String]) -> (Vec<&str>, Vec<&str>) {
     (positive, negated)
 }
 
-/// Maps `SearchParams` field names to Bugzilla internal field names
-/// used in boolean chart `fN` parameters. Most are identical, but some
-/// differ (e.g. `status` → `bug_status`, `creator` → `reporter`).
-pub const BOOLEAN_CHART_FIELD_NAMES: &[(&str, &str)] = &[
-    ("product", "product"),
-    ("component", "component"),
-    ("status", "bug_status"),
-    ("assigned_to", "assigned_to"),
-    ("creator", "reporter"),
-    ("priority", "priority"),
-    ("severity", "bug_severity"),
+/// Maps a filterable field across all naming contexts.
+pub struct FieldMapping {
+    /// Name on `SearchParams` / `SavedQuery` (e.g. "status").
+    /// Also used as the REST API query parameter.
+    pub struct_field: &'static str,
+    /// `buglist.cgi` URL parameter name (e.g. `bug_status`).
+    pub url_param: &'static str,
+    /// Bugzilla internal name for boolean charts (e.g. `bug_status`).
+    pub internal_name: &'static str,
+}
+
+/// Canonical field-mapping table for the 7 multi-value filter fields.
+pub const FIELD_MAPPINGS: &[FieldMapping] = &[
+    FieldMapping {
+        struct_field: "product",
+        url_param: "product",
+        internal_name: "product",
+    },
+    FieldMapping {
+        struct_field: "component",
+        url_param: "component",
+        internal_name: "component",
+    },
+    FieldMapping {
+        struct_field: "status",
+        url_param: "bug_status",
+        internal_name: "bug_status",
+    },
+    FieldMapping {
+        struct_field: "assigned_to",
+        url_param: "assigned_to",
+        internal_name: "assigned_to",
+    },
+    FieldMapping {
+        struct_field: "creator",
+        url_param: "reporter",
+        internal_name: "reporter",
+    },
+    FieldMapping {
+        struct_field: "priority",
+        url_param: "priority",
+        internal_name: "priority",
+    },
+    FieldMapping {
+        struct_field: "severity",
+        url_param: "bug_severity",
+        internal_name: "bug_severity",
+    },
 ];
 
 #[derive(Debug, Serialize)]
@@ -330,6 +387,21 @@ impl SavedQuery {
             exclude_fields: self.exclude_fields.clone(),
             raw_params: self.raw_params.clone(),
             ..Default::default()
+        }
+    }
+
+    /// Access a multi-value filter field mutably by its `struct_field` name.
+    /// Maps `assigned_to` to `self.assignee` (TOML-friendly name).
+    pub fn get_field_mut(&mut self, name: &str) -> Option<&mut Vec<String>> {
+        match name {
+            "product" => Some(&mut self.product),
+            "component" => Some(&mut self.component),
+            "status" => Some(&mut self.status),
+            "assigned_to" => Some(&mut self.assignee),
+            "creator" => Some(&mut self.creator),
+            "priority" => Some(&mut self.priority),
+            "severity" => Some(&mut self.severity),
+            _ => None,
         }
     }
 
@@ -639,5 +711,76 @@ mod tests {
             ..Default::default()
         };
         assert!(params.has_filters());
+    }
+
+    #[test]
+    fn field_mappings_covers_all_search_params_vec_fields() {
+        let params = SearchParams::default();
+        for mapping in FIELD_MAPPINGS {
+            let field = params.get_field(mapping.struct_field);
+            assert!(
+                field.is_empty(),
+                "default field should be empty: {}",
+                mapping.struct_field
+            );
+        }
+    }
+
+    #[test]
+    fn field_mappings_has_expected_count() {
+        assert_eq!(FIELD_MAPPINGS.len(), 7);
+    }
+
+    #[test]
+    fn field_mappings_url_param_lookup() {
+        let status = FIELD_MAPPINGS.iter().find(|m| m.url_param == "bug_status");
+        assert!(status.is_some());
+        assert_eq!(status.unwrap().struct_field, "status");
+        assert_eq!(status.unwrap().internal_name, "bug_status");
+    }
+
+    #[test]
+    fn field_mappings_internal_name_for_creator() {
+        let creator = FIELD_MAPPINGS.iter().find(|m| m.struct_field == "creator");
+        assert!(creator.is_some());
+        assert_eq!(creator.unwrap().internal_name, "reporter");
+    }
+
+    #[test]
+    fn search_params_get_field_returns_correct_data() {
+        let params = SearchParams {
+            product: vec!["Firefox".into()],
+            status: vec!["NEW".into(), "ASSIGNED".into()],
+            ..Default::default()
+        };
+        assert_eq!(params.get_field("product"), &["Firefox"]);
+        assert_eq!(params.get_field("status"), &["NEW", "ASSIGNED"]);
+        assert!(params.get_field("creator").is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown field")]
+    fn search_params_get_field_panics_on_unknown() {
+        let params = SearchParams::default();
+        params.get_field("nonexistent");
+    }
+
+    #[test]
+    fn saved_query_get_field_mut_returns_correct_fields() {
+        let mut query = SavedQuery::default();
+        query
+            .get_field_mut("assigned_to")
+            .unwrap()
+            .push("dev@example.com".into());
+        assert_eq!(query.assignee, vec!["dev@example.com"]);
+
+        query.get_field_mut("status").unwrap().push("NEW".into());
+        assert_eq!(query.status, vec!["NEW"]);
+    }
+
+    #[test]
+    fn saved_query_get_field_mut_returns_none_for_unknown() {
+        let mut query = SavedQuery::default();
+        assert!(query.get_field_mut("nonexistent").is_none());
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -8,9 +8,9 @@ mod user;
 
 pub use attachment::{Attachment, UpdateAttachmentParams, UploadAttachmentParams};
 pub use bug::{
-    partition_filters, Bug, BugTemplate, CreateBugParams, FieldChange, FieldValue, HistoryEntry,
-    IdListUpdate, QueryKind, SavedQuery, SearchParams, StatusTransition, UpdateBugParams,
-    BOOLEAN_CHART_FIELD_NAMES,
+    partition_filters, Bug, BugTemplate, CreateBugParams, FieldChange, FieldMapping, FieldValue,
+    HistoryEntry, IdListUpdate, QueryKind, SavedQuery, SearchParams, StatusTransition,
+    UpdateBugParams, FIELD_MAPPINGS,
 };
 pub use comment::{Comment, UpdateCommentTagsParams};
 pub use common::{

--- a/src/url_parser.rs
+++ b/src/url_parser.rs
@@ -422,57 +422,32 @@ mod tests {
 
     #[test]
     fn parses_known_name_into_suggested_name() {
-        let config = make_config("https://bugzilla.example.com");
-        let result = parse_bugzilla_url(
-            "https://bugzilla.example.com/buglist.cgi?product=Firefox&known_name=my%20saved%20search",
-            &config,
-        )
-        .unwrap();
-        assert_eq!(result.suggested_name, Some("my saved search".into()));
+        let parsed = parse_test_url("product=Firefox&known_name=my%20saved%20search");
+        assert_eq!(parsed.suggested_name, Some("my saved search".into()));
     }
 
     #[test]
     fn prefers_known_name_over_query_based_on() {
-        let config = make_config("https://bugzilla.example.com");
-        let result = parse_bugzilla_url(
-            "https://bugzilla.example.com/buglist.cgi?product=Firefox&known_name=preferred&query_based_on=ancestor",
-            &config,
-        )
-        .unwrap();
-        assert_eq!(result.suggested_name, Some("preferred".into()));
+        let parsed = parse_test_url("product=Firefox&known_name=preferred&query_based_on=ancestor");
+        assert_eq!(parsed.suggested_name, Some("preferred".into()));
     }
 
     #[test]
     fn falls_back_to_query_based_on() {
-        let config = make_config("https://bugzilla.example.com");
-        let result = parse_bugzilla_url(
-            "https://bugzilla.example.com/buglist.cgi?product=Firefox&query_based_on=ancestor%20query",
-            &config,
-        )
-        .unwrap();
-        assert_eq!(result.suggested_name, Some("ancestor query".into()));
+        let parsed = parse_test_url("product=Firefox&query_based_on=ancestor%20query");
+        assert_eq!(parsed.suggested_name, Some("ancestor query".into()));
     }
 
     #[test]
     fn no_suggested_name_when_absent() {
-        let config = make_config("https://bugzilla.example.com");
-        let result = parse_bugzilla_url(
-            "https://bugzilla.example.com/buglist.cgi?product=Firefox",
-            &config,
-        )
-        .unwrap();
-        assert!(result.suggested_name.is_none());
+        let parsed = parse_test_url("product=Firefox");
+        assert!(parsed.suggested_name.is_none());
     }
 
     #[test]
     fn empty_known_name_ignored() {
-        let config = make_config("https://bugzilla.example.com");
-        let result = parse_bugzilla_url(
-            "https://bugzilla.example.com/buglist.cgi?product=Firefox&known_name=",
-            &config,
-        )
-        .unwrap();
-        assert!(result.suggested_name.is_none());
+        let parsed = parse_test_url("product=Firefox&known_name=");
+        assert!(parsed.suggested_name.is_none());
     }
 
     #[test]

--- a/src/url_parser.rs
+++ b/src/url_parser.rs
@@ -4,7 +4,7 @@ use url::Url;
 
 use crate::config::Config;
 use crate::error::{BzrError, Result};
-use crate::types::{QueryKind, SavedQuery};
+use crate::types::{QueryKind, SavedQuery, FIELD_MAPPINGS};
 
 /// Parameters containing credentials that must not be stored or forwarded.
 const CREDENTIAL_PARAMS: &[&str] = &["bugzilla_api_key", "token", "api_key"];
@@ -97,19 +97,11 @@ pub fn parse_bugzilla_url(url_str: &str, config: &Config) -> Result<ParsedUrl> {
         }
 
         // Recognized vec fields — map Bugzilla URL param names to SavedQuery fields
-        let target = match key {
-            "product" => Some(&mut query.product),
-            "component" => Some(&mut query.component),
-            "bug_status" => Some(&mut query.status),
-            "assigned_to" => Some(&mut query.assignee),
-            "reporter" => Some(&mut query.creator),
-            "priority" => Some(&mut query.priority),
-            "bug_severity" => Some(&mut query.severity),
-            _ => None,
-        };
-        if let Some(target) = target {
-            target.push(value.to_string());
-            continue;
+        if let Some(mapping) = FIELD_MAPPINGS.iter().find(|m| m.url_param == key) {
+            if let Some(target) = query.get_field_mut(mapping.struct_field) {
+                target.push(value.to_string());
+                continue;
+            }
         }
 
         // Strip credential params — never store or forward these

--- a/src/url_parser.rs
+++ b/src/url_parser.rs
@@ -111,12 +111,18 @@ pub fn parse_bugzilla_url(url_str: &str, config: &Config) -> Result<ParsedUrl> {
             continue;
         }
 
-        // Recognized vec fields — map Bugzilla URL param names to SavedQuery fields
+        // Recognized vec fields — map Bugzilla URL param names to SavedQuery fields.
+        // get_field_mut is guaranteed to return Some for any struct_field in
+        // FIELD_MAPPINGS — a None here means the two tables are out of sync.
         if let Some(mapping) = FIELD_MAPPINGS.iter().find(|m| m.url_param == key) {
-            if let Some(target) = query.get_field_mut(mapping.struct_field) {
-                target.push(value.to_string());
-                continue;
-            }
+            let Some(target) = query.get_field_mut(mapping.struct_field) else {
+                unreachable!(
+                    "FIELD_MAPPINGS struct_field '{}' missing from get_field_mut",
+                    mapping.struct_field
+                );
+            };
+            target.push(value.to_string());
+            continue;
         }
 
         // Strip credential params — never store or forward these

--- a/src/url_parser.rs
+++ b/src/url_parser.rs
@@ -10,18 +10,14 @@ use crate::types::{QueryKind, SavedQuery, FIELD_MAPPINGS};
 const CREDENTIAL_PARAMS: &[&str] = &["bugzilla_api_key", "token", "api_key"];
 
 /// Parameters ignored during URL parsing (display/session metadata).
-const IGNORED_PARAMS: &[&str] = &[
-    "columnlist",
-    "list_id",
-    "query_format",
-    "known_name",
-    "query_based_on",
-];
+const IGNORED_PARAMS: &[&str] = &["columnlist", "list_id", "query_format"];
 
 /// Result of parsing a Bugzilla URL.
 #[derive(Debug)]
 pub struct ParsedUrl {
     pub query: SavedQuery,
+    /// Suggested name extracted from URL's `known_name` or `query_based_on` param.
+    pub suggested_name: Option<String>,
 }
 
 /// Strip credential query parameters from a URL, returning the sanitized string.
@@ -81,11 +77,30 @@ pub fn parse_bugzilla_url(url_str: &str, config: &Config) -> Result<ParsedUrl> {
         ..SavedQuery::default()
     };
 
+    let mut known_name: Option<String> = None;
+    let mut query_based_on: Option<String> = None;
+
     for (key, value) in url.query_pairs() {
         let key = key.as_ref();
         let value = value.as_ref();
 
         if IGNORED_PARAMS.contains(&key) {
+            continue;
+        }
+
+        if key == "known_name" {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                known_name = Some(trimmed.to_string());
+            }
+            continue;
+        }
+
+        if key == "query_based_on" {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                query_based_on = Some(trimmed.to_string());
+            }
             continue;
         }
 
@@ -113,7 +128,10 @@ pub fn parse_bugzilla_url(url_str: &str, config: &Config) -> Result<ParsedUrl> {
         query.raw_params.push((key.to_string(), value.to_string()));
     }
 
-    Ok(ParsedUrl { query })
+    Ok(ParsedUrl {
+        query,
+        suggested_name: known_name.or(query_based_on),
+    })
 }
 
 fn find_server_by_hostname<'a>(config: &'a Config, hostname: &str) -> Option<&'a str> {
@@ -394,6 +412,61 @@ mod tests {
             source.contains("product=Firefox"),
             "non-credential params should remain: {source}"
         );
+    }
+
+    #[test]
+    fn parses_known_name_into_suggested_name() {
+        let config = make_config("https://bugzilla.example.com");
+        let result = parse_bugzilla_url(
+            "https://bugzilla.example.com/buglist.cgi?product=Firefox&known_name=my%20saved%20search",
+            &config,
+        )
+        .unwrap();
+        assert_eq!(result.suggested_name, Some("my saved search".into()));
+    }
+
+    #[test]
+    fn prefers_known_name_over_query_based_on() {
+        let config = make_config("https://bugzilla.example.com");
+        let result = parse_bugzilla_url(
+            "https://bugzilla.example.com/buglist.cgi?product=Firefox&known_name=preferred&query_based_on=ancestor",
+            &config,
+        )
+        .unwrap();
+        assert_eq!(result.suggested_name, Some("preferred".into()));
+    }
+
+    #[test]
+    fn falls_back_to_query_based_on() {
+        let config = make_config("https://bugzilla.example.com");
+        let result = parse_bugzilla_url(
+            "https://bugzilla.example.com/buglist.cgi?product=Firefox&query_based_on=ancestor%20query",
+            &config,
+        )
+        .unwrap();
+        assert_eq!(result.suggested_name, Some("ancestor query".into()));
+    }
+
+    #[test]
+    fn no_suggested_name_when_absent() {
+        let config = make_config("https://bugzilla.example.com");
+        let result = parse_bugzilla_url(
+            "https://bugzilla.example.com/buglist.cgi?product=Firefox",
+            &config,
+        )
+        .unwrap();
+        assert!(result.suggested_name.is_none());
+    }
+
+    #[test]
+    fn empty_known_name_ignored() {
+        let config = make_config("https://bugzilla.example.com");
+        let result = parse_bugzilla_url(
+            "https://bugzilla.example.com/buglist.cgi?product=Firefox&known_name=",
+            &config,
+        )
+        .unwrap();
+        assert!(result.suggested_name.is_none());
     }
 
     #[test]

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -3,8 +3,7 @@ use std::collections::BTreeMap;
 use crate::error::{BzrError, Result};
 use crate::http::AUTH_QUERY_PARAM;
 use crate::types::{
-    partition_filters, Bug, CreateUserParams, GroupInfo, GroupMember, SearchParams,
-    BOOLEAN_CHART_FIELD_NAMES,
+    partition_filters, Bug, CreateUserParams, GroupInfo, GroupMember, SearchParams, FIELD_MAPPINGS,
 };
 use crate::xmlrpc::{self, Value};
 
@@ -75,16 +74,7 @@ impl XmlRpcClient {
 
         // Multi-value Vec fields: positive values sent as XML-RPC arrays,
         // negated values sent as fN/oN/vN boolean chart params.
-        let vec_fields: &[(&str, &[String])] = &[
-            ("product", &params.product),
-            ("component", &params.component),
-            ("status", &params.status),
-            ("assigned_to", &params.assigned_to),
-            ("creator", &params.creator),
-            ("priority", &params.priority),
-            ("severity", &params.severity),
-        ];
-        add_vec_filters(&mut rpc_params, vec_fields);
+        add_vec_filters(&mut rpc_params, params);
 
         // Single-value Option fields
         let option_fields: &[(&str, &Option<String>)] = &[
@@ -188,23 +178,16 @@ fn extract_id(response: &Value) -> Result<u64> {
     Ok(id as u64)
 }
 
-fn add_vec_filters(rpc_params: &mut BTreeMap<String, Value>, vec_fields: &[(&str, &[String])]) {
+fn add_vec_filters(rpc_params: &mut BTreeMap<String, Value>, params: &SearchParams) {
     let mut chart_idx = 1u32;
-    for &(key, values) in vec_fields {
-        let (positive, negated) = partition_filters(values);
+    for mapping in FIELD_MAPPINGS {
+        let (positive, negated) = partition_filters(params.get_field(mapping.struct_field));
         if !positive.is_empty() {
             let arr: Vec<Value> = positive.iter().map(|v| Value::from(*v)).collect();
-            rpc_params.insert(key.into(), Value::Array(arr));
+            rpc_params.insert(mapping.struct_field.into(), Value::Array(arr));
         }
-        if negated.is_empty() {
-            continue;
-        }
-        let chart_field = BOOLEAN_CHART_FIELD_NAMES
-            .iter()
-            .find(|&&(k, _)| k == key)
-            .map_or(key, |&(_, v)| v);
         for v in negated {
-            rpc_params.insert(format!("f{chart_idx}"), Value::from(chart_field));
+            rpc_params.insert(format!("f{chart_idx}"), Value::from(mapping.internal_name));
             rpc_params.insert(format!("o{chart_idx}"), Value::from("notequals"));
             rpc_params.insert(format!("v{chart_idx}"), Value::from(v));
             chart_idx += 1;


### PR DESCRIPTION
## Summary

Addresses 6 deferred review items from the `--from-url` PR (#94):

- **#88** — Replace `BOOLEAN_CHART_FIELD_NAMES` and 3 inline field arrays with a single `FIELD_MAPPINGS` table + `get_field`/`get_field_mut` accessors
- **#89** — Add consuming `into_search_params(self)` to avoid cloning; `to_search_params` delegates to it
- **#90** — Migrate `output/query.rs` from `println!` to `writeln!(io::stdout())`
- **#91** — Reject negated filters combined with raw boolean chart params (`InputValidation` error)
- **#92** — `--save-as` optionally derives name from URL's `known_name` parameter
- **#93** — Server override test now verifies override of a different saved server with `.expect(1)`

Closes #88, closes #89, closes #90, closes #91, closes #92, closes #93

## Test plan

- [ ] `cargo test` — 666 tests pass (609 lib + 14 integration + 43 doc)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] Verify `BOOLEAN_CHART_FIELD_NAMES` no longer exists in source
- [ ] Verify no `println!` remains in `output/query.rs`
- [ ] Test `--save-as` without a name on a URL with `known_name`
- [ ] Test `--save-as` without a name on a URL without `known_name` (should error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)