### PR TITLE
fix: show full error chain for HTTP errors and strip shell-escaped URLs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -105,8 +105,9 @@ pub(crate) fn format_error_chain(err: &dyn std::error::Error) -> String {
 
 /// Format a reqwest error for display: redact API keys and add TLS hints.
 fn format_http_error(err: &reqwest::Error) -> String {
-    let mut msg = redact_api_key(&format_error_chain(err));
-    if crate::http::is_tls_cert_error(err) {
+    let chain = format_error_chain(err);
+    let mut msg = redact_api_key(&chain);
+    if err.is_connect() && crate::http::looks_like_tls_error(&chain) {
         msg.push_str(
             "\n  hint: if this server uses a self-signed certificate or sits \
              behind a TLS-intercepting proxy, re-run:\n    \

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,21 +86,26 @@ const EXIT_CODE_KEYRING: i32 = 12;
 /// Used for retry logic in hybrid mode when extensions crash.
 pub const BUGZILLA_INTERNAL_ERROR: i64 = 100_500;
 
-/// Format a reqwest error for display: redact API keys and add TLS hints.
+/// Walk a `std::error::Error` source chain into a single string.
 ///
-/// reqwest's `Display` impl only shows the error kind and URL, omitting
-/// the source chain (which contains the actual cause like "connection
-/// refused" or "certificate verify failed"). We walk the source chain
-/// manually to build a complete, actionable error message.
-fn format_http_error(err: &reqwest::Error) -> String {
+/// reqwest's `Display` only shows the error kind and URL, omitting the
+/// underlying cause. This helper concatenates the full chain so callers
+/// get actionable messages like "error sending request …: invalid peer
+/// certificate: `UnknownIssuer`".
+pub(crate) fn format_error_chain(err: &dyn std::error::Error) -> String {
     let mut full = err.to_string();
-    let mut source = std::error::Error::source(err);
+    let mut source = err.source();
     while let Some(cause) = source {
         full.push_str(": ");
         full.push_str(&cause.to_string());
         source = cause.source();
     }
-    let mut msg = redact_api_key(&full);
+    full
+}
+
+/// Format a reqwest error for display: redact API keys and add TLS hints.
+fn format_http_error(err: &reqwest::Error) -> String {
+    let mut msg = redact_api_key(&format_error_chain(err));
     if crate::http::is_tls_cert_error(err) {
         msg.push_str(
             "\n  hint: if this server uses a self-signed certificate or sits \

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,8 +87,20 @@ const EXIT_CODE_KEYRING: i32 = 12;
 pub const BUGZILLA_INTERNAL_ERROR: i64 = 100_500;
 
 /// Format a reqwest error for display: redact API keys and add TLS hints.
+///
+/// reqwest's `Display` impl only shows the error kind and URL, omitting
+/// the source chain (which contains the actual cause like "connection
+/// refused" or "certificate verify failed"). We walk the source chain
+/// manually to build a complete, actionable error message.
 fn format_http_error(err: &reqwest::Error) -> String {
-    let mut msg = redact_api_key(&err.to_string());
+    let mut full = err.to_string();
+    let mut source = std::error::Error::source(err);
+    while let Some(cause) = source {
+        full.push_str(": ");
+        full.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    let mut msg = redact_api_key(&full);
     if crate::http::is_tls_cert_error(err) {
         msg.push_str(
             "\n  hint: if this server uses a self-signed certificate or sits \
@@ -341,5 +353,40 @@ mod tests {
         assert_eq!(err.exit_code(), 12);
         assert_eq!(err.error_type(), "keyring");
         assert_eq!(err.to_string(), "keyring error: keychain locked");
+    }
+
+    /// reqwest's `Display` omits the source chain (e.g. "connection refused").
+    /// Verify that `format_http_error` walks the chain so the user sees the
+    /// actual cause, not just "error sending request for url (URL)".
+    #[tokio::test]
+    async fn format_http_error_includes_source_chain() {
+        let client = reqwest::Client::builder().build().unwrap();
+        // Connect to a port that is almost certainly not listening.
+        let err = client
+            .get("http://127.0.0.1:1/unreachable")
+            .send()
+            .await
+            .unwrap_err();
+
+        // reqwest Display: only kind + URL, no cause
+        let display_only = err.to_string();
+        assert!(
+            display_only.contains("error sending request"),
+            "expected reqwest error kind: {display_only}"
+        );
+
+        let formatted = format_http_error(&err);
+        // Our formatter must include the underlying OS-level cause
+        assert!(
+            formatted.len() > display_only.len(),
+            "format_http_error should include source chain, got: {formatted}"
+        );
+        // The source chain should mention connection-level detail
+        assert!(
+            formatted.contains("connect")
+                || formatted.contains("refused")
+                || formatted.contains("tcp"),
+            "expected connection-level detail in: {formatted}"
+        );
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -67,21 +67,15 @@ pub(crate) fn build_http_client(
         .build()
 }
 
+/// Check if an error message string contains TLS-related keywords.
+pub(crate) fn looks_like_tls_error(msg: &str) -> bool {
+    let lower = msg.to_ascii_lowercase();
+    lower.contains("cert") || lower.contains("ssl") || lower.contains("tls")
+}
+
 /// Check if a reqwest error looks like a TLS certificate verification failure.
-///
-/// reqwest's `Display` (and `{:#}`) only shows the error kind and URL,
-/// so we walk the `.source()` chain to find TLS keywords that live in
-/// the underlying `hyper` / `rustls` errors.
 pub(crate) fn is_tls_cert_error(err: &reqwest::Error) -> bool {
-    if !err.is_connect() {
-        return false;
-    }
-    let full = crate::error::format_error_chain(err);
-    let lower = full.to_ascii_lowercase();
-    lower.contains("certificate")
-        || lower.contains("cert")
-        || lower.contains("ssl")
-        || lower.contains("tls")
+    err.is_connect() && looks_like_tls_error(&crate::error::format_error_chain(err))
 }
 
 /// Append a `--tls-insecure` hint to a message when a TLS certificate

--- a/src/http.rs
+++ b/src/http.rs
@@ -68,17 +68,20 @@ pub(crate) fn build_http_client(
 }
 
 /// Check if a reqwest error looks like a TLS certificate verification failure.
+///
+/// reqwest's `Display` (and `{:#}`) only shows the error kind and URL,
+/// so we walk the `.source()` chain to find TLS keywords that live in
+/// the underlying `hyper` / `rustls` errors.
 pub(crate) fn is_tls_cert_error(err: &reqwest::Error) -> bool {
     if !err.is_connect() {
         return false;
     }
-    let msg = format!("{err:#}");
-    let lower = msg.to_ascii_lowercase();
+    let full = crate::error::format_error_chain(err);
+    let lower = full.to_ascii_lowercase();
     lower.contains("certificate")
         || lower.contains("cert")
         || lower.contains("ssl")
         || lower.contains("tls")
-        || lower.contains("invalid peer certificate")
 }
 
 /// Append a `--tls-insecure` hint to a message when a TLS certificate

--- a/src/url_parser.rs
+++ b/src/url_parser.rs
@@ -36,6 +36,33 @@ fn sanitize_url(url: &Url) -> String {
     sanitized.to_string()
 }
 
+/// Strip backslashes that precede URL-significant characters (`?`, `&`, `=`).
+///
+/// When a user pastes a raw URL into zsh without quotes, the shell
+/// auto-escapes these characters (e.g. `buglist.cgi\?foo\=bar\&baz`).
+/// If the escaped form is then quoted or copied, the backslashes become
+/// literal and pollute every query-param name and value (`chfield%5C`).
+/// Backslashes before these characters are never valid in HTTP URLs, so
+/// stripping them is always safe.
+fn strip_shell_backslashes(url: &str) -> String {
+    if !url.contains('\\') {
+        return url.to_string();
+    }
+    tracing::warn!(
+        "URL contains backslash-escaped characters (e.g. \\? \\& \\=); \
+         stripping shell escapes — quote the URL to avoid this"
+    );
+    let mut out = String::with_capacity(url.len());
+    let mut chars = url.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' && matches!(chars.peek(), Some('?' | '&' | '=' | '%')) {
+            continue; // drop the backslash, keep the next char
+        }
+        out.push(ch);
+    }
+    out
+}
+
 /// Parse a Bugzilla `buglist.cgi` URL into a `SavedQuery`.
 ///
 /// Recognized parameters are mapped to structured `SavedQuery` fields.
@@ -43,8 +70,9 @@ fn sanitize_url(url: &Url) -> String {
 /// passthrough to the REST API. Display/session params are ignored.
 /// Credential parameters are stripped from both `source_url` and `raw_params`.
 pub fn parse_bugzilla_url(url_str: &str, config: &Config) -> Result<ParsedUrl> {
+    let cleaned = strip_shell_backslashes(url_str);
     let url =
-        Url::parse(url_str).map_err(|e| BzrError::InputValidation(format!("invalid URL: {e}")))?;
+        Url::parse(&cleaned).map_err(|e| BzrError::InputValidation(format!("invalid URL: {e}")))?;
 
     if !url.path().contains("buglist.cgi") {
         return Err(BzrError::InputValidation(
@@ -468,5 +496,44 @@ mod tests {
                     .any(|k| k.to_ascii_lowercase().contains("key")
                         || k.eq_ignore_ascii_case("token"))
         );
+    }
+
+    #[test]
+    fn strip_shell_backslashes_cleans_escaped_url() {
+        let escaped =
+            r"https://bugzilla.example.com/buglist.cgi\?product\=Firefox\&bug_status\=NEW";
+        let cleaned = strip_shell_backslashes(escaped);
+        assert_eq!(
+            cleaned,
+            "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW"
+        );
+    }
+
+    #[test]
+    fn strip_shell_backslashes_preserves_clean_url() {
+        let clean = "https://bugzilla.example.com/buglist.cgi?product=Firefox";
+        let result = strip_shell_backslashes(clean);
+        assert_eq!(result, clean);
+    }
+
+    #[test]
+    fn strip_shell_backslashes_preserves_percent_encoding() {
+        // Backslash before % should be stripped; the %20 must survive intact
+        let escaped = r"https://bugzilla.example.com/buglist.cgi\?product\=PPC64\%20Development";
+        let cleaned = strip_shell_backslashes(escaped);
+        assert_eq!(
+            cleaned,
+            "https://bugzilla.example.com/buglist.cgi?product=PPC64%20Development"
+        );
+    }
+
+    #[test]
+    fn parse_url_with_shell_backslashes_succeeds() {
+        let config = make_config("https://bugzilla.example.com");
+        let escaped =
+            r"https://bugzilla.example.com/buglist.cgi\?product\=Firefox\&bug_status\=NEW";
+        let parsed = parse_bugzilla_url(escaped, &config).unwrap();
+        assert_eq!(parsed.query.product, vec!["Firefox"]);
+        assert_eq!(parsed.query.status, vec!["NEW"]);
     }
 }

--- a/src/url_parser.rs
+++ b/src/url_parser.rs
@@ -528,6 +528,22 @@ mod tests {
     }
 
     #[test]
+    fn strip_shell_backslashes_ignores_non_special() {
+        // Backslash before a non-URL-significant character is kept
+        let input = r"https://bugzilla.example.com/buglist.cgi?summary=foo\bar";
+        let result = strip_shell_backslashes(input);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn strip_shell_backslashes_trailing_backslash() {
+        // Trailing backslash with no following char is preserved
+        let input = r"https://bugzilla.example.com/buglist.cgi?product=Firefox\";
+        let result = strip_shell_backslashes(input);
+        assert_eq!(result, input);
+    }
+
+    #[test]
     fn parse_url_with_shell_backslashes_succeeds() {
         let config = make_config("https://bugzilla.example.com");
         let escaped =
@@ -535,5 +551,18 @@ mod tests {
         let parsed = parse_bugzilla_url(escaped, &config).unwrap();
         assert_eq!(parsed.query.product, vec!["Firefox"]);
         assert_eq!(parsed.query.status, vec!["NEW"]);
+    }
+
+    #[test]
+    fn parse_url_with_shell_backslashes_boolean_chart() {
+        let config = make_config("https://bugzilla.example.com");
+        let escaped = r"https://bugzilla.example.com/buglist.cgi\?f1\=qa_contact\&o1\=changedfrom\&v1\=user\%40example.com\&classification\=Community";
+        let parsed = parse_bugzilla_url(escaped, &config).unwrap();
+
+        let keys = raw_keys(&parsed);
+        assert!(keys.contains(&"f1"), "boolean chart f1 missing: {keys:?}");
+        assert!(keys.contains(&"o1"), "boolean chart o1 missing: {keys:?}");
+        assert_eq!(raw_value(&parsed, "v1"), "user@example.com");
+        assert_eq!(raw_value(&parsed, "classification"), "Community");
     }
 }

--- a/src/url_parser.rs
+++ b/src/url_parser.rs
@@ -56,7 +56,7 @@ fn strip_shell_backslashes(url: &str) -> String {
     let mut chars = url.chars().peekable();
     while let Some(ch) = chars.next() {
         if ch == '\\' && matches!(chars.peek(), Some('?' | '&' | '=' | '%')) {
-            continue; // drop the backslash, keep the next char
+            continue;
         }
         out.push(ch);
     }


### PR DESCRIPTION
## Summary

- **Show full HTTP error chain**: reqwest's `Display` only shows error kind and URL, omitting the source chain where the actual cause lives (e.g. "invalid peer certificate: UnknownIssuer", "connection refused"). Walk `Error::source()` to build complete, actionable error messages.
- **Fix TLS hint detection**: `is_tls_cert_error` used `format!("{err:#}")` which also omits the source chain, so the `--tls-insecure` hint never appeared for cert errors. Now uses the same chain-walking helper.
- **Strip shell-escaped backslashes from `--from-url`**: When pasting a URL into zsh without quotes, the shell auto-escapes `?`, `&`, `=` with backslashes. These literal backslashes pollute every query param (`chfield%5C=qa_contact%5C`). Detect and strip them with a warning.

Before:
```
error: HTTP request failed: error sending request for url (https://...)
```

After:
```
error: HTTP request failed: error sending request for url (https://...): client error (Connect): invalid peer certificate: UnknownIssuer
  hint: if this server uses a self-signed certificate or sits behind a TLS-intercepting proxy, re-run:
    bzr config set-server <NAME> ... --tls-insecure
```

## Test plan

- [x] `format_http_error_includes_source_chain` — verifies source chain appears in formatted error
- [x] `strip_shell_backslashes_*` — 5 unit tests covering clean URLs, escaped URLs, percent encoding, non-special chars, trailing backslash
- [x] `parse_url_with_shell_backslashes_*` — 2 end-to-end tests parsing escaped URLs into correct query structs
- [x] All 617 existing tests pass
- [x] Manual test against real Bugzilla server with untrusted cert confirms full error chain + TLS hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)