### PR TITLE
fix(tls): probe TLS at connect-time for cached servers

### DIFF
--- a/src/commands/shared.rs
+++ b/src/commands/shared.rs
@@ -33,10 +33,40 @@ fn persist_detected_settings(
 /// Returns `true` when the error is a TLS certificate verification failure
 /// and no trust mechanism (insecure, CA cert, or pin) is already configured.
 fn should_offer_tofu(err: &BzrError, tls_config: &TlsConfig) -> bool {
-    if tls_config.insecure || tls_config.ca_cert_path.is_some() || tls_config.pin_sha256.is_some() {
+    if !tls_uses_default_trust(tls_config) {
         return false;
     }
     matches!(err, BzrError::Http(e) if crate::http::is_tls_cert_error(e))
+}
+
+/// Check whether the connection relies on the default OS trust store with
+/// no user-configured anchor (insecure flag, custom CA, or pinned cert).
+///
+/// When this returns `true`, TLS errors at first contact are eligible for
+/// the TOFU prompt; when `false`, the user has already expressed how they
+/// want the server's certificate verified and we don't override that.
+fn tls_uses_default_trust(tls_config: &TlsConfig) -> bool {
+    !tls_config.insecure && tls_config.ca_cert_path.is_none() && tls_config.pin_sha256.is_none()
+}
+
+/// Probe TLS reachability with a single HEAD against the server URL.
+///
+/// Used on the cached connection path to surface certificate-verification
+/// errors at connect time instead of deferring them to the first real API
+/// call. The probe uses the user's configured `TlsConfig` (default trust
+/// store, custom CA, or pin) so any handshake failure mirrors what the
+/// real request would see.
+///
+/// HTTP-level responses (any status) are reported as `Ok(())` — the goal
+/// is purely to surface transport errors. Network/transport failures are
+/// returned as the original `BzrError::Http` so callers can classify them
+/// (TLS cert error, pin mismatch, etc.).
+async fn probe_tls(url: &str, tls_config: &TlsConfig) -> Result<()> {
+    let client = crate::tls::build_tls_client(tls_config)?;
+    match client.head(url).send().await {
+        Ok(_) => Ok(()),
+        Err(e) => Err(BzrError::Http(e)),
+    }
 }
 
 /// Check if a reqwest error contains a `PIN_MISMATCH` from the pinned verifier.
@@ -319,7 +349,34 @@ pub async fn connect_and_configure(
 
     // Three cases: fully cached, partially cached (auth only), or uncached.
     let (auth, resolved_mode) = match (srv.auth_method, srv.api_mode) {
-        (Some(method), Some(mode)) => (method, mode),
+        (Some(method), Some(mode)) => {
+            // Even with full cache, surface TLS errors at connect-time so
+            // the TOFU/rotation prompts can fire. Skipped when the user
+            // has already configured a trust mechanism (insecure / CA /
+            // pin) — in those cases either no verification happens or
+            // mismatches surface through the existing pinned-verifier
+            // error path.
+            if tls_uses_default_trust(&tls_config) {
+                if let Err(e) = probe_tls(&url, &tls_config).await {
+                    if should_offer_tofu(&e, &tls_config) {
+                        let client = handle_tofu(
+                            &server_name,
+                            &url,
+                            &api_key,
+                            email.as_deref(),
+                            api_override,
+                            &mut config,
+                        )
+                        .await?;
+                        return Ok(client);
+                    }
+                    // Non-TLS transport errors don't block: the actual
+                    // command will hit the same condition and report it
+                    // with full request context.
+                }
+            }
+            (method, mode)
+        }
         (Some(method), None) => {
             tracing::debug!("auth_method cached but api_mode missing; re-detecting");
             match detect_with_tofu_fallback(

--- a/src/commands/shared.rs
+++ b/src/commands/shared.rs
@@ -57,12 +57,17 @@ fn tls_uses_default_trust(tls_config: &TlsConfig) -> bool {
 /// store, custom CA, or pin) so any handshake failure mirrors what the
 /// real request would see.
 ///
+/// Redirects are not followed: the probe must validate only the
+/// certificate presented by the configured URL itself, otherwise a 301
+/// to a different host would lead the prompt to describe one endpoint
+/// while pinning (or PIN_MISMATCH-rotating against) another.
+///
 /// HTTP-level responses (any status) are reported as `Ok(())` — the goal
 /// is purely to surface transport errors. Network/transport failures are
 /// returned as the original `BzrError::Http` so callers can classify them
 /// (TLS cert error, pin mismatch, etc.).
 async fn probe_tls(url: &str, tls_config: &TlsConfig) -> Result<()> {
-    let client = crate::tls::build_tls_client(tls_config)?;
+    let client = crate::tls::build_probe_client(tls_config)?;
     match client.head(url).send().await {
         Ok(_) => Ok(()),
         Err(e) => Err(BzrError::Http(e)),

--- a/src/commands/shared.rs
+++ b/src/commands/shared.rs
@@ -260,6 +260,63 @@ async fn detect_and_build_client(
     )
 }
 
+/// Classify a TLS-layer failure and dispatch to the appropriate prompt.
+///
+/// Returns:
+/// - `Ok(Some(client))` — TOFU or rotation fired and produced a client.
+/// - `Ok(None)` — the error is not a TLS verification failure; caller
+///   should propagate the original error (or, on the probe path, ignore
+///   it and let the actual command surface it with full context).
+/// - `Err(_)` — issuer changed (treated as a hard failure with a clear
+///   remediation hint), or a downstream prompt/probe error.
+#[expect(clippy::too_many_arguments, reason = "private orchestration fn")]
+async fn classify_and_handle_tls_failure(
+    err: &BzrError,
+    server_name: &str,
+    url: &str,
+    api_key: &str,
+    email: Option<&str>,
+    api_override: Option<ApiMode>,
+    tls_config: &TlsConfig,
+    config: &mut Config,
+) -> Result<Option<BugzillaClient>> {
+    if should_offer_tofu(err, tls_config) {
+        let client = handle_tofu(server_name, url, api_key, email, api_override, config).await?;
+        return Ok(Some(client));
+    }
+    if is_pin_mismatch(err) {
+        let old_pin = tls_config.pin_sha256.as_deref().unwrap_or("<unknown>");
+        let chain = match err {
+            BzrError::Http(re) => crate::error::format_error_chain(re),
+            _ => String::new(),
+        };
+        let (new_fp, new_issuer) = parse_pin_mismatch_details(&chain)
+            .unwrap_or_else(|| ("<unknown>".to_string(), "<unknown>".to_string()));
+        let client = handle_pin_rotation(
+            server_name,
+            url,
+            api_key,
+            email,
+            api_override,
+            old_pin,
+            &new_fp,
+            &new_issuer,
+            config,
+        )
+        .await?;
+        return Ok(Some(client));
+    }
+    if is_issuer_changed(err) {
+        return Err(BzrError::config(format!(
+            "TLS certificate issuer changed for server \"{server_name}\" \
+                 — this could indicate a MITM attack.\n  \
+                 If this is expected, clear the pin and re-connect:\n    \
+                 bzr config set-server {server_name} --tls-pin-clear"
+        )));
+    }
+    Ok(None)
+}
+
 /// Run `detect_server_settings` and handle TLS errors with TOFU or
 /// pin rotation flows as appropriate.
 async fn detect_with_tofu_fallback(
@@ -271,44 +328,24 @@ async fn detect_with_tofu_fallback(
     tls_config: &TlsConfig,
     config: &mut Config,
 ) -> Result<DetectOrClient> {
-    let result = crate::client::detect_server_settings(url, api_key, email, tls_config).await;
-
-    match result {
-        Ok(settings) => Ok(DetectOrClient::Settings(settings)),
-        Err(ref e) if should_offer_tofu(e, tls_config) => {
-            let client =
-                handle_tofu(server_name, url, api_key, email, api_override, config).await?;
-            Ok(DetectOrClient::Client(client))
-        }
-        Err(ref e) if is_pin_mismatch(e) => {
-            let old_pin = tls_config.pin_sha256.as_deref().unwrap_or("<unknown>");
-            let chain = match e {
-                BzrError::Http(re) => crate::error::format_error_chain(re),
-                _ => String::new(),
-            };
-            let (new_fp, new_issuer) = parse_pin_mismatch_details(&chain)
-                .unwrap_or_else(|| ("<unknown>".to_string(), "<unknown>".to_string()));
-            let client = handle_pin_rotation(
-                server_name,
-                url,
-                api_key,
-                email,
-                api_override,
-                old_pin,
-                &new_fp,
-                &new_issuer,
-                config,
-            )
-            .await?;
-            Ok(DetectOrClient::Client(client))
-        }
-        Err(ref e) if is_issuer_changed(e) => Err(BzrError::config(format!(
-            "TLS certificate issuer changed for server \"{server_name}\" \
-                 — this could indicate a MITM attack.\n  \
-                 If this is expected, clear the pin and re-connect:\n    \
-                 bzr config set-server {server_name} --tls-pin-clear"
-        ))),
-        Err(e) => Err(e),
+    let err = match crate::client::detect_server_settings(url, api_key, email, tls_config).await {
+        Ok(settings) => return Ok(DetectOrClient::Settings(settings)),
+        Err(e) => e,
+    };
+    match classify_and_handle_tls_failure(
+        &err,
+        server_name,
+        url,
+        api_key,
+        email,
+        api_override,
+        tls_config,
+        config,
+    )
+    .await?
+    {
+        Some(client) => Ok(DetectOrClient::Client(client)),
+        None => Err(err),
     }
 }
 
@@ -351,23 +388,25 @@ pub async fn connect_and_configure(
     let (auth, resolved_mode) = match (srv.auth_method, srv.api_mode) {
         (Some(method), Some(mode)) => {
             // Even with full cache, surface TLS errors at connect-time so
-            // the TOFU/rotation prompts can fire. Skipped when the user
-            // has already configured a trust mechanism (insecure / CA /
-            // pin) — in those cases either no verification happens or
-            // mismatches surface through the existing pinned-verifier
-            // error path.
-            if tls_uses_default_trust(&tls_config) {
+            // TOFU and pin-rotation prompts can fire. Skipped only when
+            // verification is explicitly disabled (`tls_insecure`); for
+            // pinned servers and custom-CA servers we still probe so a
+            // rotated cert / issuer change is caught here rather than at
+            // the first real API call.
+            if !tls_config.insecure {
                 if let Err(e) = probe_tls(&url, &tls_config).await {
-                    if should_offer_tofu(&e, &tls_config) {
-                        let client = handle_tofu(
-                            &server_name,
-                            &url,
-                            &api_key,
-                            email.as_deref(),
-                            api_override,
-                            &mut config,
-                        )
-                        .await?;
+                    if let Some(client) = classify_and_handle_tls_failure(
+                        &e,
+                        &server_name,
+                        &url,
+                        &api_key,
+                        email.as_deref(),
+                        api_override,
+                        &tls_config,
+                        &mut config,
+                    )
+                    .await?
+                    {
                         return Ok(client);
                     }
                     // Non-TLS transport errors don't block: the actual

--- a/src/commands/shared_tests.rs
+++ b/src/commands/shared_tests.rs
@@ -691,9 +691,10 @@ fn tls_uses_default_trust_false_when_pin_set() {
     assert!(!super::tls_uses_default_trust(&tls));
 }
 
-/// Cached-path connect should probe TLS via a HEAD request when no trust
-/// mechanism is configured, so TLS cert errors surface at connect-time
-/// rather than being deferred to the first real API call.
+/// Cached-path connect should probe TLS via a HEAD request whenever
+/// verification is enabled, so TLS cert errors (TOFU, pin mismatch,
+/// issuer change) surface at connect-time rather than being deferred to
+/// the first real API call.
 #[tokio::test]
 async fn cached_path_probes_tls_when_default_trust() {
     let _lock = ENV_LOCK.lock().await;
@@ -723,9 +724,39 @@ async fn cached_path_probes_tls_when_default_trust() {
     // Mock expectation verified on drop.
 }
 
-/// Cached-path connect should NOT probe when a trust mechanism (pin, CA,
-/// or insecure) is configured — those cases either pin to an explicit
-/// fingerprint (rotation handled separately) or bypass verification.
+/// Pinned cached path must also probe — without this, a rotated cert
+/// would only surface lazily from the first real API call, bypassing
+/// the rotation prompt.
+#[tokio::test]
+async fn cached_path_probes_tls_when_pinned() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock = MockServer::start().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    // Cached config with a pinned fingerprint. Wiremock is HTTP, so the
+    // pinned verifier is never invoked; the probe HEAD reaches the
+    // server normally and returns 404.
+    write_config(
+        &tmp,
+        &mock.uri(),
+        "auth_method = \"header\"\napi_mode = \"rest\"\n\
+         tls_pin_sha256 = \"sha256//AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\"",
+    );
+
+    Mock::given(method("HEAD"))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let result = super::connect_and_configure(None, None).await;
+    assert!(
+        result.is_ok(),
+        "cached path with pinned cert should still succeed after probe"
+    );
+}
+
+/// Cached-path connect should NOT probe when verification is explicitly
+/// disabled — there is no TLS error class to surface in that mode.
 #[tokio::test]
 async fn cached_path_skips_probe_when_insecure() {
     let _lock = ENV_LOCK.lock().await;
@@ -737,8 +768,7 @@ async fn cached_path_skips_probe_when_insecure() {
         "auth_method = \"header\"\napi_mode = \"rest\"\ntls_insecure = true",
     );
 
-    // Assert HEAD never reaches the server when trust is explicitly
-    // configured (here, insecure).
+    // Assert HEAD never reaches the server when verification is off.
     Mock::given(method("HEAD"))
         .respond_with(ResponseTemplate::new(200))
         .expect(0)
@@ -748,6 +778,6 @@ async fn cached_path_skips_probe_when_insecure() {
     let result = super::connect_and_configure(None, None).await;
     assert!(
         result.is_ok(),
-        "cached path with explicit trust should skip probe"
+        "cached path with insecure flag should skip probe"
     );
 }

--- a/src/commands/shared_tests.rs
+++ b/src/commands/shared_tests.rs
@@ -755,6 +755,46 @@ async fn cached_path_probes_tls_when_pinned() {
     );
 }
 
+/// The probe must not follow HTTP redirects. If it did, a 301/302 from
+/// the configured server URL to a different host would pin (or
+/// `PIN_MISMATCH` against) the redirect target's certificate — i.e., the
+/// prompt would describe one endpoint while validating another.
+#[tokio::test]
+async fn cached_path_probe_does_not_follow_redirects() {
+    let _lock = ENV_LOCK.lock().await;
+    let primary = MockServer::start().await;
+    let secondary = MockServer::start().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    write_config(
+        &tmp,
+        &primary.uri(),
+        "auth_method = \"header\"\napi_mode = \"rest\"",
+    );
+
+    // Primary: 301 -> secondary URI. Secondary: any HEAD must NOT be
+    // received (probe should treat the 301 as a completed handshake and
+    // stop there).
+    Mock::given(method("HEAD"))
+        .respond_with(
+            ResponseTemplate::new(301).insert_header("Location", secondary.uri().as_str()),
+        )
+        .expect(1)
+        .mount(&primary)
+        .await;
+    Mock::given(method("HEAD"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&secondary)
+        .await;
+
+    let result = super::connect_and_configure(None, None).await;
+    assert!(
+        result.is_ok(),
+        "probe should treat 301 as connect-success and not chase redirects"
+    );
+    // Secondary's expect(0) verified on drop — no hit means no redirect followed.
+}
+
 /// Cached-path connect should NOT probe when verification is explicitly
 /// disabled — there is no TLS error class to surface in that mode.
 #[tokio::test]

--- a/src/commands/shared_tests.rs
+++ b/src/commands/shared_tests.rs
@@ -658,3 +658,96 @@ fn parse_pin_mismatch_handles_marker_at_start() {
     assert_eq!(fp, "new");
     assert_eq!(issuer, "CN=X");
 }
+
+#[test]
+fn tls_uses_default_trust_true_for_default_config() {
+    assert!(super::tls_uses_default_trust(&TlsConfig::default()));
+}
+
+#[test]
+fn tls_uses_default_trust_false_when_insecure() {
+    let tls = TlsConfig {
+        insecure: true,
+        ..Default::default()
+    };
+    assert!(!super::tls_uses_default_trust(&tls));
+}
+
+#[test]
+fn tls_uses_default_trust_false_when_ca_cert_set() {
+    let tls = TlsConfig {
+        ca_cert_path: Some("/path/to/ca.pem".into()),
+        ..Default::default()
+    };
+    assert!(!super::tls_uses_default_trust(&tls));
+}
+
+#[test]
+fn tls_uses_default_trust_false_when_pin_set() {
+    let tls = TlsConfig {
+        pin_sha256: Some("sha256//AAAA".into()),
+        ..Default::default()
+    };
+    assert!(!super::tls_uses_default_trust(&tls));
+}
+
+/// Cached-path connect should probe TLS via a HEAD request when no trust
+/// mechanism is configured, so TLS cert errors surface at connect-time
+/// rather than being deferred to the first real API call.
+#[tokio::test]
+async fn cached_path_probes_tls_when_default_trust() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock = MockServer::start().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    write_config(
+        &tmp,
+        &mock.uri(),
+        "auth_method = \"header\"\napi_mode = \"rest\"",
+    );
+
+    // The probe sends a HEAD to the server URL. Wiremock returns 404 for
+    // unmounted paths; the probe treats any non-transport error response
+    // as "TLS handshake completed, no error to surface." We mount an
+    // explicit expectation here to assert the probe actually fires.
+    Mock::given(method("HEAD"))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let result = super::connect_and_configure(None, None).await;
+    assert!(
+        result.is_ok(),
+        "cached path with default trust should still succeed after probe"
+    );
+    // Mock expectation verified on drop.
+}
+
+/// Cached-path connect should NOT probe when a trust mechanism (pin, CA,
+/// or insecure) is configured — those cases either pin to an explicit
+/// fingerprint (rotation handled separately) or bypass verification.
+#[tokio::test]
+async fn cached_path_skips_probe_when_insecure() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock = MockServer::start().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    write_config(
+        &tmp,
+        &mock.uri(),
+        "auth_method = \"header\"\napi_mode = \"rest\"\ntls_insecure = true",
+    );
+
+    // Assert HEAD never reaches the server when trust is explicitly
+    // configured (here, insecure).
+    Mock::given(method("HEAD"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let result = super::connect_and_configure(None, None).await;
+    assert!(
+        result.is_ok(),
+        "cached path with explicit trust should skip probe"
+    );
+}

--- a/src/commands/shared_tests.rs
+++ b/src/commands/shared_tests.rs
@@ -795,6 +795,85 @@ async fn cached_path_probe_does_not_follow_redirects() {
     // Secondary's expect(0) verified on drop — no hit means no redirect followed.
 }
 
+/// `classify_and_handle_tls_failure` must silently pass through non-TLS
+/// transport errors so the cached-path probe doesn't block on transient
+/// network issues. The actual command will surface the same error with
+/// full request context.
+#[tokio::test]
+async fn classify_and_handle_tls_failure_returns_none_for_non_tls_error() {
+    // Build a real reqwest::Error from a connection failure — error
+    // chain contains no TLS markers, so all three predicates miss.
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_millis(50))
+        .build()
+        .unwrap();
+    let err = client
+        .get("http://127.0.0.1:1/unreachable")
+        .send()
+        .await
+        .unwrap_err();
+    let bzr_err = BzrError::Http(err);
+
+    let mut config = crate::config::Config::default();
+    let tls_config = TlsConfig::default();
+    let result = super::classify_and_handle_tls_failure(
+        &bzr_err,
+        "test",
+        "http://127.0.0.1:1/unreachable",
+        "key",
+        None,
+        None,
+        &tls_config,
+        &mut config,
+    )
+    .await;
+    match result {
+        Ok(None) => {}
+        Ok(Some(_)) => panic!("expected Ok(None) for non-TLS error, got Some(client)"),
+        Err(e) => panic!("expected Ok(None) for non-TLS error, got Err: {e}"),
+    }
+}
+
+/// `probe_tls` must return `Err` (wrapped in `BzrError::Http`) when the
+/// underlying request fails on transport. The cached-path branch then
+/// delegates to `classify_and_handle_tls_failure`, which for non-TLS
+/// errors returns `Ok(None)` and the cached values flow through.
+#[tokio::test]
+async fn probe_tls_returns_err_on_unreachable_address() {
+    let tls_config = TlsConfig::default();
+    let result = super::probe_tls("http://127.0.0.1:1/unreachable", &tls_config).await;
+    match result {
+        Err(BzrError::Http(_)) => {}
+        Err(other) => panic!("expected Http error, got {other:?}"),
+        Ok(()) => panic!("expected probe to fail against unreachable address"),
+    }
+}
+
+/// Cached-path with default trust where the probe fails on a non-TLS
+/// transport error: the connect call should still succeed (returning
+/// the cached client) because non-TLS probe failures are silent.
+#[tokio::test]
+async fn cached_path_proceeds_when_probe_fails_on_non_tls_error() {
+    let _lock = ENV_LOCK.lock().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    // Point the configured server at an unreachable port so probe_tls
+    // returns Err with a non-TLS connection error. classify_and_handle
+    // _tls_failure should return Ok(None) for that, and the cached
+    // path should fall through to building the client with cached
+    // settings.
+    write_config(
+        &tmp,
+        "http://127.0.0.1:1",
+        "auth_method = \"header\"\napi_mode = \"rest\"",
+    );
+
+    let result = super::connect_and_configure(None, None).await;
+    assert!(
+        result.is_ok(),
+        "non-TLS probe failures must not block the cached path"
+    );
+}
+
 /// Cached-path connect should NOT probe when verification is explicitly
 /// disabled — there is no TLS error class to surface in that mode.
 #[tokio::test]

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -37,18 +37,17 @@ pub struct TlsConfig {
     pub server_name: Option<String>,
 }
 
-/// Build a `reqwest::Client` with the appropriate TLS configuration.
+/// Apply the verification mode encoded in `TlsConfig` to a builder.
 ///
-/// Selects the verification mode based on `TlsConfig` fields:
+/// Selects:
 /// 1. `insecure` — accept all certs (`danger_accept_invalid_certs`)
 /// 2. `ca_cert_path` — custom CA added to root store
 /// 3. `pin_sha256` — pinned certificate fingerprint verification
 /// 4. None — default system roots
-pub fn build_tls_client(config: &TlsConfig) -> crate::error::Result<reqwest::Client> {
-    let mut builder = reqwest::Client::builder()
-        .connect_timeout(crate::http::CONNECT_TIMEOUT)
-        .timeout(crate::http::REQUEST_TIMEOUT);
-
+fn apply_tls_verification(
+    mut builder: reqwest::ClientBuilder,
+    config: &TlsConfig,
+) -> crate::error::Result<reqwest::ClientBuilder> {
     if config.insecure {
         builder = builder.danger_accept_invalid_certs(true);
     } else if let Some(ca_path) = &config.ca_cert_path {
@@ -63,8 +62,36 @@ pub fn build_tls_client(config: &TlsConfig) -> crate::error::Result<reqwest::Cli
         )?;
         builder = builder.use_preconfigured_tls(tls_config);
     }
+    Ok(builder)
+}
 
-    builder.build().map_err(crate::error::BzrError::Http)
+/// Build a `reqwest::Client` with the configured TLS verification mode.
+/// Used for real API calls; follows redirects per reqwest defaults.
+pub fn build_tls_client(config: &TlsConfig) -> crate::error::Result<reqwest::Client> {
+    let builder = reqwest::Client::builder()
+        .connect_timeout(crate::http::CONNECT_TIMEOUT)
+        .timeout(crate::http::REQUEST_TIMEOUT);
+    apply_tls_verification(builder, config)?
+        .build()
+        .map_err(crate::error::BzrError::Http)
+}
+
+/// Build a `reqwest::Client` for cert-detection probes.
+///
+/// Same TLS verification mode as `build_tls_client`, but redirects are
+/// disabled so the probe only validates the certificate presented by the
+/// configured URL itself. Following a redirect off-host would surface a
+/// TLS error (or pin mismatch) for an endpoint the user did not
+/// configure, and any subsequent prompt would describe one host while
+/// trusting another.
+pub(crate) fn build_probe_client(config: &TlsConfig) -> crate::error::Result<reqwest::Client> {
+    let builder = reqwest::Client::builder()
+        .connect_timeout(crate::http::CONNECT_TIMEOUT)
+        .timeout(crate::http::REQUEST_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none());
+    apply_tls_verification(builder, config)?
+        .build()
+        .map_err(crate::error::BzrError::Http)
 }
 
 #[cfg(test)]

--- a/src/tls/tofu.rs
+++ b/src/tls/tofu.rs
@@ -81,10 +81,15 @@ pub(crate) async fn probe_server_cert(url: &str) -> Result<(String, String, Opti
         .with_custom_certificate_verifier(capture.clone())
         .with_no_client_auth();
 
+    // Redirects are disabled: the captured certificate must belong to
+    // the configured URL itself. Following a 301/302 off-host would
+    // record a different server's cert and the subsequent prompt would
+    // describe one endpoint while pinning another.
     let client = reqwest::Client::builder()
         .use_preconfigured_tls(tls_config)
         .connect_timeout(crate::http::CONNECT_TIMEOUT)
         .timeout(crate::http::REQUEST_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|e| BzrError::config(format!("failed to build TLS probe client: {e}")))?;
 


### PR DESCRIPTION
## Summary

Closes a defect found during v0.2.0-rc1 soak: when both `auth_method` and `api_mode` are cached for a server, `connect_and_configure` returned the client without probing TLS, so the existing TOFU/rotation prompts in `detect_with_tofu_fallback` were never reached. Users hitting an untrusted-CA Bugzilla on a cached server saw the bare reqwest cert error and the misleading "re-run interactively" hint, but no prompt ever fired.

This branch is three commits, each closing a strictly wider scope of the same root cause (lazy TLS verification on the cached path):

1. `0019ef2` — eager probe + TOFU dispatch for default-trust cached servers (the originally-reported scenario).
2. `f5d7d89` — extends the probe to pinned/custom-CA cached servers and consolidates dispatch into a shared `classify_and_handle_tls_failure` helper, so cert rotation triggers the rotation prompt at connect time instead of `PIN_MISMATCH` from the first real API call.
3. `16c34dd` — disables redirect-following in both probes (`probe_tls` and `probe_server_cert`). Without this, a configured URL that 301s to a different host would describe one endpoint to the user while pinning (or `PIN_MISMATCH`-rotating against) another. Production `BugzillaClient` still follows redirects per reqwest defaults — only cert-detection paths needed to lock to the configured URL.

The probe is gated on `!tls_config.insecure` (verification is on), so the `--tls-insecure` path is unchanged. Non-TLS transport errors from the probe are silently dropped on the floor: the actual command will hit the same condition and report it with full request context.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --locked` — 848 unit + integration tests pass, including new tests for default-trust probe, pinned probe, insecure skip, and redirect non-following
- [x] `make functional-test-all` — 358 functional tests pass across bz50/bz52/bz53
- [ ] CI green
- [x] Manual re-test against the originally-failing scenario (`bug search --from-url=https://bugzilla.linux.ibm.com/...` on a cached server with default trust) — TOFU prompt now fires

## Soak record

This fix is the rc1→rc2 driver. After merge: rename `[0.2.0-rc1]` → `[0.2.0-rc2]` in `CHANGELOG.md` (appending a `### Fixed` line for this defect), then tag `v0.2.0-rc2` and restart the 3-day clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)