### PR TITLE
Release v0.2.0-rc2 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.2.0-rc1] - 2026-04-28
+## [0.2.0-rc2] - 2026-04-28
 
 ### Added
 
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   diagnostics surface even when wrapped in transport errors.
 - `bzr bug search --from-url` strips shell-escaped backslashes from URL
   arguments pasted from terminals that quote them.
+- TLS verification is now eager at connect time on the fully-cached
+  path. Previously, when both `auth_method` and `api_mode` were cached
+  for a server, `connect_and_configure` returned a client without
+  probing TLS, so untrusted-CA errors and pin rotations only surfaced
+  from the first real API call — bypassing the TOFU and rotation
+  prompts entirely. Cert-detection probes also no longer follow HTTP
+  redirects, so prompts always describe the configured URL itself
+  rather than a redirect target.
 
 ## [0.1.2] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.2.0-rc2] - 2026-04-28
 
+> Same-day re-spin of rc1 to fix a defect found during smoke testing
+> (PR #102: eager TLS probe on the cached connection path). Both rc1
+> and rc2 carry the 2026-04-28 date because both were cut on the same
+> calendar day.
+
 ### Added
 
 - TLS certificate pinning with trust-on-first-use (TOFU) prompt flow.


### PR DESCRIPTION
## Summary
- Renames `CHANGELOG.md` heading from `[0.2.0-rc1]` to `[0.2.0-rc2]`
- Adds a leading blockquote noting that both rc1 and rc2 carry the 2026-04-28 date because they were cut on the same calendar day
- Appends the eager-TLS-probe fix (PR #102) under `### Fixed`

The rc1 soak surfaced one defect: TOFU and rotation prompts never fired when both `auth_method` and `api_mode` were cached for a server. PR #102 makes TLS verification eager at connect time and disables redirect-following in cert-detection probes.

`Cargo.toml` stays at `0.2.0` — Cargo doesn't distinguish rc tags at the package-version level for this project's purposes.

## Test plan
- [ ] CI green
- [ ] After merge: tag `v0.2.0-rc2` from main and re-run smoke matrix on x86_64-linux, aarch64-darwin, ppc64le-linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)