### PR TITLE
ci(scorecard): pin actions to commit SHAs, not annotated tag SHAs

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2  # v2.4.3
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -32,6 +32,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61  # v4
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Fix `OpenSSF Scorecard` workflow failure on the publish-results step (`imposter commit: 99c09fe... does not belong to ossf/scorecard-action`)
- Two pins resolved to **annotated tag object SHAs** rather than the underlying commit SHAs; GitHub Actions accepts both in `uses:`, but `scorecard.dev`'s publish endpoint validates the OIDC-claimed SHA against the commit graph of `ossf/scorecard-action`, so a tag-object SHA fails verification

## Changes

| Action | Old SHA (annotated tag) | New SHA (commit) |
|---|---|---|
| `ossf/scorecard-action` v2.4.3 | `99c09fe975337306107572b4fdf4db224cf8e2f2` | `4eaacf0543bb3f2c246792bd56e8cdeffafb205a` |
| `github/codeql-action/upload-sarif` v4 | `b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61` | `95e58e9a2cdfd71adc6e0353d5c52f41a045d225` |

The other two pins (`actions/checkout` v6, `actions/upload-artifact` v7) were already commit SHAs (those repos use lightweight tags) and are unchanged.

Verified by dereferencing each annotated tag via `gh api repos/<org>/<repo>/git/tags/<sha>`.

## Test plan

- [ ] After merge, the next push to `main` triggers `OpenSSF Scorecard` and the workflow completes green
- [ ] Results appear on https://scorecard.dev/viewer/?uri=github.com/randomparity/bzr
- [ ] `zizmor .github/workflows/scorecard.yml` reports no new findings (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)