### PR TITLE
deps: bump rand to clear RUSTSEC-2026-0097

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,7 +1636,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1679,9 +1679,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1690,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1972,7 +1972,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "sha2",
  "zbus",
@@ -3093,7 +3093,7 @@ dependencies = [
  "hex",
  "nix",
  "ordered-stream",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_repr",
  "sha1",


### PR DESCRIPTION
## Summary

- Clear RUSTSEC-2026-0097 ("Rand is unsound with a custom logger using `rand::rng()`") on both transitive `rand` deps via semver-compatible patch bumps
- Lockfile-only change; no parent dep changes required

## Changes

| Crate | Before | After | Path |
|---|---|---|---|
| `rand` | 0.8.5 | 0.8.6 | `keyring → secret-service → zbus → rand 0.8` |
| `rand` | 0.9.2 | 0.9.4 | `reqwest → quinn → quinn-proto → rand 0.9` |

## Verification

- `cargo audit` no longer reports RUSTSEC-2026-0097 (only RUSTSEC-2026-0009 remains, which is already justified-ignored in `deny.toml` pending an MSRV bump from 1.84 → 1.88)
- `cargo deny check advisories bans sources` passes
- `cargo test --locked` passes (56 tests)

## Expected Scorecard impact

- `Vulnerabilities`: 8 → 9 (one of two advisories cleared)
- The remaining advisory (`time` 0.3.45 / RUSTSEC-2026-0009) requires Rust 1.88 to fix, which is a separate MSRV-policy decision

## Test plan

- [ ] CI passes (Test, Clippy, Build, Format, MSRV, cargo-deny)
- [ ] After merge, next Scorecard run on `main` shows `Vulnerabilities: 9` and only the `time` advisory listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)