### PR TITLE
deps: bump MSRV to 1.88, upgrade time to 0.3.47

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Install libdbus-1-dev
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # 1.84.1
+      - uses: dtolnay/rust-toolchain@98e1b82157cd469e843cb7f524c1313b4ad9492c  # 1.88.0
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae  # v2
         with:
-          key: msrv-1.84.1
+          key: msrv-1.88.0
       - run: cargo test --locked
 
   fmt:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2290,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -2305,15 +2305,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 resolver = "3"
 description = "A CLI for Bugzilla, inspired by gh"
 license = "MIT"
-rust-version = "1.84"
+rust-version = "1.88"
 repository = "https://github.com/randomparity/bzr"
 homepage = "https://github.com/randomparity/bzr"
 keywords = ["bugzilla", "cli", "bug-tracker"]
@@ -23,7 +23,6 @@ test-helpers = ["dep:wiremock", "dep:tempfile"]
 
 [dependencies]
 base64 = "0.22"
-# Keep clap below 4.6 to preserve Rust 1.84 / RHEL 9.6 compatibility.
 clap = { version = ">=4.5.60, <4.6", features = ["derive"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots"], default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["std"] }

--- a/deny.toml
+++ b/deny.toml
@@ -1,12 +1,7 @@
 [advisories]
 version = 2
 yanked = "warn"
-ignore = [
-    # time 0.3.45 DoS via stack exhaustion (RUSTSEC-2026-0009).
-    # Dev-only transitive dep from rcgen -> yasna -> time.
-    # time 0.3.47 fixes it but requires Rust 1.88 (MSRV is 1.84).
-    { id = "RUSTSEC-2026-0009", reason = "dev-only dep, can't upgrade due to MSRV" },
-]
+ignore = []
 
 [bans]
 multiple-versions = "warn"


### PR DESCRIPTION
## Summary

- Clear RUSTSEC-2026-0009 (`time 0.3.45` stack-exhaustion DoS, CVSS 6.8) by upgrading to `time 0.3.47`, which requires Rust 1.88
- Raise project MSRV from 1.84 to 1.88
- Re-pin the CI MSRV job to actually install 1.88.0 (the prior pin was silently installing `stable`)

## RHEL compatibility

Researched before raising MSRV:

| RHEL | Released | rust-toolset shipped |
|---|---|---|
| 9.5 | late 2024 | 1.79.0 |
| 9.6 | 2025-05-13 | 1.84.1 ← prior MSRV target |
| 9.7 | 2025-11-12 | **1.88.0** ← new MSRV target |

`rust-toolset` is a [rolling Application Stream](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) — Red Hat only supports the latest version. A maintained RHEL 9.6 system pulling current AppStream gets 1.88.0 already; a "pure RHEL 9.6, no updates" system with 1.84.1 isn't a Red Hat-supported configuration in the first place. So 1.88 is the safe floor.

## Changes

- `Cargo.toml`: `rust-version = "1.84"` → `"1.88"`; drop the now-stale clap-cap comment (the `<4.6` value is unchanged — that's a follow-up if we want to lift it)
- `Cargo.lock`: `time 0.3.45 → 0.3.47` (+ tightly-coupled `time-core`, `time-macros`, `num-conv`)
- `deny.toml`: remove the RUSTSEC-2026-0009 ignore
- `.github/workflows/ci.yml` MSRV job: re-pin `dtolnay/rust-toolchain` from `29eef336d...` to `98e1b82157cd469e843cb7f524c1313b4ad9492c` (the real `1.88.0` branch HEAD); cache key bumped to `msrv-1.88.0`

### Why the MSRV pin was wrong before

The previous pin `29eef336d9b2848a0b548edc03f92a220660cdb8` is the `stable` branch HEAD of `dtolnay/rust-toolchain`. The action requires a `toolchain` input or a non-stable branch ref to install anything other than current stable. The MSRV job has no `with: toolchain:` input, so it inherited the SHA's `stable` default. Verified empirically: the most recent pre-#107 MSRV CI run installed Rust **1.95.0**, not 1.84.1.

The other CI jobs (Test, Clippy, Build, Cross-check, etc.) using the same SHA were already correctly installing stable, which matches their intent. **`fuzz.yml` is also fine** — its explicit `with: toolchain: nightly` input overrides the SHA's stable default. Verified: the most recent fuzz run installed `1.97.0-nightly`.

The post-fix MSRV run on this PR's branch installs Rust **1.88.0** as intended.

## Verification

- `cargo audit`: clean (only the rand 0.8.5/0.9.2 warnings remain, cleared by #106)
- `cargo deny check advisories bans sources`: ok
- `cargo build --release --locked`: ok
- `cargo clippy --locked --all-targets -- -D warnings`: clean
- `cargo test --locked`: 56 passed
- CI MSRV job: confirmed installs 1.88.0

## Expected Scorecard impact

Combined with #106 (rand bumps), `Vulnerabilities` reaches 10/10.

## Test plan

- [ ] CI passes — particularly the MSRV job, which now actually pins 1.88.0
- [ ] cargo-deny job passes (ignore was removed)
- [ ] Cross-check jobs (aarch64, ppc64le, s390x) still build clean on 1.88-compatible toolchains

🤖 Generated with [Claude Code](https://claude.com/claude-code)