### PR TITLE
ci(release): attest build provenance for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write       # OIDC token for keyless Sigstore signing
+      attestations: write   # publish SLSA build provenance
     strategy:
       fail-fast: false
       matrix:
@@ -113,6 +117,11 @@ jobs:
           Copy-Item LICENSE, README.md "$STAGING\"
           Compress-Archive -Path "$STAGING\*" -DestinationPath "$STAGING.zip"
         shell: pwsh
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4
+        with:
+          subject-path: bzr-${{ github.ref_name }}-${{ matrix.target }}.${{ matrix.archive }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:


### PR DESCRIPTION
## Summary

- Publish SLSA build-provenance attestations for each release artifact via [`actions/attest-build-provenance@v4`](https://github.com/actions/attest-build-provenance) (GitHub's free Sigstore-keyless signing infrastructure)
- Adds a `permissions:` block to the build job — minimum perms only (`contents: read`, `id-token: write`, `attestations: write`); replaces the top-level `read-all` default for that job

## Why

OpenSSF Scorecard's `Signed-Releases` check is currently 0/10 — releases have neither cryptographic signatures nor provenance. SLSA provenance via `attest-build-provenance` satisfies the check and adds meaningful supply-chain signal: anyone can verify that a downloaded artifact was actually built by this repo's release workflow at a specific commit.

## Verification (after merge + first tagged release)

```sh
gh attestation verify bzr-v0.2.0-rc3-x86_64-unknown-linux-gnu.tar.gz \
  --repo randomparity/bzr
```

Attestations also visible at: https://github.com/randomparity/bzr/attestations

Each of the 7 matrix targets gets one attestation, bound to its archive:

- `x86_64-unknown-linux-gnu` (`.tar.gz`)
- `aarch64-unknown-linux-gnu` (`.tar.gz`, cross-compiled)
- `powerpc64le-unknown-linux-gnu` (`.tar.gz`, QEMU)
- `s390x-unknown-linux-gnu` (`.tar.gz`, cross-compiled)
- `aarch64-apple-darwin` (`.tar.gz`)
- `x86_64-pc-windows-msvc` (`.zip`)
- `aarch64-pc-windows-msvc` (`.zip`)

## Expected Scorecard impact

`Signed-Releases`: 0 → 8–10 once a release is cut with this workflow active. (Score depends on Scorecard's age cutoff for "latest release".)

## Test plan

- [ ] First test is on the next tag push — current 0.2.0-rc2 is unaffected
- [ ] After 0.2.0-rc3 (or whatever next tag) is cut, verify attestations appear at https://github.com/randomparity/bzr/attestations
- [ ] `gh attestation verify <artifact> --repo randomparity/bzr` succeeds for all 7 targets
- [ ] Next Scorecard run on `main` shows `Signed-Releases` significantly improved

## Notes

- The action SHA `a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` is the dereferenced commit for the `v4` annotated tag (verified via `gh api repos/actions/attest-build-provenance/git/tags/<tag-sha>`), avoiding the same imposter-commit issue PR #104 fixed for `ossf/scorecard-action`.
- Build job permissions are now job-scoped instead of inheriting top-level — least-privilege per OpenSSF guidance and Scorecard's `Token-Permissions` check (already 10/10, this preserves it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)