### PR TITLE
test(mutants): finish mutation-testing rollout (Waves 5-8)

### DIFF
--- a/docs/dev/mutation-baseline.md
+++ b/docs/dev/mutation-baseline.md
@@ -77,7 +77,7 @@ Largest-first. `–` means the wave hasn't started yet.
 |------|--------:|--------|-------:|-------:|---------:|--------:|------:|-----------|
 | src/tls/verifier.rs                 | 102 | swept   | 96 | 0 |  6 | 0 | 100 % | 2026-05-01 |
 | src/xmlrpc/parsing.rs               |  81 | swept   | 57 | 0 | 11 | 0 | 100 % | 2026-05-01 |
-| src/types/bug.rs                    |  77 | pending | – | – | – | – | – | – |
+| src/types/bug.rs                    |  77 | swept   | 77 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/shared.rs              |  49 | swept   | 24 | 0 |  4 | 0 | 100 % | 2026-05-01 |
 | src/config.rs                       |  47 | swept   | 33 | 0 |  5 | 0 | 100 % | 2026-05-01 |
 | src/xmlrpc/client.rs                |  42 | swept   | 35 | 0 |  7 | 0 | 100 % | 2026-05-01 |
@@ -92,7 +92,7 @@ Largest-first. `–` means the wave hasn't started yet.
 | src/commands/config.rs              |  18 | swept   | 18 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/flags.rs               |  17 | swept   | 10 | 0 |  7 | 0 | 100 % | 2026-05-01 |
 | src/client/version.rs               |  17 | swept   | 13 | 0 |  4 | 0 | 100 % | 2026-05-01 |
-| src/types/common.rs                 |  16 | pending | – | – | – | – | – | – |
+| src/types/common.rs                 |  16 | swept   | 12 | 0 |  4 | 0 | 100 % | 2026-05-01 |
 | src/main.rs                         |  16 | pending | – | – | – | – | – | – |
 | src/commands/attachment.rs          |  16 | swept   | 16 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/output/query.rs                 |  13 | pending | – | – | – | – | – | – |
@@ -119,13 +119,13 @@ Largest-first. `–` means the wave hasn't started yet.
 | src/output/bug.rs                   |   6 | pending | – | – | – | – | – | – |
 | src/client/product.rs               |   6 | swept   |  4 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/client/auth/whoami.rs           |   6 | swept   |  4 | 0 |  2 | 0 | 100 % | 2026-05-01 |
-| src/types/attachment.rs             |   5 | pending | – | – | – | – | – | – |
+| src/types/attachment.rs             |   5 | swept   |  3 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/tls/mod.rs                      |   5 | pending | – | – | – | – | – | – |
 | src/output/user.rs                  |   5 | pending | – | – | – | – | – | – |
 | src/tls/fingerprint.rs              |   4 | pending | – | – | – | – | – | – |
 | src/credentials/keyring_stub.rs     |   4 | pending | – | – | – | – | – | – |
 | src/commands/user.rs                |   4 | swept   |  4 | 0 |  0 | 0 | 100 % | 2026-05-01 |
-| src/types/product.rs                |   3 | pending | – | – | – | – | – | – |
+| src/types/product.rs                |   3 | swept   |  3 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/field.rs               |   3 | swept   |  3 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/bug/clone.rs           |   3 | swept   |  3 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/client/server.rs                |   3 | swept   |  2 | 0 |  1 | 0 | 100 % | 2026-05-01 |
@@ -135,7 +135,7 @@ Largest-first. `–` means the wave hasn't started yet.
 | src/output/group.rs                 |   2 | pending | – | – | – | – | – | – |
 | src/output/field.rs                 |   2 | pending | – | – | – | – | – | – |
 | src/output/classification.rs        |   2 | pending | – | – | – | – | – | – |
-| src/types/user.rs                   |   1 | pending | – | – | – | – | – | – |
+| src/types/user.rs                   |   1 | swept   |  0 | 0 |  1 | 0 | 100 % | 2026-05-01 |
 | src/output/comment.rs               |   1 | pending | – | – | – | – | – | – |
 | src/output/attachment.rs            |   1 | pending | – | – | – | – | – | – |
 | src/lib.rs                          |   1 | pending | – | – | – | – | – | – |

--- a/docs/dev/mutation-baseline.md
+++ b/docs/dev/mutation-baseline.md
@@ -93,7 +93,7 @@ Largest-first. `–` means the wave hasn't started yet.
 | src/commands/flags.rs               |  17 | swept   | 10 | 0 |  7 | 0 | 100 % | 2026-05-01 |
 | src/client/version.rs               |  17 | swept   | 13 | 0 |  4 | 0 | 100 % | 2026-05-01 |
 | src/types/common.rs                 |  16 | swept   | 12 | 0 |  4 | 0 | 100 % | 2026-05-01 |
-| src/main.rs                         |  16 | pending | – | – | – | – | – | – |
+| src/main.rs                         |  16 | swept   | 12 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/attachment.rs          |  16 | swept   | 16 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/output/query.rs                 |  13 | swept   | 13 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/bug/list.rs            |  13 | swept   | 13 | 0 |  0 | 0 | 100 % | 2026-05-01 |
@@ -114,16 +114,16 @@ Largest-first. `–` means the wave hasn't started yet.
 | src/client/auth/mod.rs              |   8 | swept   |  6 | 0 |  1 | 0 | 100 % | 2026-05-01 |
 | src/output/template.rs              |   7 | swept   |  7 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/output/product.rs               |   7 | swept   |  7 | 0 |  0 | 0 | 100 % | 2026-05-01 |
-| src/credentials/keyring.rs          |   7 | pending | – | – | – | – | – | – |
+| src/credentials/keyring.rs          |   7 | swept   |  5 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/client/field.rs                 |   7 | swept   |  4 | 0 |  3 | 0 | 100 % | 2026-05-01 |
 | src/output/bug.rs                   |   6 | swept   |  5 | 0 |  1 | 0 | 100 % | 2026-05-01 |
 | src/client/product.rs               |   6 | swept   |  4 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/client/auth/whoami.rs           |   6 | swept   |  4 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/types/attachment.rs             |   5 | swept   |  3 | 0 |  2 | 0 | 100 % | 2026-05-01 |
-| src/tls/mod.rs                      |   5 | pending | – | – | – | – | – | – |
+| src/tls/mod.rs                      |   5 | swept   |  3 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/output/user.rs                  |   5 | swept   |  3 | 0 |  2 | 0 | 100 % | 2026-05-01 |
-| src/tls/fingerprint.rs              |   4 | pending | – | – | – | – | – | – |
-| src/credentials/keyring_stub.rs     |   4 | pending | – | – | – | – | – | – |
+| src/tls/fingerprint.rs              |   4 | swept   |  4 | 0 |  0 | 0 | 100 % | 2026-05-01 |
+| src/credentials/keyring_stub.rs     |   4 | swept   |  0 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/user.rs                |   4 | swept   |  4 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/types/product.rs                |   3 | swept   |  3 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/field.rs               |   3 | swept   |  3 | 0 |  0 | 0 | 100 % | 2026-05-01 |
@@ -138,7 +138,7 @@ Largest-first. `–` means the wave hasn't started yet.
 | src/types/user.rs                   |   1 | swept   |  0 | 0 |  1 | 0 | 100 % | 2026-05-01 |
 | src/output/comment.rs               |   1 | swept   |  1 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/output/attachment.rs            |   1 | swept   |  1 | 0 |  0 | 0 | 100 % | 2026-05-01 |
-| src/lib.rs                          |   1 | pending | – | – | – | – | – | – |
+| src/lib.rs                          |   1 | swept   |  1 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/whoami.rs              |   1 | swept   |  1 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/server.rs              |   1 | swept   |  1 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/product.rs             |   1 | swept   |  1 | 0 |  0 | 0 | 100 % | 2026-05-01 |
@@ -193,3 +193,6 @@ related code changes — they may have rotted):
 | `read_secret_from_prompt_or_env` (non-keyring) | `src/commands/config.rs` | `#[cfg(not(feature = "keyring"))]` — dead code on the default-feature Linux test platform |
 | `should_offer_tofu` / `is_pin_mismatch` / `is_issuer_changed` / `classify_and_handle_tls_failure` | `src/commands/shared.rs` | TLS-failure predicates can only return true given a real TLS handshake error from reqwest, which has no public Error constructor |
 | `handle_tofu` / `handle_pin_rotation` (whole functions, via `#[cfg_attr(test, mutants::skip)]`) | `src/commands/shared.rs` | TOFU/rotation handlers only fire after a terminal-stdin prompt accepts; cargo-mutants v27 cannot reach `delete field` mutations through `exclude_re`, so the attribute is used instead |
+| `main` (whole function, via `#[cfg_attr(test, mutants::skip)]`) | `src/main.rs` | Binary entry point; observing exit codes / stderr requires spawning the compiled binary (e.g. via `assert_cmd`/`escargot`). The pure helpers it delegates to are unit-tested directly. |
+| `suppress_stdout` non-unix variants (whole functions, via `#[cfg_attr(test, mutants::skip)]`) | `src/main.rs` | `#[cfg(windows)]` and `#[cfg(not(any(unix, windows)))]` are dead code on the Linux test platform |
+| `store` / `retrieve` / `delete` (whole functions, via `#[cfg_attr(test, mutants::skip)]`) | `src/credentials/keyring_stub.rs` | `#[cfg(not(feature = "keyring"))]` — never compiled into the test binary, since `.cargo/mutants.toml` runs with `--all-features` |

--- a/docs/dev/mutation-baseline.md
+++ b/docs/dev/mutation-baseline.md
@@ -84,7 +84,7 @@ Largest-first. `–` means the wave hasn't started yet.
 | src/client/mod.rs                   |  41 | swept   | 30 | 0 | 10 | 0 | 100 % | 2026-05-01 |
 | src/client/bug.rs                   |  38 | swept   | 28 | 0 | 10 | 0 | 100 % | 2026-05-01 |
 | src/tls/tofu.rs                     |  36 | swept   | 28 | 0 |  4 | 0 | 100 % | 2026-05-01 |
-| src/output/formatting.rs            |  34 | pending | – | – | – | – | – | – |
+| src/output/formatting.rs            |  34 | swept   | 34 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/xmlrpc/mod.rs                   |  28 | swept   | 21 | 0 |  7 | 0 | 100 % | 2026-05-01 |
 | src/url_parser.rs                   |  25 | swept   | 23 | 0 | 2 | 0 | 100 % | 2026-05-01 |
 | src/error.rs                        |  19 | swept   | 17 | 0 |  1 | 0 | 100 % | 2026-05-01 |
@@ -95,7 +95,7 @@ Largest-first. `–` means the wave hasn't started yet.
 | src/types/common.rs                 |  16 | swept   | 12 | 0 |  4 | 0 | 100 % | 2026-05-01 |
 | src/main.rs                         |  16 | pending | – | – | – | – | – | – |
 | src/commands/attachment.rs          |  16 | swept   | 16 | 0 |  0 | 0 | 100 % | 2026-05-01 |
-| src/output/query.rs                 |  13 | pending | – | – | – | – | – | – |
+| src/output/query.rs                 |  13 | swept   | 13 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/bug/list.rs            |  13 | swept   | 13 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/client/group.rs                 |  13 | swept   | 12 | 0 |  1 | 0 | 100 % | 2026-05-01 |
 | src/commands/comment.rs             |  12 | swept   |  7 | 0 |  0 | 0 | 100 % | 2026-05-01 |
@@ -103,25 +103,25 @@ Largest-first. `–` means the wave hasn't started yet.
 | src/http.rs                         |  11 | swept   | 10 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/commands/bug/my.rs              |  11 | swept   | 11 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/client/auth/valid_login.rs      |  11 | swept   |  8 | 0 |  3 | 0 | 100 % | 2026-05-01 |
-| src/output/result_types.rs          |  10 | pending | – | – | – | – | – | – |
+| src/output/result_types.rs          |  10 | swept   |  1 | 0 |  9 | 0 | 100 % | 2026-05-01 |
 | src/commands/bug/update.rs          |  10 | swept   | 10 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/bug/search.rs          |  10 | swept   | 10 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/client/comment.rs               |  10 | swept   |  9 | 0 |  1 | 0 | 100 % | 2026-05-01 |
-| src/output/config.rs                |   9 | pending | – | – | – | – | – | – |
+| src/output/config.rs                |   9 | swept   |  7 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/commands/template.rs            |   9 | swept   |  9 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/client/user.rs                  |   9 | swept   |  4 | 0 |  3 | 0 | 100 % | 2026-05-01 |
 | src/xmlrpc/call.rs                  |   8 | swept   |  6 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/client/auth/mod.rs              |   8 | swept   |  6 | 0 |  1 | 0 | 100 % | 2026-05-01 |
-| src/output/template.rs              |   7 | pending | – | – | – | – | – | – |
-| src/output/product.rs               |   7 | pending | – | – | – | – | – | – |
+| src/output/template.rs              |   7 | swept   |  7 | 0 |  0 | 0 | 100 % | 2026-05-01 |
+| src/output/product.rs               |   7 | swept   |  7 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/credentials/keyring.rs          |   7 | pending | – | – | – | – | – | – |
 | src/client/field.rs                 |   7 | swept   |  4 | 0 |  3 | 0 | 100 % | 2026-05-01 |
-| src/output/bug.rs                   |   6 | pending | – | – | – | – | – | – |
+| src/output/bug.rs                   |   6 | swept   |  5 | 0 |  1 | 0 | 100 % | 2026-05-01 |
 | src/client/product.rs               |   6 | swept   |  4 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/client/auth/whoami.rs           |   6 | swept   |  4 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/types/attachment.rs             |   5 | swept   |  3 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/tls/mod.rs                      |   5 | pending | – | – | – | – | – | – |
-| src/output/user.rs                  |   5 | pending | – | – | – | – | – | – |
+| src/output/user.rs                  |   5 | swept   |  3 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/tls/fingerprint.rs              |   4 | pending | – | – | – | – | – | – |
 | src/credentials/keyring_stub.rs     |   4 | pending | – | – | – | – | – | – |
 | src/commands/user.rs                |   4 | swept   |  4 | 0 |  0 | 0 | 100 % | 2026-05-01 |
@@ -131,13 +131,13 @@ Largest-first. `–` means the wave hasn't started yet.
 | src/client/server.rs                |   3 | swept   |  2 | 0 |  1 | 0 | 100 % | 2026-05-01 |
 | src/client/component.rs             |   3 | swept   |  2 | 0 |  1 | 0 | 100 % | 2026-05-01 |
 | src/xmlrpc/fault.rs                 |   2 | swept   |  1 | 0 |  1 | 0 | 100 % | 2026-05-01 |
-| src/output/server.rs                |   2 | pending | – | – | – | – | – | – |
-| src/output/group.rs                 |   2 | pending | – | – | – | – | – | – |
-| src/output/field.rs                 |   2 | pending | – | – | – | – | – | – |
-| src/output/classification.rs        |   2 | pending | – | – | – | – | – | – |
+| src/output/server.rs                |   2 | swept   |  1 | 0 |  1 | 0 | 100 % | 2026-05-01 |
+| src/output/group.rs                 |   2 | swept   |  2 | 0 |  0 | 0 | 100 % | 2026-05-01 |
+| src/output/field.rs                 |   2 | swept   |  2 | 0 |  0 | 0 | 100 % | 2026-05-01 |
+| src/output/classification.rs        |   2 | swept   |  2 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/types/user.rs                   |   1 | swept   |  0 | 0 |  1 | 0 | 100 % | 2026-05-01 |
-| src/output/comment.rs               |   1 | pending | – | – | – | – | – | – |
-| src/output/attachment.rs            |   1 | pending | – | – | – | – | – | – |
+| src/output/comment.rs               |   1 | swept   |  1 | 0 |  0 | 0 | 100 % | 2026-05-01 |
+| src/output/attachment.rs            |   1 | swept   |  1 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/lib.rs                          |   1 | pending | – | – | – | – | – | – |
 | src/commands/whoami.rs              |   1 | swept   |  1 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/commands/server.rs              |   1 | swept   |  1 | 0 |  0 | 0 | 100 % | 2026-05-01 |

--- a/docs/dev/mutation-baseline.md
+++ b/docs/dev/mutation-baseline.md
@@ -80,12 +80,12 @@ Largest-first. `–` means the wave hasn't started yet.
 | src/types/bug.rs                    |  77 | pending | – | – | – | – | – | – |
 | src/commands/shared.rs              |  49 | swept   | 24 | 0 |  4 | 0 | 100 % | 2026-05-01 |
 | src/config.rs                       |  47 | swept   | 33 | 0 |  5 | 0 | 100 % | 2026-05-01 |
-| src/xmlrpc/client.rs                |  42 | pending | – | – | – | – | – | – |
+| src/xmlrpc/client.rs                |  42 | swept   | 35 | 0 |  7 | 0 | 100 % | 2026-05-01 |
 | src/client/mod.rs                   |  41 | swept   | 30 | 0 | 10 | 0 | 100 % | 2026-05-01 |
 | src/client/bug.rs                   |  38 | swept   | 28 | 0 | 10 | 0 | 100 % | 2026-05-01 |
 | src/tls/tofu.rs                     |  36 | swept   | 28 | 0 |  4 | 0 | 100 % | 2026-05-01 |
 | src/output/formatting.rs            |  34 | pending | – | – | – | – | – | – |
-| src/xmlrpc/mod.rs                   |  28 | pending | – | – | – | – | – | – |
+| src/xmlrpc/mod.rs                   |  28 | swept   | 21 | 0 |  7 | 0 | 100 % | 2026-05-01 |
 | src/url_parser.rs                   |  25 | swept   | 23 | 0 | 2 | 0 | 100 % | 2026-05-01 |
 | src/error.rs                        |  19 | swept   | 17 | 0 |  1 | 0 | 100 % | 2026-05-01 |
 | src/commands/query.rs               |  19 | swept   | 18 | 0 |  1 | 0 | 100 % | 2026-05-01 |
@@ -110,7 +110,7 @@ Largest-first. `–` means the wave hasn't started yet.
 | src/output/config.rs                |   9 | pending | – | – | – | – | – | – |
 | src/commands/template.rs            |   9 | swept   |  9 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/client/user.rs                  |   9 | swept   |  4 | 0 |  3 | 0 | 100 % | 2026-05-01 |
-| src/xmlrpc/call.rs                  |   8 | pending | – | – | – | – | – | – |
+| src/xmlrpc/call.rs                  |   8 | swept   |  6 | 0 |  2 | 0 | 100 % | 2026-05-01 |
 | src/client/auth/mod.rs              |   8 | swept   |  6 | 0 |  1 | 0 | 100 % | 2026-05-01 |
 | src/output/template.rs              |   7 | pending | – | – | – | – | – | – |
 | src/output/product.rs               |   7 | pending | – | – | – | – | – | – |
@@ -130,7 +130,7 @@ Largest-first. `–` means the wave hasn't started yet.
 | src/commands/bug/clone.rs           |   3 | swept   |  3 | 0 |  0 | 0 | 100 % | 2026-05-01 |
 | src/client/server.rs                |   3 | swept   |  2 | 0 |  1 | 0 | 100 % | 2026-05-01 |
 | src/client/component.rs             |   3 | swept   |  2 | 0 |  1 | 0 | 100 % | 2026-05-01 |
-| src/xmlrpc/fault.rs                 |   2 | pending | – | – | – | – | – | – |
+| src/xmlrpc/fault.rs                 |   2 | swept   |  1 | 0 |  1 | 0 | 100 % | 2026-05-01 |
 | src/output/server.rs                |   2 | pending | – | – | – | – | – | – |
 | src/output/group.rs                 |   2 | pending | – | – | – | – | – | – |
 | src/output/field.rs                 |   2 | pending | – | – | – | – | – | – |

--- a/src/client/bug_tests.rs
+++ b/src/client/bug_tests.rs
@@ -433,24 +433,6 @@ fn has_raw_boolean_chart_params_false_for_empty() {
     assert!(!super::has_raw_boolean_chart_params(&params));
 }
 
-#[test]
-fn search_params_has_filters() {
-    let empty = SearchParams::default();
-    assert!(!empty.has_filters());
-
-    let with_product = SearchParams {
-        product: vec!["P".into()],
-        ..Default::default()
-    };
-    assert!(with_product.has_filters());
-
-    let with_quicksearch = SearchParams {
-        quicksearch: Some("crash".into()),
-        ..Default::default()
-    };
-    assert!(with_quicksearch.has_filters());
-}
-
 #[tokio::test]
 async fn search_bugs_multi_value_sends_repeated_params() {
     let mock = MockServer::start().await;

--- a/src/credentials/keyring.rs
+++ b/src/credentials/keyring.rs
@@ -126,6 +126,12 @@ mod tests {
         let got = retrieve("bzr-test-roundtrip", "acct1").unwrap();
         assert_eq!(got, "secret-value");
         delete("bzr-test-roundtrip", "acct1").unwrap();
+        // Retrieve must now fail; otherwise delete was a no-op.
+        let err = retrieve("bzr-test-roundtrip", "acct1").unwrap_err();
+        assert!(
+            err.to_string().contains("no API key found"),
+            "expected NoEntry after delete, got: {err}"
+        );
     }
 
     #[test]

--- a/src/credentials/keyring_stub.rs
+++ b/src/credentials/keyring_stub.rs
@@ -8,14 +8,21 @@ use crate::error::{BzrError, Result};
 const UNSUPPORTED: &str = "this bzr build was compiled without keyring support; \
      rebuild with --features keyring or use api_key_env";
 
+// This file is `cfg(not(feature = "keyring"))`; cargo-mutants runs with
+// `--all-features`, so the bodies are never compiled into the test binary
+// and the inline tests below never execute. Skip the function-body
+// mutations rather than carry an additional no-keyring test invocation.
+#[cfg_attr(test, mutants::skip)]
 pub fn store(_service: &str, _account: &str, _secret: &str) -> Result<()> {
     Err(BzrError::Keyring(UNSUPPORTED.into()))
 }
 
+#[cfg_attr(test, mutants::skip)]
 pub fn retrieve(_service: &str, _account: &str) -> Result<String> {
     Err(BzrError::Keyring(UNSUPPORTED.into()))
 }
 
+#[cfg_attr(test, mutants::skip)]
 pub fn delete(_service: &str, _account: &str) -> Result<()> {
     Err(BzrError::Keyring(UNSUPPORTED.into()))
 }

--- a/src/credentials/keyring_stub.rs
+++ b/src/credentials/keyring_stub.rs
@@ -8,10 +8,11 @@ use crate::error::{BzrError, Result};
 const UNSUPPORTED: &str = "this bzr build was compiled without keyring support; \
      rebuild with --features keyring or use api_key_env";
 
-// This file is `cfg(not(feature = "keyring"))`; cargo-mutants runs with
-// `--all-features`, so the bodies are never compiled into the test binary
-// and the inline tests below never execute. Skip the function-body
-// mutations rather than carry an additional no-keyring test invocation.
+// Mutation testing: this file is `cfg(not(feature = "keyring"))`;
+// cargo-mutants runs with `--all-features`, so the bodies are never
+// compiled into the test binary and the inline tests below never execute.
+// Skip function-body mutations rather than carry a separate no-keyring
+// test invocation.
 #[cfg_attr(test, mutants::skip)]
 pub fn store(_service: &str, _account: &str, _secret: &str) -> Result<()> {
     Err(BzrError::Keyring(UNSUPPORTED.into()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,13 @@ use bzr::cli::Cli;
 use bzr::error::{self, BzrError};
 use bzr::types::OutputFormat;
 
+// `main` is the binary entry point: defeating mutations in its body
+// requires spawning the compiled binary (e.g. via assert_cmd or
+// escargot) to observe exit codes and stderr. The pure helpers it
+// delegates to (`tracing_filter_directive`, `format_dispatch_error`,
+// `exit_code`, `resolve_format`, `suppress_stdout`) are unit-tested
+// directly; the orchestration glue is not worth a new dev-dependency.
+#[cfg_attr(test, mutants::skip)]
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
     let cli = Cli::parse();
@@ -117,6 +124,8 @@ fn suppress_stdout() {
     }
 }
 
+// Dead code on the Linux test platform; cannot be observed.
+#[cfg_attr(test, mutants::skip)]
 #[cfg(windows)]
 fn suppress_stdout() {
     use std::os::windows::io::IntoRawHandle;
@@ -139,6 +148,8 @@ fn suppress_stdout() {
     }
 }
 
+// Dead code on the Linux test platform.
+#[cfg_attr(test, mutants::skip)]
 #[cfg(not(any(unix, windows)))]
 fn suppress_stdout() {
     // No platform-specific suppression available; --quiet will only
@@ -398,34 +409,63 @@ mod tests {
         assert!(out.contains("kaboom"));
     }
 
-    /// Asserts `suppress_stdout()` runs without panicking and that fd 1 is
-    /// restored afterward. The function calls `dup2(devnull_fd, 1)` under
-    /// the hood; we save+restore fd 1 around it so the rest of the test
-    /// process keeps a working stdout. The cargo test runner uses its own
-    /// per-test thread-local stdout (`println!`), so redirecting the raw
-    /// fd here doesn't break test reporting.
+    /// After `suppress_stdout()` runs, writes to fd 1 must NOT reach
+    /// whatever fd 1 pointed at before the call. We redirect fd 1 to a
+    /// temp file, invoke `suppress_stdout()`, write a marker, then
+    /// inspect the temp file: if `suppress_stdout` is a no-op the marker
+    /// lands in our file; if it works the marker goes to /dev/null.
     #[cfg(unix)]
     #[test]
     fn suppress_stdout_redirects_fd1_to_devnull() {
+        use std::io::{Read, Seek};
+        use std::os::unix::io::AsRawFd;
+
         extern "C" {
             fn dup(fd: std::ffi::c_int) -> std::ffi::c_int;
             fn dup2(oldfd: std::ffi::c_int, newfd: std::ffi::c_int) -> std::ffi::c_int;
             fn close(fd: std::ffi::c_int) -> std::ffi::c_int;
+            fn write(fd: std::ffi::c_int, buf: *const u8, count: usize) -> isize;
         }
 
         let _guard = env_lock();
-        // SAFETY: dup() on a valid fd returns a duplicate; we restore it below.
+        let tmp = tempfile::NamedTempFile::new().expect("tmpfile");
+        let tmp_fd = tmp.as_file().as_raw_fd();
+
+        // SAFETY: dup() returns a duplicate of fd 1; we restore it below.
         let saved = unsafe { dup(1) };
         assert!(saved >= 0, "dup(1) failed");
+        // SAFETY: dup2 redirects fd 1 to the temp file.
+        unsafe {
+            dup2(tmp_fd, 1);
+        }
 
         suppress_stdout();
 
-        // Restore fd 1 so subsequent tests (and cargo's harness) keep a
-        // working stdout.
-        // SAFETY: dup2() on valid fds is safe; close() releases the dup.
+        let marker = b"MARKER_AFTER_SUPPRESS";
+        // SAFETY: writing a small buffer to fd 1 (now /dev/null after a
+        // successful suppress_stdout, or our temp file if the call was
+        // mutated to no-op).
+        unsafe {
+            write(1, marker.as_ptr(), marker.len());
+        }
+
+        // Restore fd 1 BEFORE reading the temp file so cargo's harness
+        // and any later test gets a working stdout.
+        // SAFETY: dup2/close on valid fds.
         unsafe {
             dup2(saved, 1);
             close(saved);
         }
+
+        let mut captured = Vec::new();
+        let mut f = tmp.reopen().expect("reopen");
+        f.seek(std::io::SeekFrom::Start(0)).expect("seek");
+        f.read_to_end(&mut captured).expect("read");
+
+        let captured_str = String::from_utf8_lossy(&captured);
+        assert!(
+            !captured_str.contains("MARKER_AFTER_SUPPRESS"),
+            "suppress_stdout did not redirect fd 1; marker reached temp file: {captured_str:?}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,12 @@ use bzr::cli::Cli;
 use bzr::error::{self, BzrError};
 use bzr::types::OutputFormat;
 
-// `main` is the binary entry point: defeating mutations in its body
-// requires spawning the compiled binary (e.g. via assert_cmd or
-// escargot) to observe exit codes and stderr. The pure helpers it
-// delegates to (`tracing_filter_directive`, `format_dispatch_error`,
-// `exit_code`, `resolve_format`, `suppress_stdout`) are unit-tested
-// directly; the orchestration glue is not worth a new dev-dependency.
+// Mutation testing: `main` is the binary entry point. Defeating body-level
+// mutations requires spawning the compiled binary (e.g. via assert_cmd or
+// escargot) to observe exit codes and stderr. The pure helpers it delegates
+// to (`tracing_filter_directive`, `format_dispatch_error`, `exit_code`,
+// `resolve_format`, `suppress_stdout`) are unit-tested directly; the
+// orchestration glue is not worth a new dev-dependency.
 #[cfg_attr(test, mutants::skip)]
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
@@ -124,7 +124,7 @@ fn suppress_stdout() {
     }
 }
 
-// Dead code on the Linux test platform; cannot be observed.
+// Mutation testing: dead code on the Linux test platform; cannot be observed.
 #[cfg_attr(test, mutants::skip)]
 #[cfg(windows)]
 fn suppress_stdout() {
@@ -148,7 +148,7 @@ fn suppress_stdout() {
     }
 }
 
-// Dead code on the Linux test platform.
+// Mutation testing: dead code on the Linux test platform.
 #[cfg_attr(test, mutants::skip)]
 #[cfg(not(any(unix, windows)))]
 fn suppress_stdout() {

--- a/src/output/classification.rs
+++ b/src/output/classification.rs
@@ -1,21 +1,28 @@
+use std::io::{self, Write as _};
+
 use colored::Colorize;
 
 use super::formatting::{print_formatted, truncate};
 use crate::types::{Classification, OutputFormat};
 
-#[expect(clippy::print_stdout)]
 pub fn print_classification(classification: &Classification, format: OutputFormat) {
     print_formatted(classification, format, |classification| {
-        println!(
+        let _ = writeln!(
+            io::stdout(),
             "{} {}\n{}\n",
             "Classification".bold(),
             classification.name.bold(),
             classification.description,
         );
         if !classification.products.is_empty() {
-            println!("{}:", "Products".bold());
+            let _ = writeln!(io::stdout(), "{}:", "Products".bold());
             for p in &classification.products {
-                println!("  {} - {}", p.name, truncate(&p.description, 60));
+                let _ = writeln!(
+                    io::stdout(),
+                    "  {} - {}",
+                    p.name,
+                    truncate(&p.description, 60)
+                );
             }
         }
     });
@@ -82,5 +89,42 @@ mod tests {
         let json = serde_json::to_string(&classification).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed["products"].as_array().unwrap().len(), 0);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn print_classification_table_omits_products_header_when_empty() {
+        let _lock = crate::ENV_LOCK.lock().await;
+        let with_products = Classification {
+            id: 1,
+            name: "Software".into(),
+            description: "Software products".into(),
+            sort_key: 0,
+            products: vec![ClassificationProduct {
+                id: 10,
+                name: "Widget".into(),
+                description: "A widget".into(),
+            }],
+        };
+        let empty = Classification {
+            id: 2,
+            name: "Empty".into(),
+            description: "Nothing here".into(),
+            sort_key: 0,
+            products: vec![],
+        };
+
+        let ((), populated) = crate::test_helpers::capture_stdout(async {
+            super::print_classification(&with_products, crate::types::OutputFormat::Table);
+        })
+        .await;
+        let ((), bare) = crate::test_helpers::capture_stdout(async {
+            super::print_classification(&empty, crate::types::OutputFormat::Table);
+        })
+        .await;
+
+        assert!(populated.contains("Products"));
+        assert!(populated.contains("Widget"));
+        assert!(!bare.contains("Products"));
     }
 }

--- a/src/output/formatting.rs
+++ b/src/output/formatting.rs
@@ -183,10 +183,9 @@ mod tests {
 
     #[test]
     fn colorize_status_known_statuses_emit_ansi_escapes() {
-        // Force color output so the test assertion is reliable regardless
-        // of TTY detection in cargo test. The catch-all match arm returns
-        // the input unchanged, so a deleted known-status arm would fall
-        // through and produce no escape codes.
+        // Force color output: cargo test pipes stdout, so colored auto-disables
+        // and the catch-all arm produces output identical to the colored arms,
+        // hiding `delete match arm` mutations.
         struct ColorOverride;
         impl Drop for ColorOverride {
             fn drop(&mut self) {
@@ -211,7 +210,6 @@ mod tests {
                 "expected ANSI escape in colorize_status({status:?}), got {result:?}"
             );
         }
-        // Unknown statuses must NOT receive coloring.
         assert_eq!(colorize_status("CUSTOM"), "CUSTOM");
     }
 

--- a/src/output/formatting.rs
+++ b/src/output/formatting.rs
@@ -181,6 +181,40 @@ mod tests {
         assert!(result.contains("new"));
     }
 
+    #[test]
+    fn colorize_status_known_statuses_emit_ansi_escapes() {
+        // Force color output so the test assertion is reliable regardless
+        // of TTY detection in cargo test. The catch-all match arm returns
+        // the input unchanged, so a deleted known-status arm would fall
+        // through and produce no escape codes.
+        struct ColorOverride;
+        impl Drop for ColorOverride {
+            fn drop(&mut self) {
+                colored::control::unset_override();
+            }
+        }
+        colored::control::set_override(true);
+        let _guard = ColorOverride;
+
+        for status in [
+            "NEW",
+            "UNCONFIRMED",
+            "ASSIGNED",
+            "IN_PROGRESS",
+            "RESOLVED",
+            "VERIFIED",
+            "CLOSED",
+        ] {
+            let result = colorize_status(status);
+            assert!(
+                result.contains("\x1b["),
+                "expected ANSI escape in colorize_status({status:?}), got {result:?}"
+            );
+        }
+        // Unknown statuses must NOT receive coloring.
+        assert_eq!(colorize_status("CUSTOM"), "CUSTOM");
+    }
+
     // ── shorten_email ────────────────────────────────────────────────
 
     #[test]

--- a/src/output/template.rs
+++ b/src/output/template.rs
@@ -271,41 +271,4 @@ mod tests {
         .await;
         assert!(output.contains("No templates configured."));
     }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn template_list_names_sort_before_render() {
-        let _lock = crate::ENV_LOCK.lock().await;
-        let mut templates: HashMap<String, BugTemplate> = HashMap::new();
-        templates.insert("zzz".into(), make_template());
-        templates.insert(
-            "aaa".into(),
-            BugTemplate {
-                product: Some("Alpha".into()),
-                component: None,
-                version: None,
-                priority: None,
-                severity: None,
-                assignee: None,
-                op_sys: None,
-                rep_platform: None,
-                description: None,
-            },
-        );
-
-        let mut names: Vec<&str> = templates.keys().map(String::as_str).collect();
-        names.sort_unstable();
-        let rendered: Vec<String> = names
-            .into_iter()
-            .map(|name| template_summary_line(name, &templates[name]))
-            .collect();
-
-        assert_eq!(
-            rendered,
-            vec![
-                "aaa (product=Alpha)".to_string(),
-                "zzz (product=Widget, component=Backend, priority=P1, severity=major)".to_string(),
-            ]
-        );
-    }
 }

--- a/src/output/template.rs
+++ b/src/output/template.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io::{self, Write as _};
 
 use crate::types::{BugTemplate, OutputFormat};
 
@@ -35,7 +36,7 @@ pub fn print_template_saved(name: &str, verb: &str, format: OutputFormat) {
             print_json(&serde_json::json!({"name": name, "action": verb.to_lowercase()}));
         }
         OutputFormat::Table => {
-            println!("{}", template_saved_message(name, verb));
+            let _ = writeln!(io::stdout(), "{}", template_saved_message(name, verb));
         }
     }
 }
@@ -43,13 +44,17 @@ pub fn print_template_saved(name: &str, verb: &str, format: OutputFormat) {
 pub fn print_template_list(templates: &HashMap<String, BugTemplate>, format: OutputFormat) {
     print_formatted(templates, format, |templates| {
         if templates.is_empty() {
-            println!("No templates configured.");
+            let _ = writeln!(io::stdout(), "No templates configured.");
             return;
         }
         let mut names: Vec<&str> = templates.keys().map(String::as_str).collect();
         names.sort_unstable();
         for name in names {
-            println!("{}", template_summary_line(name, &templates[name]));
+            let _ = writeln!(
+                io::stdout(),
+                "{}",
+                template_summary_line(name, &templates[name])
+            );
         }
     });
 }
@@ -220,6 +225,51 @@ mod tests {
         assert!(output.contains("  -"));
         assert!(output.contains("Description"));
         assert!(output.contains("Default description"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn print_template_list_table_renders_sorted_summaries() {
+        let _lock = crate::ENV_LOCK.lock().await;
+        let mut templates: HashMap<String, BugTemplate> = HashMap::new();
+        templates.insert("zzz".into(), make_template());
+        templates.insert(
+            "aaa".into(),
+            BugTemplate {
+                product: Some("Alpha".into()),
+                component: None,
+                version: None,
+                priority: None,
+                severity: None,
+                assignee: None,
+                op_sys: None,
+                rep_platform: None,
+                description: None,
+            },
+        );
+
+        let ((), output) = crate::test_helpers::capture_stdout(async {
+            print_template_list(&templates, OutputFormat::Table);
+        })
+        .await;
+
+        let aaa_pos = output.find("aaa").expect("aaa should appear in output");
+        let zzz_pos = output.find("zzz").expect("zzz should appear in output");
+        assert!(aaa_pos < zzz_pos, "templates should be sorted by name");
+        assert!(output.contains("product=Alpha"));
+        assert!(output.contains("product=Widget"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn print_template_list_table_announces_empty() {
+        let _lock = crate::ENV_LOCK.lock().await;
+        let templates: HashMap<String, BugTemplate> = HashMap::new();
+        let ((), output) = crate::test_helpers::capture_stdout(async {
+            print_template_list(&templates, OutputFormat::Table);
+        })
+        .await;
+        assert!(output.contains("No templates configured."));
     }
 
     #[cfg(unix)]

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -616,29 +616,9 @@ mod tests {
     }
 
     #[test]
-    fn saved_query_has_filters_true() {
-        let query = SavedQuery {
-            kind: QueryKind::List,
-            product: vec!["Firefox".into()],
-            ..SavedQuery::default()
-        };
-        assert!(query.has_filters());
-    }
-
-    #[test]
     fn saved_query_has_filters_false_empty() {
         let query = SavedQuery::default();
         assert!(!query.has_filters());
-    }
-
-    #[test]
-    fn saved_query_has_filters_search_only() {
-        let query = SavedQuery {
-            kind: QueryKind::Search,
-            quicksearch: Some("crash".into()),
-            ..SavedQuery::default()
-        };
-        assert!(query.has_filters());
     }
 
     fn sample_raw_params() -> Vec<(String, String)> {
@@ -717,25 +697,6 @@ mod tests {
         assert_eq!(params.limit, Some(100));
         assert_eq!(params.raw_params.len(), 2);
         assert_eq!(params.raw_params[0], ("f1".into(), "qa_contact".into()));
-    }
-
-    #[test]
-    fn saved_query_url_kind_has_filters_with_only_raw_params() {
-        let query = SavedQuery {
-            kind: QueryKind::Url,
-            raw_params: vec![("f1".into(), "qa_contact".into())],
-            ..SavedQuery::default()
-        };
-        assert!(query.has_filters());
-    }
-
-    #[test]
-    fn search_params_has_filters_with_raw_params() {
-        let params = SearchParams {
-            raw_params: vec![("f1".into(), "qa_contact".into())],
-            ..Default::default()
-        };
-        assert!(params.has_filters());
     }
 
     #[test]

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -810,6 +810,89 @@ mod tests {
     }
 
     #[test]
+    fn search_params_has_filters_for_each_individual_field() {
+        type Setter = fn(&mut SearchParams);
+        let cases: &[(&str, Setter)] = &[
+            ("product", |p| p.product.push("X".into())),
+            ("component", |p| p.component.push("X".into())),
+            ("status", |p| p.status.push("X".into())),
+            ("assigned_to", |p| p.assigned_to.push("X".into())),
+            ("creator", |p| p.creator.push("X".into())),
+            ("priority", |p| p.priority.push("X".into())),
+            ("severity", |p| p.severity.push("X".into())),
+            ("cc", |p| p.cc = Some("X".into())),
+            ("alias", |p| p.alias = Some("X".into())),
+            ("id", |p| p.id = vec![1]),
+            ("summary", |p| p.summary = Some("X".into())),
+            ("quicksearch", |p| p.quicksearch = Some("X".into())),
+            ("raw_params", |p| {
+                p.raw_params = vec![("f1".into(), "X".into())];
+            }),
+        ];
+        for (name, setter) in cases {
+            let mut p = SearchParams::default();
+            setter(&mut p);
+            assert!(
+                p.has_filters(),
+                "field `{name}` alone should make has_filters() return true"
+            );
+        }
+    }
+
+    #[test]
+    fn saved_query_has_filters_for_each_individual_field() {
+        type Setter = fn(&mut SavedQuery);
+        let cases: &[(&str, Setter)] = &[
+            ("product", |q| q.product.push("X".into())),
+            ("component", |q| q.component.push("X".into())),
+            ("status", |q| q.status.push("X".into())),
+            ("assignee", |q| q.assignee.push("X".into())),
+            ("creator", |q| q.creator.push("X".into())),
+            ("priority", |q| q.priority.push("X".into())),
+            ("severity", |q| q.severity.push("X".into())),
+            ("quicksearch", |q| q.quicksearch = Some("X".into())),
+            ("raw_params", |q| {
+                q.raw_params = vec![("f1".into(), "X".into())];
+            }),
+        ];
+        for (name, setter) in cases {
+            let mut q = SavedQuery::default();
+            setter(&mut q);
+            assert!(
+                q.has_filters(),
+                "field `{name}` alone should make has_filters() return true"
+            );
+        }
+    }
+
+    #[test]
+    fn id_list_update_is_empty_when_both_empty() {
+        let upd = IdListUpdate {
+            add: vec![],
+            remove: vec![],
+        };
+        assert!(upd.is_empty());
+    }
+
+    #[test]
+    fn id_list_update_not_empty_when_only_add() {
+        let upd = IdListUpdate {
+            add: vec![1],
+            remove: vec![],
+        };
+        assert!(!upd.is_empty());
+    }
+
+    #[test]
+    fn id_list_update_not_empty_when_only_remove() {
+        let upd = IdListUpdate {
+            add: vec![],
+            remove: vec![2],
+        };
+        assert!(!upd.is_empty());
+    }
+
+    #[test]
     fn into_search_params_moves_fields() {
         let query = SavedQuery {
             kind: QueryKind::List,

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -243,10 +243,14 @@ mod tests {
 
     #[test]
     fn flag_status_display_emits_status_char() {
-        assert_eq!(FlagStatus::Grant.to_string(), "+");
-        assert_eq!(FlagStatus::Deny.to_string(), "-");
-        assert_eq!(FlagStatus::Request.to_string(), "?");
-        assert_eq!(FlagStatus::Clear.to_string(), "X");
+        for (status, expected) in [
+            (FlagStatus::Grant, "+"),
+            (FlagStatus::Deny, "-"),
+            (FlagStatus::Request, "?"),
+            (FlagStatus::Clear, "X"),
+        ] {
+            assert_eq!(status.to_string(), expected);
+        }
     }
 
     #[test]

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -242,6 +242,14 @@ mod tests {
     }
 
     #[test]
+    fn flag_status_display_emits_status_char() {
+        assert_eq!(FlagStatus::Grant.to_string(), "+");
+        assert_eq!(FlagStatus::Deny.to_string(), "-");
+        assert_eq!(FlagStatus::Request.to_string(), "?");
+        assert_eq!(FlagStatus::Clear.to_string(), "X");
+    }
+
+    #[test]
     fn flag_status_invalid_deserialize() {
         let json = serde_json::json!("Z");
         let err = serde_json::from_value::<FlagStatus>(json).unwrap_err();

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -82,33 +82,6 @@ mod tests {
         assert!(!params.has_filters());
     }
 
-    #[test]
-    fn search_params_has_filters_with_product() {
-        let params = SearchParams {
-            product: vec!["TestProduct".into()],
-            ..Default::default()
-        };
-        assert!(params.has_filters());
-    }
-
-    #[test]
-    fn search_params_has_filters_with_ids() {
-        let params = SearchParams {
-            id: vec![1, 2, 3],
-            ..Default::default()
-        };
-        assert!(params.has_filters());
-    }
-
-    #[test]
-    fn search_params_has_filters_with_quicksearch() {
-        let params = SearchParams {
-            quicksearch: Some("crash".into()),
-            ..Default::default()
-        };
-        assert!(params.has_filters());
-    }
-
     // Bug deserialization tests
 
     #[test]

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -721,7 +721,7 @@ mod tests {
             password: Some("hunter2".into()),
         };
         let id = client.create_user(&params).await.unwrap();
-        assert_eq!(id, 4242, "expected id 4242 from server response");
+        assert_eq!(id, 4242);
     }
 
     #[test]
@@ -733,7 +733,6 @@ mod tests {
         let mut rpc = BTreeMap::new();
         add_vec_filters(&mut rpc, &params);
 
-        // Two distinct chart indices must be emitted, one per negation.
         assert_eq!(rpc.get("f1").and_then(Value::as_str), Some("product"));
         assert_eq!(rpc.get("o1").and_then(Value::as_str), Some("notequals"));
         assert_eq!(rpc.get("v1").and_then(Value::as_str), Some("Bad"));

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -685,4 +685,129 @@ mod tests {
         assert_eq!(info.membership[0].id, 7);
         assert_eq!(info.membership[0].real_name.as_deref(), Some("Alice"));
     }
+
+    #[tokio::test]
+    async fn create_user_returns_id_from_response() {
+        let mock = MockServer::start().await;
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+              <params>
+                <param>
+                  <value>
+                    <struct>
+                      <member>
+                        <name>id</name>
+                        <value><int>4242</int></value>
+                      </member>
+                    </struct>
+                  </value>
+                </param>
+              </params>
+            </methodResponse>"#;
+        Mock::given(method("POST"))
+            .and(path("/xmlrpc.cgi"))
+            .and(body_string_contains("User.create"))
+            .and(body_string_contains("alice@example.com"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(xml))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+        let params = CreateUserParams {
+            email: "alice@example.com".into(),
+            login: Some("alice".into()),
+            full_name: Some("Alice Example".into()),
+            password: Some("hunter2".into()),
+        };
+        let id = client.create_user(&params).await.unwrap();
+        assert_eq!(id, 4242, "expected id 4242 from server response");
+    }
+
+    #[test]
+    fn add_vec_filters_increments_chart_index_per_negation() {
+        let params = SearchParams {
+            product: vec!["!Bad".into(), "!Worse".into()],
+            ..Default::default()
+        };
+        let mut rpc = BTreeMap::new();
+        add_vec_filters(&mut rpc, &params);
+
+        // Two distinct chart indices must be emitted, one per negation.
+        assert_eq!(rpc.get("f1").and_then(Value::as_str), Some("product"));
+        assert_eq!(rpc.get("o1").and_then(Value::as_str), Some("notequals"));
+        assert_eq!(rpc.get("v1").and_then(Value::as_str), Some("Bad"));
+        assert_eq!(rpc.get("f2").and_then(Value::as_str), Some("product"));
+        assert_eq!(rpc.get("o2").and_then(Value::as_str), Some("notequals"));
+        assert_eq!(rpc.get("v2").and_then(Value::as_str), Some("Worse"));
+    }
+
+    #[test]
+    fn get_nonempty_str_filters_empty_and_non_string() {
+        let mut m = BTreeMap::new();
+        m.insert("empty".into(), Value::String(String::new()));
+        m.insert("filled".into(), Value::String("x".into()));
+        m.insert("not_string".into(), Value::Int(5));
+        assert!(get_nonempty_str(&m, "empty").is_none());
+        assert_eq!(get_nonempty_str(&m, "filled").as_deref(), Some("x"));
+        assert!(get_nonempty_str(&m, "not_string").is_none());
+        assert!(get_nonempty_str(&m, "missing").is_none());
+    }
+
+    #[test]
+    fn get_datetime_str_covers_datetime_string_and_fallthrough() {
+        let mut m = BTreeMap::new();
+        m.insert("dt".into(), Value::DateTime("2024-01-01T00:00:00".into()));
+        m.insert("s_full".into(), Value::String("2024-02-02".into()));
+        m.insert("s_empty".into(), Value::String(String::new()));
+        m.insert("other".into(), Value::Int(42));
+        assert_eq!(
+            get_datetime_str(&m, "dt").as_deref(),
+            Some("2024-01-01T00:00:00")
+        );
+        assert_eq!(
+            get_datetime_str(&m, "s_full").as_deref(),
+            Some("2024-02-02")
+        );
+        assert!(get_datetime_str(&m, "s_empty").is_none());
+        assert!(get_datetime_str(&m, "other").is_none());
+        assert!(get_datetime_str(&m, "missing").is_none());
+    }
+
+    #[test]
+    fn get_str_array_returns_strings_only() {
+        let mut m = BTreeMap::new();
+        m.insert(
+            "tags".into(),
+            Value::Array(vec![
+                Value::String("alpha".into()),
+                Value::String("beta".into()),
+                Value::Int(99),
+            ]),
+        );
+        m.insert("not_array".into(), Value::String("oops".into()));
+        assert_eq!(
+            get_str_array(&m, "tags"),
+            vec!["alpha".to_string(), "beta".to_string()]
+        );
+        assert!(get_str_array(&m, "not_array").is_empty());
+        assert!(get_str_array(&m, "missing").is_empty());
+    }
+
+    #[test]
+    fn get_int_array_returns_ints_only() {
+        let mut m = BTreeMap::new();
+        m.insert(
+            "blocks".into(),
+            Value::Array(vec![
+                Value::Int(42),
+                Value::Int(100),
+                Value::String("nope".into()),
+            ]),
+        );
+        m.insert("not_array".into(), Value::Int(5));
+        assert_eq!(get_int_array(&m, "blocks"), vec![42_u64, 100]);
+        assert!(get_int_array(&m, "not_array").is_empty());
+        assert!(get_int_array(&m, "missing").is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

Phase 1 of the mutation-testing rollout: sweep the remaining 29 source
files left pending after PR #114, taking the project from 46/75 files
swept to 75/75 at 100% caught on viable mutants.

## Wave breakdown

| Wave | Files | Mutants | Caught | Missed | Unviable |
|------|------:|--------:|-------:|-------:|---------:|
| Wave 5 (xmlrpc/*)         |  4 |  80 |  63 | 0 | 17 |
| Wave 6 (types/*)          |  5 | 102 |  95 | 0 |  7 |
| Wave 7 (output/**)        | 14 | 101 |  86 | 0 | 15 |
| Wave 8 (cross-cutting)    |  6 |  29 |  25 | 0 |  4 |
| **Total**                 | **29** | **312** | **269** | **0** | **43** |

100% caught on viable across every newly swept file. Combined with
PR #114 (46 files, 587/710 caught), the entire `src/` tree is at the
ratchet floor.

## Wave 5 — XML-RPC remainder (`73505b7`, `56c07d3`)

`xmlrpc/{client,mod,call,fault}.rs`. 18 missed in `client.rs`; the
other three files were clean. Added direct unit tests for the
leaf helpers (`get_nonempty_str`, `get_datetime_str`, `get_str_array`,
`get_int_array`), plus a wiremock test for `create_user` and a
two-negation test that pins `add_vec_filters`'s chart-index increment.
Single-negation tests miss the `+=` mutation because `chart_idx` only
gets used once.

## Wave 6 — Types (`2979243`, `89e2ec7`, `fae9cd0`)

`types/{bug,common,attachment,product,user}.rs`. 16 missed, mostly
boolean grids in `SearchParams::has_filters` and
`SavedQuery::has_filters` plus the `IdListUpdate::is_empty` `&&`. Added
two parametrized per-field tests that walk every filter individually
and three small `IdListUpdate` cases. The `flag_status_display_emits_status_char`
test closes a gap that slipped through `exclude_re = \"impl .* Display for\"`
because `impl std::fmt::Display for FlagStatus` has no space before
\`Display\`.

Cleanup: removed 8 pre-existing single-field `has_filters` tests now
strictly subsumed by the new parametrized grids (kept the two
`*_empty` tests since the grids only assert the true direction).

## Wave 7 — Output formatters (`6d0c4b9`, `7f77862`)

`output/**` (14 files). Only 5 missed — much smaller than the wave
plan estimated, so insta wasn't adopted. Two `println!` -> `writeln!(io::stdout(), …)`
migrations (so `capture_stdout` can observe them) plus four direct
tests close everything. The `colorize_status` test forces
`colored::control::set_override(true)` with a `Drop` guard — without
it, cargo test's piped stdout suppresses ANSI codes and the
\`delete match arm\` mutations produce output identical to the
catch-all.

## Wave 8 — Cross-cutting (`d77a710`, `ba340f0`)

`main.rs`, `lib.rs`, `credentials/{keyring,keyring_stub}.rs`,
`tls/{mod,fingerprint}.rs`. 10 missed; closed via two test
improvements plus seven `#[cfg_attr(test, mutants::skip)]`
annotations:

- `keyring.rs::store_retrieve_delete_roundtrip` now asserts
  retrieve fails after delete (previously the delete result was
  unused, so a no-op delete passed the test).
- `main.rs::suppress_stdout_redirects_fd1_to_devnull` now redirects
  fd 1 to a temp file, calls `suppress_stdout`, writes a marker, and
  asserts the marker did NOT reach the temp file (i.e. it went to
  /dev/null). The previous test only checked that the call did not
  panic.
- Skips on `fn main` itself (would need `assert_cmd`/`escargot` to
  spawn the compiled binary), the `cfg(windows)` and
  `cfg(not(any(unix, windows)))` variants of `suppress_stdout` (dead
  on the Linux test platform), and `keyring_stub.rs::{store,retrieve,delete}`
  (the file is `cfg(not(feature = \"keyring\"))` and never compiled
  with `--all-features`).

## Notes

- Each wave was followed by a `/simplify` review pass; the
  \`refactor(mutants): apply Wave N review feedback\` commits show the
  applied feedback (DRY-ups, comment trims, dead test removal).
- The `colorize_status` test holds a process-global `set_override(true)`
  during execution. cargo-mutants uses `--test-threads=1`, so the
  override is restored before any other test runs. Under default
  parallel `cargo test` no other test asserts on color absence today;
  flagged in the review notes if a future test ever does.
- 913 unit/binary/integration tests pass; `cargo fmt --check` and
  `cargo clippy --workspace --all-features -- -D warnings` are clean.

## Testing

- 836 unit tests + 21 binary tests + 56 integration tests pass.
- All 29 swept files re-verified at 100% caught on viable mutants.
- `mutation-baseline.md` updated with per-file scores and an
  expanded skip-list audit table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)