### PR TITLE
ship manpages, .deb/.rpm packages, and Homebrew tap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,32 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2
       - run: cargo build --release --locked
 
+  manpages:
+    name: Manpages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2
+        with:
+          key: manpages
+      - name: Generate manpages
+        run: cargo run -p xtask --no-default-features --release --locked -- man --out man/man1
+      - name: Verify expected pages exist
+        run: |
+          set -euo pipefail
+          test -s man/man1/bzr.1
+          test -s man/man1/bzr-bug.1
+          test -s man/man1/bzr-bug-list.1
+          test -s man/man1/bzr-config-set-server.1
+      - name: Render with groff (catches malformed roff)
+        run: |
+          set -euo pipefail
+          sudo apt-get update && sudo apt-get install -y groff
+          for page in man/man1/*.1; do
+            groff -man -Tutf8 "$page" > /dev/null
+          done
+
   cross-check:
     name: Cross-check ${{ matrix.target }}
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,28 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  manpages:
+    name: Generate manpages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2
+        with:
+          key: manpages
+      - name: Generate manpages
+        run: cargo run -p xtask --no-default-features --release --locked -- man --out man/man1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: bzr-manpages
+          path: man/man1/*.1
+          if-no-files-found: error
+
   build:
     name: Build ${{ matrix.target }}
+    needs: manpages
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -25,19 +45,28 @@ jobs:
             os: ubuntu-latest
             use_cross: false
             archive: tar.gz
+            pkg_deb: true
+            pkg_rpm: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             use_cross: true
             archive: tar.gz
+            pkg_deb: true
+            pkg_rpm: true
           - target: powerpc64le-unknown-linux-gnu
             os: ubuntu-latest
             use_cross: false
             use_qemu: true
             archive: tar.gz
+            pkg_deb: true
+            pkg_rpm: true
           - target: s390x-unknown-linux-gnu
             os: ubuntu-latest
             use_cross: true
             archive: tar.gz
+            # .deb skipped: Debian s390x audience is effectively zero.
+            pkg_deb: false
+            pkg_rpm: true
           - target: aarch64-apple-darwin
             os: macos-14
             use_cross: false
@@ -98,6 +127,12 @@ jobs:
           fi
         shell: bash
 
+      - name: Download manpages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: bzr-manpages
+          path: man/man1
+
       - name: Package (unix)
         if: matrix.archive == 'tar.gz'
         run: |
@@ -105,6 +140,8 @@ jobs:
           mkdir "$STAGING"
           cp "target/${{ matrix.target }}/release/bzr" "$STAGING/"
           cp LICENSE README.md "$STAGING/"
+          mkdir -p "$STAGING/man/man1"
+          cp man/man1/*.1 "$STAGING/man/man1/"
           tar czf "$STAGING.tar.gz" "$STAGING"
         shell: bash
 
@@ -115,18 +152,90 @@ jobs:
           New-Item -ItemType Directory -Path $STAGING
           Copy-Item "target\${{ matrix.target }}\release\bzr.exe" "$STAGING\"
           Copy-Item LICENSE, README.md "$STAGING\"
+          New-Item -ItemType Directory -Path "$STAGING\man\man1"
+          Copy-Item "man\man1\*.1" "$STAGING\man\man1\"
           Compress-Archive -Path "$STAGING\*" -DestinationPath "$STAGING.zip"
         shell: pwsh
+
+      - name: Install cargo-deb
+        if: matrix.pkg_deb
+        uses: taiki-e/install-action@49ba71bf46962339e6e5c0a7a4ec3ed4c8af28ac
+        with:
+          tool: cargo-deb
+
+      - name: Install cargo-generate-rpm
+        if: matrix.pkg_rpm
+        uses: taiki-e/install-action@49ba71bf46962339e6e5c0a7a4ec3ed4c8af28ac
+        with:
+          tool: cargo-generate-rpm
+
+      - name: Build .deb
+        if: matrix.pkg_deb
+        run: cargo deb --no-build --no-strip --target ${{ matrix.target }}
+        shell: bash
+
+      - name: Build .rpm
+        if: matrix.pkg_rpm
+        run: cargo generate-rpm --target ${{ matrix.target }}
+        shell: bash
+
+      - name: Stage packages alongside tarball
+        if: matrix.pkg_deb || matrix.pkg_rpm
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.pkg_deb }}" = "true" ]; then
+            cp target/${{ matrix.target }}/debian/*.deb .
+          fi
+          if [ "${{ matrix.pkg_rpm }}" = "true" ]; then
+            cp target/${{ matrix.target }}/generate-rpm/*.rpm .
+          fi
+        shell: bash
+
+      - name: Lint .deb (warn-only)
+        if: matrix.pkg_deb
+        continue-on-error: true
+        run: |
+          sudo apt-get update && sudo apt-get install -y lintian
+          lintian --no-tag-display-limit *.deb || true
+        shell: bash
+
+      - name: Lint .rpm (warn-only)
+        if: matrix.pkg_rpm
+        continue-on-error: true
+        run: |
+          sudo apt-get update && sudo apt-get install -y rpmlint
+          rpmlint *.rpm || true
+        shell: bash
+
+      - name: Install-test .deb (x86_64 only)
+        if: matrix.target == 'x86_64-unknown-linux-gnu' && matrix.pkg_deb
+        run: |
+          docker run --rm -v "$PWD:/pkg" -w /pkg debian:stable bash -c '
+            apt-get update && apt-get install -y ./*.deb && bzr --version'
+        shell: bash
+
+      - name: Install-test .rpm (x86_64 only)
+        if: matrix.target == 'x86_64-unknown-linux-gnu' && matrix.pkg_rpm
+        run: |
+          docker run --rm -v "$PWD:/pkg" -w /pkg fedora:latest bash -c '
+            dnf install -y ./*.rpm && bzr --version'
+        shell: bash
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4
         with:
-          subject-path: bzr-${{ github.ref_name }}-${{ matrix.target }}.${{ matrix.archive }}
+          subject-path: |
+            bzr-${{ github.ref_name }}-${{ matrix.target }}.${{ matrix.archive }}
+            *.deb
+            *.rpm
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: bzr-${{ matrix.target }}
-          path: bzr-${{ github.ref_name }}-${{ matrix.target }}.*
+          path: |
+            bzr-${{ github.ref_name }}-${{ matrix.target }}.*
+            *.deb
+            *.rpm
 
   release:
     name: Create Release

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,67 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    name: Bump randomparity/homebrew-tap
+    runs-on: ubuntu-latest
+    # Skip pre-release tags (e.g., v0.2.0-rc3) — only stable releases bump the formula.
+    if: ${{ !github.event.release.prerelease }}
+    steps:
+      - name: Checkout bzr (for template)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Checkout tap
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          repository: randomparity/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Render formula
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          BASE="https://github.com/randomparity/bzr/releases/download/${TAG}"
+
+          fetch_sha() {
+            curl --fail --silent --show-error --location "$1" | sha256sum | awk '{print $1}'
+          }
+
+          MAC_ARM_SHA=$(fetch_sha   "${BASE}/bzr-${TAG}-aarch64-apple-darwin.tar.gz")
+          LINUX_ARM_SHA=$(fetch_sha "${BASE}/bzr-${TAG}-aarch64-unknown-linux-gnu.tar.gz")
+          LINUX_INTEL_SHA=$(fetch_sha "${BASE}/bzr-${TAG}-x86_64-unknown-linux-gnu.tar.gz")
+          SRC_SHA=$(fetch_sha       "https://github.com/randomparity/bzr/archive/refs/tags/${TAG}.tar.gz")
+
+          mkdir -p tap/Formula
+          sed \
+            -e "s|{{VERSION}}|${VERSION}|g" \
+            -e "s|{{MAC_ARM_SHA}}|${MAC_ARM_SHA}|g" \
+            -e "s|{{LINUX_ARM_SHA}}|${LINUX_ARM_SHA}|g" \
+            -e "s|{{LINUX_INTEL_SHA}}|${LINUX_INTEL_SHA}|g" \
+            -e "s|{{SRC_SHA}}|${SRC_SHA}|g" \
+            homebrew/bzr.rb.template > tap/Formula/bzr.rb
+
+      - name: Commit and push
+        working-directory: tap
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/bzr.rb
+          if git diff --staged --quiet; then
+            echo "Formula already up-to-date for ${TAG}; nothing to commit."
+            exit 0
+          fi
+          git commit -m "bzr ${TAG#v}"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Rust build artifacts
 target/
 
+# Generated manpages (produced by `make man` / xtask)
+man/
+
 # cargo-mutants run output
 mutants.out/
 mutants.out.old/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.0-rc3] - 2026-05-01
+
+### Added
+
+- Manpages: `bzr` and one roff page per subcommand, auto-generated from
+  the clap-derive CLI tree by a new `xtask` workspace member. Run
+  `make man` locally; release tarballs ship them under `man/man1/`.
+- `.deb` packages for amd64, arm64, and ppc64el; `.rpm` packages for
+  x86_64, aarch64, ppc64le, and s390x. Built and attached to GitHub
+  releases by `release.yml`, with `lintian`/`rpmlint` checks (warn-only)
+  and Docker install smoke-tests for the x86_64 packages.
+- Homebrew tap support via `randomparity/homebrew-tap`: pre-built
+  binaries on macOS arm64 and Linux x86_64/aarch64; Intel Mac falls
+  back to a source build with a build-time `rust` dep. The
+  `update-homebrew.yml` workflow auto-bumps the formula on each
+  stable release.
+
 ## [0.2.0-rc2] - 2026-04-28
 
 > Same-day re-spin of rc1 to fix a defect found during smoke testing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +437,16 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "clap_mangen"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1850,6 +1866,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
+
+[[package]]
 name = "rpassword"
 version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3039,6 +3061,16 @@ checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "xtask"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bzr",
+ "clap",
+ "clap_mangen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
 members = [".", "xtask"]
+# `fuzz/` is a standalone cargo-fuzz package built with nightly + sanitizers
+# via its own toolchain. It must not share the workspace's resolver/lockfile.
+exclude = ["fuzz"]
 resolver = "3"
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,11 @@
+[workspace]
+members = [".", "xtask"]
+resolver = "3"
+
 [package]
 name = "bzr"
 version = "0.2.0"
 edition = "2021"
-resolver = "3"
 description = "A CLI for Bugzilla, inspired by gh"
 license = "MIT"
 rust-version = "1.88"
@@ -59,6 +62,67 @@ keyring = { version = "3" }
 # `exclude_re` in .cargo/mutants.toml cannot reach (e.g. cargo-mutants's
 # `delete field` operator on struct expressions).
 mutants = "0.0.3"
+
+[package.metadata.deb]
+maintainer = "David Christensen <randomparity@gmail.com>"
+copyright = "2025-2026 David Christensen <randomparity@gmail.com>"
+license-file = ["LICENSE", "0"]
+extended-description = """
+bzr is a Bugzilla CLI inspired by GitHub's gh, supporting both REST and
+XML-RPC APIs, multi-server configuration, saved queries and templates,
+and OS-keychain-backed credential storage."""
+section = "devel"
+priority = "optional"
+# Explicit dependencies. We do not use cargo-deb's `$auto` because the binary
+# is cross-compiled in CI and ldd-based introspection would scan the wrong
+# architecture.
+depends = "libc6, libdbus-1-3"
+recommends = "ca-certificates"
+assets = [
+    ["target/release/bzr",                     "usr/bin/",                          "755"],
+    ["man/man1/bzr.1",                         "usr/share/man/man1/",               "644"],
+    ["man/man1/bzr-*.1",                       "usr/share/man/man1/",               "644"],
+    ["README.md",                              "usr/share/doc/bzr/README.md",       "644"],
+    ["CHANGELOG.md",                           "usr/share/doc/bzr/CHANGELOG.md",    "644"],
+]
+
+[package.metadata.generate-rpm]
+summary = "A CLI for Bugzilla, inspired by gh"
+# Disable rpm-build's automatic Requires extraction. It runs `ldd` on the host
+# which produces wrong results for cross-compiled binaries; declare deps
+# explicitly below instead.
+auto-req = "no"
+[package.metadata.generate-rpm.requires]
+glibc = "*"
+dbus-libs = "*"
+[[package.metadata.generate-rpm.assets]]
+source = "target/release/bzr"
+dest = "/usr/bin/bzr"
+mode = "755"
+[[package.metadata.generate-rpm.assets]]
+source = "man/man1/bzr.1"
+dest = "/usr/share/man/man1/bzr.1"
+mode = "644"
+doc = true
+[[package.metadata.generate-rpm.assets]]
+source = "man/man1/bzr-*.1"
+dest = "/usr/share/man/man1/"
+mode = "644"
+doc = true
+[[package.metadata.generate-rpm.assets]]
+source = "README.md"
+dest = "/usr/share/doc/bzr/README.md"
+mode = "644"
+doc = true
+[[package.metadata.generate-rpm.assets]]
+source = "CHANGELOG.md"
+dest = "/usr/share/doc/bzr/CHANGELOG.md"
+mode = "644"
+doc = true
+[[package.metadata.generate-rpm.assets]]
+source = "LICENSE"
+dest = "/usr/share/licenses/bzr/LICENSE"
+mode = "644"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CARGO ?= cargo
 RUST_MIN_VERSION := 1.84.0
 
 .PHONY: setup check-rust ensure-components ensure-coverage-prereqs ensure-mutants-prereq install-hooks \
-        build release test coverage fmt clippy lint clean help \
+        build release test coverage fmt clippy lint clean help man \
         mutants mutants-fast mutants-list audit-mutant-skips \
         functional-build functional-start functional-test functional-stop \
         functional-test-bz52 functional-test-bz53 functional-test-all functional-stop-all \
@@ -90,6 +90,10 @@ lint: fmt clippy ## Run all linters (fmt + clippy)
 
 clean: ## Remove build artifacts
 	$(CARGO) clean
+	rm -rf man
+
+man: ## Generate manpages into man/man1/
+	$(CARGO) run -p xtask --no-default-features --release --quiet -- man --out man/man1
 
 ## Mutation Testing
 #

--- a/README.md
+++ b/README.md
@@ -39,6 +39,40 @@ Available platforms: Linux (x86_64, aarch64, ppc64le, s390x), macOS (Apple Silic
 
 Intel Mac users can install from source with `cargo install bzr --locked`.
 
+### Homebrew (macOS, Linux)
+
+```bash
+brew tap randomparity/tap
+brew install bzr
+```
+
+The tap ships pre-built binaries for macOS arm64 and Linux x86_64/aarch64.
+Intel Mac builds from source automatically (a `rust` build dependency is
+pulled in for that path).
+
+### Linux packages (`.deb` / `.rpm`)
+
+Each release attaches `.deb` and `.rpm` packages alongside the tarballs:
+
+- `.deb` for `amd64`, `arm64`, `ppc64el`
+- `.rpm` for `x86_64`, `aarch64`, `ppc64le`, `s390x`
+
+Install on Debian/Ubuntu:
+
+```bash
+sudo apt install ./bzr_X.Y.Z-1_amd64.deb
+```
+
+Install on Fedora/RHEL:
+
+```bash
+sudo dnf install ./bzr-X.Y.Z-1.x86_64.rpm
+```
+
+Both packages install the binary, manpages under `/usr/share/man/man1/`, and
+documentation under `/usr/share/doc/bzr/`. They depend on `libdbus-1-3`
+(Debian) / `dbus-libs` (RPM) for the OS keychain backend.
+
 ### From crates.io
 
 ```bash
@@ -80,6 +114,21 @@ variable credentials; only the `config set-keyring` /
 `migrate-to-keyring` subcommands become unavailable. See
 [`docs/troubleshooting.md`](docs/troubleshooting.md) for diagnosing
 keychain errors.
+
+### Manual pages
+
+Release tarballs ship roff manpages under `man/man1/` (`bzr.1`, `bzr-bug.1`,
+`bzr-bug-list.1`, ...). Install them manually:
+
+```bash
+sudo install -Dm644 man/man1/bzr.1 /usr/local/share/man/man1/bzr.1
+sudo install -Dm644 man/man1/bzr-*.1 /usr/local/share/man/man1/
+sudo mandb   # or `sudo makewhatis` on BSD
+```
+
+The `.deb` and `.rpm` packages install them automatically. `cargo install bzr`
+does **not** install manpages — use a release tarball or distro package, or
+regenerate from a source checkout with `make man`.
 
 ## Onboarding
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,9 +60,46 @@ git push origin vX.Y.Z
 
 Pushing a `v*` tag triggers `.github/workflows/release.yml`, which:
 
+- Generates manpages once via `cargo run -p xtask -- man` and shares them across all targets
 - Builds release binaries for supported platforms
-- Packages them with `LICENSE` and `README.md`
-- Creates a GitHub Release for the tag
+- Packages each binary with `LICENSE`, `README.md`, and `man/man1/*.1` into a tarball or zip
+- Builds `.deb` packages for `x86_64`, `aarch64`, and `ppc64el` Linux targets
+- Builds `.rpm` packages for `x86_64`, `aarch64`, `ppc64le`, and `s390x` Linux targets
+- Runs `lintian` and `rpmlint` (warn-only) on the resulting packages
+- Smoke-tests `dpkg`/`dnf` install of the x86_64 packages in containers
+- Creates a GitHub Release for the tag with all artifacts attached
+
+If you change runtime dependencies (e.g., add a new linked native library), update the
+`depends`/`requires` fields in `[package.metadata.deb]` and
+`[package.metadata.generate-rpm]` in `Cargo.toml`. The defaults declare `libc6`,
+`libdbus-1-3` (Debian) and `glibc`, `dbus-libs` (RPM) for the keyring backend.
+
+To regenerate manpages locally:
+
+```bash
+make man    # writes to man/man1/
+```
+
+### Homebrew tap
+
+Each stable (non-prerelease) `v*` release also triggers
+`.github/workflows/update-homebrew.yml`, which:
+
+- Downloads the release tarballs for macOS arm64 and Linux x86_64/aarch64
+- Computes their SHA256 sums
+- Renders `homebrew/bzr.rb.template` into `Formula/bzr.rb` in
+  [`randomparity/homebrew-tap`](https://github.com/randomparity/homebrew-tap)
+- Commits and pushes the bumped formula
+
+Pre-release tags (e.g. `v0.2.0-rc3`) are skipped: brew users always pull the latest
+stable release, so RC builds shouldn't override the formula.
+
+The workflow needs a `HOMEBREW_TAP_TOKEN` repo secret — a fine-grained PAT with
+`Contents: Write` on `randomparity/homebrew-tap`. See
+[`homebrew/README.md`](homebrew/README.md) for one-time tap setup.
+
+**Future goal:** publish to `homebrew-core` so users don't need a custom tap. Defer
+until `bzr` has a stable track record across multiple releases.
 
 ### crates.io publish
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,3 +1,9 @@
+# Standalone (non-member) workspace: cargo-fuzz builds this crate with
+# nightly + sanitizers via its own toolchain, so it must not share the
+# parent workspace's resolver or lockfile. The empty `[workspace]` table
+# stops cargo's parent-workspace auto-discovery.
+[workspace]
+
 [package]
 name = "bzr-fuzz"
 version = "0.0.0"

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,0 +1,72 @@
+# Homebrew tap
+
+This directory holds the formula template that
+[`.github/workflows/update-homebrew.yml`](../.github/workflows/update-homebrew.yml)
+renders into `Formula/bzr.rb` in the
+[`randomparity/homebrew-tap`](https://github.com/randomparity/homebrew-tap)
+repository on each stable (non-prerelease) `v*` release.
+
+## End-user install
+
+```bash
+brew tap randomparity/tap
+brew install bzr
+```
+
+Supported pre-built platforms:
+
+- macOS arm64 (Apple Silicon)
+- Linux x86_64 (glibc)
+- Linux aarch64 (glibc)
+
+Intel Mac (`x86_64-apple-darwin`) builds from source via `cargo` and a
+build-time `rust` dep. No prebuilt binary is published for Intel macOS.
+
+## One-time tap setup
+
+The first time the tap is published, do this manually (the workflow assumes the
+tap repo and the formula already exist):
+
+1. Create the tap repo:
+
+   ```bash
+   gh repo create randomparity/homebrew-tap --public \
+     --description "Homebrew tap for randomparity projects"
+   ```
+
+2. Clone it, copy the rendered formula in, commit, and push:
+
+   ```bash
+   git clone https://github.com/randomparity/homebrew-tap
+   cd homebrew-tap
+   mkdir -p Formula
+   # Render the template manually for the first release, e.g. with the same
+   # sed pipeline the workflow uses, then commit it as Formula/bzr.rb.
+   git add Formula/bzr.rb
+   git commit -m "bzr X.Y.Z"
+   git push
+   ```
+
+3. Create a fine-grained PAT with `Contents: Write` on `randomparity/homebrew-tap`
+   and add it to this repo's secrets as `HOMEBREW_TAP_TOKEN`. The
+   `update-homebrew.yml` workflow uses it to push subsequent updates.
+
+After the one-time setup, every stable release auto-bumps the formula.
+
+## Future: homebrew-core
+
+A long-term goal is to publish `bzr` to homebrew-core so users don't need to
+tap. homebrew-core has higher requirements:
+
+- Stable, in-active-use, with verifiable maintainer
+- No conflicts with existing formulas
+- Submitted via PR to homebrew/homebrew-core
+
+Defer until the project has a track record (multiple stable releases, real
+user base, no outstanding regressions).
+
+## Editing the formula
+
+Update `bzr.rb.template` in this directory; the workflow re-renders it into
+the tap on the next release. Keep placeholders (`{{VERSION}}`,
+`{{MAC_ARM_SHA}}`, etc.) intact — the workflow's `sed` pass replaces them.

--- a/homebrew/bzr.rb.template
+++ b/homebrew/bzr.rb.template
@@ -1,0 +1,47 @@
+class Bzr < Formula
+  desc "CLI for Bugzilla, inspired by gh"
+  homepage "https://github.com/randomparity/bzr"
+  license "MIT"
+  version "{{VERSION}}"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/randomparity/bzr/releases/download/v{{VERSION}}/bzr-v{{VERSION}}-aarch64-apple-darwin.tar.gz"
+      sha256 "{{MAC_ARM_SHA}}"
+    end
+    on_intel do
+      # No prebuilt Intel macOS binary — fall back to a source build.
+      url "https://github.com/randomparity/bzr/archive/refs/tags/v{{VERSION}}.tar.gz"
+      sha256 "{{SRC_SHA}}"
+      depends_on "rust" => :build
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/randomparity/bzr/releases/download/v{{VERSION}}/bzr-v{{VERSION}}-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "{{LINUX_ARM_SHA}}"
+    end
+    on_intel do
+      url "https://github.com/randomparity/bzr/releases/download/v{{VERSION}}/bzr-v{{VERSION}}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "{{LINUX_INTEL_SHA}}"
+    end
+  end
+
+  def install
+    if OS.mac? && Hardware::CPU.intel?
+      ENV["CARGO_TARGET_DIR"] = buildpath/"target"
+      system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+      system "cargo", "run", "-p", "xtask", "--no-default-features", "--release", "--",
+             "man", "--out", "#{buildpath}/man/man1"
+      man1.install Dir["#{buildpath}/man/man1/*.1"]
+    else
+      bin.install "bzr"
+      man1.install Dir["man/man1/*.1"]
+    end
+  end
+
+  test do
+    assert_match "bzr", shell_output("#{bin}/bzr --version")
+  end
+end

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "xtask"
+version = "0.0.0"
+edition = "2021"
+publish = false
+description = "Internal build helpers for bzr (manpage generation, etc.)"
+license = "MIT"
+
+[[bin]]
+name = "xtask"
+path = "src/main.rs"
+
+[dependencies]
+bzr = { path = "..", default-features = false }
+clap = { version = ">=4.5.60, <4.6", features = ["derive"] }
+clap_mangen = "0.3"
+anyhow = "1"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,51 @@
+//! Build helpers for the `bzr` workspace.
+//!
+//! Currently exposes a single `man` subcommand that generates roff manpages
+//! for `bzr` and all of its subcommands by introspecting the clap-derive CLI
+//! tree at `bzr::cli::Cli`.
+//!
+//! Run via `cargo run -p xtask -- man [--out DIR]`.
+
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::{CommandFactory, Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "xtask", about = "Internal build helpers for bzr")]
+struct Xtask {
+    #[command(subcommand)]
+    cmd: XtaskCmd,
+}
+
+#[derive(Subcommand)]
+enum XtaskCmd {
+    /// Generate roff manpages for `bzr` and all subcommands.
+    Man {
+        /// Output directory; created if missing. Defaults to `man/man1` at the
+        /// workspace root so packagers can consume a stable path.
+        #[arg(long, default_value = "man/man1")]
+        out: PathBuf,
+    },
+}
+
+fn main() -> Result<()> {
+    let xtask = Xtask::parse();
+    match xtask.cmd {
+        XtaskCmd::Man { out } => generate_man(&out),
+    }
+}
+
+fn generate_man(out: &PathBuf) -> Result<()> {
+    fs::create_dir_all(out)
+        .with_context(|| format!("creating manpage output directory {}", out.display()))?;
+
+    let cmd = <bzr::cli::Cli as CommandFactory>::command();
+
+    clap_mangen::generate_to(cmd, out)
+        .with_context(|| format!("writing manpages to {}", out.display()))?;
+
+    eprintln!("wrote manpages to {}", out.display());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds three distribution channels for `bzr` binaries:

- **Manpages** — a new `xtask` workspace member generates roff for `bzr` and every subcommand from the existing clap-derive CLI tree (via `clap_mangen`). Pages are produced once per release run and shipped under `man/man1/` inside each tarball (Linux, macOS, Windows). A `Manpages` CI job verifies they generate and render with `groff` on every push. `make man` for local generation.
- **Linux packages** — `[package.metadata.deb]` and `[package.metadata.generate-rpm]` in `Cargo.toml` drive `cargo-deb` and `cargo-generate-rpm` from the release matrix to produce `.deb` (amd64, arm64, ppc64el) and `.rpm` (x86_64, aarch64, ppc64le, s390x) packages. `lintian` and `rpmlint` run as warn-only; `dpkg`/`dnf` install smoke-tests run against `debian:stable` and `fedora:latest` on x86_64. Both tools are installed via `taiki-e/install-action` to skip the cargo-install penalty.
- **Homebrew tap** — `homebrew/bzr.rb.template` plus `update-homebrew.yml` auto-bump [`randomparity/homebrew-tap`](https://github.com/randomparity/homebrew-tap) on each stable (non-prerelease) release. macOS arm64 + Linux x86_64/aarch64 install pre-built binaries; Intel Mac falls back to a source build (build-time `rust` dep). Tap repo is bootstrapped; `HOMEBREW_TAP_TOKEN` secret is set; first formula targeting `v0.2.0-rc2` is already pushed.

## Operational notes

- The `update-homebrew.yml` workflow skips prerelease tags, so `v0.2.0-rc3` won't auto-bump the formula. First fully-automatic bump fires on stable `v0.2.0`. The rc2 formula already published works for the three binary platforms; Intel Mac source build will fail until rc3+ (xtask isn't in older source archives) — acceptable for now.
- Release workflow's `build` matrix now `needs: manpages`. A manpage generation failure blocks every binary build for that release — intended.
- `attest-build-provenance` and `upload-artifact` `path:` globs include `*.deb` / `*.rpm`. macOS/Windows targets match nothing — both actions tolerate empty matches when at least one pattern resolves.
- ppc64el `.deb` `Architecture:` and ppc64le `.rpm` `BuildArch:` correctness should be visually verified the first time a release runs (`dpkg-deb -I`, `rpm -qpi`). Not blocking; flagged for the rc3 release verification.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `make man` produces 66 pages; `groff -man -Tutf8` renders all of them clean
- [x] `cargo check --no-default-features` (release-workflow path) clean; xtask binary verified to not link `libdbus`
- [x] Workflow YAMLs parse
- [x] Formula template renders to syntactically clean Ruby with `sed` substitutions
- [ ] First release run after merge: confirm `.deb`/`.rpm` files attach to the GitHub release with correct architectures
- [ ] First stable release after merge: confirm `update-homebrew.yml` succeeds and pushes a formula bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)