### PR TITLE
fix(release): pin ppc64le QEMU container to latest stable Rust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,9 +116,13 @@ jobs:
           PKG_CONFIG_ALLOW_CROSS: "1"
         run: |
           if [ "${{ matrix.use_qemu }}" = "true" ]; then
+            # Use the latest stable Rust image so the container's rustc tracks
+            # `dtolnay/rust-toolchain@stable` used by the rest of the matrix.
+            # A pinned older image (e.g. rust:1.85-bookworm) silently breaks
+            # whenever Cargo.toml's `rust-version` advances.
             docker run --rm --platform linux/ppc64le \
               -v "${{ github.workspace }}:/workspace" -w /workspace \
-              rust:1.85-bookworm \
+              rust:bookworm \
               bash -c "apt-get update && apt-get install -y libdbus-1-dev pkg-config && cargo build --release --locked --target ${{ matrix.target }}"
           elif [ "${{ matrix.use_cross }}" = "true" ]; then
             cross build --release --locked --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary

The ppc64le QEMU container in `release.yml` was pinned to `rust:1.85-bookworm` (rustc 1.85). Cargo.toml's `rust-version = "1.88"` makes `cargo build --locked` abort with:

```
error: rustc 1.85.1 is not supported by the following packages:
  bzr@0.2.0 requires rustc 1.88
```

The other six matrix entries use `dtolnay/rust-toolchain@stable` and don't see this. Switching the container to `rust:bookworm` mirrors the "latest stable" semantics of the rest of the matrix and removes a manual update on future MSRV bumps.

## Surfaced

Tagging `v0.2.0-rc3` triggered `release.yml`; six of seven build legs passed; the `Create Release` job was correctly skipped because of the failed leg, so no broken artifacts shipped. The tag was deleted before opening this PR. Once this merges, the rc3 tag will be re-pushed against the fix.

## Test plan

- [x] YAML validates
- [ ] Re-tag `v0.2.0-rc3` after merge; full release matrix completes
- [ ] ppc64le tarball + .deb + .rpm appear in the GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)