### PR TITLE
fix(release): chown target/ after QEMU build for host-side packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,11 @@ jobs:
               -v "${{ github.workspace }}:/workspace" -w /workspace \
               rust:bookworm \
               bash -c "apt-get update && apt-get install -y libdbus-1-dev pkg-config && cargo build --release --locked --target ${{ matrix.target }}"
+            # The container ran as root and left target/ owned by root.
+            # Subsequent host-side steps (cargo deb / cargo generate-rpm /
+            # tarball staging / lintian) run as the runner user and would
+            # otherwise hit "Permission denied" on target/.
+            sudo chown -R "$(id -u):$(id -g)" target
           elif [ "${{ matrix.use_cross }}" = "true" ]; then
             cross build --release --locked --target ${{ matrix.target }}
           else


### PR DESCRIPTION
## Summary

The ppc64le build runs inside a Docker container as root and leaves `target/` owned by root. Host-side packaging steps added in PR #116 (`cargo deb`, `cargo generate-rpm`, tarball staging, `lintian`) run as the runner user and hit:

```
error: Error while clearing temp directory
  cause: I/O error: Permission denied (os error 13)
```

This was masked while the QEMU container was pinned to `rust:1.85-bookworm` (PR #118 fixed that): the build itself failed before any host-side step could touch `target/`. Now that the build succeeds, the next layer of breakage shows up.

Add `sudo chown -R "$(id -u):$(id -g)" target` immediately after the QEMU `docker run`. Subsequent matrix steps then own the artifacts.

## Surfaced

Re-tagging `v0.2.0-rc3` after #118 merged. Six legs passed; ppc64le failed at `Build .deb`. Tag deleted, this PR is the next layer.

## Test plan

- [x] YAML validates
- [ ] Re-tag `v0.2.0-rc3` after merge; full release matrix completes
- [ ] ppc64le `.deb` and `.rpm` appear in the GitHub release
- [ ] `dpkg-deb -I bzr_*_ppc64el.deb` shows `Architecture: ppc64el`

🤖 Generated with [Claude Code](https://claude.com/claude-code)