### PR TITLE
fix(release): exclude internal manpages artifact from release uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,6 +258,10 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           path: artifacts
+          # Match per-target artifacts (e.g. bzr-x86_64-pc-windows-msvc) but
+          # exclude bzr-manpages, which is an internal artifact consumed by
+          # the build matrix and must not appear on the release page.
+          pattern: bzr-*-*
           merge-multiple: true
 
       - name: Generate SHA256SUMS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Release page no longer attaches stray manpage `.1` files. The
+  `release` job's artifact download now filters with `pattern: bzr-*-*`
+  so the internal `bzr-manpages` artifact (used by the build matrix to
+  bundle pages into tarballs and packages) is not pulled into the
+  release upload set. `SHA256SUMS` correspondingly lists only the
+  published archives and packages.
+
 ### Documentation
 
 - Every man page and every `--help` long-form output across `bzr`


### PR DESCRIPTION
## Summary

- The `release` job pulled every workflow artifact into `artifacts/` (`merge-multiple: true`), including `bzr-manpages` — an internal artifact the build matrix uses to bundle pages into tarballs/packages — so `gh release create artifacts/*` attached 66 loose `.1` files to the release page and `SHA256SUMS` hashed them.
- Add `pattern: bzr-*-*` to the download step so only per-target artifacts (`bzr-x86_64-pc-windows-msvc`, `bzr-aarch64-apple-darwin`, etc.) flow into the release set; `bzr-manpages` (one hyphen) is excluded.
- Inline comment captures intent so the pattern doesn't decay if a future target name is unusual.

The `build` job's `Download manpages` step uses `name: bzr-manpages` directly and is unaffected by this filter — tarballs, `.deb`, and `.rpm` still bundle manpages under `man/man1/`.

Closes #120

## Test plan

- [x] `python3 -c yaml.safe_load` confirms YAML parses
- [x] `zizmor .github/workflows/release.yml` — no new findings (pre-existing low/medium notes on `Swatinem/rust-cache` and `dtolnay/rust-toolchain` are unchanged)
- [ ] After merge, tag `v0.2.0-rc4` and confirm the GitHub release page lists exactly 15 assets (7 archives + 7 Linux packages + `SHA256SUMS`)
- [ ] Confirm `SHA256SUMS` lists 14 entries
- [ ] Confirm a tarball still bundles `man/man1/*.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)