### PR TITLE
release: prep v0.2.0-rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.2.0-rc4] - 2026-05-02
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Promote `[Unreleased]` → `[0.2.0-rc4] - 2026-05-02` in `CHANGELOG.md`. CHANGELOG-only, matching the rc1/rc2 prep convention.

This rc covers two changes since rc3:
- **docs(cli)** — every man page and `--help` long-form now carries full descriptive prose, examples, and cross-refs (PR #122).
- **fix(release)** — exclude the internal `bzr-manpages` artifact from release uploads so the release page lists only published archives and packages (PR #123, closes #120).

Cutting an rc here validates the expanded manpages on real release tarballs and exercises the artifact-filter fix on a live release page before v0.2.0 promotion.

## Tag plan

After merge:
1. \`git fetch origin && git checkout main && git pull\`
2. \`git tag -a v0.2.0-rc4 -m "v0.2.0-rc4"\`
3. \`git push origin v0.2.0-rc4\` — fires \`release.yml\`

\`release.yml\` extracts notes from CHANGELOG via awk on \`## [0.2.0-rc4]\`; \`-rc4\` carries a hyphen so it auto-marks as prerelease.

## Test plan

- [ ] Tag pushed; release workflow runs to completion
- [ ] GitHub release page lists exactly 15 assets (7 archives + 7 Linux packages + SHA256SUMS)
- [ ] SHA256SUMS lists 14 entries
- [ ] A tarball still bundles \`man/man1/*.1\` and the pages render with full prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)