### PR TITLE
release: prep v0.2.0-rc5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.2.0-rc5] - 2026-05-04
 
 ### Added
 
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   from GitHub Releases, with SHA-256 verification against the published
   `SHA256SUMS` file. Hosted at the `main` branch URL for always-current
   installs and as release assets pinned to each tag for reproducibility.
+
+### Fixed
+
+- Windows release zip layout now wraps contents in a top-level
+  `bzr-<tag>-<target>/` directory, matching the Unix tarball.
+  Previously the zip stored `bzr.exe`, `LICENSE`, `README.md`,
+  and `man/man1/` at the archive root.
+
+### CI
+
+- Pin nightly to `nightly-2026-05-02` in the Fuzz workflow as a
+  workaround for `rustix v0.36.5` (transitively pulled by
+  `cargo-fuzz 0.13.1`) failing to compile against newer rustc
+  nightlies. Pin will be lifted once `cargo-fuzz` ships a release
+  that drops the affected `rustix` version.
 
 ## [0.2.0-rc4] - 2026-05-02
 


### PR DESCRIPTION
## Summary

Promotes the `[Unreleased]` section of CHANGELOG.md to `[0.2.0-rc5] - 2026-05-04`. Since rc4 the only change that landed is the installer-scripts work (#126):

- `install.sh` and `install.ps1` for one-line installation from GitHub Releases, with SHA-256 verification against the published `SHA256SUMS`.
- Windows release zip layout fixed so contents live under `bzr-<tag>-<target>/`, matching the Unix tarball.
- Fuzz workflow's nightly toolchain pinned to `2026-05-02` to work around `cargo-fuzz 0.13.1`'s transitive `rustix 0.36.5` failing to build on newer rustc nightlies.

`Cargo.toml` stays at `version = "0.2.0"` per the project pattern (publish-crates is gated to non-prerelease tags via `if: !contains(github.ref_name, '-')`).

## Why an rc5

The new `installer-smoke` job in `release.yml` runs the just-published `install.sh`/`install.ps1` against the real GitHub Releases CDN and verifies `bzr --version` matches the released tag. rc5 is the canary that exercises this end-to-end before v0.2.0 stable.

## Test plan

- [ ] CI checks pass on this PR
- [ ] After merge: tag `v0.2.0-rc5` and confirm:
  - [ ] Release workflow publishes archives, packages, `SHA256SUMS`, and the templated `install.sh` / `install.ps1`
  - [ ] `installer-smoke` job passes on `ubuntu-latest` and `windows-latest`
  - [ ] Manual: `curl -fsSL https://github.com/randomparity/bzr/releases/download/v0.2.0-rc5/install.sh | sh` lands `bzr 0.2.0-rc5` on a clean Linux host