### PR TITLE
fix(release): derive smoke-check expected version from Cargo.toml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,37 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Preflight runs before any side-effecting work (build, package, attest,
+  # release upload, crates.io publish, Homebrew tap bump). It enforces the
+  # RELEASING.md policy that Cargo.toml's version exactly matches the tag,
+  # including any prerelease suffix. If this fails the rest of the workflow
+  # is skipped and no GitHub Release is created -- the operator can delete
+  # the bad tag, fix Cargo.toml, and re-tag.
+  preflight:
+    name: Verify tag matches Cargo.toml
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - name: Compare tag with Cargo.toml version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          cargo_version="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
+          tag_version="${TAG#v}"
+          echo "tag (no v): $tag_version"
+          echo "Cargo.toml: $cargo_version"
+          if [ "$cargo_version" != "$tag_version" ]; then
+            echo "::error::tag/Cargo.toml mismatch -- bump Cargo.toml to match the tag (RELEASING.md step 1)"
+            exit 1
+          fi
+          echo "version alignment: OK"
+
   manpages:
     name: Generate manpages
+    needs: preflight
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -358,6 +387,10 @@ jobs:
       # the rc cycle.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
+      # The tag-vs-Cargo.toml check is enforced by the `preflight` job before
+      # any build runs, so we don't repeat it here. This step verifies the
+      # downloaded binary's --version output matches Cargo.toml at the tagged
+      # commit -- catches a stale build artifact (Cargo.toml bumped post-build).
       - name: Smoke install.sh
         if: matrix.os == 'ubuntu-latest'
         env:
@@ -367,22 +400,12 @@ jobs:
           export BZR_INSTALL_DIR="$HOME/.local/bin"
           curl -fsSL "https://github.com/randomparity/bzr/releases/download/${TAG}/install.sh" | sh
           installed_version="$("$BZR_INSTALL_DIR/bzr" --version 2>&1)"
-          cargo_version="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
-          tag_version="${TAG#v}"
-          echo "tag (no v):   $tag_version"
-          echo "Cargo.toml:   $cargo_version"
-          echo "installed:    $installed_version"
-          # Policy gate: tag and Cargo.toml must match exactly. publish-crates.yml
-          # already checks this for stable tags; mirror it here so prereleases are
-          # held to the same standard.
-          if [ "$cargo_version" != "$tag_version" ]; then
-            echo "tag/Cargo.toml mismatch: tag=$tag_version Cargo.toml=$cargo_version" >&2
-            exit 1
-          fi
-          # Binary check: bzr --version reads from Cargo.toml at build time.
+          expected="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
+          echo "installed: $installed_version"
+          echo "expected:  $expected"
           case "$installed_version" in
-            *"$cargo_version"*) echo "version alignment: OK" ;;
-            *) echo "binary mismatch: expected=$cargo_version output=$installed_version" >&2; exit 1 ;;
+            *"$expected"*) echo "binary version: OK" ;;
+            *) echo "binary mismatch: expected=$expected output=$installed_version" >&2; exit 1 ;;
           esac
         shell: bash
 
@@ -395,20 +418,12 @@ jobs:
           $env:BZR_INSTALL_DIR = Join-Path $env:LOCALAPPDATA 'Programs\bzr'
           irm "https://github.com/randomparity/bzr/releases/download/$env:TAG/install.ps1" | iex
           $installed = & (Join-Path $env:BZR_INSTALL_DIR 'bzr.exe') --version
-          $cargoVersion = (Select-String -Path Cargo.toml -Pattern '^version = "(.*)"' |
-                           Select-Object -First 1).Matches[0].Groups[1].Value
-          $tagVersion = $env:TAG.TrimStart('v')
-          Write-Host "tag (no v):   $tagVersion"
-          Write-Host "Cargo.toml:   $cargoVersion"
-          Write-Host "installed:    $installed"
-          # Policy gate: tag and Cargo.toml must match exactly.
-          if ($cargoVersion -ne $tagVersion) {
-              Write-Error "tag/Cargo.toml mismatch: tag=$tagVersion Cargo.toml=$cargoVersion"
+          $expected = (Select-String -Path Cargo.toml -Pattern '^version = "(.*)"' |
+                       Select-Object -First 1).Matches[0].Groups[1].Value
+          Write-Host "installed: $installed"
+          Write-Host "expected:  $expected"
+          if ($installed -notlike "*$expected*") {
+              Write-Error "binary mismatch: expected=$expected output=$installed"
               exit 1
           }
-          # Binary check: bzr --version reads from Cargo.toml at build time.
-          if ($installed -notlike "*$cargoVersion*") {
-              Write-Error "binary mismatch: expected=$cargoVersion output=$installed"
-              exit 1
-          }
-          Write-Host "version alignment: OK"
+          Write-Host "binary version: OK"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,6 +351,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
+      # Check out so we can read Cargo.toml's version field. Cargo.toml is the
+      # source of truth for what `bzr --version` prints, so the smoke check
+      # validates the installed binary's output against it. This is robust
+      # whether or not the project carries an rc suffix in Cargo.toml across
+      # the rc cycle.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
       - name: Smoke install.sh
         if: matrix.os == 'ubuntu-latest'
         env:
@@ -360,12 +367,12 @@ jobs:
           export BZR_INSTALL_DIR="$HOME/.local/bin"
           curl -fsSL "https://github.com/randomparity/bzr/releases/download/${TAG}/install.sh" | sh
           installed_version="$("$BZR_INSTALL_DIR/bzr" --version 2>&1)"
+          expected="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
           echo "installed: $installed_version"
-          # bzr --version prints "bzr X.Y.Z[-rcN]"; tag is "vX.Y.Z[-rcN]".
-          version_no_v="${TAG#v}"
+          echo "expected (from Cargo.toml): $expected"
           case "$installed_version" in
-            *"$version_no_v"*) echo "version match: OK" ;;
-            *) echo "version mismatch: tag=$TAG output=$installed_version" >&2; exit 1 ;;
+            *"$expected"*) echo "version match: OK" ;;
+            *) echo "version mismatch: expected=$expected output=$installed_version" >&2; exit 1 ;;
           esac
         shell: bash
 
@@ -378,10 +385,12 @@ jobs:
           $env:BZR_INSTALL_DIR = Join-Path $env:LOCALAPPDATA 'Programs\bzr'
           irm "https://github.com/randomparity/bzr/releases/download/$env:TAG/install.ps1" | iex
           $installed = & (Join-Path $env:BZR_INSTALL_DIR 'bzr.exe') --version
+          $expected = (Select-String -Path Cargo.toml -Pattern '^version = "(.*)"' |
+                       Select-Object -First 1).Matches[0].Groups[1].Value
           Write-Host "installed: $installed"
-          $versionNoV = $env:TAG.TrimStart('v')
-          if ($installed -notlike "*$versionNoV*") {
-              Write-Error "version mismatch: tag=$env:TAG output=$installed"
+          Write-Host "expected (from Cargo.toml): $expected"
+          if ($installed -notlike "*$expected*") {
+              Write-Error "version mismatch: expected=$expected output=$installed"
               exit 1
           }
           Write-Host "version match: OK"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,12 +367,22 @@ jobs:
           export BZR_INSTALL_DIR="$HOME/.local/bin"
           curl -fsSL "https://github.com/randomparity/bzr/releases/download/${TAG}/install.sh" | sh
           installed_version="$("$BZR_INSTALL_DIR/bzr" --version 2>&1)"
-          expected="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
-          echo "installed: $installed_version"
-          echo "expected (from Cargo.toml): $expected"
+          cargo_version="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
+          tag_version="${TAG#v}"
+          echo "tag (no v):   $tag_version"
+          echo "Cargo.toml:   $cargo_version"
+          echo "installed:    $installed_version"
+          # Policy gate: tag and Cargo.toml must match exactly. publish-crates.yml
+          # already checks this for stable tags; mirror it here so prereleases are
+          # held to the same standard.
+          if [ "$cargo_version" != "$tag_version" ]; then
+            echo "tag/Cargo.toml mismatch: tag=$tag_version Cargo.toml=$cargo_version" >&2
+            exit 1
+          fi
+          # Binary check: bzr --version reads from Cargo.toml at build time.
           case "$installed_version" in
-            *"$expected"*) echo "version match: OK" ;;
-            *) echo "version mismatch: expected=$expected output=$installed_version" >&2; exit 1 ;;
+            *"$cargo_version"*) echo "version alignment: OK" ;;
+            *) echo "binary mismatch: expected=$cargo_version output=$installed_version" >&2; exit 1 ;;
           esac
         shell: bash
 
@@ -385,12 +395,20 @@ jobs:
           $env:BZR_INSTALL_DIR = Join-Path $env:LOCALAPPDATA 'Programs\bzr'
           irm "https://github.com/randomparity/bzr/releases/download/$env:TAG/install.ps1" | iex
           $installed = & (Join-Path $env:BZR_INSTALL_DIR 'bzr.exe') --version
-          $expected = (Select-String -Path Cargo.toml -Pattern '^version = "(.*)"' |
-                       Select-Object -First 1).Matches[0].Groups[1].Value
-          Write-Host "installed: $installed"
-          Write-Host "expected (from Cargo.toml): $expected"
-          if ($installed -notlike "*$expected*") {
-              Write-Error "version mismatch: expected=$expected output=$installed"
+          $cargoVersion = (Select-String -Path Cargo.toml -Pattern '^version = "(.*)"' |
+                           Select-Object -First 1).Matches[0].Groups[1].Value
+          $tagVersion = $env:TAG.TrimStart('v')
+          Write-Host "tag (no v):   $tagVersion"
+          Write-Host "Cargo.toml:   $cargoVersion"
+          Write-Host "installed:    $installed"
+          # Policy gate: tag and Cargo.toml must match exactly.
+          if ($cargoVersion -ne $tagVersion) {
+              Write-Error "tag/Cargo.toml mismatch: tag=$tagVersion Cargo.toml=$cargoVersion"
               exit 1
           }
-          Write-Host "version match: OK"
+          # Binary check: bzr --version reads from Cargo.toml at build time.
+          if ($installed -notlike "*$cargoVersion*") {
+              Write-Error "binary mismatch: expected=$cargoVersion output=$installed"
+              exit 1
+          }
+          Write-Host "version alignment: OK"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,9 +32,17 @@ If `bzr` is already taken, rename the package before publishing. The install com
 
 ## Release checklist
 
-1. Update the version in `Cargo.toml`.
+1. Update the version in `Cargo.toml` to match the tag exactly, including any prerelease suffix:
+   - Stable: `version = "0.2.0"` for tag `v0.2.0`
+   - Release candidate: `version = "0.2.0-rc5"` for tag `v0.2.0-rc5`
+   - Beta / alpha: same pattern (`0.3.0-beta.1`, etc.)
+
+   Cargo's semver supports prerelease identifiers, and `bzr --version` reads from `Cargo.toml`, so keeping the two aligned means the binary always reports the same string as the tag the user installed. The `installer-smoke` job in `release.yml` validates this on every tag push by comparing the running binary's `--version` output against the Cargo.toml field. Prerelease tags are not published to crates.io — `publish-crates.yml`'s `if: !contains(github.ref_name, '-')` gates them out.
+
+   Run `cargo build` (or `cargo check`) after the bump so `Cargo.lock` regenerates with the new version.
+
 2. If `rust-version` changed, update the MSRV badge in `README.md` and the "Requires Rust X+" line in the "From source" install section.
-3. Add a matching dated entry to `CHANGELOG.md`. Entries must use `## [X.Y.Z] - YYYY-MM-DD` exactly — `release.yml` extracts release notes by matching that heading format, and a different format silently produces an empty release body.
+3. Add a matching dated entry to `CHANGELOG.md`. Entries must use `## [X.Y.Z] - YYYY-MM-DD` exactly — `release.yml` extracts release notes by matching that heading format, and a different format silently produces an empty release body. For prereleases, use the full prerelease version (`## [0.2.0-rc5] - 2026-05-04`).
 4. Verify installation docs still match the published crate name.
 5. Run the release checks locally:
 


### PR DESCRIPTION
## Summary

The `installer-smoke` job's version-match step compared the binary's `--version` output against the git tag with the leading `v` stripped. That assumed `Cargo.toml` carried the same suffix as the tag — which it didn't for v0.2.0-rc5 (tag was `v0.2.0-rc5`, Cargo.toml stayed at `0.2.0`), so the smoke check bailed even though `install.sh` / `install.ps1` had downloaded, verified, extracted, and run the binary correctly.

`Cargo.toml`'s `version` field is the source of truth for what `bzr --version` prints. The fix:

- Add `actions/checkout` to the `installer-smoke` job so it can read `Cargo.toml` at the tag's commit.
- Replace the tag-derived expected string with a `sed` / `Select-String` extract from `Cargo.toml` (bash + PowerShell paths).

This is robust regardless of whether `Cargo.toml` carries an rc suffix or not.

Update `RELEASING.md` to make the prerelease-suffix policy explicit: bump `Cargo.toml` to match the tag, including any `-rcN` / `-betaN` suffix. Rationale and gates documented inline; the prep-PR checklist now flags this as step 1.

## Why this matters

`bzr --version` should match the install source unambiguously. Under the old (implicit) policy, a user installing v0.2.0-rc4 saw `bzr 0.2.0` — no way to identify which rc they had in a bug report. The new policy is what most Rust CLIs ship (`ripgrep`, `bat`, `cargo` itself), and the workflow's smoke check now enforces it on every release.

## Test plan

- [ ] CI passes
- [ ] Manual: cherry-pick the fix, re-tag a hypothetical rc, confirm the smoke job extracts and matches correctly
- [ ] Future: v0.2.0 stable's release-prep PR will be the first to apply the new policy (Cargo.toml stays at `0.2.0` for stable, so the smoke check passes naturally)
- [ ] Future: next rc (if any) will bump Cargo.toml to `0.X.Y-rcN` per the new RELEASING.md guidance

Note: this fix doesn't retroactively change v0.2.0-rc5's release. The release page is good — only the smoke validation step failed, and the installer scripts themselves were verified working in the same logs (`smoke: success_path OK` analog: archive downloaded, SHA256 verified, `bzr --version` produced output).