### PR TITLE
release: prep v0.2.0-rc6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.0-rc6] - 2026-05-04
+
+### Changed
+
+- `Cargo.toml` and `bzr --version` now carry the prerelease suffix
+  on rc builds (`bzr 0.2.0-rc6` for tag `v0.2.0-rc6`). Earlier rcs
+  shipped with `Cargo.toml` pinned to the base `0.2.0`, so users
+  on rc binaries had no way to tell which rc they had installed
+  from `bzr --version` alone. The new policy is documented in
+  `RELEASING.md` and enforced on every tag push by the release
+  workflow's `preflight` job.
+
+### CI
+
+- Add release-workflow `preflight` job that asserts the tag and
+  `Cargo.toml`'s version match exactly before any build, package,
+  attestation, or release upload runs. A misaligned release-prep
+  PR now aborts the workflow up-front instead of being detected
+  after the GitHub Release has already been created and downstream
+  workflows (Homebrew tap auto-bump, etc.) have fired.
+- `installer-smoke` job now compares the installed binary's
+  `--version` output against `Cargo.toml`'s version field rather
+  than the tag string, so it remains correct under any policy
+  variant.
+
 ## [0.2.0-rc5] - 2026-05-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,37 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.2.0-rc6] - 2026-05-04
 
-### Changed
-
-- `Cargo.toml` and `bzr --version` now carry the prerelease suffix
-  on rc builds (`bzr 0.2.0-rc6` for tag `v0.2.0-rc6`). Earlier rcs
-  shipped with `Cargo.toml` pinned to the base `0.2.0`, so users
-  on rc binaries had no way to tell which rc they had installed
-  from `bzr --version` alone. The new policy is documented in
-  `RELEASING.md` and enforced on every tag push by the release
-  workflow's `preflight` job.
-
-### CI
-
-- Add release-workflow `preflight` job that asserts the tag and
-  `Cargo.toml`'s version match exactly before any build, package,
-  attestation, or release upload runs. A misaligned release-prep
-  PR now aborts the workflow up-front instead of being detected
-  after the GitHub Release has already been created and downstream
-  workflows (Homebrew tap auto-bump, etc.) have fired.
-- `installer-smoke` job now compares the installed binary's
-  `--version` output against `Cargo.toml`'s version field rather
-  than the tag string, so it remains correct under any policy
-  variant.
-
-## [0.2.0-rc5] - 2026-05-04
+> Same-day re-spin of rc5. rc5's `installer-smoke` job failed
+> against the published release because `Cargo.toml` carried the
+> base version (`0.2.0`) while the tag was `v0.2.0-rc5`, so the
+> smoke check could not verify alignment. rc6 adopts the policy
+> that `Cargo.toml` mirrors the tag exactly (including any
+> prerelease suffix) and adds a release-workflow `preflight` gate
+> that enforces it before any build runs. The installer scripts
+> themselves were verified working in the rc5 logs; rc6 carries
+> the same artifact set with the version-string and CI-gate
+> changes layered on top. Both rc5 and rc6 are dated 2026-05-04
+> because both were cut on the same calendar day.
 
 ### Added
 
-- Installer scripts (`install.sh`, `install.ps1`) for one-line installation
-  from GitHub Releases, with SHA-256 verification against the published
-  `SHA256SUMS` file. Hosted at the `main` branch URL for always-current
-  installs and as release assets pinned to each tag for reproducibility.
+- Installer scripts (`install.sh`, `install.ps1`) for one-line
+  installation from GitHub Releases, with SHA-256 verification
+  against the published `SHA256SUMS` file. Hosted at the `main`
+  branch URL for always-current installs and as release assets
+  pinned to each tag for reproducibility.
+
+### Changed
+
+- `Cargo.toml` and `bzr --version` now carry the prerelease
+  suffix on rc builds (`bzr 0.2.0-rc6` for tag `v0.2.0-rc6`).
+  Earlier rcs shipped with `Cargo.toml` pinned to the base
+  `0.2.0`, so users on rc binaries had no way to tell which rc
+  they had installed from `bzr --version` alone. The new policy
+  is documented in `RELEASING.md` and enforced on every tag push.
 
 ### Fixed
 
@@ -48,6 +45,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### CI
 
+- Add release-workflow `preflight` job that asserts the tag and
+  `Cargo.toml`'s version match exactly before any build, package,
+  attestation, or release upload runs. A misaligned release-prep
+  PR now aborts the workflow up-front instead of being detected
+  after the GitHub Release has already been created and
+  downstream workflows (Homebrew tap auto-bump, etc.) have fired.
+- `installer-smoke` job now compares the installed binary's
+  `--version` output against `Cargo.toml`'s version field rather
+  than the tag string, so it remains correct under any policy
+  variant.
 - Pin nightly to `nightly-2026-05-02` in the Fuzz workflow as a
   workaround for `rustix v0.36.5` (transitively pulled by
   `cargo-fuzz 0.13.1`) failing to compile against newer rustc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzr"
-version = "0.2.0"
+version = "0.2.0-rc6"
 dependencies = [
  "base64",
  "bzr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 
 [package]
 name = "bzr"
-version = "0.2.0"
+version = "0.2.0-rc6"
 edition = "2021"
 description = "A CLI for Bugzilla, inspired by gh"
 license = "MIT"


### PR DESCRIPTION
## Summary

First rc cut under the new "Cargo.toml carries the rc suffix" policy adopted in #128.

- `Cargo.toml` bumped: `0.2.0` → `0.2.0-rc6` (Cargo.lock follows automatically).
- `CHANGELOG.md` gets a `[0.2.0-rc6] - 2026-05-04` section documenting the policy change visible to users (`bzr --version` now carries the rc suffix) and the workflow CI changes (preflight + installer-smoke updates).

## Why an rc6

rc5 already cut and validated the installer-scripts feature against the real CDN. rc6 exists specifically to validate the **new release gates** against a real prerelease tag:

- `preflight` job in `release.yml` asserts `Cargo.toml::version == ref_name without leading 'v'`. This is the first prerelease tag where the rc suffix actually lives in `Cargo.toml` per the new policy, so this exercises the prerelease branch of the check. (rc5's `Cargo.toml` was `0.2.0` so the check would have failed under the new logic — that's the bug rc6 demonstrates is now caught up-front.)
- `installer-smoke` reads `Cargo.toml`'s version and matches it against `bzr --version` output. With the bumped Cargo.toml, the binary will print `bzr 0.2.0-rc6`, matching exactly.
- `publish-crates.yml` should still skip (gated on non-`-` tags).
- `update-homebrew.yml` should still skip (gated on non-prerelease).

If all those land green, v0.2.0 stable is the next step with confidence.

## Test plan

- [ ] PR CI green
- [ ] After merge: tag `v0.2.0-rc6` on the merge commit and observe:
  - [ ] `preflight` passes (tag `v0.2.0-rc6` matches `Cargo.toml = "0.2.0-rc6"`)
  - [ ] Build matrix succeeds for all 7 targets
  - [ ] Release page populated with archives, packages, `SHA256SUMS`, `install.sh`, `install.ps1`
  - [ ] `installer-smoke` ubuntu-latest + windows-latest both green (`bzr 0.2.0-rc6` matches Cargo.toml)
  - [ ] `publish-crates` skipped
  - [ ] `update-homebrew` does NOT run

Local confirmation:
```
$ /target/release/bzr --version
bzr 0.2.0-rc6
```