### PR TITLE
fix(release): translate '-' to '~' in RPM version on prerelease tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,8 +214,17 @@ jobs:
 
       - name: Build .rpm
         if: matrix.pkg_rpm
-        run: cargo generate-rpm --target ${{ matrix.target }}
         shell: bash
+        run: |
+          # RPM's Version field disallows '-' (it separates the package's
+          # Version from its Release in NVR notation), so 0.2.0-rc6 is a
+          # hard error from cargo-generate-rpm. Translate the prerelease
+          # suffix to '~', which RPM accepts and which sorts correctly:
+          # 0.2.0~rc6 < 0.2.0 < 0.2.0~rc7. cargo-deb (run earlier in this
+          # job) accepts the hyphen form and is unaffected; this rewrite
+          # only persists for the rest of the cross-compile job in CI.
+          sed -i 's/^version = "\([^-"]*\)-\(.*\)"/version = "\1~\2"/' Cargo.toml
+          cargo generate-rpm --target ${{ matrix.target }}
 
       - name: Stage packages alongside tarball
         if: matrix.pkg_deb || matrix.pkg_rpm


### PR DESCRIPTION
## Summary

`cargo-generate-rpm` failed on v0.2.0-rc6 with:

```
invalid version "0.2.0-rc6": contains invalid character
(allowed: alphanumeric, '.', '_', '+', '%', '{', '}', '~', '^')
```

RPM's `Version` field disallows `-` because RPM uses `-` as the NVR (Name-Version-Release) separator. Earlier rcs (rc1–rc5) didn't hit this because `Cargo.toml` stayed at the hyphen-free `0.2.0` under the old policy. The new "`Cargo.toml` mirrors the tag" policy adopted in #128 first exposes the issue.

RPM accepts `~` for prerelease versions and sorts them correctly:

```
0.2.0~rc5 < 0.2.0~rc6 < 0.2.0 < 0.2.0~rc7 < 0.2.1
                       ^stable^
```

Insert a regex-anchored `sed` rewrite into `Cargo.toml` right before `cargo generate-rpm`. No-op on stable releases (no `-` in the version), so v0.2.0 and later are unaffected.

`cargo-deb` accepts the hyphen form and ran successfully on rc6 — only the RPM step needs the rewrite. The rewrite is contained to the single cross-compile job in CI; the source tree on disk is ephemeral.

## Test plan

- [ ] CI green (workflow syntax)
- [ ] After merge: re-cut rc6 (or cut rc7) to validate the .rpm step end-to-end with a prerelease version

## Note on rc6's current state

v0.2.0-rc6's tag exists in git but no GitHub Release page was created — `Create Release` is gated behind `needs: build` which never succeeded. This is exactly the safe-recovery scenario the preflight gate enables: bad release detected before any side effects (no GitHub Release, no Homebrew bump, no crates.io publish).

After this fix lands, you can either:
- Delete the failed rc6 tag and re-cut against the fix commit, or
- Cut a fresh rc7 with the fix included (and bumping Cargo.toml to `0.2.0-rc7`).