### PR TITLE
build(makefile): bump RUST_MIN_VERSION to 1.88.0 with upgrade hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   including private entries; it falls back to REST only when the
   server doesn't expose `xmlrpc.cgi`. No configuration change
   required. Affects #125.
+- `make setup` now requires Rust 1.88.0 (matching `Cargo.toml`'s
+  `rust-version`) and prints a `rustup update stable && rustup
+  default stable` upgrade hint when the local toolchain is older.
+  Previously the threshold was 1.84.0, so `make setup` would pass
+  the version check on rustc 1.85-1.87 and then fail later when
+  `cargo install cargo-llvm-cov` rejected the toolchain. Fixes #138.
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CARGO ?= cargo
-RUST_MIN_VERSION := 1.84.0
+RUST_MIN_VERSION := 1.88.0
 
 .PHONY: setup check-rust ensure-components ensure-coverage-prereqs ensure-mutants-prereq install-hooks \
         build release test coverage fmt clippy lint clean help man \
@@ -22,7 +22,9 @@ check-rust:
 	printf "%s " "$$RUST_VER"; \
 	LOWEST=$$(printf '%s\n%s\n' "$(RUST_MIN_VERSION)" "$$RUST_VER" | sort -V | head -n1); \
 	if [ "$$LOWEST" != "$(RUST_MIN_VERSION)" ]; then \
-		echo "(need >= $(RUST_MIN_VERSION))"; exit 1; \
+		echo "(need >= $(RUST_MIN_VERSION))"; \
+		echo "  Upgrade with: rustup update stable && rustup default stable"; \
+		exit 1; \
 	fi
 	@echo "ok"
 


### PR DESCRIPTION
## Summary

- Aligns `Makefile`'s `RUST_MIN_VERSION` with `Cargo.toml`'s `rust-version = "1.88"`. The gate previously read `1.84.0`, so `make setup` accepted rustc 1.85-1.87 and then failed downstream when `cargo install cargo-llvm-cov` (which now requires rustc 1.87+) rejected the toolchain — masking the real cause behind a misleading later error.
- Adds a `rustup update stable && rustup default stable` upgrade hint to the failure branch so users get an actionable next step instead of bare `(need >= 1.88.0)`.
- `CHANGELOG.md` 0.2.1 `### Fixed` entry describes the bump and the prior failure mode.

Repo-wide audit confirmed no other stale Rust-version references in active config: `Cargo.toml`, `README.md` MSRV badge, and `.github/workflows/ci.yml` (toolchain pin + `msrv-1.88.0` cache key) are all already on 1.88. CHANGELOG entries and `docs/plans/` references to older versions are historical and intentionally left alone.

Fixes #138.

## Test plan

- [x] `make check-rust` on rustc 1.94.0 prints `1.94.0 ok` (success path unchanged).
- [x] `make check-rust RUST_MIN_VERSION=1.99.0` prints `(need >= 1.99.0)` followed by the indented `Upgrade with: rustup ...` line and exits non-zero (failure path).
- [x] `cargo fmt --check` + `cargo clippy` (pre-commit hook) pass.
- [x] `cargo test` (pre-push hook) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)