### PR TITLE
Fix #133: hybrid-mode XML-RPC fallback for attachment list and download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   including private entries; it falls back to REST only when the
   server doesn't expose `xmlrpc.cgi`. No configuration change
   required. Affects #125.
+- `bzr attachment list` and `bzr attachment download` now return
+  private attachments on the same Bugzilla 5.0.x deployments —
+  REST silently filters them under non-admin API-key auth, while
+  XML-RPC `Bug.attachments` returns the full set. Hybrid mode now
+  routes both `attachment list` and `attachment download` through
+  XML-RPC with REST fallback only on transport failure, mirroring
+  the comment-list fix from #125. Affects #133.
 - `make setup` now requires Rust 1.88.0 (matching `Cargo.toml`'s
   `rust-version`) and prints a `rustup update stable && rustup
   default stable` upgrade hint when the local toolchain is older.
@@ -39,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - XML-RPC `Bug.comments` support in the embedded XML-RPC client,
   used by Hybrid-mode comment fallback and directly when a server
   is configured with `api_mode = "xmlrpc"`.
+- XML-RPC `Bug.attachments` support in the embedded XML-RPC
+  client, covering both bug-scoped (`ids: [bug_id]`) and
+  attachment-by-ID (`attachment_ids: [id]`) lookups. Used by
+  Hybrid-mode `attachment list` and `attachment download`
+  fallback (#133) and directly when `api_mode = "xmlrpc"`.
 - `bzr comment add --private` flag, sets `is_private: true` on the
   posted comment.
 - `bzr attachment upload --private` flag, sets `is_private: true`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   is configured with `api_mode = "xmlrpc"`.
 - `bzr comment add --private` flag, sets `is_private: true` on the
   posted comment.
+- `bzr attachment upload --private` flag, sets `is_private: true`
+  on the uploaded attachment.
 
 ## [0.2.0] - 2026-05-04
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -110,7 +110,7 @@ bzr [--server <NAME>] [--output table|json] [--json] [--no-color] [--quiet] [--a
 ├── attachment
 │   ├── list <BUG_ID>
 │   ├── download <ATTACHMENT_ID> [-o <FILE>]
-│   ├── upload <BUG_ID> <FILE> [--summary <S>] [--content-type <MIME>] [--flag <F>...]
+│   ├── upload <BUG_ID> <FILE> [--summary <S>] [--content-type <MIME>] [--private] [--flag <F>...]
 │   └── update <ATTACHMENT_ID> [--summary <S>] [--file-name <N>] [--content-type <MIME>]
 │                               [--obsolete <BOOL>] [--is-patch <BOOL>]
 │                               [--is-private <BOOL>] [--flag <F>...]
@@ -479,12 +479,13 @@ Agent note: omit `-o` only when the current working directory and original filen
 
 ### `bzr attachment upload`
 
-Upload a file as an attachment to a bug. MIME type is auto-detected from the file extension if not specified.
+Upload a file as an attachment to a bug. MIME type is auto-detected from the file extension if not specified. Add `--private` to mark the attachment as visible only to users with elevated permissions on the server.
 
 ```bash
 bzr attachment upload 12345 screenshot.png
 bzr attachment upload 12345 data.csv --summary "Performance data" --content-type text/csv
 bzr attachment upload 12345 patch.diff --flag "review?(alice@example.com)"
+bzr attachment upload 12345 secret.bin --summary "internal trace" --private
 ```
 
 | Option | Required | Description |
@@ -493,6 +494,7 @@ bzr attachment upload 12345 patch.diff --flag "review?(alice@example.com)"
 | `<FILE>` | Yes | File to upload |
 | `--summary <S>` | No | Description of the attachment (default: filename) |
 | `--content-type <MIME>` | No | MIME type (auto-detected if omitted) |
+| `--private` | No | Mark the attachment as private (visible only to users with elevated permissions) |
 | `--flag <F>` | No | Set flags (repeatable; see [Flag Syntax](#flag-syntax)) |
 
 Agent note: for clearer audit trails, agents should usually pass `--summary` explicitly instead of relying on the filename-derived default.

--- a/src/cli/attachment.rs
+++ b/src/cli/attachment.rs
@@ -80,6 +80,12 @@ pub enum AttachmentAction {
         /// MIME type (auto-detected if not provided)
         #[arg(long)]
         content_type: Option<String>,
+        /// Mark the new attachment as private.
+        ///
+        /// Private attachments are visible only to users in the bug's
+        /// `insider` group (server-configured). Use carefully.
+        #[arg(long)]
+        private: bool,
         /// Set, request, or clear a flag using Bugzilla flag syntax.
         ///
         /// Repeatable. Accepted forms:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1511,6 +1511,42 @@ mod tests {
     }
 
     #[test]
+    fn parse_attachment_upload_with_private_flag() {
+        let cli = Cli::try_parse_from([
+            "bzr",
+            "attachment",
+            "upload",
+            "42",
+            "secret.bin",
+            "--private",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Attachment {
+                action:
+                    AttachmentAction::Upload {
+                        bug_id, private, ..
+                    },
+            } => {
+                assert_eq!(bug_id, 42);
+                assert!(private, "--private should set the flag to true");
+            }
+            _ => panic!("expected Attachment Upload"),
+        }
+    }
+
+    #[test]
+    fn parse_attachment_upload_without_private_defaults_to_false() {
+        let cli = Cli::try_parse_from(["bzr", "attachment", "upload", "42", "f.txt"]).unwrap();
+        match cli.command {
+            Commands::Attachment {
+                action: AttachmentAction::Upload { private, .. },
+            } => assert!(!private, "--private absent should default to false"),
+            _ => panic!("expected Attachment Upload"),
+        }
+    }
+
+    #[test]
     fn parse_template_delete() {
         let cli = Cli::try_parse_from(["bzr", "template", "delete", "security-bug"]).unwrap();
         match cli.command {

--- a/src/client/attachment.rs
+++ b/src/client/attachment.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 
 use super::BugzillaClient;
 use crate::error::{BzrError, Result};
-use crate::types::{Attachment, UpdateAttachmentParams, UploadAttachmentParams};
+use crate::types::{ApiMode, Attachment, UpdateAttachmentParams, UploadAttachmentParams};
 
 #[derive(Deserialize)]
 struct AttachmentBugResponse {
@@ -45,7 +45,32 @@ fn extract_flat_envelope(value: &serde_json::Value) -> Result<Vec<Attachment>> {
 }
 
 impl BugzillaClient {
+    /// In Hybrid mode, attachments are fetched via XML-RPC `Bug.attachments`
+    /// rather than REST. Bugzilla 5.0.x REST silently filters private
+    /// attachments under API-key auth (issue #133), and the truncation is
+    /// not reliably detectable from the REST response — XML-RPC is the
+    /// only path that returns the full set. REST is the fallback when the
+    /// server doesn't expose `xmlrpc.cgi`.
     pub async fn get_attachments(&self, bug_id: u64) -> Result<Vec<Attachment>> {
+        match self.api_mode {
+            ApiMode::Rest => self.get_attachments_rest(bug_id).await,
+            ApiMode::XmlRpc => self.xmlrpc_client()?.get_attachments(bug_id).await,
+            ApiMode::Hybrid => match self.xmlrpc_client()?.get_attachments(bug_id).await {
+                Ok(attachments) => Ok(attachments),
+                Err(e) if e.is_transport_failure() => {
+                    tracing::info!(
+                        bug_id,
+                        error = %e,
+                        "XML-RPC attachment list failed, retrying via REST"
+                    );
+                    self.get_attachments_rest(bug_id).await
+                }
+                Err(e) => Err(e),
+            },
+        }
+    }
+
+    async fn get_attachments_rest(&self, bug_id: u64) -> Result<Vec<Attachment>> {
         let value = self
             .get_json_value(&format!("bug/{bug_id}/attachment"))
             .await?;
@@ -58,7 +83,38 @@ impl BugzillaClient {
         )
     }
 
+    /// Like `get_attachments`, dispatches on `api_mode` so that
+    /// `bzr attachment download` of a private attachment works on
+    /// Bugzilla 5.0.x deployments where REST silently filters
+    /// private content under non-admin scope (issue #133).
     pub async fn get_attachment(&self, attachment_id: u64) -> Result<Attachment> {
+        match self.api_mode {
+            ApiMode::Rest => self.get_attachment_rest(attachment_id).await,
+            ApiMode::XmlRpc => {
+                self.xmlrpc_client()?
+                    .get_attachment_by_id(attachment_id)
+                    .await
+            }
+            ApiMode::Hybrid => match self
+                .xmlrpc_client()?
+                .get_attachment_by_id(attachment_id)
+                .await
+            {
+                Ok(attachment) => Ok(attachment),
+                Err(e) if e.is_transport_failure() => {
+                    tracing::info!(
+                        attachment_id,
+                        error = %e,
+                        "XML-RPC attachment fetch failed, retrying via REST"
+                    );
+                    self.get_attachment_rest(attachment_id).await
+                }
+                Err(e) => Err(e),
+            },
+        }
+    }
+
+    async fn get_attachment_rest(&self, attachment_id: u64) -> Result<Attachment> {
         let data: AttachmentByIdResponse = self
             .get_json(&format!("bug/attachment/{attachment_id}"))
             .await?;

--- a/src/client/attachment_tests.rs
+++ b/src/client/attachment_tests.rs
@@ -3,8 +3,288 @@
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use crate::client::test_helpers::test_client;
+use crate::client::test_helpers::{test_client, test_client_hybrid, test_client_xmlrpc};
 use crate::types::{FlagStatus, FlagUpdate, UpdateAttachmentParams, UploadAttachmentParams};
+
+fn rest_attachments_response_json(ids: &[u64]) -> serde_json::Value {
+    let attachments: Vec<serde_json::Value> = ids
+        .iter()
+        .map(|&id| {
+            serde_json::json!({
+                "id": id,
+                "bug_id": 42,
+                "file_name": format!("rest-{id}.txt"),
+                "summary": format!("rest {id}"),
+                "content_type": "text/plain",
+                "creator": "alice@test",
+                "creation_time": "2026-01-01T00:00:00Z",
+                "last_change_time": "2026-01-01T00:00:00Z",
+                "size": 1,
+                "is_obsolete": false,
+                "is_private": false
+            })
+        })
+        .collect();
+    serde_json::json!({"bugs": {"42": attachments}})
+}
+
+fn xmlrpc_attachments_response(ids: &[u64]) -> String {
+    use std::fmt::Write;
+    let mut entries = String::new();
+    for &id in ids {
+        write!(
+            entries,
+            "<value><struct>\
+                <member><name>id</name><value><int>{id}</int></value></member>\
+                <member><name>bug_id</name><value><int>42</int></value></member>\
+                <member><name>file_name</name><value><string>xmlrpc-{id}.txt</string></value></member>\
+                <member><name>summary</name><value><string>xmlrpc {id}</string></value></member>\
+                <member><name>content_type</name><value><string>text/plain</string></value></member>\
+                <member><name>size</name><value><int>1</int></value></member>\
+                <member><name>is_obsolete</name><value><int>0</int></value></member>\
+                <member><name>is_private</name><value><int>0</int></value></member>\
+            </struct></value>",
+        )
+        .unwrap();
+    }
+    format!(
+        "<?xml version=\"1.0\"?><methodResponse><params><param><value><struct>\
+            <member><name>bugs</name><value><struct>\
+                <member><name>42</name><value><array>\
+<data>{entries}</data></array></value></member>\
+            </struct></value></member>\
+        </struct></value></param></params></methodResponse>"
+    )
+}
+
+#[tokio::test]
+async fn hybrid_uses_xmlrpc_directly_for_attachment_list() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42/attachment"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/xmlrpc.cgi"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(xmlrpc_attachments_response(&[1, 2, 3])),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client_hybrid(&mock.uri());
+    let attachments = client.get_attachments(42).await.unwrap();
+    assert_eq!(attachments.len(), 3);
+    assert_eq!(attachments[0].file_name, "xmlrpc-1.txt");
+}
+
+#[tokio::test]
+async fn hybrid_xmlrpc_transport_error_falls_back_to_rest_for_attachment_list() {
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/xmlrpc.cgi"))
+        .respond_with(ResponseTemplate::new(502))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42/attachment"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(rest_attachments_response_json(&[10, 11])),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client_hybrid(&mock.uri());
+    let attachments = client.get_attachments(42).await.unwrap();
+    assert_eq!(attachments.len(), 2);
+    assert_eq!(attachments[0].file_name, "rest-10.txt");
+}
+
+#[tokio::test]
+async fn rest_mode_uses_rest_only_for_attachment_list() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42/attachment"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(rest_attachments_response_json(&[5])),
+        )
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/xmlrpc.cgi"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let attachments = client.get_attachments(42).await.unwrap();
+    assert_eq!(attachments.len(), 1);
+    assert_eq!(attachments[0].id, 5);
+}
+
+fn xmlrpc_attachment_by_id_response(id: u64, is_private: bool) -> String {
+    format!(
+        "<?xml version=\"1.0\"?><methodResponse><params><param><value><struct>\
+            <member><name>attachments</name><value><struct>\
+                <member><name>{id}</name><value><struct>\
+                    <member><name>id</name><value><int>{id}</int></value></member>\
+                    <member><name>bug_id</name><value><int>42</int></value></member>\
+                    <member><name>file_name</name><value><string>x-{id}.txt</string></value></member>\
+                    <member><name>summary</name><value><string>x</string></value></member>\
+                    <member><name>content_type</name><value><string>text/plain</string></value></member>\
+                    <member><name>size</name><value><int>1</int></value></member>\
+                    <member><name>is_obsolete</name><value><int>0</int></value></member>\
+                    <member><name>is_private</name><value><int>{p}</int></value></member>\
+                </struct></value></member>\
+            </struct></value></member>\
+        </struct></value></param></params></methodResponse>",
+        p = u8::from(is_private),
+    )
+}
+
+fn rest_attachment_by_id_response_json(id: u64) -> serde_json::Value {
+    serde_json::json!({
+        "attachments": {
+            id.to_string(): {
+                "id": id,
+                "bug_id": 42,
+                "file_name": format!("rest-{id}.txt"),
+                "summary": "rest",
+                "content_type": "text/plain",
+                "creator": "alice@test",
+                "creation_time": "2026-01-01T00:00:00Z",
+                "last_change_time": "2026-01-01T00:00:00Z",
+                "size": 1,
+                "is_obsolete": false,
+                "is_private": false,
+                "data": "aGVsbG8="
+            }
+        }
+    })
+}
+
+#[tokio::test]
+async fn hybrid_uses_xmlrpc_directly_for_get_attachment() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/2001"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/xmlrpc.cgi"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(xmlrpc_attachment_by_id_response(2001, true)),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client_hybrid(&mock.uri());
+    let attachment = client.get_attachment(2001).await.unwrap();
+    assert_eq!(attachment.id, 2001);
+    assert!(attachment.is_private);
+    assert_eq!(attachment.file_name, "x-2001.txt");
+}
+
+#[tokio::test]
+async fn hybrid_xmlrpc_transport_error_falls_back_to_rest_for_get_attachment() {
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/xmlrpc.cgi"))
+        .respond_with(ResponseTemplate::new(502))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/2002"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(rest_attachment_by_id_response_json(2002)),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client_hybrid(&mock.uri());
+    let attachment = client.get_attachment(2002).await.unwrap();
+    assert_eq!(attachment.id, 2002);
+    assert_eq!(attachment.file_name, "rest-2002.txt");
+}
+
+#[tokio::test]
+async fn rest_mode_uses_rest_only_for_get_attachment() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/2003"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(rest_attachment_by_id_response_json(2003)),
+        )
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/xmlrpc.cgi"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let attachment = client.get_attachment(2003).await.unwrap();
+    assert_eq!(attachment.id, 2003);
+}
+
+#[tokio::test]
+async fn xmlrpc_mode_skips_rest_for_get_attachment() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/2004"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/xmlrpc.cgi"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(xmlrpc_attachment_by_id_response(2004, false)),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client_xmlrpc(&mock.uri());
+    let attachment = client.get_attachment(2004).await.unwrap();
+    assert_eq!(attachment.id, 2004);
+}
+
+#[tokio::test]
+async fn xmlrpc_mode_skips_rest_for_attachment_list() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42/attachment"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/xmlrpc.cgi"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(xmlrpc_attachments_response(&[7, 8, 9])),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client_xmlrpc(&mock.uri());
+    let attachments = client.get_attachments(42).await.unwrap();
+    assert_eq!(attachments.len(), 3);
+}
 
 #[tokio::test]
 async fn update_attachment_sends_put() {

--- a/src/client/attachment_tests.rs
+++ b/src/client/attachment_tests.rs
@@ -28,6 +28,64 @@ async fn update_attachment_sends_put() {
 }
 
 #[tokio::test]
+async fn upload_attachment_private_sets_is_private_in_body() {
+    use wiremock::matchers::body_string_contains;
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/1/attachment"))
+        .and(body_string_contains("\"is_private\":true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [301]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let id = client
+        .upload_attachment(&UploadAttachmentParams {
+            bug_id: 1,
+            file_name: "secret.bin".into(),
+            summary: "secret".into(),
+            content_type: "application/octet-stream".into(),
+            data: b"shh".to_vec(),
+            flags: Vec::new(),
+            is_private: true,
+        })
+        .await
+        .unwrap();
+    assert_eq!(id, 301);
+}
+
+#[tokio::test]
+async fn upload_attachment_public_omits_is_private_or_sets_false() {
+    use wiremock::matchers::body_string_contains;
+    let mock = MockServer::start().await;
+    // Public uploads must not send is_private:true. They may either omit
+    // the field or send is_private:false.
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/1/attachment"))
+        .and(body_string_contains("\"is_private\":false"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [302]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let id = client
+        .upload_attachment(&UploadAttachmentParams {
+            bug_id: 1,
+            file_name: "public.txt".into(),
+            summary: "public".into(),
+            content_type: "text/plain".into(),
+            data: b"hello".to_vec(),
+            flags: Vec::new(),
+            is_private: false,
+        })
+        .await
+        .unwrap();
+    assert_eq!(id, 302);
+}
+
+#[tokio::test]
 async fn upload_attachment_with_flags_sends_flags() {
     let mock = MockServer::start().await;
     Mock::given(method("POST"))
@@ -51,6 +109,7 @@ async fn upload_attachment_with_flags_sends_flags() {
             content_type: "text/plain".into(),
             data: b"hello".to_vec(),
             flags,
+            is_private: false,
         })
         .await
         .unwrap();

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -38,6 +38,7 @@ pub async fn execute(
             file,
             summary,
             content_type,
+            private,
             flag,
         } => {
             let path = Path::new(file);
@@ -56,6 +57,7 @@ pub async fn execute(
                 content_type: ct.to_string(),
                 data,
                 flags,
+                is_private: *private,
             };
             let att_id = client.upload_attachment(&upload_params).await?;
             output::print_result(
@@ -205,6 +207,7 @@ mod tests {
             file: upload_file.to_string_lossy().into_owned(),
             summary: Some("Test".into()),
             content_type: None,
+            private: false,
             flag: vec![],
         };
         let result = super::execute(&action, None, OutputFormat::Json, None).await;
@@ -255,6 +258,7 @@ mod tests {
             file: upload_file.to_string_lossy().into_owned(),
             summary: Some("Test upload".into()),
             content_type: Some("text/plain".into()),
+            private: false,
             flag: vec![],
         };
         let (result, output) =

--- a/src/types/attachment.rs
+++ b/src/types/attachment.rs
@@ -54,6 +54,7 @@ pub struct UploadAttachmentParams {
     pub data: Vec<u8>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub flags: Vec<FlagUpdate>,
+    pub is_private: bool,
 }
 
 // Serde serialize_with requires &T signature for the field type.

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -1211,45 +1211,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn xmlrpc_get_attachment_by_id_does_not_exclude_data() {
-        // The single-attachment fetch is the download path — data must
-        // be returned, so the request must NOT carry exclude_fields=data.
-        let mock = MockServer::start().await;
-        let response_xml = r#"<?xml version="1.0"?>
-<methodResponse><params><param><value><struct>
-  <member><name>attachments</name><value><struct>
-    <member><name>5</name><value><struct>
-      <member><name>id</name><value><int>5</int></value></member>
-      <member><name>bug_id</name><value><int>42</int></value></member>
-      <member><name>file_name</name><value><string>x.bin</string></value></member>
-      <member><name>summary</name><value><string>x</string></value></member>
-      <member><name>content_type</name><value><string>application/octet-stream</string></value></member>
-      <member><name>size</name><value><int>3</int></value></member>
-      <member><name>is_obsolete</name><value><int>0</int></value></member>
-      <member><name>is_private</name><value><int>0</int></value></member>
-      <member><name>data</name><value><base64>aGk=</base64></value></member>
-    </struct></value></member>
-  </struct></value></member>
-</struct></value></param></params></methodResponse>"#;
-
-        Mock::given(method("POST"))
-            .and(path("/xmlrpc.cgi"))
-            .and(body_string_contains("Bug.attachments"))
-            .and(body_string_contains("attachment_ids"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(response_xml))
-            .expect(1)
-            .mount(&mock)
-            .await;
-
-        // Negative-match assertion lives in the next test
-        // (xmlrpc_get_attachment_by_id_request_body_omits_exclude_fields)
-        // via a custom NotBodyContains matcher.
-        let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
-        let attachment = client.get_attachment_by_id(5).await.unwrap();
-        assert_eq!(attachment.data.as_deref(), Some("aGk="));
-    }
-
-    #[tokio::test]
     async fn xmlrpc_get_attachment_by_id_request_body_omits_exclude_fields() {
         use wiremock::matchers::body_string_contains;
         let mock = MockServer::start().await;

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -312,13 +312,18 @@ fn value_to_bug(val: &Value) -> Result<Bug> {
     })
 }
 
-fn extract_comments(response: &Value, bug_id: u64) -> Result<Vec<crate::types::Comment>> {
+/// Navigate a `Bug.*` XML-RPC response from `top -> bugs -> {bug_id_str}`.
+///
+/// Returns `Ok(None)` when the server acknowledged the call but didn't
+/// return data for this bug (caller should treat as empty result, not
+/// error). Returns `Err` when the response shape is malformed.
+fn lookup_bug_entry(response: &Value, bug_id: u64) -> Result<Option<&Value>> {
     let top = response
         .as_struct()
         .ok_or_else(|| BzrError::XmlRpc("expected struct response".into()))?;
 
     let Some(bugs_val) = top.get("bugs") else {
-        return Ok(Vec::new());
+        return Ok(None);
     };
 
     let bugs_struct = bugs_val
@@ -327,8 +332,11 @@ fn extract_comments(response: &Value, bug_id: u64) -> Result<Vec<crate::types::C
 
     // Bugzilla returns the inner key as a string even though the input is
     // an integer. Look up by string form.
-    let key = bug_id.to_string();
-    let Some(bug_entry) = bugs_struct.get(&key) else {
+    Ok(bugs_struct.get(&bug_id.to_string()))
+}
+
+fn extract_comments(response: &Value, bug_id: u64) -> Result<Vec<crate::types::Comment>> {
+    let Some(bug_entry) = lookup_bug_entry(response, bug_id)? else {
         return Ok(Vec::new());
     };
 
@@ -384,20 +392,7 @@ fn value_to_comment(val: &Value) -> Result<crate::types::Comment> {
 }
 
 fn extract_attachments(response: &Value, bug_id: u64) -> Result<Vec<crate::types::Attachment>> {
-    let top = response
-        .as_struct()
-        .ok_or_else(|| BzrError::XmlRpc("expected struct response".into()))?;
-
-    let Some(bugs_val) = top.get("bugs") else {
-        return Ok(Vec::new());
-    };
-
-    let bugs_struct = bugs_val
-        .as_struct()
-        .ok_or_else(|| BzrError::XmlRpc("expected bugs to be a struct keyed by bug ID".into()))?;
-
-    let key = bug_id.to_string();
-    let Some(bug_entry) = bugs_struct.get(&key) else {
+    let Some(bug_entry) = lookup_bug_entry(response, bug_id)? else {
         return Ok(Vec::new());
     };
 
@@ -619,6 +614,29 @@ mod tests {
                 </value>
               </fault>
             </methodResponse>"#
+        )
+    }
+
+    /// Wrap an inner array of `<value><struct>...</struct></value>` items in
+    /// the standard `bugs -> {bug_id} -> array` XML-RPC response envelope.
+    fn xmlrpc_bugs_envelope(bug_id: u64, inner: &str) -> String {
+        format!(
+            "<?xml version=\"1.0\"?><methodResponse><params><param><value><struct>\
+                <member><name>bugs</name><value><struct>\
+                    <member><name>{bug_id}</name><value><array><data>{inner}</data></array></value></member>\
+                </struct></value></member>\
+            </struct></value></param></params></methodResponse>"
+        )
+    }
+
+    /// Wrap inner `<member>...</member>` entries in the
+    /// `attachments -> {attachment_id}` XML-RPC response envelope used by
+    /// `Bug.attachments` when called with `attachment_ids`.
+    fn xmlrpc_attachments_keyed_envelope(inner: &str) -> String {
+        format!(
+            "<?xml version=\"1.0\"?><methodResponse><params><param><value><struct>\
+                <member><name>attachments</name><value><struct>{inner}</struct></value></member>\
+            </struct></value></param></params></methodResponse>"
         )
     }
 
@@ -1123,41 +1141,36 @@ mod tests {
     #[tokio::test]
     async fn xmlrpc_get_attachments_parses_full_response() {
         let mock = MockServer::start().await;
-        let response_xml = r#"<?xml version="1.0"?>
-<methodResponse><params><param><value><struct>
-  <member><name>bugs</name><value><struct>
-    <member><name>42</name><value><array><data>
-      <value><struct>
-        <member><name>id</name><value><int>2001</int></value></member>
-        <member><name>bug_id</name><value><int>42</int></value></member>
-        <member><name>file_name</name><value><string>public.txt</string></value></member>
-        <member><name>summary</name><value><string>public file</string></value></member>
-        <member><name>content_type</name><value><string>text/plain</string></value></member>
-        <member><name>creator</name><value><string>alice@test</string></value></member>
-        <member><name>creation_time</name><value><dateTime.iso8601>20260101T00:00:00</dateTime.iso8601></value></member>
-        <member><name>last_change_time</name><value><dateTime.iso8601>20260101T00:00:00</dateTime.iso8601></value></member>
-        <member><name>size</name><value><int>11</int></value></member>
-        <member><name>is_obsolete</name><value><int>0</int></value></member>
-        <member><name>is_private</name><value><int>0</int></value></member>
-        <member><name>data</name><value><base64>aGVsbG8gd29ybGQK</base64></value></member>
-      </struct></value>
-      <value><struct>
-        <member><name>id</name><value><int>2002</int></value></member>
-        <member><name>bug_id</name><value><int>42</int></value></member>
-        <member><name>file_name</name><value><string>private.bin</string></value></member>
-        <member><name>summary</name><value><string>private file</string></value></member>
-        <member><name>content_type</name><value><string>application/octet-stream</string></value></member>
-        <member><name>creator</name><value><string>bob@test</string></value></member>
-        <member><name>creation_time</name><value><dateTime.iso8601>20260102T00:00:00</dateTime.iso8601></value></member>
-        <member><name>last_change_time</name><value><dateTime.iso8601>20260102T00:00:00</dateTime.iso8601></value></member>
-        <member><name>size</name><value><int>4</int></value></member>
-        <member><name>is_obsolete</name><value><int>0</int></value></member>
-        <member><name>is_private</name><value><int>1</int></value></member>
-        <member><name>data</name><value><base64>YmVlZg==</base64></value></member>
-      </struct></value>
-    </data></array></value></member>
-  </struct></value></member>
-</struct></value></param></params></methodResponse>"#;
+        let inner = "\
+            <value><struct>\
+                <member><name>id</name><value><int>2001</int></value></member>\
+                <member><name>bug_id</name><value><int>42</int></value></member>\
+                <member><name>file_name</name><value><string>public.txt</string></value></member>\
+                <member><name>summary</name><value><string>public file</string></value></member>\
+                <member><name>content_type</name><value><string>text/plain</string></value></member>\
+                <member><name>creator</name><value><string>alice@test</string></value></member>\
+                <member><name>creation_time</name><value><dateTime.iso8601>20260101T00:00:00</dateTime.iso8601></value></member>\
+                <member><name>last_change_time</name><value><dateTime.iso8601>20260101T00:00:00</dateTime.iso8601></value></member>\
+                <member><name>size</name><value><int>11</int></value></member>\
+                <member><name>is_obsolete</name><value><int>0</int></value></member>\
+                <member><name>is_private</name><value><int>0</int></value></member>\
+                <member><name>data</name><value><base64>aGVsbG8gd29ybGQK</base64></value></member>\
+            </struct></value>\
+            <value><struct>\
+                <member><name>id</name><value><int>2002</int></value></member>\
+                <member><name>bug_id</name><value><int>42</int></value></member>\
+                <member><name>file_name</name><value><string>private.bin</string></value></member>\
+                <member><name>summary</name><value><string>private file</string></value></member>\
+                <member><name>content_type</name><value><string>application/octet-stream</string></value></member>\
+                <member><name>creator</name><value><string>bob@test</string></value></member>\
+                <member><name>creation_time</name><value><dateTime.iso8601>20260102T00:00:00</dateTime.iso8601></value></member>\
+                <member><name>last_change_time</name><value><dateTime.iso8601>20260102T00:00:00</dateTime.iso8601></value></member>\
+                <member><name>size</name><value><int>4</int></value></member>\
+                <member><name>is_obsolete</name><value><int>0</int></value></member>\
+                <member><name>is_private</name><value><int>1</int></value></member>\
+                <member><name>data</name><value><base64>YmVlZg==</base64></value></member>\
+            </struct></value>";
+        let response_xml = xmlrpc_bugs_envelope(42, inner);
 
         Mock::given(method("POST"))
             .and(path("/xmlrpc.cgi"))
@@ -1189,12 +1202,7 @@ mod tests {
         // in `bzr attachment list` output. Download paths get data via
         // get_attachment_by_id, which does not exclude it.
         let mock = MockServer::start().await;
-        let response_xml = r#"<?xml version="1.0"?>
-<methodResponse><params><param><value><struct>
-  <member><name>bugs</name><value><struct>
-    <member><name>42</name><value><array><data></data></array></value></member>
-  </struct></value></member>
-</struct></value></param></params></methodResponse>"#;
+        let response_xml = xmlrpc_bugs_envelope(42, "");
 
         Mock::given(method("POST"))
             .and(path("/xmlrpc.cgi"))
@@ -1218,28 +1226,24 @@ mod tests {
         // If the request carried exclude_fields, the download path would
         // get data:None and fail. Mock will only match a request that
         // does NOT contain "exclude_fields" via a custom matcher.
+        let response_xml = xmlrpc_attachments_keyed_envelope(
+            "<member><name>9</name><value><struct>\
+                <member><name>id</name><value><int>9</int></value></member>\
+                <member><name>bug_id</name><value><int>42</int></value></member>\
+                <member><name>file_name</name><value><string>y.bin</string></value></member>\
+                <member><name>summary</name><value><string>y</string></value></member>\
+                <member><name>content_type</name><value><string>application/octet-stream</string></value></member>\
+                <member><name>size</name><value><int>2</int></value></member>\
+                <member><name>is_obsolete</name><value><int>0</int></value></member>\
+                <member><name>is_private</name><value><int>0</int></value></member>\
+                <member><name>data</name><value><base64>YmU=</base64></value></member>\
+            </struct></value></member>",
+        );
         Mock::given(method("POST"))
             .and(path("/xmlrpc.cgi"))
             .and(body_string_contains("attachment_ids"))
             .and(NotBodyContains("exclude_fields"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                r#"<?xml version="1.0"?>
-<methodResponse><params><param><value><struct>
-  <member><name>attachments</name><value><struct>
-    <member><name>9</name><value><struct>
-      <member><name>id</name><value><int>9</int></value></member>
-      <member><name>bug_id</name><value><int>42</int></value></member>
-      <member><name>file_name</name><value><string>y.bin</string></value></member>
-      <member><name>summary</name><value><string>y</string></value></member>
-      <member><name>content_type</name><value><string>application/octet-stream</string></value></member>
-      <member><name>size</name><value><int>2</int></value></member>
-      <member><name>is_obsolete</name><value><int>0</int></value></member>
-      <member><name>is_private</name><value><int>0</int></value></member>
-      <member><name>data</name><value><base64>YmU=</base64></value></member>
-    </struct></value></member>
-  </struct></value></member>
-</struct></value></param></params></methodResponse>"#,
-            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response_xml))
             .expect(1)
             .mount(&mock)
             .await;
@@ -1263,23 +1267,19 @@ mod tests {
     #[tokio::test]
     async fn xmlrpc_get_attachment_by_id_parses_response() {
         let mock = MockServer::start().await;
-        let response_xml = r#"<?xml version="1.0"?>
-<methodResponse><params><param><value><struct>
-  <member><name>attachments</name><value><struct>
-    <member><name>2002</name><value><struct>
-      <member><name>id</name><value><int>2002</int></value></member>
-      <member><name>bug_id</name><value><int>42</int></value></member>
-      <member><name>file_name</name><value><string>private.bin</string></value></member>
-      <member><name>summary</name><value><string>private file</string></value></member>
-      <member><name>content_type</name><value><string>application/octet-stream</string></value></member>
-      <member><name>size</name><value><int>4</int></value></member>
-      <member><name>is_obsolete</name><value><int>0</int></value></member>
-      <member><name>is_private</name><value><int>1</int></value></member>
-      <member><name>data</name><value><base64>YmVlZg==</base64></value></member>
-    </struct></value></member>
-  </struct></value></member>
-</struct></value></param></params></methodResponse>"#;
-
+        let response_xml = xmlrpc_attachments_keyed_envelope(
+            "<member><name>2002</name><value><struct>\
+                <member><name>id</name><value><int>2002</int></value></member>\
+                <member><name>bug_id</name><value><int>42</int></value></member>\
+                <member><name>file_name</name><value><string>private.bin</string></value></member>\
+                <member><name>summary</name><value><string>private file</string></value></member>\
+                <member><name>content_type</name><value><string>application/octet-stream</string></value></member>\
+                <member><name>size</name><value><int>4</int></value></member>\
+                <member><name>is_obsolete</name><value><int>0</int></value></member>\
+                <member><name>is_private</name><value><int>1</int></value></member>\
+                <member><name>data</name><value><base64>YmVlZg==</base64></value></member>\
+            </struct></value></member>",
+        );
         Mock::given(method("POST"))
             .and(path("/xmlrpc.cgi"))
             .and(body_string_contains("Bug.attachments"))
@@ -1298,11 +1298,7 @@ mod tests {
     #[tokio::test]
     async fn xmlrpc_get_attachment_by_id_not_found_returns_error() {
         let mock = MockServer::start().await;
-        let response_xml = r#"<?xml version="1.0"?>
-<methodResponse><params><param><value><struct>
-  <member><name>attachments</name><value><struct></struct></value></member>
-</struct></value></param></params></methodResponse>"#;
-
+        let response_xml = xmlrpc_attachments_keyed_envelope("");
         Mock::given(method("POST"))
             .and(path("/xmlrpc.cgi"))
             .and(body_string_contains("Bug.attachments"))
@@ -1324,13 +1320,7 @@ mod tests {
     #[tokio::test]
     async fn xmlrpc_get_attachments_returns_empty_when_bug_has_none() {
         let mock = MockServer::start().await;
-        let response_xml = r#"<?xml version="1.0"?>
-<methodResponse><params><param><value><struct>
-  <member><name>bugs</name><value><struct>
-    <member><name>42</name><value><array><data></data></array></value></member>
-  </struct></value></member>
-</struct></value></param></params></methodResponse>"#;
-
+        let response_xml = xmlrpc_bugs_envelope(42, "");
         Mock::given(method("POST"))
             .and(path("/xmlrpc.cgi"))
             .and(body_string_contains("Bug.attachments"))

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -179,6 +179,37 @@ impl XmlRpcClient {
         let result = self.call("Bug.comments", rpc_params).await?;
         extract_comments(&result, bug_id)
     }
+
+    pub async fn get_attachments(&self, bug_id: u64) -> Result<Vec<crate::types::Attachment>> {
+        let mut rpc_params = BTreeMap::new();
+        #[expect(clippy::cast_possible_wrap, reason = "bug IDs fit in i64")]
+        let bug_id_value = Value::Int(bug_id as i64);
+        rpc_params.insert("ids".into(), Value::Array(vec![bug_id_value]));
+        // Match stock Bugzilla 5.0 REST `attachment list` behavior, which
+        // omits the base64 `data` field. Without this, `bzr attachment list`
+        // would inline multi-MB payloads in JSON output. The download path
+        // (get_attachment_by_id) does not exclude data.
+        rpc_params.insert(
+            "exclude_fields".into(),
+            Value::Array(vec![Value::from("data")]),
+        );
+
+        let result = self.call("Bug.attachments", rpc_params).await?;
+        extract_attachments(&result, bug_id)
+    }
+
+    pub async fn get_attachment_by_id(
+        &self,
+        attachment_id: u64,
+    ) -> Result<crate::types::Attachment> {
+        let mut rpc_params = BTreeMap::new();
+        #[expect(clippy::cast_possible_wrap, reason = "attachment IDs fit in i64")]
+        let id_value = Value::Int(attachment_id as i64);
+        rpc_params.insert("attachment_ids".into(), Value::Array(vec![id_value]));
+
+        let result = self.call("Bug.attachments", rpc_params).await?;
+        extract_attachment_by_id(&result, attachment_id)
+    }
 }
 
 fn extract_id(response: &Value) -> Result<u64> {
@@ -350,6 +381,116 @@ fn value_to_comment(val: &Value) -> Result<crate::types::Comment> {
             .and_then(Value::as_bool)
             .unwrap_or(false),
     })
+}
+
+fn extract_attachments(response: &Value, bug_id: u64) -> Result<Vec<crate::types::Attachment>> {
+    let top = response
+        .as_struct()
+        .ok_or_else(|| BzrError::XmlRpc("expected struct response".into()))?;
+
+    let Some(bugs_val) = top.get("bugs") else {
+        return Ok(Vec::new());
+    };
+
+    let bugs_struct = bugs_val
+        .as_struct()
+        .ok_or_else(|| BzrError::XmlRpc("expected bugs to be a struct keyed by bug ID".into()))?;
+
+    let key = bug_id.to_string();
+    let Some(bug_entry) = bugs_struct.get(&key) else {
+        return Ok(Vec::new());
+    };
+
+    let attachments_arr = bug_entry
+        .as_array()
+        .ok_or_else(|| BzrError::XmlRpc("expected attachments array".into()))?;
+
+    let mut attachments = Vec::with_capacity(attachments_arr.len());
+    for a in attachments_arr {
+        attachments.push(value_to_attachment(a)?);
+    }
+    Ok(attachments)
+}
+
+fn extract_attachment_by_id(
+    response: &Value,
+    attachment_id: u64,
+) -> Result<crate::types::Attachment> {
+    let top = response
+        .as_struct()
+        .ok_or_else(|| BzrError::XmlRpc("expected struct response".into()))?;
+
+    let attachments_struct = top
+        .get("attachments")
+        .and_then(Value::as_struct)
+        .ok_or_else(|| {
+            BzrError::XmlRpc("expected attachments to be a struct keyed by attachment ID".into())
+        })?;
+
+    let key = attachment_id.to_string();
+    let entry = attachments_struct
+        .get(&key)
+        .ok_or_else(|| BzrError::NotFound {
+            resource: "attachment",
+            id: attachment_id.to_string(),
+        })?;
+
+    value_to_attachment(entry)
+}
+
+fn value_to_attachment(val: &Value) -> Result<crate::types::Attachment> {
+    let m = val
+        .as_struct()
+        .ok_or_else(|| BzrError::XmlRpc("expected struct for attachment".into()))?;
+
+    let id = m
+        .get("id")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| BzrError::XmlRpc("attachment missing id field".into()))?;
+    let bug_id = m.get("bug_id").and_then(Value::as_i64).unwrap_or(0);
+    let size = m.get("size").and_then(Value::as_i64).unwrap_or(0);
+
+    #[expect(clippy::cast_sign_loss, reason = "attachment IDs are non-negative")]
+    let id = id as u64;
+    #[expect(clippy::cast_sign_loss, reason = "bug IDs are non-negative")]
+    let bug_id = bug_id as u64;
+    #[expect(clippy::cast_sign_loss, reason = "attachment sizes are non-negative")]
+    let size = size as u64;
+
+    let data = match m.get("data") {
+        Some(Value::Base64(bytes)) => Some(base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            bytes,
+        )),
+        Some(Value::String(s)) if !s.is_empty() => Some(s.clone()),
+        _ => None,
+    };
+
+    Ok(crate::types::Attachment {
+        id,
+        bug_id,
+        file_name: get_str(m, "file_name").unwrap_or_default(),
+        summary: get_str(m, "summary").unwrap_or_default(),
+        content_type: get_str(m, "content_type").unwrap_or_default(),
+        creator: get_nonempty_str(m, "creator"),
+        creation_time: get_datetime_str(m, "creation_time"),
+        last_change_time: get_datetime_str(m, "last_change_time"),
+        size,
+        is_obsolete: get_bool_flag(m, "is_obsolete"),
+        is_private: get_bool_flag(m, "is_private"),
+        data,
+    })
+}
+
+/// Returns a struct member as a bool, accepting either `<boolean>1</boolean>`
+/// or `<int>1</int>` on the wire. Bugzilla 5.0.x XML-RPC responses use both
+/// shapes interchangeably for the same flag depending on the field.
+fn get_bool_flag(m: &BTreeMap<String, Value>, key: &str) -> bool {
+    match m.get(key) {
+        Some(Value::Bool(b)) => *b,
+        Some(Value::Int(n)) => *n != 0,
+        _ => false,
+    }
 }
 
 fn get_str(m: &BTreeMap<String, Value>, key: &str) -> Option<String> {
@@ -977,5 +1118,267 @@ mod tests {
             .await
             .unwrap();
         assert!(comments.is_empty());
+    }
+
+    #[tokio::test]
+    async fn xmlrpc_get_attachments_parses_full_response() {
+        let mock = MockServer::start().await;
+        let response_xml = r#"<?xml version="1.0"?>
+<methodResponse><params><param><value><struct>
+  <member><name>bugs</name><value><struct>
+    <member><name>42</name><value><array><data>
+      <value><struct>
+        <member><name>id</name><value><int>2001</int></value></member>
+        <member><name>bug_id</name><value><int>42</int></value></member>
+        <member><name>file_name</name><value><string>public.txt</string></value></member>
+        <member><name>summary</name><value><string>public file</string></value></member>
+        <member><name>content_type</name><value><string>text/plain</string></value></member>
+        <member><name>creator</name><value><string>alice@test</string></value></member>
+        <member><name>creation_time</name><value><dateTime.iso8601>20260101T00:00:00</dateTime.iso8601></value></member>
+        <member><name>last_change_time</name><value><dateTime.iso8601>20260101T00:00:00</dateTime.iso8601></value></member>
+        <member><name>size</name><value><int>11</int></value></member>
+        <member><name>is_obsolete</name><value><int>0</int></value></member>
+        <member><name>is_private</name><value><int>0</int></value></member>
+        <member><name>data</name><value><base64>aGVsbG8gd29ybGQK</base64></value></member>
+      </struct></value>
+      <value><struct>
+        <member><name>id</name><value><int>2002</int></value></member>
+        <member><name>bug_id</name><value><int>42</int></value></member>
+        <member><name>file_name</name><value><string>private.bin</string></value></member>
+        <member><name>summary</name><value><string>private file</string></value></member>
+        <member><name>content_type</name><value><string>application/octet-stream</string></value></member>
+        <member><name>creator</name><value><string>bob@test</string></value></member>
+        <member><name>creation_time</name><value><dateTime.iso8601>20260102T00:00:00</dateTime.iso8601></value></member>
+        <member><name>last_change_time</name><value><dateTime.iso8601>20260102T00:00:00</dateTime.iso8601></value></member>
+        <member><name>size</name><value><int>4</int></value></member>
+        <member><name>is_obsolete</name><value><int>0</int></value></member>
+        <member><name>is_private</name><value><int>1</int></value></member>
+        <member><name>data</name><value><base64>YmVlZg==</base64></value></member>
+      </struct></value>
+    </data></array></value></member>
+  </struct></value></member>
+</struct></value></param></params></methodResponse>"#;
+
+        Mock::given(method("POST"))
+            .and(path("/xmlrpc.cgi"))
+            .and(body_string_contains("Bug.attachments"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response_xml))
+            .mount(&mock)
+            .await;
+
+        let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+        let attachments = client.get_attachments(42).await.unwrap();
+
+        assert_eq!(attachments.len(), 2);
+        assert_eq!(attachments[0].id, 2001);
+        assert_eq!(attachments[0].file_name, "public.txt");
+        assert!(!attachments[0].is_private);
+        assert_eq!(attachments[0].size, 11);
+        assert_eq!(attachments[0].data.as_deref(), Some("aGVsbG8gd29ybGQK"));
+        assert_eq!(attachments[1].id, 2002);
+        assert_eq!(attachments[1].file_name, "private.bin");
+        assert!(attachments[1].is_private);
+        assert_eq!(attachments[1].data.as_deref(), Some("YmVlZg=="));
+    }
+
+    #[tokio::test]
+    async fn xmlrpc_get_attachments_excludes_data_field_from_request() {
+        // Stock Bugzilla 5.0 REST `attachment list` omits the base64 `data`
+        // field; the XML-RPC list path must match by passing
+        // `exclude_fields: ["data"]` so we don't inline multi-MB payloads
+        // in `bzr attachment list` output. Download paths get data via
+        // get_attachment_by_id, which does not exclude it.
+        let mock = MockServer::start().await;
+        let response_xml = r#"<?xml version="1.0"?>
+<methodResponse><params><param><value><struct>
+  <member><name>bugs</name><value><struct>
+    <member><name>42</name><value><array><data></data></array></value></member>
+  </struct></value></member>
+</struct></value></param></params></methodResponse>"#;
+
+        Mock::given(method("POST"))
+            .and(path("/xmlrpc.cgi"))
+            .and(body_string_contains("Bug.attachments"))
+            .and(body_string_contains("exclude_fields"))
+            .and(body_string_contains("data"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response_xml))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+        let _ = client.get_attachments(42).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn xmlrpc_get_attachment_by_id_does_not_exclude_data() {
+        // The single-attachment fetch is the download path — data must
+        // be returned, so the request must NOT carry exclude_fields=data.
+        let mock = MockServer::start().await;
+        let response_xml = r#"<?xml version="1.0"?>
+<methodResponse><params><param><value><struct>
+  <member><name>attachments</name><value><struct>
+    <member><name>5</name><value><struct>
+      <member><name>id</name><value><int>5</int></value></member>
+      <member><name>bug_id</name><value><int>42</int></value></member>
+      <member><name>file_name</name><value><string>x.bin</string></value></member>
+      <member><name>summary</name><value><string>x</string></value></member>
+      <member><name>content_type</name><value><string>application/octet-stream</string></value></member>
+      <member><name>size</name><value><int>3</int></value></member>
+      <member><name>is_obsolete</name><value><int>0</int></value></member>
+      <member><name>is_private</name><value><int>0</int></value></member>
+      <member><name>data</name><value><base64>aGk=</base64></value></member>
+    </struct></value></member>
+  </struct></value></member>
+</struct></value></param></params></methodResponse>"#;
+
+        Mock::given(method("POST"))
+            .and(path("/xmlrpc.cgi"))
+            .and(body_string_contains("Bug.attachments"))
+            .and(body_string_contains("attachment_ids"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response_xml))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        // Negative-match assertion lives in the next test
+        // (xmlrpc_get_attachment_by_id_request_body_omits_exclude_fields)
+        // via a custom NotBodyContains matcher.
+        let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+        let attachment = client.get_attachment_by_id(5).await.unwrap();
+        assert_eq!(attachment.data.as_deref(), Some("aGk="));
+    }
+
+    #[tokio::test]
+    async fn xmlrpc_get_attachment_by_id_request_body_omits_exclude_fields() {
+        use wiremock::matchers::body_string_contains;
+        let mock = MockServer::start().await;
+
+        // If the request carried exclude_fields, the download path would
+        // get data:None and fail. Mock will only match a request that
+        // does NOT contain "exclude_fields" via a custom matcher.
+        Mock::given(method("POST"))
+            .and(path("/xmlrpc.cgi"))
+            .and(body_string_contains("attachment_ids"))
+            .and(NotBodyContains("exclude_fields"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"<?xml version="1.0"?>
+<methodResponse><params><param><value><struct>
+  <member><name>attachments</name><value><struct>
+    <member><name>9</name><value><struct>
+      <member><name>id</name><value><int>9</int></value></member>
+      <member><name>bug_id</name><value><int>42</int></value></member>
+      <member><name>file_name</name><value><string>y.bin</string></value></member>
+      <member><name>summary</name><value><string>y</string></value></member>
+      <member><name>content_type</name><value><string>application/octet-stream</string></value></member>
+      <member><name>size</name><value><int>2</int></value></member>
+      <member><name>is_obsolete</name><value><int>0</int></value></member>
+      <member><name>is_private</name><value><int>0</int></value></member>
+      <member><name>data</name><value><base64>YmU=</base64></value></member>
+    </struct></value></member>
+  </struct></value></member>
+</struct></value></param></params></methodResponse>"#,
+            ))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+        let attachment = client.get_attachment_by_id(9).await.unwrap();
+        assert_eq!(attachment.data.as_deref(), Some("YmU="));
+    }
+
+    /// Custom wiremock matcher: body must NOT contain the given substring.
+    struct NotBodyContains(&'static str);
+
+    impl wiremock::Match for NotBodyContains {
+        fn matches(&self, request: &wiremock::Request) -> bool {
+            !std::str::from_utf8(&request.body)
+                .map(|s| s.contains(self.0))
+                .unwrap_or(false)
+        }
+    }
+
+    #[tokio::test]
+    async fn xmlrpc_get_attachment_by_id_parses_response() {
+        let mock = MockServer::start().await;
+        let response_xml = r#"<?xml version="1.0"?>
+<methodResponse><params><param><value><struct>
+  <member><name>attachments</name><value><struct>
+    <member><name>2002</name><value><struct>
+      <member><name>id</name><value><int>2002</int></value></member>
+      <member><name>bug_id</name><value><int>42</int></value></member>
+      <member><name>file_name</name><value><string>private.bin</string></value></member>
+      <member><name>summary</name><value><string>private file</string></value></member>
+      <member><name>content_type</name><value><string>application/octet-stream</string></value></member>
+      <member><name>size</name><value><int>4</int></value></member>
+      <member><name>is_obsolete</name><value><int>0</int></value></member>
+      <member><name>is_private</name><value><int>1</int></value></member>
+      <member><name>data</name><value><base64>YmVlZg==</base64></value></member>
+    </struct></value></member>
+  </struct></value></member>
+</struct></value></param></params></methodResponse>"#;
+
+        Mock::given(method("POST"))
+            .and(path("/xmlrpc.cgi"))
+            .and(body_string_contains("Bug.attachments"))
+            .and(body_string_contains("attachment_ids"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response_xml))
+            .mount(&mock)
+            .await;
+
+        let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+        let attachment = client.get_attachment_by_id(2002).await.unwrap();
+        assert_eq!(attachment.id, 2002);
+        assert!(attachment.is_private);
+        assert_eq!(attachment.data.as_deref(), Some("YmVlZg=="));
+    }
+
+    #[tokio::test]
+    async fn xmlrpc_get_attachment_by_id_not_found_returns_error() {
+        let mock = MockServer::start().await;
+        let response_xml = r#"<?xml version="1.0"?>
+<methodResponse><params><param><value><struct>
+  <member><name>attachments</name><value><struct></struct></value></member>
+</struct></value></param></params></methodResponse>"#;
+
+        Mock::given(method("POST"))
+            .and(path("/xmlrpc.cgi"))
+            .and(body_string_contains("Bug.attachments"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response_xml))
+            .mount(&mock)
+            .await;
+
+        let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+        let err = client.get_attachment_by_id(9999).await.unwrap_err();
+        assert!(matches!(
+            err,
+            BzrError::NotFound {
+                resource: "attachment",
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn xmlrpc_get_attachments_returns_empty_when_bug_has_none() {
+        let mock = MockServer::start().await;
+        let response_xml = r#"<?xml version="1.0"?>
+<methodResponse><params><param><value><struct>
+  <member><name>bugs</name><value><struct>
+    <member><name>42</name><value><array><data></data></array></value></member>
+  </struct></value></member>
+</struct></value></param></params></methodResponse>"#;
+
+        Mock::given(method("POST"))
+            .and(path("/xmlrpc.cgi"))
+            .and(body_string_contains("Bug.attachments"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response_xml))
+            .mount(&mock)
+            .await;
+
+        let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+        let attachments = client.get_attachments(42).await.unwrap();
+        assert!(attachments.is_empty());
     }
 }

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -876,6 +876,73 @@ else test_skip "no BUG1"; fi
 echo ""
 
 # ══════════════════════════════════════════════════════════════════════
+# Phase 15b: Private attachment visibility (#133 hybrid fallback)
+# ══════════════════════════════════════════════════════════════════════
+# Mirrors the issue reporter's deployment: REST silently filters private
+# attachments under non-admin scope, while XML-RPC Bug.attachments returns
+# the full set. The fixture entrypoints already configure insidergroup
+# (for #125), which is also the precondition for private attachments.
+echo "── Phase 15b: Private attachments (Hybrid mode) ──────────────"
+
+test_begin "100a. attachment upload --private"
+if [[ -n "$BUG1" ]]; then
+    run_bzr attachment upload "$BUG1" /tmp/bzr-func-test.txt \
+        --summary "Private test attachment" --private
+    if assert_success && assert_json_exists '.id'; then
+        PRIVATE_ATTACH_ID=$(jq -r '.id' "$BZR_STDOUT" 2>/dev/null || echo "")
+        test_pass
+    fi
+else test_skip "no BUG1"; fi
+
+test_begin "100b. attachment list returns private attachment in Hybrid mode"
+if [[ -n "$BUG1" ]]; then
+    run_bzr --api hybrid attachment list "$BUG1"
+    # Earlier tests uploaded ≥2 public attachments + 1 private = ≥3 total,
+    # AND the private one must be visible (is_private: true present).
+    if assert_success \
+        && assert_json_array_min_length '.' 3 \
+        && [[ "$(jq '[.[] | select(.is_private == true)] | length' "$BZR_STDOUT")" -ge 1 ]]; then
+        test_pass
+    fi
+else test_skip "no BUG1"; fi
+
+test_begin "100c. attachment list returns private attachment in XML-RPC mode"
+if [[ -n "$BUG1" ]]; then
+    run_bzr --api xmlrpc attachment list "$BUG1"
+    if assert_success \
+        && assert_json_array_min_length '.' 3 \
+        && [[ "$(jq '[.[] | select(.is_private == true)] | length' "$BZR_STDOUT")" -ge 1 ]]; then
+        test_pass
+    fi
+else test_skip "no BUG1"; fi
+
+test_begin "100d. attachment download (private) in Hybrid mode"
+if [[ -n "${PRIVATE_ATTACH_ID:-}" ]] && [[ "$PRIVATE_ATTACH_ID" != "null" ]]; then
+    rm -f /tmp/bzr-func-private-hybrid.txt
+    run_bzr --api hybrid attachment download "$PRIVATE_ATTACH_ID" \
+        --out /tmp/bzr-func-private-hybrid.txt
+    if assert_success && assert_file_contains /tmp/bzr-func-private-hybrid.txt "bzr functional test content"; then
+        test_pass
+    fi
+else
+    test_skip "no private attachment ID"
+fi
+
+test_begin "100e. attachment download (private) in XML-RPC mode"
+if [[ -n "${PRIVATE_ATTACH_ID:-}" ]] && [[ "$PRIVATE_ATTACH_ID" != "null" ]]; then
+    rm -f /tmp/bzr-func-private-xmlrpc.txt
+    run_bzr --api xmlrpc attachment download "$PRIVATE_ATTACH_ID" \
+        --out /tmp/bzr-func-private-xmlrpc.txt
+    if assert_success && assert_file_contains /tmp/bzr-func-private-xmlrpc.txt "bzr functional test content"; then
+        test_pass
+    fi
+else
+    test_skip "no private attachment ID"
+fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════════════════
 # Phase 16: Global Options Smoke Tests
 # ══════════════════════════════════════════════════════════════════════
 echo "── Phase 16: Global Options ────────────────────────────────"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -854,6 +854,7 @@ async fn attachment_upload_integration() {
         file: upload_file.to_string_lossy().into_owned(),
         summary: Some("Test upload".to_string()),
         content_type: Some("text/plain".to_string()),
+        private: false,
         flag: vec![],
     };
     let result = bzr::commands::attachment::execute(


### PR DESCRIPTION
## Summary

- In `ApiMode::Hybrid` (the default), `bzr attachment list` and `bzr attachment download` now use XML-RPC `Bug.attachments` directly, falling back to REST only on transport failure. Bugzilla 5.0.x silently filters private attachments out of REST under non-admin API-key auth (verified against `bugzilla.linux.ibm.com`: REST returned 2 of 3 attachments, XML-RPC returned all 3 under the same scope).
- New XML-RPC `Bug.attachments` support, covering both bug-scoped (`ids: [bug_id]`) and attachment-by-ID (`attachment_ids: [id]`) lookups. Used by Hybrid fallback and directly when `api_mode = "xmlrpc"`.
- New `--private` flag on `bzr attachment upload`, mirroring `bzr comment add --private` from #125.

The list path passes `exclude_fields: ["data"]` to match stock Bugzilla 5.0 REST behavior, so `bzr attachment list` doesn't inline multi-MB base64 payloads in JSON output. The download path does not exclude data — `bzr attachment download` still gets the bytes it needs.

## Design note

Following the #125 resolution (PR #134), this uses "always XML-RPC in Hybrid" rather than count-divergence detection. Attachments lack a sequential `count` field, and the latency cost of an extra XML-RPC round trip on these infrequent calls is negligible compared to the correctness gain.

Closes #133. A follow-up issue (#140) is filed for an unrelated robustness gap in `value_to_comment` discovered during review.

## Commits

Four reviewable chunks, each builds standalone:

- `a7eeb0f` — `feat(attachment): add --private flag to attachment upload`
- `6a3651c` — `feat(xmlrpc): add Bug.attachments support to XML-RPC client`
- `03c2507` — `fix(attachment): hybrid-mode XML-RPC fallback for list and download (#133)`
- `958e21f` — `test(xmlrpc): drop redundant get_attachment_by_id positive-data test`

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` clean: 890 lib + 21 bin + 56 integration = 967 tests pass
- [x] New unit tests for orchestrator routing (Hybrid → XML-RPC, Hybrid → REST on transport failure, Rest mode, XmlRpc mode) on both `get_attachments` and `get_attachment`
- [x] New parser tests for `Bug.attachments` covering both response shapes (bug-scoped and attachment-by-id)
- [x] New tests asserting `exclude_fields: ["data"]` is sent on the list path and NOT sent on the download path
- [x] CLI parse tests for `--private` flag on `attachment upload`
- [x] Body-shape tests asserting `is_private: true` lands in the upload POST body
- [x] Functional tests added (Phase 15b in `tests/functional/run-tests.sh`) for private-attachment list and download visibility in Hybrid and XML-RPC modes — `make functional-test-all` not run locally, defer to CI
- [x] Verified end-to-end against `bugzilla.linux.ibm.com` during issue verification (#133 comment trail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)