### PR TITLE
test(attachment): hybrid non-transport-fault regression (#136)

### DIFF
--- a/src/client/attachment_tests.rs
+++ b/src/client/attachment_tests.rs
@@ -4,7 +4,17 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::client::test_helpers::{test_client, test_client_hybrid, test_client_xmlrpc};
+use crate::error::BzrError;
 use crate::types::{FlagStatus, FlagUpdate, UpdateAttachmentParams, UploadAttachmentParams};
+
+fn xmlrpc_fault_response(code: i64, message: &str) -> String {
+    format!(
+        "<?xml version=\"1.0\"?><methodResponse><fault><value><struct>\
+            <member><name>faultCode</name><value><int>{code}</int></value></member>\
+            <member><name>faultString</name><value><string>{message}</string></value></member>\
+        </struct></value></fault></methodResponse>"
+    )
+}
 
 fn rest_attachments_response_json(ids: &[u64]) -> serde_json::Value {
     let attachments: Vec<serde_json::Value> = ids
@@ -102,6 +112,40 @@ async fn hybrid_xmlrpc_transport_error_falls_back_to_rest_for_attachment_list() 
     let attachments = client.get_attachments(42).await.unwrap();
     assert_eq!(attachments.len(), 2);
     assert_eq!(attachments[0].file_name, "rest-10.txt");
+}
+
+#[tokio::test]
+async fn hybrid_xmlrpc_fault_does_not_fall_back_to_rest_for_attachment_list() {
+    // An XML-RPC `<fault>` (e.g. permission denied) is a domain error, not a
+    // transport failure: `is_transport_failure()` is false for `BzrError::Api`,
+    // so Hybrid mode must propagate it instead of silently retrying via REST,
+    // where the same call would return a permission-filtered (and therefore
+    // wrong) result. Regression guard for issue #136.
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/xmlrpc.cgi"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(xmlrpc_fault_response(410, "You are not authorized")),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42/attachment"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(rest_attachments_response_json(&[99])),
+        )
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let client = test_client_hybrid(&mock.uri());
+    let err = client.get_attachments(42).await.unwrap_err();
+    assert!(
+        matches!(&err, BzrError::Api { code, .. } if *code == 410),
+        "expected Api error with code 410, got {err:?}"
+    );
 }
 
 #[tokio::test]
@@ -215,6 +259,38 @@ async fn hybrid_xmlrpc_transport_error_falls_back_to_rest_for_get_attachment() {
     let attachment = client.get_attachment(2002).await.unwrap();
     assert_eq!(attachment.id, 2002);
     assert_eq!(attachment.file_name, "rest-2002.txt");
+}
+
+#[tokio::test]
+async fn hybrid_xmlrpc_fault_does_not_fall_back_to_rest_for_get_attachment() {
+    // Mirror of the list-path regression: a server-side fault for `Bug.attachments`
+    // by attachment id must propagate as `BzrError::Api`, not silently fall through
+    // to REST where private content is filtered (issue #133/#136).
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/xmlrpc.cgi"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(xmlrpc_fault_response(410, "You are not authorized")),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/2002"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(rest_attachment_by_id_response_json(2002)),
+        )
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let client = test_client_hybrid(&mock.uri());
+    let err = client.get_attachment(2002).await.unwrap_err();
+    assert!(
+        matches!(&err, BzrError::Api { code, .. } if *code == 410),
+        "expected Api error with code 410, got {err:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds two regression tests in `src/client/attachment_tests.rs` for the contract already encoded by `is_transport_failure()`: in Hybrid mode an XML-RPC `<fault>` (mapped to `BzrError::Api`) must propagate, not silently fall back to REST where private content is filtered on Bugzilla 5.0.x.
- New tests: `hybrid_xmlrpc_fault_does_not_fall_back_to_rest_for_attachment_list` and `hybrid_xmlrpc_fault_does_not_fall_back_to_rest_for_get_attachment`.
- The behaviour itself shipped in commit 03c2507 (PR #133, which expanded scope from #133 to also cover the path #136 reports). This PR is tests-only — no behaviour change.

## Verification

- `cargo test --lib -- client::attachment` — 19/19 passing.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt -- --check` — clean.
- Mutation check: temporarily widening `is_transport_failure()` to include `BzrError::Api { .. }` causes both new tests to fail with the expected REST-fallback panic; reverting restores green.
- `make functional-test` against bz50 — 127/127 passing, 1 skipped, 0 failing. Phase 15b (tests 100b/100c) exercises `--api hybrid attachment list` and `--api xmlrpc attachment list` end-to-end against a private attachment, which is load-bearing evidence that the bug from #136 is fixed.

## Test plan

- [x] `cargo test --lib`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `make functional-test` (bz50)
- [x] Mutation check confirms tests catch the regression

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)