### PR TITLE
fix(xmlrpc): accept <int> shape for is_private and is_active (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Previously the threshold was 1.84.0, so `make setup` would pass
   the version check on rustc 1.85-1.87 and then fail later when
   `cargo install cargo-llvm-cov` rejected the toolchain. Fixes #138.
+- The XML-RPC parser now accepts both `<boolean>1</boolean>` and
+  `<int>1</int>` wire shapes for the `is_private` field on
+  `Bug.comments` responses and the `is_active` field on `Group.get`
+  responses. Bugzilla 5.0.x deployments encode the same flag using
+  either shape depending on the field; previously the parser only
+  recognized `<boolean>`, so int-shaped values were silently
+  classified as `false`. Attachment fields already accepted both
+  shapes via the same helper. Fixes #140.
 
 ### Added
 

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -384,10 +384,7 @@ fn value_to_comment(val: &Value) -> Result<crate::types::Comment> {
         creator: get_nonempty_str(m, "creator"),
         creation_time: get_datetime_str(m, "creation_time"),
         count,
-        is_private: m
-            .get("is_private")
-            .and_then(Value::as_bool)
-            .unwrap_or(false),
+        is_private: get_bool_flag(m, "is_private"),
     })
 }
 
@@ -576,7 +573,7 @@ fn value_to_group_info(val: &Value) -> Result<GroupInfo> {
         id,
         name: get_str(m, "name").unwrap_or_default(),
         description: get_str(m, "description").unwrap_or_default(),
-        is_active: m.get("is_active").and_then(Value::as_bool).unwrap_or(false),
+        is_active: get_bool_flag(m, "is_active"),
         membership,
     })
 }
@@ -931,6 +928,33 @@ mod tests {
         assert_eq!(info.membership.len(), 1);
         assert_eq!(info.membership[0].id, 7);
         assert_eq!(info.membership[0].real_name.as_deref(), Some("Alice"));
+    }
+
+    #[test]
+    fn value_to_group_info_parses_int_is_active() {
+        let mut group = BTreeMap::new();
+        group.insert("id".into(), Value::Int(1));
+        group.insert("name".into(), Value::String("admin".into()));
+        group.insert("description".into(), Value::String("Administrators".into()));
+        group.insert("is_active".into(), Value::Int(1));
+        group.insert("membership".into(), Value::Array(Vec::new()));
+
+        let info = value_to_group_info(&Value::Struct(group)).unwrap();
+        assert!(info.is_active);
+    }
+
+    #[test]
+    fn value_to_comment_parses_int_is_private() {
+        let mut comment = BTreeMap::new();
+        comment.insert("id".into(), Value::Int(1001));
+        comment.insert("bug_id".into(), Value::Int(42));
+        comment.insert("count".into(), Value::Int(1));
+        comment.insert("text".into(), Value::String("private".into()));
+        comment.insert("creator".into(), Value::String("alice@test".into()));
+        comment.insert("is_private".into(), Value::Int(1));
+
+        let parsed = value_to_comment(&Value::Struct(comment)).unwrap();
+        assert!(parsed.is_private);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The XML-RPC parser read `is_private` on `Bug.comments` and `is_active` on `Group.get` via `Value::as_bool`, which only matches the `<boolean>` wire form. Bugzilla 5.0.x XML-RPC implementations encode the same flag using either `<boolean>1</boolean>` or `<int>1</int>` depending on the field; when the int form arrived, private comments and active groups were silently classified as `false`. Both call sites now route through the existing `get_bool_flag` helper (already used by `value_to_attachment` for `is_obsolete` and `is_private`), which accepts both wire shapes.

#140 named the comment-side gap. An audit of the rest of the parser surfaced one more site with the same bug — `is_active` in `value_to_group_info` — so it's fixed in the same change. No other `Value::as_bool` sites remain in the response-parsing path.

Closes #140.

## Changes

- `src/xmlrpc/client.rs`
  - `value_to_comment`: `is_private` now uses `get_bool_flag`.
  - `value_to_group_info`: `is_active` now uses `get_bool_flag`.
  - Two new synchronous parser tests covering the `<int>1</int>` form for both fields. Existing tests already cover the `<boolean>` form.
- `CHANGELOG.md` — `Fixed` entry under `[0.2.1]`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` clean: 894 lib + 21 bin + 56 integration = 971 tests pass
- [x] TDD discipline: both new tests confirmed failing against the unfixed parser before the fix landed (RED), passing after (GREEN)
- [ ] Functional tests not run locally (no behavior change in fixtures, which use `<boolean>` consistently); defer to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
