### PR TITLE
release: prep v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.2.1] - YYYY-MM-DD
+## [0.3.0] - YYYY-MM-DD
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.3.0] - YYYY-MM-DD
+## [0.3.0] - 2026-05-05
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzr"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "base64",
  "bzr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 
 [package]
 name = "bzr"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "A CLI for Bugzilla, inspired by gh"
 license = "MIT"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,14 +54,31 @@ cargo build --release
 cargo publish --dry-run
 ```
 
-6. Commit the release changes.
-7. Create and push a version tag:
+6. Commit the release changes on a `release/vX.Y.Z-prep` branch:
 
 ```bash
-git tag vX.Y.Z
-git push origin main
+git checkout -b release/vX.Y.Z-prep
+git add Cargo.toml Cargo.lock CHANGELOG.md
+git commit -m "chore: bump version to X.Y.Z"
+# If the CHANGELOG date is a separate commit, that's fine:
+git commit -m "chore: date CHANGELOG entry for vX.Y.Z"
+git push -u origin release/vX.Y.Z-prep
+```
+
+The project blocks direct pushes to `main` (a pre-commit-style guardrail mirrored by the `Never push directly to main` rule). Release prep follows the same PR-based flow as feature work — see the v0.2.0 lineage (`git log --first-parent v0.2.0` shows the tag landed on `Merge pull request #131 from randomparity/release/v0.2.0-prep`).
+
+7. Open a `release: prep vX.Y.Z` PR against `main`. Wait for CI to go green, then merge it. The resulting merge commit on `main` is what you tag.
+
+8. Tag the merge commit and push the tag:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git tag -a vX.Y.Z -m "bzr vX.Y.Z"
 git push origin vX.Y.Z
 ```
+
+Pushing the tag triggers `release.yml` (multi-arch build, GitHub Release, installer smoke, Homebrew tap bump on stable tags) and `publish-crates.yml` (crates.io publish on stable tags). Both workflows verify the tag version matches `Cargo.toml`.
 
 ## What automation does
 
@@ -139,14 +156,15 @@ Create the token from crates.io and store it in GitHub Actions secrets as:
 
 ## Recommended release order
 
-1. Merge the release commit to `main`
-2. Push the `vX.Y.Z` tag
-3. Confirm the crates.io publish workflow succeeds
-4. Confirm the GitHub release workflow succeeds
-5. Verify installation from crates.io:
+1. Open and merge the `release/vX.Y.Z-prep` PR to `main`
+2. Pull `main` locally and tag the merge commit (`git tag -a vX.Y.Z -m "bzr vX.Y.Z"`)
+3. Push the tag (`git push origin vX.Y.Z`)
+4. Confirm `release.yml` succeeds (preflight → manpages → build → release → installer-smoke → homebrew)
+5. Confirm `publish-crates.yml` succeeds (stable tags only)
+6. Verify installation from crates.io:
 
 ```bash
-cargo install bzr --version X.Y.Z
+cargo install bzr --version X.Y.Z --locked
 bzr --version
 ```
 


### PR DESCRIPTION
## Summary

Release prep for `bzr` v0.3.0 — a minor bump from 0.2.0 covering the Bugzilla 5.0.x compatibility work and two new `--private` flags.

Three commits on this branch:

- `chore: bump version to 0.3.0` — Cargo.toml + Cargo.lock + CHANGELOG heading (escalates the staged 0.2.1 patch bump to 0.3.0; the `### Added` block contains user-visible features, which strict pre-1.0 semver treats as a minor bump)
- `chore: date CHANGELOG entry for v0.3.0` — replaces `YYYY-MM-DD` with `2026-05-05`
- `docs(releasing): document PR-based release-prep flow` — fixes RELEASING.md to match the project's actual release flow (release-prep PR → merge → tag the merge commit), which the hook system already enforces

## What ships in v0.3.0

### Fixed
- Resilient response envelopes for Bugzilla 5.0.x (#135) — `attachment list`/`comment list` now accept flat envelopes
- `BzrError::Deserialize` errors carry a redacted ~512-char body preview
- Hybrid-mode XML-RPC fallback for `comment list` (#125) — restores private comments truncated by REST on 5.0.x
- Hybrid-mode XML-RPC fallback for `attachment list`/`download` (#133) — restores private attachments truncated by REST on 5.0.x
- `make setup` now requires Rust 1.88.0, matching `Cargo.toml`'s `rust-version` (#138)
- XML-RPC parser now accepts both `<boolean>` and `<int>` for `is_private` and `is_active` fields (#140)

### Added
- XML-RPC `Bug.comments` support in the embedded XML-RPC client
- XML-RPC `Bug.attachments` support (bug-scoped + attachment-by-ID lookups)
- `bzr comment add --private`
- `bzr attachment upload --private`

## Local validation already run

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 894 lib + 21 main + 56 integration tests pass
- `make check-test-layout` — clean
- `cargo build --release --locked` — clean
- `target/release/bzr --version` — reports 0.3.0
- `make man` — 66 manpages generated
- `cargo publish --dry-run --locked` — packaged 257 files, 2.1 MiB, no errors
- `origin/main` CI run on `908422b` is green

## Test plan

- [ ] CI on this PR passes
- [ ] After merge: `git checkout main && git pull --ff-only && git tag -a v0.3.0 -m "bzr v0.3.0" && git push origin v0.3.0`
- [ ] `release.yml` succeeds (preflight → manpages → build matrix → release → installer-smoke → homebrew)
- [ ] `publish-crates.yml` succeeds
- [ ] `cargo install bzr --version 0.3.0 --locked` works
- [ ] Homebrew tap has `Formula/bzr.rb` referencing v0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)