### PR TITLE
ci: open post-release version-bump PR automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -503,3 +503,160 @@ jobs:
           fi
           git commit -m "bzr ${TAG#v}"
           git push
+
+  # Open a post-release version-bump PR on main. Stable releases only
+  # (`-` filters out pre-release tags). Folded into release.yml for the
+  # same GITHUB_TOKEN-doesn't-fire-downstream-events reason as the
+  # homebrew job above.
+  #
+  # The default bump is `patch` (e.g. v0.4.0 -> 0.4.1-dev), which is
+  # the smallest forward step. If the next planned release is a minor
+  # or major bump instead, the maintainer edits Cargo.toml/Cargo.lock
+  # on the auto-opened PR before merging — that's the human-in-the-
+  # loop angle. The PR is opened against `main`, so it can be amended
+  # exactly like a hand-crafted release-prep PR.
+  #
+  # CI does not run on PRs opened by GITHUB_TOKEN; see the PR body
+  # the job emits for the empty-commit kick-off recipe.
+  post-release-bump:
+    name: Open post-release version-bump PR
+    needs: [release, installer-smoke]
+    if: ${{ !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          ref: main
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - name: Compute next dev version
+        id: ver
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          # Default bump policy: patch. Maintainer can override the
+          # version on the auto-opened PR before merging.
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          NEXT_PATCH=$((PATCH + 1))
+          NEXT="${MAJOR}.${MINOR}.${NEXT_PATCH}-dev"
+          BRANCH="chore/bump-to-v${MAJOR}.${MINOR}.${NEXT_PATCH}-dev"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Computed next dev version: $NEXT (branch: $BRANCH)"
+
+      - name: Abort if branch already exists on remote
+        env:
+          BRANCH: ${{ steps.ver.outputs.branch }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null; then
+            echo "::error::Branch $BRANCH already exists on origin; resolve manually." >&2
+            exit 1
+          fi
+
+      - name: Update Cargo.toml
+        env:
+          NEXT: ${{ steps.ver.outputs.next }}
+        run: |
+          set -euo pipefail
+          # Replace the version line inside [package] only. Dependency
+          # lines have `version = "..."` mid-line, so anchoring on `^`
+          # is necessary; section tracking ensures we ignore version
+          # entries in other tables (e.g. [workspace.package] if added).
+          awk -v v="$NEXT" '
+            /^\[/ { in_pkg = ($0 == "[package]") }
+            in_pkg && /^version = "[^"]*"$/ {
+              sub(/"[^"]*"/, "\"" v "\"")
+            }
+            { print }
+          ' Cargo.toml > Cargo.toml.new
+          mv Cargo.toml.new Cargo.toml
+          grep -n "^version = " Cargo.toml | head -n 1
+
+      - name: Refresh Cargo.lock
+        run: cargo update -p bzr
+
+      - name: Prepend [Unreleased] to CHANGELOG.md
+        run: |
+          set -euo pipefail
+          if grep -q '^## \[Unreleased\]' CHANGELOG.md; then
+            echo "[Unreleased] section already present; skipping prepend."
+            exit 0
+          fi
+          awk '
+            BEGIN { inserted = 0 }
+            !inserted && /^## \[/ {
+              print "## [Unreleased]"
+              print ""
+              inserted = 1
+            }
+            { print }
+          ' CHANGELOG.md > CHANGELOG.md.new
+          mv CHANGELOG.md.new CHANGELOG.md
+
+      - name: Commit and push branch
+        env:
+          BRANCH: ${{ steps.ver.outputs.branch }}
+          NEXT: ${{ steps.ver.outputs.next }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add Cargo.toml Cargo.lock CHANGELOG.md
+          if git diff --staged --quiet; then
+            echo "::error::No changes staged after bump steps; investigate." >&2
+            exit 1
+          fi
+          git commit -m "chore: bump version to $NEXT after $TAG release"
+          git push -u origin "$BRANCH"
+
+      - name: Render PR body
+        env:
+          BRANCH: ${{ steps.ver.outputs.branch }}
+          NEXT: ${{ steps.ver.outputs.next }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          cat > /tmp/pr-body.md <<EOF
+          Automated post-release version bump opened by \`release.yml\` after \`$TAG\` shipped successfully (\`release\` + \`installer-smoke\` green).
+
+          The default bump policy is \`patch\` (\`$TAG\` -> \`$NEXT\`) -- the smallest forward step. If the next planned release is a minor or major bump, edit \`Cargo.toml\`, run \`cargo update -p bzr\` to refresh \`Cargo.lock\`, and amend the version line in this commit before merging.
+
+          Per the dev-version convention in [\`RELEASING.md\`](../blob/main/RELEASING.md), \`Cargo.toml\` on \`main\` between releases carries a \`-dev\` SemVer pre-release suffix so dev builds are visually distinct from the most recent release. \`build.rs\` additionally embeds the git short SHA, so \`bzr --version\` prints e.g. \`bzr $NEXT (abcdef12)\`.
+
+          ### CI on this PR
+
+          Pull requests opened by \`GITHUB_TOKEN\` do not trigger downstream \`pull_request\` workflows. To run CI before merging, push an empty commit:
+
+          \`\`\`bash
+          gh pr checkout $BRANCH
+          git commit --allow-empty -m "trigger ci"
+          git push
+          \`\`\`
+
+          Or run the test suite locally (\`cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test\`).
+
+          🤖 Generated with [Claude Code](https://claude.com/claude-code)
+          EOF
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.ver.outputs.branch }}
+          NEXT: ${{ steps.ver.outputs.next }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: bump version to $NEXT (post-$TAG)" \
+            --body-file /tmp/pr-body.md

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -187,13 +187,34 @@ cargo install bzr --version X.Y.Z --locked
 bzr --version
 ```
 
-7. Open a follow-up `chore/bump-version-to-X.Y'.Z'-dev` PR that bumps
-   `Cargo.toml` from the just-released `X.Y.Z` to the next planned
-   release with a `-dev` suffix (e.g. `0.4.0` → `0.5.0-dev`, or
-   `0.4.0` → `0.4.1-dev` if the next release is a patch). Run
-   `cargo build` so `Cargo.lock` regenerates, and add an empty
-   `## [Unreleased]` section at the top of `CHANGELOG.md` that
-   subsequent feature/fix PRs can extend as the work lands.
+7. The `post-release-bump` job in `release.yml` will automatically
+   open a `chore/bump-to-vX.Y.Z'-dev` PR after the `release` and
+   `installer-smoke` jobs succeed (stable releases only — pre-release
+   tags skip this step). The auto-PR:
+   - Bumps `Cargo.toml` from the just-released `X.Y.Z` to the next
+     **patch** version with a `-dev` suffix (e.g. `0.4.0` →
+     `0.4.1-dev`). Patch is the safest default; if the next planned
+     release is a minor or major bump (e.g. `0.4.0` → `0.5.0-dev`),
+     edit the version on the PR before merging.
+   - Refreshes `Cargo.lock` via `cargo update -p bzr`.
+   - Prepends an empty `## [Unreleased]` section to `CHANGELOG.md`,
+     ready for subsequent feature/fix PRs to extend.
+
+   **CI on the auto-PR.** Pull requests opened by `GITHUB_TOKEN` do
+   not trigger downstream `pull_request` workflows (the same
+   safeguard that pushed the homebrew bump back into `release.yml`).
+   The auto-PR's body contains a kick-off recipe — push an empty
+   commit, or run the suite locally — so CI signal is available
+   before merge. The bump itself is a 3-line diff, so the local-run
+   path is usually fastest.
+
+   If for any reason the job fails or the auto-PR is closed without
+   merging, open a hand-crafted bump PR following the same shape
+   (`chore: bump version to X.Y.Z'-dev after vX.Y.Z release`).
+   `main` carrying the released version (no `-dev`) past a release
+   is not catastrophic — the next release-prep PR will still land
+   cleanly — but it does mean dev builds reuse the released version
+   in `bzr --version`.
 
 ## If publish fails
 


### PR DESCRIPTION
## Summary

Automates the manual post-release step from PR #153 (`RELEASING.md` step 7): a new `post-release-bump` job in `release.yml` opens a `chore/bump-to-vX.Y.Z'-dev` PR after a stable release succeeds, so the bump-back-to-`-dev` can't be forgotten.

The job runs after `release` and `installer-smoke` go green and is gated to stable tags only (`!contains(github.ref_name, '-')`). It:

- Computes the next dev version from the tag — default **patch** bump (e.g. `v0.4.0` → `0.4.1-dev`). Patch is the smallest forward step; if the next planned release is minor or major, the maintainer edits the auto-PR before merging.
- Edits `Cargo.toml`'s `[package]` version line via awk (anchored on the section header so dependency `version = "..."` lines and any future `[workspace.package]` block are untouched).
- Refreshes `Cargo.lock` with `cargo update -p bzr` (does not pull unrelated transitive deps).
- Prepends `## [Unreleased]` to `CHANGELOG.md`. Idempotent — skips when the section is already present.
- Aborts loudly if the bump branch already exists on `origin`, so a re-run after partial failure can't silently overwrite work.
- Renders the PR body via heredoc → temp file → `--body-file`, avoiding YAML literal-block indentation issues.

## Why fold into `release.yml` instead of a separate workflow

Same reason as the `homebrew` job: events emitted by `GITHUB_TOKEN` do not trigger downstream workflows (the well-known GH Actions safeguard against workflow recursion, already documented at `.github/workflows/release.yml:440-446`). A separate `post-release-bump.yml` keyed on `release: published` would never run.

## CI on the auto-PR

PRs opened by `GITHUB_TOKEN` also do not trigger downstream `pull_request` workflows. The auto-PR's body explains the empty-commit kick-off and notes that local `cargo test` is fastest for a 3-line bump diff. (A future enhancement could use a fine-grained PAT to side-step this, mirroring the `HOMEBREW_TAP_TOKEN` pattern; deferred until needed.)

## Test plan

- [x] `actionlint .github/workflows/release.yml` clean (only pre-existing SC2035 warnings on `lintian`/`rpmlint` steps remain — unrelated).
- [x] Local awk patterns verified against the current `Cargo.toml` and `CHANGELOG.md` shapes:
  - Cargo.toml: only the `[package]` version line is changed; `rust-version` and dependency lines untouched.
  - CHANGELOG.md: `## [Unreleased]` is inserted before the first dated `## [X.Y.Z] - YYYY-MM-DD` heading; the prepend step skips when `[Unreleased]` is already present.
- [x] Bump-version arithmetic checked manually: `v0.4.0` → `0.4.1-dev`, `v1.0.0` → `1.0.1-dev`, `v0.4.1` → `0.4.2-dev`.
- [ ] Full end-to-end verification only happens on the next stable release tag — flagged in the PR body so the next release is the integration test.

## RELEASING.md updates

Step 7 of "Recommended release order" now points at the automation, documents the patch-bump default + edit-on-PR override, and explains the CI-on-auto-PR workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)