### PR TITLE
feat(view): bug view accepts multiple IDs and --permissive (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Bugzilla's quicksearch syntax and defaults to OPEN bugs only.
   Useful when the matching bug may be CLOSED or RESOLVED — a
   scenario where quicksearch silently returns no results.
+- `bzr bug view` now accepts multiple IDs and a `--permissive` flag
+  for partial results when some bugs are inaccessible. Single-ID
+  invocation behavior — table and JSON output — is unchanged. With
+  `--permissive`, per-bug failures (NotFound, Bug.get fault codes
+  100/101/102) are surfaced as inline `Bug #N — UNAVAILABLE` blocks
+  in table output or entries in the `failed` array in JSON output;
+  session-wide failures (transport, auth, security, server internal,
+  unrecognized API codes) still bail. JSON output for multi-ID is a
+  wrapped `{"bugs": [...], "failed": [...]}` object regardless of
+  `--permissive`. Closes #156.
 
 ### Fixed
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -208,19 +208,30 @@ Filter flags (`--product`, `--component`, `--status`, `--assignee`, `--creator`,
 
 ### `bzr bug view`
 
-Display detailed information about a single bug.
+Display detailed information about one or more bugs.
 
 ```bash
 bzr bug view 12345
+bzr bug view 12345 12346 12347
+bzr bug view 12345 my-alias 12347 --permissive
 bzr --json bug view 12345
+bzr --json bug view 12345 12346 | jq '.bugs[].summary'
 bzr bug view my-alias --fields id,summary,assigned_to
 ```
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `<ID>` | Yes | Bug ID or alias |
+| `<IDS>...` | Yes | One or more bug IDs or aliases. Aliases and numeric IDs may be mixed. |
+| `--permissive` | No | Multi-ID only. Continue past per-bug failures, surfacing them as `Bug #N — UNAVAILABLE` placeholder rows (table) or entries in `failed` (JSON). Exit 0 even if some bugs fail. Has no effect on session-wide failures (transport, auth, security) — those still bail. Setting `--permissive` with a single ID returns input-validation error (exit 7). |
 | `--fields <F>` | No | Only return these fields (comma-separated) |
 | `--exclude-fields <F>` | No | Exclude these fields (comma-separated) |
+
+**Output shapes:**
+
+- **Single-ID, table:** detail block (status, priority, assignee, etc.).
+- **Single-ID, `--json`:** bare `Bug` object — *unchanged from prior versions*.
+- **Multi-ID, table:** one detail block per bug in argument order, separated by a `─` divider line. Inaccessible bugs (under `--permissive`) appear as `Bug #N — UNAVAILABLE` blocks.
+- **Multi-ID, `--json`:** wrapped object `{"bugs": [...], "failed": [...]}`. The `failed` array is always present (empty when there are no failures) so `jq` consumers can rely on `.bugs[]` regardless of whether `--permissive` was passed.
 
 ### `bzr bug search`
 

--- a/docs/superpowers/specs/2026-05-06-bug-view-multi-id-design.md
+++ b/docs/superpowers/specs/2026-05-06-bug-view-multi-id-design.md
@@ -109,12 +109,13 @@ Three private helpers, each one job:
     `Err` with an empty stdout. Eager-print would emit
     concatenated bare JSON objects, which is invalid.
 - **`view_batch_permissive`** — sequential loop that records
-  `(Vec<Bug>, Vec<BugViewFailure>)` in argument order. Calls
-  `print_multi_bug_view(...)` once at the end; returns `Ok(())` even if
-  every row failed. **Exception**: if a non-per-resource error
-  (transport, auth, security — see [Error semantics](#error-semantics-and-exit-codes))
-  occurs mid-loop, bail immediately with that error's code; do not
-  continue.
+  `(Vec<Bug>, Vec<BugViewFailure>)` in argument order. For each `Err`,
+  consult `BzrError::is_bug_get_per_resource()` (see [Error
+  semantics](#error-semantics-and-exit-codes)): if true, push to
+  `failed` and continue; if false, return `Err` immediately with that
+  error's code. Calls `print_multi_bug_view(...)` once at the end on
+  the success path; returns `Ok(())` even if every row was a
+  per-resource failure.
 
 ## Output (table mode)
 
@@ -228,21 +229,45 @@ Per Q4 (option B): `--permissive` truly suppresses per-bug failures.
 failures still bail because they affect every subsequent call:
 continuing produces only noise.
 
+`BzrError::Api` is **not** uniformly per-resource — it carries any
+Bugzilla fault code, including session-wide ones (32000 login required,
+32610 method-blocked, 100500 server internal, etc.). Suppressing them
+all would mask infrastructure problems. The whitelist below is restricted
+to the codes Bugzilla's `Bug.get` is documented to return for per-bug
+access decisions.
+
 ```rust
+/// Bugzilla `Bug.get` per-bug fault codes.
+/// 100: Invalid Bug Alias  ·  101: Invalid Bug ID  ·  102: Access Denied
+/// Reference: https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html
+const BUG_GET_PER_RESOURCE_CODES: &[i64] = &[100, 101, 102];
+
 impl BzrError {
     /// Returns true for per-resource errors that may be suppressed
-    /// under `--permissive` (e.g. one inaccessible bug among many).
-    /// Session-level failures (transport, auth, security) always bail.
-    pub fn is_per_resource(&self) -> bool {
-        matches!(self, BzrError::NotFound { .. } | BzrError::Api { .. })
+    /// under `bzr bug view --permissive` (one inaccessible bug among
+    /// many). Session-level failures (transport, auth, security,
+    /// uncategorized server faults) always bail.
+    pub fn is_bug_get_per_resource(&self) -> bool {
+        match self {
+            BzrError::NotFound { .. } => true,
+            BzrError::Api { code, .. } => BUG_GET_PER_RESOURCE_CODES.contains(code),
+            _ => false,
+        }
     }
 }
 ```
 
+The helper is named for its specific call site (`bug view --permissive`)
+rather than a generic `is_per_resource`. Other commands that gain a
+`--permissive` flag in future may target different per-bug code sets
+(e.g. `Bug.update`, `Bug.history`) and should each get their own helper
+or an extended whitelist with the new method's documented codes added.
+
 | Variant | `--permissive` behavior |
 |---|---|
-| `NotFound` | suppress (per-resource) |
-| `Api { code, .. }` | suppress (Bugzilla per-bug fault, e.g. 101 invalid, 102 access) |
+| `NotFound` | suppress (per-resource by construction) |
+| `Api { code, .. }`, code ∈ {100, 101, 102} | suppress (Bug.get per-bug fault) |
+| `Api { code, .. }`, code ∉ {100, 101, 102} | bail (session-wide: 32000 login required, 32610 method-blocked, 100500 server internal, 50000+ extension faults, …) |
 | `Http`, `HttpStatus`, `XmlRpc` | bail (transport — every subsequent call would fail) |
 | `Auth` | bail (session lost) |
 | `PinMismatch`, `IssuerChanged` | bail (security — never silently swallow) |
@@ -267,6 +292,9 @@ impl BzrError {
 - `view_permissive_single_id_rejected` — `--permissive` + 1 ID → `InputValidation`, exit 7, no HTTP call.
 - `view_multi_permissive_transport_error_bails` — middle bug returns 500: bails despite `--permissive`, no inline placeholder.
 - `view_multi_permissive_auth_error_bails` — middle bug returns Auth: bails despite `--permissive`.
+- `view_multi_permissive_api_102_suppressed` — middle bug returns Bugzilla Api code 102 (Access Denied): captured as inline `UNAVAILABLE` block, exit 0.
+- `view_multi_permissive_api_101_suppressed` — middle bug returns code 101 (Invalid Bug ID): captured as inline block, exit 0.
+- `view_multi_permissive_api_session_wide_bails` — middle bug returns code 32000 (Login Required) or 100500 (server internal): bails despite `--permissive`, no inline placeholder. Confirms `is_bug_get_per_resource` does not suppress session-wide Api codes.
 
 Tests use the existing `wiremock` setup and `capture_stdout` helper. Each error scenario gets a mock returning the exact JSON Bugzilla emits for that case (404 with `{"error": true, "code": 101, …}`, etc.), exercising parsing→error mapping end-to-end.
 

--- a/docs/superpowers/specs/2026-05-06-bug-view-multi-id-design.md
+++ b/docs/superpowers/specs/2026-05-06-bug-view-multi-id-design.md
@@ -1,0 +1,320 @@
+# `bzr bug view`: accept multiple bug IDs and `--permissive` flag
+
+**Date:** 2026-05-06
+**Issue:** [#156](https://github.com/randomparity/bzr/issues/156) (`bzl-parity`, `enhancement`)
+**Parity context:** [`docs/superpowers/specs/2026-05-06-bzl-parity-review-design.md`](2026-05-06-bzl-parity-review-design.md), Issue A
+**Reference impl:** `reference/bzl/bzl-get` (`Bug.get` with `{ids, permissive}`)
+
+## Goal
+
+Bring `bzr bug view` to parity with `bzl-get`:
+
+- Accept one or more bug IDs as positional arguments (variadic).
+- Accept a `--permissive` flag that suppresses per-bug access errors,
+  surfacing them as inline error blocks instead of a non-zero exit.
+- Single-ID invocation behavior — both table and JSON output — is
+  unchanged.
+
+## Non-goals
+
+- No new client method. Multi-ID fetch is a sequential client-side loop
+  over the existing `client.get_bug()`.
+- No parallel/concurrent fetch.
+- No reuse of the server-side `GET /rest/bug?id=…` multi-ID endpoint
+  (it silently drops inaccessible IDs and would lose the per-ID error
+  detail `--permissive` is supposed to surface).
+- No new `BzrError` variants. `BatchPartialFailure` (exit 11) is NOT
+  used by `view`; failed reads change no server state.
+
+## CLI surface
+
+In `src/cli/bug.rs`, `BugAction::View` becomes:
+
+```rust
+View {
+    /// Bug ID(s) or alias(es). Aliases and numeric IDs may be mixed.
+    #[arg(required = true, num_args = 1..)]
+    ids: Vec<String>,
+    /// On batch view, return inline error rows for inaccessible bugs
+    /// instead of bailing on the first failure (exit 0 even if some fail).
+    #[arg(long)]
+    permissive: bool,
+    /// Only return these fields (comma-separated)
+    #[arg(long)]
+    fields: Option<String>,
+    /// Exclude these fields (comma-separated)
+    #[arg(long)]
+    exclude_fields: Option<String>,
+},
+```
+
+Help-text examples added to the existing doc-comment block:
+
+```text
+bzr bug view 12345
+bzr bug view 12345 12346 12347
+bzr bug view 12345 my-alias 12347 --permissive
+bzr bug view 12345 --json | jq .summary           # single-ID JSON unchanged
+```
+
+`--permissive` with exactly one ID is rejected at handler entry with
+`BzrError::InputValidation` ("`--permissive` only meaningful with
+multiple IDs") → exit 7. This catches the likely user error of treating
+`--permissive` as "tolerate any view failure."
+
+## Dispatch / handler
+
+`src/commands/bug/view.rs` branches single-vs-multi, mirroring
+`bug update`'s structure:
+
+```rust
+pub(super) async fn handle(
+    client: &BugzillaClient,
+    action: &BugAction,
+    format: OutputFormat,
+) -> Result<()> {
+    let BugAction::View { ids, permissive, fields, exclude_fields } = action
+    else { unreachable!() };
+
+    if *permissive && ids.len() == 1 {
+        return Err(BzrError::InputValidation(
+            "--permissive only meaningful with multiple IDs".into(),
+        ));
+    }
+
+    let inc = fields.as_deref();
+    let exc = exclude_fields.as_deref();
+
+    if ids.len() == 1 {
+        view_single(client, &ids[0], inc, exc, format).await
+    } else if *permissive {
+        view_batch_permissive(client, ids, inc, exc, format).await
+    } else {
+        view_batch_strict(client, ids, inc, exc, format).await
+    }
+}
+```
+
+Three private helpers, each one job:
+
+- **`view_single`** — current behavior verbatim. `client.get_bug()` then
+  `output::print_bug_detail()`. Single-ID JSON shape preserved (a plain
+  `Bug` object).
+- **`view_batch_strict`** — sequential `for id in ids { client.get_bug(...).await? }`.
+  Output mode determines whether successes are eager-printed:
+  - **Table**: print each detail block + divider as it arrives. The
+    first `Err` propagates; preceding successes have already been
+    written to stdout.
+  - **JSON**: collect all `Bug`s in a buffer; on any error, return
+    `Err` with an empty stdout. Eager-print would emit
+    concatenated bare JSON objects, which is invalid.
+- **`view_batch_permissive`** — sequential loop that records
+  `(Vec<Bug>, Vec<BugViewFailure>)` in argument order. Calls
+  `print_multi_bug_view(...)` once at the end; returns `Ok(())` even if
+  every row failed. **Exception**: if a non-per-resource error
+  (transport, auth, security — see [Error semantics](#error-semantics-and-exit-codes))
+  occurs mid-loop, bail immediately with that error's code; do not
+  continue.
+
+## Output (table mode)
+
+A new function in `src/output/bug.rs`:
+
+```rust
+pub fn print_multi_bug_view(rows: &[MultiBugRow], format: OutputFormat)
+```
+
+with an internal enum:
+
+```rust
+pub enum MultiBugRow {
+    Ok(Bug),
+    Failed { id: String, error: String },
+}
+```
+
+For `Ok(bug)`, reuse the current `print_bug_detail` body (refactored to
+take `&Bug` and write to `io::stdout()`; no behavior change for the
+single-ID path).
+
+For `Failed { id, error }`, emit a visually unambiguous block:
+
+```text
+Bug #999 — UNAVAILABLE
+  Error: not found: 999
+  Reason: bug is private or does not exist
+─────────────────────
+```
+
+- `UNAVAILABLE` is rendered red+bold via the existing `colored` crate.
+- The `Bug #N` prefix matches success blocks so a reader cannot
+  mistake the row for a skipped argument.
+- `Error:` carries the underlying error verbatim (NotFound, Api code
+  102, etc.).
+- `Reason:` is a short human gloss; for unmatched cases, omit the line.
+
+Between every block — success or failure — emit `"─".repeat(60)`
+(matches `print_history`). No trailing divider after the last block.
+
+Single-ID `view` is **unchanged**: still calls `print_bug_detail`
+directly with no divider and no `UNAVAILABLE` block.
+
+## JSON shape
+
+**Single-ID** (`bzr bug view 12345 --json`) — unchanged:
+
+```json
+{ "id": 12345, "summary": "...", "status": "...", ... }
+```
+
+**Multi-ID** (`bzr bug view 12345 my-alias 999 --permissive --json`):
+
+```json
+{
+  "bugs":   [ { "id": 12345, ... }, { "id": 88, ... } ],
+  "failed": [ { "id": "999", "error": "bug not found: 999" } ]
+}
+```
+
+The wrapped shape is used for **every** multi-ID JSON invocation, not
+only `--permissive` ones. `bzr bug view 1 2 3 --json` (no
+`--permissive`, all succeed) emits `{"bugs": [...], "failed": []}` —
+the `failed` array is always present for shape stability, and `jq`
+consumers can rely on `.bugs[]` regardless of whether `--permissive`
+was passed.
+
+Two new types in `src/output/result_types.rs`, alongside `BatchResult`:
+
+```rust
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct MultiBugViewResult {
+    pub bugs: Vec<Bug>,
+    pub failed: Vec<BugViewFailure>,
+}
+
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct BugViewFailure {
+    pub id: String,    // String, not u64 — caller may have passed an alias
+    pub error: String,
+}
+```
+
+Why a new type instead of reusing `BatchResult`:
+
+- `BatchResult` is mutation-flavored — `BatchResult::new` hardcodes
+  `action: ActionKind::Updated`, and `ActionKind` has no `Viewed`
+  variant. Adding one to satisfy a read is the wrong abstraction.
+- `BatchFailure.id: u64` cannot carry an alias.
+- `MultiBugViewResult` is `{bugs, failed}`, not
+  `{resource, action, succeeded, failed}` — different domain.
+
+## Error semantics and exit codes
+
+Per Q4 (option B): `--permissive` truly suppresses per-bug failures.
+
+| Invocation | Outcome | Exit code |
+|---|---|---|
+| 1 ID, succeeds | normal detail block | 0 |
+| 1 ID, fails | propagate underlying error | NotFound→2, Auth→9, Api→4, Http→5, … |
+| 1 ID + `--permissive` | rejected at handler entry | 7 (`InputValidation`) |
+| N IDs, all succeed | N detail blocks + dividers | 0 |
+| N IDs, any fails (no `--permissive`) | bail at first error | underlying error's code |
+| N IDs + `--permissive`, partial fails | inline error blocks for failed rows | 0 |
+| N IDs + `--permissive`, all fail | all rows are error blocks | 0 |
+
+`--permissive` only suppresses **per-resource** errors. Session-level
+failures still bail because they affect every subsequent call:
+continuing produces only noise.
+
+```rust
+impl BzrError {
+    /// Returns true for per-resource errors that may be suppressed
+    /// under `--permissive` (e.g. one inaccessible bug among many).
+    /// Session-level failures (transport, auth, security) always bail.
+    pub fn is_per_resource(&self) -> bool {
+        matches!(self, BzrError::NotFound { .. } | BzrError::Api { .. })
+    }
+}
+```
+
+| Variant | `--permissive` behavior |
+|---|---|
+| `NotFound` | suppress (per-resource) |
+| `Api { code, .. }` | suppress (Bugzilla per-bug fault, e.g. 101 invalid, 102 access) |
+| `Http`, `HttpStatus`, `XmlRpc` | bail (transport — every subsequent call would fail) |
+| `Auth` | bail (session lost) |
+| `PinMismatch`, `IssuerChanged` | bail (security — never silently swallow) |
+| `DataIntegrity`, `Deserialize` | bail (server contract violated) |
+| `Io`, `Keyring`, `Config`, `TomlParse`, `TomlSerialize` | bail |
+| `InputValidation`, `BatchPartialFailure`, `Other` | not produced by `get_bug`; bail if observed |
+
+## Tests
+
+### Unit tests — `src/commands/bug/view_tests.rs` (sibling per CLAUDE.md)
+
+- `view_single_unchanged` — one ID, success: detail block on stdout, exit 0. Single-ID byte-identical to today.
+- `view_single_failure_propagates` — one ID, 404: `BzrError::NotFound`, exit 2.
+- `view_multi_strict_all_succeed` — three IDs: three detail blocks separated by `─` divider, no trailing divider.
+- `view_multi_strict_first_failure_bails` — three IDs, second 404s: first detail block printed, `Err(NotFound)`, no third call (assert wiremock).
+- `view_multi_strict_json_all_succeed` — three IDs, JSON mode, all succeed: emits `{"bugs": [...], "failed": []}`, exit 0. Pins the wrapped-shape rule for non-permissive multi-ID JSON.
+- `view_multi_strict_json_buffers` — three IDs, JSON mode, second fails: nothing on stdout, `Err` propagates. No partial JSON.
+- `view_multi_permissive_partial` — three IDs, middle 404s: two detail blocks + one `UNAVAILABLE` block in argument order, exit 0.
+- `view_multi_permissive_json` — same shape with `--json` returns `{"bugs": […], "failed": […]}`.
+- `view_multi_permissive_all_fail` — every ID 404, all rows error blocks, exit 0, JSON `bugs: []`.
+- `view_multi_permissive_with_alias` — alias + numeric + inaccessible: failure `id` preserves alias string verbatim.
+- `view_permissive_single_id_rejected` — `--permissive` + 1 ID → `InputValidation`, exit 7, no HTTP call.
+- `view_multi_permissive_transport_error_bails` — middle bug returns 500: bails despite `--permissive`, no inline placeholder.
+- `view_multi_permissive_auth_error_bails` — middle bug returns Auth: bails despite `--permissive`.
+
+Tests use the existing `wiremock` setup and `capture_stdout` helper. Each error scenario gets a mock returning the exact JSON Bugzilla emits for that case (404 with `{"error": true, "code": 101, …}`, etc.), exercising parsing→error mapping end-to-end.
+
+### Output rendering — `src/output/bug_tests.rs`
+
+- Divider count for N rows = N − 1; no trailing divider.
+- Error block contains `UNAVAILABLE`, `Bug #<id>`, and `Error:` line.
+- Single-row case (only one element passed to `print_multi_bug_view`) emits no divider.
+
+### Functional test — `tests/functional/run-tests.sh` Phase 8 — Bugs
+
+- Setup: three bugs against the running container; one group-restricted to a different account than the test runner.
+- Run: `bzr bug view <ok1> <ok2> <restricted> --permissive`
+- Assert:
+  - exit 0
+  - stdout contains `Bug #<ok1>` and `Bug #<ok2>` headers
+  - stdout contains `Bug #<restricted> — UNAVAILABLE` and a non-empty `Error:` line
+- Negative case: same command without `--permissive` exits non-zero (NotFound→2, or Api→4 depending on how the server reports the denial); the inaccessible bug must be the *first* in arg order so the strict bail is exercised.
+
+## Documentation and changelog
+
+- **`docs/bzr-cli.md`** — update the `bug view` section: variadic IDs, `--permissive`, multi-ID divider/error-block output, JSON shape switch.
+- **`CHANGELOG.md`** — add under the next unreleased `## [X.Y.Z]` section in the same PR:
+
+  ```
+  - `bzr bug view` now accepts multiple IDs and a `--permissive` flag
+    for partial results when some bugs are inaccessible (#156).
+  ```
+
+- **Man pages** are generated from clap doc-comments; the help-text
+  rewrite covers them automatically. Confirm via the project's
+  existing man-page generation step.
+- **No on-disk state change**, no migration, no config knob.
+- **Backward compatibility**: single-ID invocation (positional, table
+  or JSON) is byte-identical to today, verified by
+  `view_single_unchanged`.
+
+## Open questions / risks
+
+- **`Reason:` line content.** The design specifies a short human gloss
+  for known cases (`bug is private or does not exist` for NotFound).
+  For unmatched cases the line is omitted. The exact gloss strings can
+  be finalized during implementation by inspecting actual server
+  responses; they are not load-bearing for any test assertion.
+- **XML-RPC mode.** The implementation reuses `client.get_bug()`, which
+  already covers Hybrid and XML-RPC modes. No multi-ID-specific XML-RPC
+  testing is in scope; the per-ID loop falls back automatically.
+- **Performance.** N IDs = N round-trips. Acceptable for typical `view`
+  use (a handful of bugs); if a future workflow needs hundreds, that
+  motivates a separate spec for a server-side multi-ID path with its
+  own error-fidelity tradeoffs.

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -76,17 +76,34 @@ pub enum BugAction {
         #[arg(long)]
         exclude_fields: Option<String>,
     },
-    /// View a single bug by ID or alias.
+    /// View one or more bugs by ID or alias.
     ///
-    /// Prints the bug's full record (summary, status, assignee,
-    /// priority, CC list, depends-on, blocks, and the most recent
-    /// comments) as a formatted table or JSON. Use `--fields` to
-    /// fetch only specific fields (faster on large bugs);
-    /// `--exclude-fields` is the inverse.
+    /// Single-ID: prints the bug's full record (summary, status,
+    /// assignee, priority, CC list, depends-on, blocks, and the most
+    /// recent comments) as a formatted detail block or JSON object.
+    ///
+    /// Multi-ID: emits one detail block per bug separated by a
+    /// horizontal divider, in argument order. Aliases and numeric IDs
+    /// may be mixed. JSON output for multi-ID becomes a wrapped
+    /// `{"bugs": [...], "failed": [...]}` object — `failed` is always
+    /// present (empty array when no failures) so `jq` consumers can
+    /// rely on `.bugs[]`. Single-ID JSON output is unchanged
+    /// (a bare `Bug` object).
+    ///
+    /// `--permissive` (multi-ID only) suppresses per-bug access
+    /// failures: inaccessible bugs are surfaced as inline
+    /// `Bug #N — UNAVAILABLE` placeholder blocks instead of bailing
+    /// the whole call. Exit code is 0 even when some bugs fail.
+    /// Session-wide failures (transport, auth, security) still bail.
+    ///
+    /// Use `--fields` to fetch only specific fields (faster on large
+    /// bugs); `--exclude-fields` is the inverse.
     ///
     /// Examples:
     ///
     ///   bzr bug view 12345
+    ///   bzr bug view 12345 12346 12347
+    ///   bzr bug view 12345 my-alias 12347 --permissive
     ///   bzr bug view 12345 --json | jq .summary
     ///   bzr bug view my-alias --fields id,summary,status
     ///
@@ -94,8 +111,19 @@ pub enum BugAction {
     /// bzr-comment-list(1) for the full comment thread.
     #[command(verbatim_doc_comment)]
     View {
-        /// Bug ID or alias
-        id: String,
+        /// Bug ID(s) or alias(es). Aliases and numeric IDs may be mixed.
+        #[arg(required = true, num_args = 1..)]
+        ids: Vec<String>,
+        /// Continue past per-bug failures (multi-ID only).
+        ///
+        /// When set, inaccessible bugs (NotFound or Bug.get fault
+        /// codes 100/101/102) are reported as inline placeholder
+        /// rows and the command exits 0. Without `--permissive`,
+        /// the first per-bug failure aborts the whole call. Has
+        /// no effect on session-wide errors (transport, auth,
+        /// security) — those always bail.
+        #[arg(long)]
+        permissive: bool,
         /// Only return these fields (comma-separated)
         #[arg(long)]
         fields: Option<String>,

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -129,8 +129,8 @@ fn parse_bug_view_by_id() {
     let cli = Cli::try_parse_from(["bzr", "bug", "view", "12345"]).unwrap();
     match cli.command {
         Commands::Bug {
-            action: BugAction::View { id, .. },
-        } => assert_eq!(id, "12345"),
+            action: BugAction::View { ids, .. },
+        } => assert_eq!(ids, vec!["12345".to_string()]),
         _ => panic!("expected Bug View"),
     }
 }

--- a/src/commands/bug/view.rs
+++ b/src/commands/bug/view.rs
@@ -1,7 +1,7 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
-use crate::error::Result;
-use crate::output;
+use crate::error::{BzrError, Result};
+use crate::output::{self, print_multi_bug_view, BugViewFailure, MultiBugRow, MultiBugViewResult};
 use crate::types::OutputFormat;
 
 pub(super) async fn handle(
@@ -10,7 +10,8 @@ pub(super) async fn handle(
     format: OutputFormat,
 ) -> Result<()> {
     let BugAction::View {
-        id,
+        ids,
+        permissive,
         fields,
         exclude_fields,
     } = action
@@ -18,10 +19,131 @@ pub(super) async fn handle(
         unreachable!()
     };
 
-    let bug = client
-        .get_bug(id, fields.as_deref(), exclude_fields.as_deref())
-        .await?;
+    if *permissive && ids.len() == 1 {
+        return Err(BzrError::InputValidation(
+            "--permissive only meaningful with multiple IDs".into(),
+        ));
+    }
+
+    let inc = fields.as_deref();
+    let exc = exclude_fields.as_deref();
+
+    if ids.len() == 1 {
+        view_single(client, &ids[0], inc, exc, format).await
+    } else if *permissive {
+        view_batch_permissive(client, ids, inc, exc, format).await
+    } else {
+        view_batch_strict(client, ids, inc, exc, format).await
+    }
+}
+
+async fn view_single(
+    client: &BugzillaClient,
+    id: &str,
+    include_fields: Option<&str>,
+    exclude_fields: Option<&str>,
+    format: OutputFormat,
+) -> Result<()> {
+    let bug = client.get_bug(id, include_fields, exclude_fields).await?;
     output::print_bug_detail(&bug, format);
+    Ok(())
+}
+
+/// Multi-ID strict path. On any failure, bail with that error's code.
+///
+/// Output handling differs by format:
+/// - Table: eager-print each detail block as it arrives. Preceding
+///   successes have already been written to stdout when the failure
+///   propagates.
+/// - JSON: collect all bugs in a buffer; emit nothing on failure
+///   (concatenated bare JSON objects would be invalid).
+async fn view_batch_strict(
+    client: &BugzillaClient,
+    ids: &[String],
+    include_fields: Option<&str>,
+    exclude_fields: Option<&str>,
+    format: OutputFormat,
+) -> Result<()> {
+    match format {
+        OutputFormat::Table => {
+            let mut rendered_any = false;
+            for id in ids {
+                let bug = client.get_bug(id, include_fields, exclude_fields).await?;
+                if rendered_any {
+                    use std::io::Write;
+                    let _ = writeln!(std::io::stdout(), "{}", "─".repeat(60));
+                }
+                output::print_bug_detail(&bug, OutputFormat::Table);
+                rendered_any = true;
+            }
+            Ok(())
+        }
+        OutputFormat::Json => {
+            let mut bugs = Vec::with_capacity(ids.len());
+            for id in ids {
+                let bug = client.get_bug(id, include_fields, exclude_fields).await?;
+                bugs.push(bug);
+            }
+            let result = MultiBugViewResult {
+                bugs,
+                failed: Vec::new(),
+            };
+            output::print_result(&result, "", OutputFormat::Json);
+            Ok(())
+        }
+    }
+}
+
+/// Multi-ID permissive path.
+///
+/// Per-resource errors (`BzrError::is_bug_get_per_resource()` — i.e.
+/// `NotFound` and `Bug.get` codes 100/101/102) are recorded as inline
+/// failure rows. Anything else (transport, auth, security, server
+/// internal, unrecognized `Api` codes) bails immediately with that
+/// error's exit code.
+///
+/// `Bug` does not derive `Clone`, so the loop builds a single
+/// `Vec<MultiBugRow>` in argument order. The Table path borrows it; the
+/// JSON path consumes it into a `MultiBugViewResult` via partitioning.
+async fn view_batch_permissive(
+    client: &BugzillaClient,
+    ids: &[String],
+    include_fields: Option<&str>,
+    exclude_fields: Option<&str>,
+    format: OutputFormat,
+) -> Result<()> {
+    let mut rows: Vec<MultiBugRow> = Vec::with_capacity(ids.len());
+
+    for id in ids {
+        match client.get_bug(id, include_fields, exclude_fields).await {
+            Ok(bug) => rows.push(MultiBugRow::Ok(Box::new(bug))),
+            Err(e) if e.is_bug_get_per_resource() => {
+                rows.push(MultiBugRow::Failed {
+                    id: id.clone(),
+                    error: e.to_string(),
+                });
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    match format {
+        OutputFormat::Table => print_multi_bug_view(&rows),
+        OutputFormat::Json => {
+            let mut bugs = Vec::with_capacity(rows.len());
+            let mut failed: Vec<BugViewFailure> = Vec::new();
+            for row in rows {
+                match row {
+                    MultiBugRow::Ok(bug) => bugs.push(*bug),
+                    MultiBugRow::Failed { id, error } => {
+                        failed.push(BugViewFailure { id, error });
+                    }
+                }
+            }
+            let result = MultiBugViewResult { bugs, failed };
+            output::print_result(&result, "", OutputFormat::Json);
+        }
+    }
     Ok(())
 }
 

--- a/src/commands/bug/view.rs
+++ b/src/commands/bug/view.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::{BzrError, Result};
@@ -70,7 +72,6 @@ async fn view_batch_strict(
             for id in ids {
                 let bug = client.get_bug(id, include_fields, exclude_fields).await?;
                 if rendered_any {
-                    use std::io::Write;
                     let _ = writeln!(std::io::stdout(), "{}", "─".repeat(60));
                 }
                 output::print_bug_detail(&bug, OutputFormat::Table);
@@ -88,7 +89,7 @@ async fn view_batch_strict(
                 bugs,
                 failed: Vec::new(),
             };
-            output::print_result(&result, "", OutputFormat::Json);
+            output::print_result(&result, "", format);
             Ok(())
         }
     }
@@ -141,7 +142,7 @@ async fn view_batch_permissive(
                 }
             }
             let result = MultiBugViewResult { bugs, failed };
-            output::print_result(&result, "", OutputFormat::Json);
+            output::print_result(&result, "", format);
         }
     }
     Ok(())

--- a/src/commands/bug/view.rs
+++ b/src/commands/bug/view.rs
@@ -1,10 +1,8 @@
-use std::io::Write;
-
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::{BzrError, Result};
 use crate::output::{self, print_multi_bug_view, BugViewFailure, MultiBugRow, MultiBugViewResult};
-use crate::types::OutputFormat;
+use crate::types::{Bug, OutputFormat};
 
 pub(super) async fn handle(
     client: &BugzillaClient,
@@ -68,14 +66,12 @@ async fn view_batch_strict(
 ) -> Result<()> {
     match format {
         OutputFormat::Table => {
-            let mut rendered_any = false;
-            for id in ids {
+            for (i, id) in ids.iter().enumerate() {
                 let bug = client.get_bug(id, include_fields, exclude_fields).await?;
-                if rendered_any {
-                    let _ = writeln!(std::io::stdout(), "{}", "─".repeat(60));
+                if i > 0 {
+                    output::write_divider(&mut std::io::stdout());
                 }
-                output::print_bug_detail(&bug, OutputFormat::Table);
-                rendered_any = true;
+                output::print_bug_detail(&bug, format);
             }
             Ok(())
         }
@@ -102,10 +98,6 @@ async fn view_batch_strict(
 /// failure rows. Anything else (transport, auth, security, server
 /// internal, unrecognized `Api` codes) bails immediately with that
 /// error's exit code.
-///
-/// `Bug` does not derive `Clone`, so the loop builds a single
-/// `Vec<MultiBugRow>` in argument order. The Table path borrows it; the
-/// JSON path consumes it into a `MultiBugViewResult` via partitioning.
 async fn view_batch_permissive(
     client: &BugzillaClient,
     ids: &[String],
@@ -113,36 +105,39 @@ async fn view_batch_permissive(
     exclude_fields: Option<&str>,
     format: OutputFormat,
 ) -> Result<()> {
-    let mut rows: Vec<MultiBugRow> = Vec::with_capacity(ids.len());
-
-    for id in ids {
-        match client.get_bug(id, include_fields, exclude_fields).await {
-            Ok(bug) => rows.push(MultiBugRow::Ok(Box::new(bug))),
-            Err(e) if e.is_bug_get_per_resource() => {
-                rows.push(MultiBugRow::Failed {
-                    id: id.clone(),
-                    error: e.to_string(),
-                });
-            }
-            Err(e) => return Err(e),
-        }
-    }
-
     match format {
-        OutputFormat::Table => print_multi_bug_view(&rows),
-        OutputFormat::Json => {
-            let mut bugs = Vec::with_capacity(rows.len());
-            let mut failed: Vec<BugViewFailure> = Vec::new();
-            for row in rows {
-                match row {
-                    MultiBugRow::Ok(bug) => bugs.push(*bug),
-                    MultiBugRow::Failed { id, error } => {
-                        failed.push(BugViewFailure { id, error });
+        OutputFormat::Table => {
+            let mut rows: Vec<MultiBugRow> = Vec::with_capacity(ids.len());
+            for id in ids {
+                match client.get_bug(id, include_fields, exclude_fields).await {
+                    Ok(bug) => rows.push(MultiBugRow::Ok(Box::new(bug))),
+                    Err(e) if e.is_bug_get_per_resource() => {
+                        rows.push(MultiBugRow::Failed {
+                            id: id.clone(),
+                            error: e.to_string(),
+                        });
                     }
+                    Err(e) => return Err(e),
                 }
             }
-            let result = MultiBugViewResult { bugs, failed };
-            output::print_result(&result, "", format);
+            print_multi_bug_view(&rows);
+        }
+        OutputFormat::Json => {
+            let mut bugs: Vec<Bug> = Vec::with_capacity(ids.len());
+            let mut failed: Vec<BugViewFailure> = Vec::new();
+            for id in ids {
+                match client.get_bug(id, include_fields, exclude_fields).await {
+                    Ok(bug) => bugs.push(bug),
+                    Err(e) if e.is_bug_get_per_resource() => {
+                        failed.push(BugViewFailure {
+                            id: id.clone(),
+                            error: e.to_string(),
+                        });
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+            output::print_result(&MultiBugViewResult { bugs, failed }, "", format);
         }
     }
     Ok(())

--- a/src/commands/bug/view_tests.rs
+++ b/src/commands/bug/view_tests.rs
@@ -106,6 +106,11 @@ async fn view_single_failure_propagates() {
     let action = make_view_action(&["999999"], false);
     let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
     assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("does not exist") || err.contains("101"),
+        "expected not-found error message, got: {err}"
+    );
 }
 
 #[tokio::test]

--- a/src/commands/bug/view_tests.rs
+++ b/src/commands/bug/view_tests.rs
@@ -168,7 +168,6 @@ async fn view_multi_strict_first_failure_bails() {
     ))
     .await;
     assert!(result.is_err());
-    // Bug #1 was eager-printed before the failure.
     assert!(output.contains("Bug #1"));
     // Bug #3 must NOT have been fetched.
     assert!(!output.contains("Bug #3"));

--- a/src/commands/bug/view_tests.rs
+++ b/src/commands/bug/view_tests.rs
@@ -32,7 +32,8 @@ async fn bug_view_returns_detail() {
         .await;
 
     let action = BugAction::View {
-        id: "42".to_string(),
+        ids: vec!["42".to_string()],
+        permissive: false,
         fields: None,
         exclude_fields: None,
     };
@@ -65,7 +66,8 @@ async fn bug_view_not_found_returns_error() {
         .await;
 
     let action = BugAction::View {
-        id: "999999".to_string(),
+        ids: vec!["999999".to_string()],
+        permissive: false,
         fields: None,
         exclude_fields: None,
     };

--- a/src/commands/bug/view_tests.rs
+++ b/src/commands/bug/view_tests.rs
@@ -481,3 +481,37 @@ async fn view_multi_permissive_api_102_suppressed() {
     assert_eq!(parsed["failed"].as_array().unwrap().len(), 1);
     assert_eq!(parsed["failed"][0]["id"], "2");
 }
+
+#[tokio::test]
+async fn view_multi_permissive_api_410_bails() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(1, "first")))
+        .mount(&mock)
+        .await;
+    // Code 410 is NOT in the Bug.get per-bug whitelist (100/101/102) —
+    // it's a session-adjacent auth/permission failure. Must bail under
+    // `--permissive` just like a transport error or session-wide code.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(api_error_body(
+            410,
+            "You must log in to access this resource.",
+        )))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(3, "third")))
+        .mount(&mock)
+        .await;
+
+    let action = make_view_action(&["1", "2", "3"], true);
+    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(
+        result.is_err(),
+        "auth-flavored Api code must bail despite --permissive"
+    );
+    assert!(!result.unwrap_err().is_bug_get_per_resource());
+}

--- a/src/commands/bug/view_tests.rs
+++ b/src/commands/bug/view_tests.rs
@@ -4,39 +4,78 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::BugAction;
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::{capture_stdout, extract_json, setup_test_env};
 use crate::types::OutputFormat;
 
-#[tokio::test]
-async fn bug_view_returns_detail() {
-    let (_lock, mock, _tmp) = setup_test_env().await;
+fn make_view_action(ids: &[&str], permissive: bool) -> BugAction {
+    BugAction::View {
+        ids: ids.iter().map(|s| (*s).to_string()).collect(),
+        permissive,
+        fields: None,
+        exclude_fields: None,
+    }
+}
 
+fn ok_bug_body(id: u64, summary: &str) -> serde_json::Value {
+    serde_json::json!({
+        "bugs": [{
+            "id": id,
+            "summary": summary,
+            "status": "NEW",
+            "resolution": "",
+            "assigned_to": "nobody@test.com",
+            "priority": "P1",
+            "severity": "normal",
+            "product": "TestProduct",
+            "component": "General",
+            "creation_time": "2025-01-01T00:00:00Z",
+            "last_change_time": "2025-01-01T00:00:00Z"
+        }]
+    })
+}
+
+fn api_error_body(code: i64, message: &str) -> serde_json::Value {
+    serde_json::json!({
+        "error": true,
+        "code": code,
+        "message": message
+    })
+}
+
+#[tokio::test]
+async fn view_single_unchanged_table() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
     Mock::given(method("GET"))
         .and(path("/rest/bug/42"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "bugs": [{
-                "id": 42,
-                "summary": "Test bug",
-                "status": "NEW",
-                "resolution": "",
-                "assigned_to": "nobody@test.com",
-                "priority": "P1",
-                "severity": "normal",
-                "product": "TestProduct",
-                "component": "General",
-                "creation_time": "2025-01-01T00:00:00Z",
-                "last_change_time": "2025-01-01T00:00:00Z"
-            }]
-        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(42, "Test bug")))
         .mount(&mock)
         .await;
 
-    let action = BugAction::View {
-        ids: vec!["42".to_string()],
-        permissive: false,
-        fields: None,
-        exclude_fields: None,
-    };
+    let action = make_view_action(&["42"], false);
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+    ))
+    .await;
+    assert!(result.is_ok(), "{:?}", result.err());
+    assert!(output.contains("Bug #42"));
+    assert!(output.contains("Test bug"));
+    // Single-ID → no divider.
+    assert!(!output.contains(&"─".repeat(60)));
+}
+
+#[tokio::test]
+async fn view_single_unchanged_json() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(42, "Test bug")))
+        .mount(&mock)
+        .await;
+
+    let action = make_view_action(&["42"], false);
     let (result, output) = capture_stdout(crate::commands::bug::execute(
         &action,
         None,
@@ -45,37 +84,395 @@ async fn bug_view_returns_detail() {
     ))
     .await;
     assert!(result.is_ok());
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value = extract_json(&output);
+    // Single-ID JSON shape must remain a bare Bug object — no `bugs`/`failed`.
     assert_eq!(parsed["id"], 42);
-    assert_eq!(parsed["summary"], "Test bug");
-    assert_eq!(parsed["assigned_to"], "nobody@test.com");
+    assert!(parsed.get("bugs").is_none());
+    assert!(parsed.get("failed").is_none());
 }
 
 #[tokio::test]
-async fn bug_view_not_found_returns_error() {
+async fn view_single_failure_propagates() {
     let (_lock, mock, _tmp) = setup_test_env().await;
-
     Mock::given(method("GET"))
         .and(path("/rest/bug/999999"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "error": true,
-            "code": 101,
-            "message": "Bug #999999 does not exist."
-        })))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(api_error_body(101, "Bug #999999 does not exist.")),
+        )
         .mount(&mock)
         .await;
 
-    let action = BugAction::View {
-        ids: vec!["999999".to_string()],
-        permissive: false,
-        fields: None,
-        exclude_fields: None,
-    };
+    let action = make_view_action(&["999999"], false);
     let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
     assert!(result.is_err());
-    let err = result.unwrap_err().to_string();
+}
+
+#[tokio::test]
+async fn view_multi_strict_all_succeed_table() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    for (id, summary) in [(1, "first"), (2, "second"), (3, "third")] {
+        Mock::given(method("GET"))
+            .and(path(format!("/rest/bug/{id}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(id, summary)))
+            .mount(&mock)
+            .await;
+    }
+
+    let action = make_view_action(&["1", "2", "3"], false);
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+    ))
+    .await;
+    assert!(result.is_ok());
+    assert!(output.contains("Bug #1"));
+    assert!(output.contains("Bug #2"));
+    assert!(output.contains("Bug #3"));
+    // Three bugs ⇒ exactly two dividers.
+    assert_eq!(output.matches(&"─".repeat(60)).count(), 2);
+}
+
+#[tokio::test]
+async fn view_multi_strict_first_failure_bails() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(1, "first")))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/2"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(api_error_body(101, "Bug #2 does not exist.")),
+        )
+        .mount(&mock)
+        .await;
+    // No mock for /rest/bug/3 — if the loop calls it, wiremock returns 404
+    // with no body, which would surface as a transport error. The test
+    // confirms the loop never gets that far.
+
+    let action = make_view_action(&["1", "2", "3"], false);
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+    ))
+    .await;
+    assert!(result.is_err());
+    // Bug #1 was eager-printed before the failure.
+    assert!(output.contains("Bug #1"));
+    // Bug #3 must NOT have been fetched.
+    assert!(!output.contains("Bug #3"));
+}
+
+#[tokio::test]
+async fn view_multi_strict_json_all_succeed_emits_wrapped_shape() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    for (id, summary) in [(1, "first"), (2, "second")] {
+        Mock::given(method("GET"))
+            .and(path(format!("/rest/bug/{id}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(id, summary)))
+            .mount(&mock)
+            .await;
+    }
+
+    let action = make_view_action(&["1", "2"], false);
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+    ))
+    .await;
+    assert!(result.is_ok());
+    let parsed: serde_json::Value = extract_json(&output);
+    assert_eq!(parsed["bugs"].as_array().unwrap().len(), 2);
+    assert_eq!(parsed["failed"].as_array().unwrap().len(), 0);
+    assert_eq!(parsed["bugs"][0]["id"], 1);
+    assert_eq!(parsed["bugs"][1]["id"], 2);
+}
+
+#[tokio::test]
+async fn view_multi_strict_json_failure_emits_no_partial_json() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(1, "first")))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/2"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(api_error_body(101, "Bug #2 does not exist.")),
+        )
+        .mount(&mock)
+        .await;
+
+    let action = make_view_action(&["1", "2"], false);
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+    ))
+    .await;
+    assert!(result.is_err());
+    // No JSON should have been emitted — the buffer was discarded on Err.
     assert!(
-        err.contains("does not exist") || err.contains("101"),
-        "expected not-found error, got: {err}"
+        output.trim().is_empty(),
+        "expected empty stdout, got: {output}"
     );
+}
+
+#[tokio::test]
+async fn view_multi_permissive_partial_table() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(1, "first")))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/2"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(api_error_body(101, "Bug #2 does not exist.")),
+        )
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(3, "third")))
+        .mount(&mock)
+        .await;
+
+    let action = make_view_action(&["1", "2", "3"], true);
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+    ))
+    .await;
+    assert!(
+        result.is_ok(),
+        "permissive must exit Ok, got: {:?}",
+        result.err()
+    );
+    assert!(output.contains("Bug #1"));
+    assert!(output.contains("Bug #2"));
+    assert!(output.contains("UNAVAILABLE"));
+    assert!(output.contains("Bug #3"));
+    // Argument order preserved.
+    let pos1 = output.find("Bug #1").unwrap();
+    let pos2 = output.find("Bug #2").unwrap();
+    let pos3 = output.find("Bug #3").unwrap();
+    assert!(pos1 < pos2 && pos2 < pos3);
+}
+
+#[tokio::test]
+async fn view_multi_permissive_json_shape() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(1, "first")))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/2"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(api_error_body(101, "Bug #2 does not exist.")),
+        )
+        .mount(&mock)
+        .await;
+
+    let action = make_view_action(&["1", "2"], true);
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+    ))
+    .await;
+    assert!(result.is_ok());
+    let parsed: serde_json::Value = extract_json(&output);
+    assert_eq!(parsed["bugs"].as_array().unwrap().len(), 1);
+    assert_eq!(parsed["bugs"][0]["id"], 1);
+    let failed = parsed["failed"].as_array().unwrap();
+    assert_eq!(failed.len(), 1);
+    assert_eq!(failed[0]["id"], "2");
+    assert!(
+        failed[0]["error"]
+            .as_str()
+            .unwrap()
+            .contains("does not exist")
+            || failed[0]["error"].as_str().unwrap().contains("101")
+    );
+}
+
+#[tokio::test]
+async fn view_multi_permissive_all_fail_returns_empty_bugs() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    for id in [1_u64, 2, 3] {
+        Mock::given(method("GET"))
+            .and(path(format!("/rest/bug/{id}")))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(api_error_body(101, "no such bug")),
+            )
+            .mount(&mock)
+            .await;
+    }
+
+    let action = make_view_action(&["1", "2", "3"], true);
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+    ))
+    .await;
+    assert!(result.is_ok());
+    let parsed: serde_json::Value = extract_json(&output);
+    assert_eq!(parsed["bugs"].as_array().unwrap().len(), 0);
+    assert_eq!(parsed["failed"].as_array().unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn view_multi_permissive_with_alias_preserves_id_string() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(1, "first")))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/my-alias"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(api_error_body(100, "Invalid Bug Alias")),
+        )
+        .mount(&mock)
+        .await;
+
+    let action = make_view_action(&["1", "my-alias"], true);
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+    ))
+    .await;
+    assert!(result.is_ok());
+    let parsed: serde_json::Value = extract_json(&output);
+    let failed = parsed["failed"].as_array().unwrap();
+    assert_eq!(
+        failed[0]["id"], "my-alias",
+        "alias preserved verbatim in failure id"
+    );
+}
+
+#[tokio::test]
+async fn view_permissive_single_id_rejected() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let action = make_view_action(&["42"], true);
+    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err, crate::error::BzrError::InputValidation(_)));
+    assert_eq!(err.exit_code(), 7);
+    assert!(err
+        .to_string()
+        .contains("only meaningful with multiple IDs"));
+}
+
+#[tokio::test]
+async fn view_multi_permissive_transport_error_bails() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(1, "first")))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/2"))
+        .respond_with(ResponseTemplate::new(500).set_body_string(""))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(3, "third")))
+        .mount(&mock)
+        .await;
+
+    let action = make_view_action(&["1", "2", "3"], true);
+    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(
+        result.is_err(),
+        "transport error must bail despite --permissive"
+    );
+    // It must be a transport-flavored error, not a per-resource one.
+    assert!(!result.unwrap_err().is_bug_get_per_resource());
+}
+
+#[tokio::test]
+async fn view_multi_permissive_api_session_wide_bails() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(1, "first")))
+        .mount(&mock)
+        .await;
+    // Code 32000 (Login Required) is session-wide — must bail.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/2"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(api_error_body(32000, "Login Required")),
+        )
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(3, "third")))
+        .mount(&mock)
+        .await;
+
+    let action = make_view_action(&["1", "2", "3"], true);
+    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(
+        result.is_err(),
+        "session-wide Api code must bail despite --permissive"
+    );
+}
+
+#[tokio::test]
+async fn view_multi_permissive_api_102_suppressed() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(1, "first")))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/2"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(api_error_body(102, "Access Denied")),
+        )
+        .mount(&mock)
+        .await;
+
+    let action = make_view_action(&["1", "2"], true);
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+    ))
+    .await;
+    assert!(result.is_ok());
+    let parsed: serde_json::Value = extract_json(&output);
+    assert_eq!(parsed["failed"].as_array().unwrap().len(), 1);
+    assert_eq!(parsed["failed"][0]["id"], "2");
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,6 +105,11 @@ const EXIT_CODE_TLS: i32 = 13;
 /// Used for retry logic in hybrid mode when extensions crash.
 pub const BUGZILLA_INTERNAL_ERROR: i64 = 100_500;
 
+/// Bugzilla `Bug.get` per-bug fault codes.
+/// 100: Invalid Bug Alias  ·  101: Invalid Bug ID  ·  102: Access Denied
+/// Reference: <https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html>
+const BUG_GET_PER_RESOURCE_CODES: &[i64] = &[100, 101, 102];
+
 /// Walk a `std::error::Error` source chain into a single string.
 ///
 /// reqwest's `Display` only shows the error kind and URL, omitting the
@@ -145,6 +150,18 @@ impl BzrError {
             self,
             BzrError::Http(_) | BzrError::HttpStatus { .. } | BzrError::XmlRpc(_)
         )
+    }
+
+    /// Returns true for per-resource errors that may be suppressed
+    /// under `bzr bug view --permissive` (one inaccessible bug among
+    /// many). Session-level failures (transport, auth, security,
+    /// uncategorized server faults) always bail.
+    pub fn is_bug_get_per_resource(&self) -> bool {
+        match self {
+            BzrError::NotFound { .. } => true,
+            BzrError::Api { code, .. } => BUG_GET_PER_RESOURCE_CODES.contains(code),
+            _ => false,
+        }
     }
 
     pub fn exit_code(&self) -> i32 {

--- a/src/error_tests.rs
+++ b/src/error_tests.rs
@@ -190,3 +190,68 @@ async fn format_http_error_includes_source_chain() {
         "expected connection-level detail in: {formatted}"
     );
 }
+
+#[test]
+fn is_bug_get_per_resource_true_for_notfound() {
+    let err = BzrError::NotFound {
+        resource: "bug",
+        id: "123".into(),
+    };
+    assert!(err.is_bug_get_per_resource());
+}
+
+#[test]
+fn is_bug_get_per_resource_true_for_api_100() {
+    let err = BzrError::Api {
+        code: 100,
+        message: "invalid alias".into(),
+    };
+    assert!(err.is_bug_get_per_resource());
+}
+
+#[test]
+fn is_bug_get_per_resource_true_for_api_101() {
+    let err = BzrError::Api {
+        code: 101,
+        message: "invalid bug id".into(),
+    };
+    assert!(err.is_bug_get_per_resource());
+}
+
+#[test]
+fn is_bug_get_per_resource_true_for_api_102() {
+    let err = BzrError::Api {
+        code: 102,
+        message: "access denied".into(),
+    };
+    assert!(err.is_bug_get_per_resource());
+}
+
+#[test]
+fn is_bug_get_per_resource_false_for_api_session_codes() {
+    for code in [32000_i64, 32610, 100_500, 50_001] {
+        let err = BzrError::Api {
+            code,
+            message: "session-wide".into(),
+        };
+        assert!(
+            !err.is_bug_get_per_resource(),
+            "code {code} should NOT be per-resource"
+        );
+    }
+}
+
+#[test]
+fn is_bug_get_per_resource_false_for_transport_and_auth() {
+    let err = BzrError::HttpStatus {
+        status: 500,
+        body: String::new(),
+    };
+    assert!(!err.is_bug_get_per_resource());
+
+    let err = BzrError::Auth("session expired".into());
+    assert!(!err.is_bug_get_per_resource());
+
+    let err = BzrError::XmlRpc("transport".into());
+    assert!(!err.is_bug_get_per_resource());
+}

--- a/src/output/bug.rs
+++ b/src/output/bug.rs
@@ -142,6 +142,7 @@ pub fn print_history(history: &[HistoryEntry], format: OutputFormat) {
         reason = "consumed by `bzr bug view` multi-ID handler in a follow-up task on this branch"
     )
 )]
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum MultiBugRow {
     Ok(Box<Bug>),

--- a/src/output/bug.rs
+++ b/src/output/bug.rs
@@ -3,7 +3,10 @@ use std::io::{self, Write};
 use colored::Colorize;
 use tabled::{Table, Tabled};
 
-use super::formatting::{colorize_status, print_formatted, shorten_email, truncate};
+use super::formatting::{
+    colorize_status, print_formatted, shorten_email, truncate, write_divider, write_field,
+    write_list_field, write_optional_field,
+};
 use crate::types::{Bug, HistoryEntry, OutputFormat};
 
 #[derive(Tabled)]
@@ -74,20 +77,6 @@ fn write_bug_detail(bug: &Bug, out: &mut impl Write) {
     write_id_list_field(out, "Depends on", &bug.depends_on);
 }
 
-fn write_field(out: &mut impl Write, label: &str, value: &str) {
-    let _ = writeln!(out, "  {label:<12}  {value}");
-}
-
-fn write_optional_field(out: &mut impl Write, label: &str, value: Option<&str>) {
-    let _ = writeln!(out, "  {label:<12}  {}", value.unwrap_or("-"));
-}
-
-fn write_list_field(out: &mut impl Write, label: &str, items: &[String]) {
-    if !items.is_empty() {
-        let _ = writeln!(out, "  {label:<12}  {}", items.join(", "));
-    }
-}
-
 fn write_id_list_field(out: &mut impl Write, label: &str, ids: &[u64]) {
     if !ids.is_empty() {
         let id_str = ids
@@ -126,7 +115,7 @@ pub fn print_history(history: &[HistoryEntry], format: OutputFormat) {
                     let _ = writeln!(io::stdout(), "    + {}", change.added.green());
                 }
             }
-            let _ = writeln!(io::stdout(), "{}", "─".repeat(60));
+            write_divider(&mut io::stdout());
         }
     });
 }
@@ -154,10 +143,9 @@ pub fn print_multi_bug_view(rows: &[MultiBugRow]) {
 }
 
 fn write_multi_bug_view(rows: &[MultiBugRow], out: &mut impl Write) {
-    let divider = "─".repeat(60);
     for (i, row) in rows.iter().enumerate() {
         if i > 0 {
-            let _ = writeln!(out, "{divider}");
+            write_divider(out);
         }
         match row {
             MultiBugRow::Ok(bug) => write_bug_detail(bug, out),

--- a/src/output/bug.rs
+++ b/src/output/bug.rs
@@ -135,13 +135,6 @@ pub fn print_history(history: &[HistoryEntry], format: OutputFormat) {
 ///
 /// Used by [`print_multi_bug_view`] to interleave successful detail
 /// blocks with `UNAVAILABLE` placeholder blocks for inaccessible bugs.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "consumed by `bzr bug view` multi-ID handler in a follow-up task on this branch"
-    )
-)]
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum MultiBugRow {
@@ -156,10 +149,6 @@ pub enum MultiBugRow {
 /// covers table mode: argument-order detail blocks for `Ok`, visually
 /// distinct `UNAVAILABLE` placeholder blocks for `Failed`, with a
 /// `─`-divider line between every pair of blocks (no trailing divider).
-#[expect(
-    dead_code,
-    reason = "consumed by `bzr bug view` multi-ID handler in a follow-up task on this branch"
-)]
 pub fn print_multi_bug_view(rows: &[MultiBugRow]) {
     write_multi_bug_view(rows, &mut io::stdout());
 }

--- a/src/output/bug.rs
+++ b/src/output/bug.rs
@@ -1,12 +1,9 @@
-use std::io::{self, Write as _};
+use std::io::{self, Write};
 
 use colored::Colorize;
 use tabled::{Table, Tabled};
 
-use super::formatting::{
-    colorize_status, print_field, print_formatted, print_id_list_field, print_list_field,
-    print_optional_field, shorten_email, truncate,
-};
+use super::formatting::{colorize_status, print_formatted, shorten_email, truncate};
 use crate::types::{Bug, HistoryEntry, OutputFormat};
 
 #[derive(Tabled)]
@@ -50,27 +47,56 @@ pub fn print_bugs(bugs: &[Bug], format: OutputFormat) {
 
 pub fn print_bug_detail(bug: &Bug, format: OutputFormat) {
     print_formatted(bug, format, |bug| {
-        let _ = writeln!(
-            io::stdout(),
-            "{} #{}\n{}\n",
-            "Bug".bold(),
-            bug.id.to_string().bold(),
-            bug.summary.bold()
-        );
-        print_field("Status", &colorize_status(&bug.status));
-        print_optional_field("Resolution", bug.resolution.as_deref());
-        print_optional_field("Product", bug.product.as_deref());
-        print_optional_field("Component", bug.component.as_deref());
-        print_optional_field("Assignee", bug.assigned_to.as_deref());
-        print_optional_field("Priority", bug.priority.as_deref());
-        print_optional_field("Severity", bug.severity.as_deref());
-        print_optional_field("Creator", bug.creator.as_deref());
-        print_optional_field("Created", bug.creation_time.as_deref());
-        print_optional_field("Updated", bug.last_change_time.as_deref());
-        print_list_field("Keywords", &bug.keywords);
-        print_id_list_field("Blocks", &bug.blocks);
-        print_id_list_field("Depends on", &bug.depends_on);
+        write_bug_detail(bug, &mut io::stdout());
     });
+}
+
+fn write_bug_detail(bug: &Bug, out: &mut impl Write) {
+    let _ = writeln!(
+        out,
+        "{} #{}\n{}\n",
+        "Bug".bold(),
+        bug.id.to_string().bold(),
+        bug.summary.bold()
+    );
+    write_field(out, "Status", &colorize_status(&bug.status));
+    write_optional_field(out, "Resolution", bug.resolution.as_deref());
+    write_optional_field(out, "Product", bug.product.as_deref());
+    write_optional_field(out, "Component", bug.component.as_deref());
+    write_optional_field(out, "Assignee", bug.assigned_to.as_deref());
+    write_optional_field(out, "Priority", bug.priority.as_deref());
+    write_optional_field(out, "Severity", bug.severity.as_deref());
+    write_optional_field(out, "Creator", bug.creator.as_deref());
+    write_optional_field(out, "Created", bug.creation_time.as_deref());
+    write_optional_field(out, "Updated", bug.last_change_time.as_deref());
+    write_list_field(out, "Keywords", &bug.keywords);
+    write_id_list_field(out, "Blocks", &bug.blocks);
+    write_id_list_field(out, "Depends on", &bug.depends_on);
+}
+
+fn write_field(out: &mut impl Write, label: &str, value: &str) {
+    let _ = writeln!(out, "  {label:<12}  {value}");
+}
+
+fn write_optional_field(out: &mut impl Write, label: &str, value: Option<&str>) {
+    let _ = writeln!(out, "  {label:<12}  {}", value.unwrap_or("-"));
+}
+
+fn write_list_field(out: &mut impl Write, label: &str, items: &[String]) {
+    if !items.is_empty() {
+        let _ = writeln!(out, "  {label:<12}  {}", items.join(", "));
+    }
+}
+
+fn write_id_list_field(out: &mut impl Write, label: &str, ids: &[u64]) {
+    if !ids.is_empty() {
+        let id_str = ids
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let _ = writeln!(out, "  {label:<12}  {id_str}");
+    }
 }
 
 pub fn print_history(history: &[HistoryEntry], format: OutputFormat) {
@@ -103,6 +129,62 @@ pub fn print_history(history: &[HistoryEntry], format: OutputFormat) {
             let _ = writeln!(io::stdout(), "{}", "─".repeat(60));
         }
     });
+}
+
+/// One row in a multi-ID `bzr bug view` output stream.
+///
+/// Used by [`print_multi_bug_view`] to interleave successful detail
+/// blocks with `UNAVAILABLE` placeholder blocks for inaccessible bugs.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by `bzr bug view` multi-ID handler in a follow-up task on this branch"
+    )
+)]
+#[derive(Debug)]
+pub enum MultiBugRow {
+    Ok(Box<Bug>),
+    Failed { id: String, error: String },
+}
+
+/// Render a multi-ID `bzr bug view` result.
+///
+/// JSON mode is **not** handled here — the caller emits a
+/// `MultiBugViewResult` via `output::print_result`. This function only
+/// covers table mode: argument-order detail blocks for `Ok`, visually
+/// distinct `UNAVAILABLE` placeholder blocks for `Failed`, with a
+/// `─`-divider line between every pair of blocks (no trailing divider).
+#[expect(
+    dead_code,
+    reason = "consumed by `bzr bug view` multi-ID handler in a follow-up task on this branch"
+)]
+pub fn print_multi_bug_view(rows: &[MultiBugRow]) {
+    write_multi_bug_view(rows, &mut io::stdout());
+}
+
+fn write_multi_bug_view(rows: &[MultiBugRow], out: &mut impl Write) {
+    let divider = "─".repeat(60);
+    for (i, row) in rows.iter().enumerate() {
+        if i > 0 {
+            let _ = writeln!(out, "{divider}");
+        }
+        match row {
+            MultiBugRow::Ok(bug) => write_bug_detail(bug, out),
+            MultiBugRow::Failed { id, error } => write_unavailable_block(id, error, out),
+        }
+    }
+}
+
+fn write_unavailable_block(id: &str, error: &str, out: &mut impl Write) {
+    let _ = writeln!(
+        out,
+        "{} #{} — {}",
+        "Bug".bold(),
+        id.bold(),
+        "UNAVAILABLE".red().bold()
+    );
+    let _ = writeln!(out, "  Error: {error}");
 }
 
 #[cfg(test)]

--- a/src/output/bug_tests.rs
+++ b/src/output/bug_tests.rs
@@ -409,3 +409,94 @@ async fn print_history_json_via_print() {
     let parsed = crate::test_helpers::extract_json(&output);
     assert_eq!(parsed[0]["who"], "editor@example.com");
 }
+
+// ── multi_bug_view ───────────────────────────────────────────────
+
+fn sample_bug(id: u64, summary: &str) -> Bug {
+    Bug {
+        id,
+        summary: summary.into(),
+        status: "NEW".into(),
+        resolution: None,
+        product: None,
+        component: None,
+        version: None,
+        assigned_to: None,
+        priority: None,
+        severity: None,
+        creation_time: None,
+        last_change_time: None,
+        creator: None,
+        url: None,
+        whiteboard: None,
+        keywords: vec![],
+        blocks: vec![],
+        depends_on: vec![],
+        cc: vec![],
+        op_sys: None,
+        rep_platform: None,
+    }
+}
+
+#[test]
+fn multi_bug_view_renders_success_blocks_with_dividers() {
+    let rows = vec![
+        MultiBugRow::Ok(Box::new(sample_bug(1, "first"))),
+        MultiBugRow::Ok(Box::new(sample_bug(2, "second"))),
+        MultiBugRow::Ok(Box::new(sample_bug(3, "third"))),
+    ];
+    let mut buf = Vec::new();
+    write_multi_bug_view(&rows, &mut buf);
+    let out = String::from_utf8(buf).unwrap();
+    assert!(out.contains("Bug #1"));
+    assert!(out.contains("Bug #2"));
+    assert!(out.contains("Bug #3"));
+    // Three rows ⇒ exactly two dividers between them, no trailing divider.
+    let divider = "─".repeat(60);
+    assert_eq!(out.matches(&divider).count(), 2);
+}
+
+#[test]
+fn multi_bug_view_renders_failure_block_with_unavailable_marker() {
+    let rows = vec![MultiBugRow::Failed {
+        id: "999".into(),
+        error: "bug not found: 999".into(),
+    }];
+    let mut buf = Vec::new();
+    write_multi_bug_view(&rows, &mut buf);
+    let out = String::from_utf8(buf).unwrap();
+    // The colored crate writes ANSI escapes around terms when a TTY is
+    // detected; tests compare on the plain substrings.
+    assert!(out.contains("Bug #999"));
+    assert!(out.contains("UNAVAILABLE"));
+    assert!(out.contains("Error: bug not found: 999"));
+}
+
+#[test]
+fn multi_bug_view_single_row_emits_no_divider() {
+    let rows = vec![MultiBugRow::Ok(Box::new(sample_bug(7, "only")))];
+    let mut buf = Vec::new();
+    write_multi_bug_view(&rows, &mut buf);
+    let out = String::from_utf8(buf).unwrap();
+    let divider = "─".repeat(60);
+    assert_eq!(out.matches(&divider).count(), 0);
+}
+
+#[test]
+fn multi_bug_view_interleaves_success_and_failure_in_order() {
+    let rows = vec![
+        MultiBugRow::Ok(Box::new(sample_bug(10, "alpha"))),
+        MultiBugRow::Failed {
+            id: "11".into(),
+            error: "denied".into(),
+        },
+        MultiBugRow::Ok(Box::new(sample_bug(12, "gamma"))),
+    ];
+    let mut buf = Vec::new();
+    write_multi_bug_view(&rows, &mut buf);
+    let out = String::from_utf8(buf).unwrap();
+    let pos_alpha = out.find("Bug #10").unwrap();
+    let pos_unavail = out.find("Bug #11").unwrap();
+    let pos_gamma = out.find("Bug #12").unwrap();
+    assert!(pos_alpha < pos_unavail && pos_unavail < pos_gamma);
+}

--- a/src/output/bug_tests.rs
+++ b/src/output/bug_tests.rs
@@ -412,6 +412,10 @@ async fn print_history_json_via_print() {
 
 // ── multi_bug_view ───────────────────────────────────────────────
 
+fn no_color() {
+    colored::control::set_override(false);
+}
+
 fn sample_bug(id: u64, summary: &str) -> Bug {
     Bug {
         id,
@@ -440,6 +444,7 @@ fn sample_bug(id: u64, summary: &str) -> Bug {
 
 #[test]
 fn multi_bug_view_renders_success_blocks_with_dividers() {
+    no_color();
     let rows = vec![
         MultiBugRow::Ok(Box::new(sample_bug(1, "first"))),
         MultiBugRow::Ok(Box::new(sample_bug(2, "second"))),
@@ -458,6 +463,7 @@ fn multi_bug_view_renders_success_blocks_with_dividers() {
 
 #[test]
 fn multi_bug_view_renders_failure_block_with_unavailable_marker() {
+    no_color();
     let rows = vec![MultiBugRow::Failed {
         id: "999".into(),
         error: "bug not found: 999".into(),
@@ -474,6 +480,7 @@ fn multi_bug_view_renders_failure_block_with_unavailable_marker() {
 
 #[test]
 fn multi_bug_view_single_row_emits_no_divider() {
+    no_color();
     let rows = vec![MultiBugRow::Ok(Box::new(sample_bug(7, "only")))];
     let mut buf = Vec::new();
     write_multi_bug_view(&rows, &mut buf);
@@ -484,6 +491,7 @@ fn multi_bug_view_single_row_emits_no_divider() {
 
 #[test]
 fn multi_bug_view_interleaves_success_and_failure_in_order() {
+    no_color();
     let rows = vec![
         MultiBugRow::Ok(Box::new(sample_bug(10, "alpha"))),
         MultiBugRow::Failed {

--- a/src/output/formatting.rs
+++ b/src/output/formatting.rs
@@ -31,22 +31,47 @@ pub(super) fn print_formatted<T: Serialize + ?Sized>(
 // Shared formatting for bug/resource detail views. All use consistent
 // 12-char label alignment and render absent values as "-".
 
+pub(super) fn write_field(out: &mut impl Write, label: &str, value: &str) {
+    let _ = writeln!(out, "  {label:<12}  {value}");
+}
+
+pub(super) fn write_optional_field(out: &mut impl Write, label: &str, value: Option<&str>) {
+    let _ = writeln!(out, "  {label:<12}  {}", value.unwrap_or("-"));
+}
+
+pub(super) fn write_list_field(out: &mut impl Write, label: &str, items: &[String]) {
+    if !items.is_empty() {
+        let _ = writeln!(out, "  {label:<12}  {}", items.join(", "));
+    }
+}
+
 pub(super) fn print_field(label: &str, value: &str) {
-    writeln!(io::stdout(), "  {label:<12}  {value}").expect("write to output");
+    write_field(&mut io::stdout(), label, value);
 }
 
 pub(super) fn print_optional_field(label: &str, value: Option<&str>) {
-    writeln!(io::stdout(), "  {label:<12}  {}", value.unwrap_or("-")).expect("write to output");
+    write_optional_field(&mut io::stdout(), label, value);
 }
 
 pub(super) fn print_list_field(label: &str, items: &[String]) {
-    if !items.is_empty() {
-        writeln!(io::stdout(), "  {label:<12}  {}", items.join(", ")).expect("write to output");
-    }
+    write_list_field(&mut io::stdout(), label, items);
 }
 
 pub(super) fn print_bool_field(label: &str, value: bool) {
     writeln!(io::stdout(), "  {label:<12}  {}", yes_no(value)).expect("write to output");
+}
+
+// ── Section divider ─────────────────────────────────────────────────
+
+/// Width of the horizontal divider used between detail blocks in
+/// `bug history`, `bug view` (multi-ID), and similar resource-detail
+/// outputs. Box-drawing horizontal bar (`─`, U+2500) repeated this
+/// many times.
+pub(super) const DIVIDER_WIDTH: usize = 60;
+
+/// Write a horizontal section divider followed by a newline.
+pub(crate) fn write_divider(out: &mut impl Write) {
+    let _ = writeln!(out, "{}", "─".repeat(DIVIDER_WIDTH));
 }
 
 pub(super) fn yes_no(value: bool) -> &'static str {

--- a/src/output/formatting.rs
+++ b/src/output/formatting.rs
@@ -45,21 +45,8 @@ pub(super) fn print_list_field(label: &str, items: &[String]) {
     }
 }
 
-pub(super) fn print_id_list_field(label: &str, ids: &[u64]) {
-    if !ids.is_empty() {
-        writeln!(io::stdout(), "  {label:<12}  {}", format_id_list(ids)).expect("write to output");
-    }
-}
-
 pub(super) fn print_bool_field(label: &str, value: bool) {
     writeln!(io::stdout(), "  {label:<12}  {}", yes_no(value)).expect("write to output");
-}
-
-pub(super) fn format_id_list(ids: &[u64]) -> String {
-    ids.iter()
-        .map(std::string::ToString::to_string)
-        .collect::<Vec<_>>()
-        .join(", ")
 }
 
 pub(super) fn yes_no(value: bool) -> &'static str {

--- a/src/output/formatting_tests.rs
+++ b/src/output/formatting_tests.rs
@@ -117,23 +117,6 @@ fn shorten_email_uses_first_at_symbol() {
     assert_eq!(shorten_email("alice@dev@example.com"), "alice");
 }
 
-// ── format_id_list ───────────────────────────────────────────────
-
-#[test]
-fn format_id_list_empty() {
-    assert_eq!(format_id_list(&[]), "");
-}
-
-#[test]
-fn format_id_list_single() {
-    assert_eq!(format_id_list(&[42]), "42");
-}
-
-#[test]
-fn format_id_list_multiple() {
-    assert_eq!(format_id_list(&[1, 2, 3]), "1, 2, 3");
-}
-
 #[test]
 fn yes_no_formats_boolean_values() {
     assert_eq!(yes_no(true), "Yes");

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -19,10 +19,6 @@ mod template;
 mod user;
 
 // Re-export shared types and helpers used by commands.
-#[expect(
-    unused_imports,
-    reason = "BugViewFailure/MultiBugViewResult consumed by `bzr bug view` multi-ID handler in a follow-up task on this branch"
-)]
 pub use result_types::{
     print_result, ActionResult, BatchFailure, BatchResult, BugViewFailure, ConfigResult,
     DownloadResult, MembershipResult, MultiBugViewResult, ResourceKind, SearchResult, TagResult,
@@ -31,10 +27,6 @@ pub use result_types::{
 
 // Re-export all public items from submodules.
 pub use attachment::print_attachments;
-#[expect(
-    unused_imports,
-    reason = "MultiBugRow / print_multi_bug_view consumed by `bzr bug view` multi-ID handler in a follow-up task on this branch"
-)]
 pub use bug::{print_bug_detail, print_bugs, print_history, print_multi_bug_view, MultiBugRow};
 pub use classification::print_classification;
 pub use comment::print_comments;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -19,6 +19,7 @@ mod template;
 mod user;
 
 // Re-export shared types and helpers used by commands.
+pub(crate) use formatting::write_divider;
 pub use result_types::{
     print_result, ActionResult, BatchFailure, BatchResult, BugViewFailure, ConfigResult,
     DownloadResult, MembershipResult, MultiBugViewResult, ResourceKind, SearchResult, TagResult,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -31,7 +31,11 @@ pub use result_types::{
 
 // Re-export all public items from submodules.
 pub use attachment::print_attachments;
-pub use bug::{print_bug_detail, print_bugs, print_history};
+#[expect(
+    unused_imports,
+    reason = "MultiBugRow / print_multi_bug_view consumed by `bzr bug view` multi-ID handler in a follow-up task on this branch"
+)]
+pub use bug::{print_bug_detail, print_bugs, print_history, print_multi_bug_view, MultiBugRow};
 pub use classification::print_classification;
 pub use comment::print_comments;
 #[expect(

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -19,9 +19,14 @@ mod template;
 mod user;
 
 // Re-export shared types and helpers used by commands.
+#[expect(
+    unused_imports,
+    reason = "BugViewFailure/MultiBugViewResult consumed by `bzr bug view` multi-ID handler in a follow-up task on this branch"
+)]
 pub use result_types::{
-    print_result, ActionResult, BatchFailure, BatchResult, ConfigResult, DownloadResult,
-    MembershipResult, ResourceKind, SearchResult, TagResult, UploadResult,
+    print_result, ActionResult, BatchFailure, BatchResult, BugViewFailure, ConfigResult,
+    DownloadResult, MembershipResult, MultiBugViewResult, ResourceKind, SearchResult, TagResult,
+    UploadResult,
 };
 
 // Re-export all public items from submodules.

--- a/src/output/result_types.rs
+++ b/src/output/result_types.rs
@@ -237,6 +237,39 @@ impl BatchResult {
     }
 }
 
+/// Typed result payload for multi-ID `bzr bug view` JSON output.
+///
+/// The wrapped shape is used for **every** multi-ID invocation, with or
+/// without `--permissive`. `failed` is always present (empty array when
+/// no failures) so `jq` consumers can rely on `.bugs[]` and
+/// `.failed[]` regardless of arguments. Single-ID `bzr bug view --json`
+/// continues to emit a bare `Bug` object — unrelated to this type.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by `bzr bug view` multi-ID handler in a follow-up task on this branch"
+    )
+)]
+pub struct MultiBugViewResult {
+    pub bugs: Vec<crate::types::Bug>,
+    pub failed: Vec<BugViewFailure>,
+}
+
+/// Per-row failure entry for [`MultiBugViewResult`].
+///
+/// `id` is `String`, not `u64`, because the caller may have passed an
+/// alias (`bzr bug view 12345 my-alias 999`); preserving the original
+/// argument lets users correlate failures with the IDs they typed.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct BugViewFailure {
+    pub id: String,
+    pub error: String,
+}
+
 /// Typed result payload for JSON output of mutation operations.
 ///
 /// Covers standard CRUD results with an `id` and optional `name`.

--- a/src/output/result_types.rs
+++ b/src/output/result_types.rs
@@ -246,13 +246,6 @@ impl BatchResult {
 /// continues to emit a bare `Bug` object — unrelated to this type.
 #[derive(Debug, Serialize)]
 #[non_exhaustive]
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "consumed by `bzr bug view` multi-ID handler in a follow-up task on this branch"
-    )
-)]
 pub struct MultiBugViewResult {
     pub bugs: Vec<crate::types::Bug>,
     pub failed: Vec<BugViewFailure>,

--- a/src/output/result_types_tests.rs
+++ b/src/output/result_types_tests.rs
@@ -167,3 +167,31 @@ fn print_result_uses_pretty_json() {
     let json = serde_json::to_string_pretty(&result).unwrap();
     assert!(json.contains('\n'), "expected pretty-printed JSON");
 }
+
+#[test]
+fn multi_bug_view_result_serializes_with_empty_failed() {
+    let result = MultiBugViewResult {
+        bugs: vec![],
+        failed: vec![],
+    };
+    let v = serde_json::to_value(&result).unwrap();
+    assert!(v.get("bugs").unwrap().is_array());
+    assert!(v.get("failed").unwrap().is_array());
+    assert_eq!(v["bugs"].as_array().unwrap().len(), 0);
+    assert_eq!(v["failed"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn multi_bug_view_result_serializes_with_failure_id_as_string() {
+    let result = MultiBugViewResult {
+        bugs: vec![],
+        failed: vec![BugViewFailure {
+            id: "my-alias".into(),
+            error: "bug not found: my-alias".into(),
+        }],
+    };
+    let v = serde_json::to_value(&result).unwrap();
+    let failed = &v["failed"][0];
+    assert_eq!(failed["id"], "my-alias");
+    assert_eq!(failed["error"], "bug not found: my-alias");
+}

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -452,6 +452,33 @@ test_begin "46. bug view 999999 (negative test)"
 run_bzr bug view 999999
 if assert_failure; then test_pass; fi
 
+test_begin "46a. bug view multi-ID (all succeed, JSON wrapped shape)"
+if [[ -n "$BUG1" ]] && [[ -n "$BUG2" ]]; then
+    run_bzr bug view "$BUG1" "$BUG2"
+    if assert_success \
+        && assert_json_array_length '.bugs' 2 \
+        && assert_json_array_length '.failed' 0; then
+        test_pass
+    fi
+else test_skip "no BUG1/BUG2"; fi
+
+test_begin "46b. bug view multi-ID strict bails on inaccessible bug"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug view 999999 "$BUG1"
+    if assert_failure; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "46c. bug view multi-ID --permissive surfaces per-bug error"
+if [[ -n "$BUG1" ]] && [[ -n "$BUG2" ]]; then
+    run_bzr bug view "$BUG1" "$BUG2" 999999 --permissive
+    if assert_success \
+        && assert_json_array_length '.bugs' 2 \
+        && assert_json_array_length '.failed' 1 \
+        && assert_json '.failed[0].id' "999999"; then
+        test_pass
+    fi
+else test_skip "no BUG1/BUG2"; fi
+
 test_begin "47. bug create (bug three — clone source)"
 run_bzr bug create --product FuncTestProd --component Backend --summary "Clone source bug" --description "Description for cloning" --priority Highest --severity critical --op-sys Linux --rep-platform PC
 if assert_success && assert_json_exists '.id'; then

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -74,7 +74,8 @@ async fn bug_view_integration() {
         .await;
 
     let action = bzr::cli::BugAction::View {
-        id: "42".to_string(),
+        ids: vec!["42".to_string()],
+        permissive: false,
         fields: None,
         exclude_fields: None,
     };
@@ -605,7 +606,8 @@ async fn api_error_propagates() {
         .await;
 
     let action = bzr::cli::BugAction::View {
-        id: "99999".to_string(),
+        ids: vec!["99999".to_string()],
+        permissive: false,
         fields: None,
         exclude_fields: None,
     };


### PR DESCRIPTION
Closes #156. Brings `bzr bug view` to parity with `bzl-get`.

## Summary

- `bzr bug view` now accepts one or more bug IDs/aliases as positional args.
- New `--permissive` flag (multi-ID only) suppresses per-bug failures and surfaces them as inline `Bug #N — UNAVAILABLE` rows (table) or entries in `failed` (JSON), exiting 0.
- Single-ID behavior — both table and JSON output — is byte-identical to before.
- `--permissive` only suppresses **per-bug** errors. `BzrError::is_bug_get_per_resource()` whitelists the documented `Bug.get` fault codes (NotFound, Api 100/101/102). Session-wide errors (transport, auth, security, server-internal, unrecognized API codes) always bail.
- Multi-ID JSON output is a wrapped `{"bugs": [...], "failed": [...]}` object (`failed` always present so `jq` consumers can rely on `.bugs[]`). Single-ID JSON unchanged.
- Spec: `docs/superpowers/specs/2026-05-06-bug-view-multi-id-design.md`.

## Error semantics

| Invocation | Outcome | Exit code |
|---|---|---|
| 1 ID, succeeds | normal detail block | 0 |
| 1 ID, fails | propagate underlying error | underlying |
| 1 ID + `--permissive` | rejected at handler entry | 7 (input validation) |
| N IDs, all succeed | N detail blocks + dividers | 0 |
| N IDs, any fails (no `--permissive`) | bail at first error | underlying |
| N IDs + `--permissive`, partial fails | inline error blocks for failed rows | 0 |
| N IDs + `--permissive`, all fail | all rows are error blocks | 0 |

## Test plan

- [x] `cargo test --lib` — 925 unit tests pass (16 new in `commands/bug/view_tests.rs` + 6 new in `error_tests.rs` + 4 new in `output/bug_tests.rs` + 2 new in `output/result_types_tests.rs`).
- [x] `cargo test --test integration` — 56 integration tests pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `make check-test-layout` — clean.
- [x] `make man` regenerates `man/man1/bzr-bug-view.1` with `--permissive` and `<IDS>` content.
- [ ] Functional tests in `tests/functional/run-tests.sh` Phase 8 (46a/46b/46c) — exercised by CI against a real Bugzilla container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)