### PR TITLE
feat(attachment upload): add --comment and --is-patch (closes #165, #166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   attachment in a single API call. Folded into the underlying
   `Bug.add_attachment` request so the attachment and comment share a
   creation timestamp. Closes #165.
+- `bzr attachment upload --is-patch` marks the attachment as a patch
+  at upload time, removing the previous two-call pattern (upload then
+  `bzr attachment update --is-patch true`). When `--content-type` is
+  not supplied, `--is-patch` defaults the type to `text/plain`,
+  matching `bzl-attachment-add`. The read-side `Attachment` struct
+  also exposes `is_patch` so `bzr attachment list --json` includes the
+  field. Closes #166.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `bzr bug create --description-file <PATH>` reads the description
   from a UTF-8 file (mutually exclusive with `--description`).
   Missing or non-UTF-8 paths exit with code 7. Closes #160.
+- `bzr attachment upload --comment <BODY>` posts a comment alongside the
+  attachment in a single API call. Folded into the underlying
+  `Bug.add_attachment` request so the attachment and comment share a
+  creation timestamp. Closes #165.
 
 ### Fixed
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -539,6 +539,7 @@ bzr attachment upload 12345 screenshot.png
 bzr attachment upload 12345 data.csv --summary "Performance data" --content-type text/csv
 bzr attachment upload 12345 patch.diff --flag "review?(alice@example.com)"
 bzr attachment upload 12345 secret.bin --summary "internal trace" --private
+bzr attachment upload 12345 fix.patch --comment "see #6789 for context"
 ```
 
 | Option | Required | Description |
@@ -548,6 +549,7 @@ bzr attachment upload 12345 secret.bin --summary "internal trace" --private
 | `--summary <S>` | No | Description of the attachment (default: filename) |
 | `--content-type <MIME>` | No | MIME type (auto-detected if omitted) |
 | `--private` | No | Mark the attachment as private (visible only to users with elevated permissions) |
+| `--comment <BODY>` | No | Post a comment alongside the attachment in the same API call |
 | `--flag <F>` | No | Set flags (repeatable; see [Flag Syntax](#flag-syntax)) |
 
 Agent note: for clearer audit trails, agents should usually pass `--summary` explicitly instead of relying on the filename-derived default.

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -540,6 +540,7 @@ bzr attachment upload 12345 data.csv --summary "Performance data" --content-type
 bzr attachment upload 12345 patch.diff --flag "review?(alice@example.com)"
 bzr attachment upload 12345 secret.bin --summary "internal trace" --private
 bzr attachment upload 12345 fix.patch --comment "see #6789 for context"
+bzr attachment upload 12345 fix.patch --is-patch
 ```
 
 | Option | Required | Description |
@@ -547,8 +548,9 @@ bzr attachment upload 12345 fix.patch --comment "see #6789 for context"
 | `<BUG_ID>` | Yes | Bug ID |
 | `<FILE>` | Yes | File to upload |
 | `--summary <S>` | No | Description of the attachment (default: filename) |
-| `--content-type <MIME>` | No | MIME type (auto-detected if omitted) |
+| `--content-type <MIME>` | No | MIME type (auto-detected if omitted; defaults to `text/plain` when `--is-patch` is set without an explicit type) |
 | `--private` | No | Mark the attachment as private (visible only to users with elevated permissions) |
+| `--is-patch` | No | Mark the attachment as a patch; defaults `--content-type` to `text/plain` |
 | `--comment <BODY>` | No | Post a comment alongside the attachment in the same API call |
 | `--flag <F>` | No | Set flags (repeatable; see [Flag Syntax](#flag-syntax)) |
 

--- a/src/cli/attachment.rs
+++ b/src/cli/attachment.rs
@@ -92,7 +92,7 @@ pub enum AttachmentAction {
         /// `insider` group (server-configured). Use carefully.
         #[arg(long)]
         private: bool,
-        /// Mark the new attachment as a patch (boolean, presence-only).
+        /// Mark the new attachment as a patch.
         ///
         /// Patches render as side-by-side diffs in the Bugzilla web UI
         /// and default `--content-type` to `text/plain` when no explicit

--- a/src/cli/attachment.rs
+++ b/src/cli/attachment.rs
@@ -71,6 +71,7 @@ pub enum AttachmentAction {
     ///   bzr attachment upload 12345 fix.patch \
     ///     --flag 'review?(maintainer@example.com)'
     ///   bzr attachment upload 12345 fix.patch --comment "see #4567 for context"
+    ///   bzr attachment upload 12345 fix.patch --is-patch
     ///
     /// See bzr-attachment-update(1) to modify metadata after upload.
     #[command(verbatim_doc_comment)]
@@ -91,6 +92,14 @@ pub enum AttachmentAction {
         /// `insider` group (server-configured). Use carefully.
         #[arg(long)]
         private: bool,
+        /// Mark the new attachment as a patch (boolean, presence-only).
+        ///
+        /// Patches render as side-by-side diffs in the Bugzilla web UI
+        /// and default `--content-type` to `text/plain` when no explicit
+        /// content type is supplied. Use this for `.diff` / `.patch`
+        /// files instead of a follow-up `bzr attachment update --is-patch true`.
+        #[arg(long)]
+        is_patch: bool,
         /// Post a comment alongside the attachment in the same request.
         ///
         /// Folded into the underlying `Bug.add_attachment` API call so

--- a/src/cli/attachment.rs
+++ b/src/cli/attachment.rs
@@ -54,6 +54,10 @@ pub enum AttachmentAction {
     /// `--summary` sets the attachment's display label;
     /// it defaults to the file name if omitted.
     ///
+    /// `--comment <BODY>` posts a comment alongside the attachment
+    /// in a single API call. Use this when the attachment needs
+    /// explanatory context — typical for patches.
+    ///
     /// `--flag` accepts Bugzilla flag syntax (`name?`, `name+`,
     /// `name-`, `name?(user@example.com)`) and is repeatable.
     /// Requires credentials with attach-file permission on the
@@ -66,6 +70,7 @@ pub enum AttachmentAction {
     ///     --content-type text/plain
     ///   bzr attachment upload 12345 fix.patch \
     ///     --flag 'review?(maintainer@example.com)'
+    ///   bzr attachment upload 12345 fix.patch --comment "see #4567 for context"
     ///
     /// See bzr-attachment-update(1) to modify metadata after upload.
     #[command(verbatim_doc_comment)]
@@ -86,6 +91,16 @@ pub enum AttachmentAction {
         /// `insider` group (server-configured). Use carefully.
         #[arg(long)]
         private: bool,
+        /// Post a comment alongside the attachment in the same request.
+        ///
+        /// Folded into the underlying `Bug.add_attachment` API call so
+        /// the comment and attachment share a creation timestamp and
+        /// are visible to the same audience as the bug. The comment
+        /// inherits the bug's default privacy; there is no Bugzilla
+        /// API for marking an `add_attachment` comment private — use
+        /// `bzr comment add --private` separately if needed.
+        #[arg(long)]
+        comment: Option<String>,
         /// Set, request, or clear a flag using Bugzilla flag syntax.
         ///
         /// Repeatable. Accepted forms:

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -1180,6 +1180,41 @@ fn parse_attachment_upload_without_comment_defaults_to_none() {
 }
 
 #[test]
+fn parse_attachment_upload_with_is_patch_flag() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "attachment",
+        "upload",
+        "42",
+        "fix.patch",
+        "--is-patch",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action: AttachmentAction::Upload {
+                bug_id, is_patch, ..
+            },
+        } => {
+            assert_eq!(bug_id, 42);
+            assert!(is_patch, "--is-patch should set the flag to true");
+        }
+        _ => panic!("expected Attachment Upload"),
+    }
+}
+
+#[test]
+fn parse_attachment_upload_without_is_patch_defaults_to_false() {
+    let cli = Cli::try_parse_from(["bzr", "attachment", "upload", "42", "f.txt"]).unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action: AttachmentAction::Upload { is_patch, .. },
+        } => assert!(!is_patch, "--is-patch absent should default to false"),
+        _ => panic!("expected Attachment Upload"),
+    }
+}
+
+#[test]
 fn parse_template_delete() {
     let cli = Cli::try_parse_from(["bzr", "template", "delete", "security-bug"]).unwrap();
     match cli.command {

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -1139,6 +1139,47 @@ fn parse_attachment_upload_without_private_defaults_to_false() {
 }
 
 #[test]
+fn parse_attachment_upload_with_comment() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "attachment",
+        "upload",
+        "42",
+        "patch.diff",
+        "--comment",
+        "see this",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action:
+                AttachmentAction::Upload {
+                    bug_id,
+                    file,
+                    comment,
+                    ..
+                },
+        } => {
+            assert_eq!(bug_id, 42);
+            assert_eq!(file, "patch.diff");
+            assert_eq!(comment.as_deref(), Some("see this"));
+        }
+        _ => panic!("expected Attachment Upload"),
+    }
+}
+
+#[test]
+fn parse_attachment_upload_without_comment_defaults_to_none() {
+    let cli = Cli::try_parse_from(["bzr", "attachment", "upload", "42", "f.txt"]).unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action: AttachmentAction::Upload { comment, .. },
+        } => assert!(comment.is_none(), "--comment absent should default to None"),
+        _ => panic!("expected Attachment Upload"),
+    }
+}
+
+#[test]
 fn parse_template_delete() {
     let cli = Cli::try_parse_from(["bzr", "template", "delete", "security-bug"]).unwrap();
     match cli.command {

--- a/src/client/attachment_tests.rs
+++ b/src/client/attachment_tests.rs
@@ -405,6 +405,8 @@ async fn upload_attachment_private_sets_is_private_in_body() {
             data: b"shh".to_vec(),
             flags: Vec::new(),
             is_private: true,
+            comment: None,
+            is_patch: false,
         })
         .await
         .unwrap();
@@ -435,6 +437,8 @@ async fn upload_attachment_public_omits_is_private_or_sets_false() {
             data: b"hello".to_vec(),
             flags: Vec::new(),
             is_private: false,
+            comment: None,
+            is_patch: false,
         })
         .await
         .unwrap();
@@ -466,10 +470,77 @@ async fn upload_attachment_with_flags_sends_flags() {
             data: b"hello".to_vec(),
             flags,
             is_private: false,
+            comment: None,
+            is_patch: false,
         })
         .await
         .unwrap();
     assert_eq!(id, 200);
+}
+
+#[tokio::test]
+async fn upload_attachment_with_comment_sends_comment() {
+    use wiremock::matchers::body_string_contains;
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/1/attachment"))
+        .and(body_string_contains("\"comment\":\"see this\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [400]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let id = client
+        .upload_attachment(&UploadAttachmentParams {
+            bug_id: 1,
+            file_name: "patch.diff".into(),
+            summary: "fix".into(),
+            content_type: "text/x-diff".into(),
+            data: b"diff --git".to_vec(),
+            flags: Vec::new(),
+            is_private: false,
+            comment: Some("see this".into()),
+            is_patch: false,
+        })
+        .await
+        .unwrap();
+    assert_eq!(id, 400);
+}
+
+#[tokio::test]
+async fn upload_attachment_without_comment_omits_comment() {
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/1/attachment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [401]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let _ = client
+        .upload_attachment(&UploadAttachmentParams {
+            bug_id: 1,
+            file_name: "f.txt".into(),
+            summary: "f".into(),
+            content_type: "text/plain".into(),
+            data: b"x".to_vec(),
+            flags: Vec::new(),
+            is_private: false,
+            comment: None,
+            is_patch: false,
+        })
+        .await
+        .unwrap();
+
+    let received = mock.received_requests().await.unwrap();
+    assert_eq!(received.len(), 1, "expected exactly one POST request");
+    let body = std::str::from_utf8(&received[0].body).unwrap();
+    assert!(
+        !body.contains("\"comment\""),
+        "comment field should be omitted when None, but body contained it: {body}"
+    );
 }
 
 #[tokio::test]

--- a/src/client/attachment_tests.rs
+++ b/src/client/attachment_tests.rs
@@ -509,6 +509,36 @@ async fn upload_attachment_with_comment_sends_comment() {
 }
 
 #[tokio::test]
+async fn upload_attachment_with_is_patch_sends_is_patch_true() {
+    use wiremock::matchers::body_string_contains;
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/1/attachment"))
+        .and(body_string_contains("\"is_patch\":true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [500]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let id = client
+        .upload_attachment(&UploadAttachmentParams {
+            bug_id: 1,
+            file_name: "fix.patch".into(),
+            summary: "fix".into(),
+            content_type: "text/plain".into(),
+            data: b"diff --git".to_vec(),
+            flags: Vec::new(),
+            is_private: false,
+            comment: None,
+            is_patch: true,
+        })
+        .await
+        .unwrap();
+    assert_eq!(id, 500);
+}
+
+#[tokio::test]
 async fn upload_attachment_without_comment_omits_comment() {
     let mock = MockServer::start().await;
     Mock::given(method("POST"))

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -39,6 +39,7 @@ pub async fn execute(
             summary,
             content_type,
             private,
+            is_patch,
             comment,
             flag,
         } => {
@@ -46,21 +47,23 @@ pub async fn execute(
             let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or(file);
             let data = std::fs::read(path)?;
             let summary = summary.as_deref().unwrap_or(file_name);
-            let ct = content_type
-                .as_deref()
-                .unwrap_or_else(|| guess_content_type(file_name));
+            let ct = match (content_type.as_deref(), *is_patch) {
+                (Some(explicit), _) => explicit.to_string(),
+                (None, true) => "text/plain".to_string(),
+                (None, false) => guess_content_type(file_name).to_string(),
+            };
             let flags = super::flags::parse_flags(flag)?;
             let size = data.len();
             let upload_params = UploadAttachmentParams {
                 bug_id: *bug_id,
                 file_name: file_name.to_string(),
                 summary: summary.to_string(),
-                content_type: ct.to_string(),
+                content_type: ct,
                 data,
                 flags,
                 is_private: *private,
                 comment: comment.clone(),
-                is_patch: false,
+                is_patch: *is_patch,
             };
             let att_id = client.upload_attachment(&upload_params).await?;
             output::print_result(

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -39,6 +39,7 @@ pub async fn execute(
             summary,
             content_type,
             private,
+            comment,
             flag,
         } => {
             let path = Path::new(file);
@@ -58,6 +59,8 @@ pub async fn execute(
                 data,
                 flags,
                 is_private: *private,
+                comment: comment.clone(),
+                is_patch: false,
             };
             let att_id = client.upload_attachment(&upload_params).await?;
             output::print_result(

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -82,6 +82,7 @@ async fn attachment_upload_api_error_propagates() {
         summary: Some("Test".into()),
         content_type: None,
         private: false,
+        comment: None,
         flag: vec![],
     };
     let result = super::execute(&action, None, OutputFormat::Json, None).await;
@@ -131,6 +132,7 @@ async fn attachment_upload_returns_id() {
         summary: Some("Test upload".into()),
         content_type: Some("text/plain".into()),
         private: false,
+        comment: None,
         flag: vec![],
     };
     let (result, output) =
@@ -138,6 +140,38 @@ async fn attachment_upload_returns_id() {
     assert!(result.is_ok());
     let parsed = extract_json(&output);
     assert_eq!(parsed["id"], 200);
+}
+
+#[tokio::test]
+async fn attachment_upload_with_comment_includes_comment_in_request() {
+    use wiremock::matchers::body_string_contains;
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/42/attachment"))
+        .and(body_string_contains("\"comment\":\"see this\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [201]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let upload_file = tmp.path().join("upload.txt");
+    std::fs::write(&upload_file, "test content").unwrap();
+
+    let action = AttachmentAction::Upload {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: Some("Test".into()),
+        content_type: Some("text/plain".into()),
+        private: false,
+        comment: Some("see this".into()),
+        flag: vec![],
+    };
+    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(
+        result.is_ok(),
+        "upload with --comment should succeed: {result:?}"
+    );
 }
 
 #[tokio::test]

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -82,6 +82,7 @@ async fn attachment_upload_api_error_propagates() {
         summary: Some("Test".into()),
         content_type: None,
         private: false,
+        is_patch: false,
         comment: None,
         flag: vec![],
     };
@@ -132,6 +133,7 @@ async fn attachment_upload_returns_id() {
         summary: Some("Test upload".into()),
         content_type: Some("text/plain".into()),
         private: false,
+        is_patch: false,
         comment: None,
         flag: vec![],
     };
@@ -164,6 +166,7 @@ async fn attachment_upload_with_comment_includes_comment_in_request() {
         summary: Some("Test".into()),
         content_type: Some("text/plain".into()),
         private: false,
+        is_patch: false,
         comment: Some("see this".into()),
         flag: vec![],
     };
@@ -171,6 +174,76 @@ async fn attachment_upload_with_comment_includes_comment_in_request() {
     assert!(
         result.is_ok(),
         "upload with --comment should succeed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn attachment_upload_with_is_patch_defaults_content_type_to_text_plain() {
+    use wiremock::matchers::body_string_contains;
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/42/attachment"))
+        .and(body_string_contains("\"is_patch\":true"))
+        .and(body_string_contains("\"content_type\":\"text/plain\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [501]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let upload_file = tmp.path().join("fix.patch");
+    std::fs::write(&upload_file, "diff --git a b").unwrap();
+
+    let action = AttachmentAction::Upload {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: None,
+        content_type: None,
+        private: false,
+        is_patch: true,
+        comment: None,
+        flag: vec![],
+    };
+    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(
+        result.is_ok(),
+        "upload --is-patch should succeed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn attachment_upload_is_patch_with_explicit_content_type_keeps_content_type() {
+    use wiremock::matchers::body_string_contains;
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/42/attachment"))
+        .and(body_string_contains("\"is_patch\":true"))
+        .and(body_string_contains(
+            "\"content_type\":\"application/octet-stream\"",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [502]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let upload_file = tmp.path().join("fix.patch");
+    std::fs::write(&upload_file, "binary").unwrap();
+
+    let action = AttachmentAction::Upload {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: None,
+        content_type: Some("application/octet-stream".to_string()),
+        private: false,
+        is_patch: true,
+        comment: None,
+        flag: vec![],
+    };
+    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(
+        result.is_ok(),
+        "upload --is-patch with explicit ct should succeed: {result:?}"
     );
 }
 

--- a/src/output/attachment.rs
+++ b/src/output/attachment.rs
@@ -12,14 +12,16 @@ pub fn print_attachments(attachments: &[Attachment], format: OutputFormat) {
             return;
         }
         for a in attachments {
+            let patch = if a.is_patch { " [PATCH]" } else { "" };
             let obsolete = if a.is_obsolete { " [OBSOLETE]" } else { "" };
             let private = if a.is_private { " [PRIVATE]" } else { "" };
             let _ = writeln!(
                 io::stdout(),
-                "{} #{} - {}{}{}",
+                "{} #{} - {}{}{}{}",
                 "Attachment".bold(),
                 a.id,
                 a.summary.bold(),
+                patch.cyan(),
                 obsolete.red(),
                 private.red(),
             );

--- a/src/output/attachment_tests.rs
+++ b/src/output/attachment_tests.rs
@@ -16,6 +16,7 @@ fn make_attachment(id: u64, summary: &str) -> Attachment {
         size: 1234,
         is_obsolete: false,
         is_private: false,
+        is_patch: false,
         data: None,
     }
 }
@@ -129,6 +130,7 @@ async fn print_attachments_table_missing_optional_fields_render_dash() {
         size: 0,
         is_obsolete: false,
         is_private: false,
+        is_patch: false,
         data: None,
     }];
     let ((), output) = crate::test_helpers::capture_stdout(async {
@@ -152,6 +154,50 @@ async fn print_attachments_table_missing_optional_fields_render_dash() {
     // Neither flag is set
     assert!(!output.contains("[OBSOLETE]"));
     assert!(!output.contains("[PRIVATE]"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn print_attachments_table_renders_patch_tag() {
+    let _lock = crate::ENV_LOCK.lock().await;
+    let mut att = make_attachment(12, "Patch attachment");
+    att.is_patch = true;
+    let attachments = vec![att];
+    let ((), output) = crate::test_helpers::capture_stdout(async {
+        print_attachments(&attachments, OutputFormat::Table);
+    })
+    .await;
+    assert!(output.contains("Attachment"));
+    assert!(output.contains("#12"));
+    assert!(output.contains("Patch attachment"));
+    assert!(output.contains("[PATCH]"));
+    // is_patch alone should not enable the other tags.
+    assert!(!output.contains("[OBSOLETE]"));
+    assert!(!output.contains("[PRIVATE]"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn print_attachments_table_patch_tag_precedes_obsolete_and_private() {
+    let _lock = crate::ENV_LOCK.lock().await;
+    let mut att = make_attachment(13, "All flags");
+    att.is_patch = true;
+    att.is_obsolete = true;
+    att.is_private = true;
+    let attachments = vec![att];
+    let ((), output) = crate::test_helpers::capture_stdout(async {
+        print_attachments(&attachments, OutputFormat::Table);
+    })
+    .await;
+    let patch_idx = output.find("[PATCH]").expect("[PATCH] tag should render");
+    let obsolete_idx = output
+        .find("[OBSOLETE]")
+        .expect("[OBSOLETE] tag should render");
+    let private_idx = output
+        .find("[PRIVATE]")
+        .expect("[PRIVATE] tag should render");
+    assert!(patch_idx < obsolete_idx);
+    assert!(obsolete_idx < private_idx);
 }
 
 #[cfg(unix)]

--- a/src/types/attachment.rs
+++ b/src/types/attachment.rs
@@ -38,6 +38,8 @@ pub struct Attachment {
     pub is_obsolete: bool,
     #[serde(default, deserialize_with = "bool_from_int_or_bool")]
     pub is_private: bool,
+    #[serde(default, deserialize_with = "bool_from_int_or_bool")]
+    pub is_patch: bool,
     #[serde(default)]
     pub data: Option<String>,
 }

--- a/src/types/attachment.rs
+++ b/src/types/attachment.rs
@@ -55,6 +55,9 @@ pub struct UploadAttachmentParams {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub flags: Vec<FlagUpdate>,
     pub is_private: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    pub is_patch: bool,
 }
 
 // Serde serialize_with requires &T signature for the field type.

--- a/src/types/attachment_tests.rs
+++ b/src/types/attachment_tests.rs
@@ -27,3 +27,24 @@ fn bool_from_int_or_bool_rejects_string() {
         "unexpected error: {err}"
     );
 }
+
+#[test]
+fn is_patch_deserializes_as_bool() {
+    let json = r#"{"id":1,"is_patch":true}"#;
+    let att: Attachment = serde_json::from_str(json).unwrap();
+    assert!(att.is_patch);
+}
+
+#[test]
+fn is_patch_deserializes_as_int() {
+    let json = r#"{"id":1,"is_patch":1}"#;
+    let att: Attachment = serde_json::from_str(json).unwrap();
+    assert!(att.is_patch);
+}
+
+#[test]
+fn is_patch_defaults_to_false_when_absent() {
+    let json = r#"{"id":1}"#;
+    let att: Attachment = serde_json::from_str(json).unwrap();
+    assert!(!att.is_patch);
+}

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -470,6 +470,7 @@ fn value_to_attachment(val: &Value) -> Result<crate::types::Attachment> {
         size,
         is_obsolete: get_bool_flag(m, "is_obsolete"),
         is_private: get_bool_flag(m, "is_private"),
+        is_patch: get_bool_flag(m, "is_patch"),
         data,
     })
 }

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -972,6 +972,30 @@ if [[ -n "$BUG1" ]]; then
     if assert_success; then test_pass; fi
 else test_skip "no BUG1"; fi
 
+test_begin "100f. attachment upload --comment posts comment in same call"
+if [[ -n "$BUG1" ]]; then
+    run_bzr comment list "$BUG1"
+    if assert_success; then
+        PRECOMMENT_COUNT=$(jq '. | length' "$BZR_STDOUT" 2>/dev/null || echo "")
+        run_bzr attachment upload "$BUG1" /tmp/bzr-func-test.txt \
+            --summary "with comment" \
+            --comment "see #165 -- bzl-parity"
+        if assert_success; then
+            run_bzr comment list "$BUG1"
+            if assert_success; then
+                POSTCOMMENT_COUNT=$(jq '. | length' "$BZR_STDOUT" 2>/dev/null || echo "")
+                if [[ -n "$PRECOMMENT_COUNT" ]] \
+                    && [[ -n "$POSTCOMMENT_COUNT" ]] \
+                    && [[ "$POSTCOMMENT_COUNT" -eq $((PRECOMMENT_COUNT + 1)) ]]; then
+                    test_pass
+                else
+                    test_fail "comment count did not grow by 1 (pre=$PRECOMMENT_COUNT post=$POSTCOMMENT_COUNT)"
+                fi
+            fi
+        fi
+    fi
+else test_skip "no BUG1"; fi
+
 echo ""
 
 # ══════════════════════════════════════════════════════════════════════

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -996,6 +996,25 @@ if [[ -n "$BUG1" ]]; then
     fi
 else test_skip "no BUG1"; fi
 
+test_begin "100g. attachment upload --is-patch marks attachment as a patch"
+if [[ -n "$BUG1" ]]; then
+    run_bzr attachment upload "$BUG1" /tmp/bzr-func-test.txt \
+        --summary "patch test" --is-patch
+    if assert_success; then
+        run_bzr attachment list "$BUG1"
+        if assert_success; then
+            IS_PATCH=$(jq -r '[.[] | select(.summary == "patch test")][-1].is_patch' "$BZR_STDOUT" 2>/dev/null || echo "")
+            if [[ "$IS_PATCH" == "true" ]]; then
+                test_pass
+            else
+                test_fail "newly uploaded attachment should have is_patch=true (got: $IS_PATCH)"
+            fi
+        fi
+    else
+        test_fail "upload with --is-patch failed"
+    fi
+else test_skip "no BUG1"; fi
+
 echo ""
 
 # ══════════════════════════════════════════════════════════════════════

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -1039,8 +1039,9 @@ else test_skip "no BUG1"; fi
 test_begin "100b. attachment list returns private attachment in Hybrid mode"
 if [[ -n "$BUG1" ]]; then
     run_bzr --api hybrid attachment list "$BUG1"
-    # Earlier tests uploaded ≥2 public attachments + 1 private = ≥3 total,
-    # AND the private one must be visible (is_private: true present).
+    # Earlier Phase 10 tests uploaded several public attachments and this
+    # phase adds 1 private; the list must include ≥3 total AND the private
+    # one must be visible (is_private: true present).
     if assert_success \
         && assert_json_array_min_length '.' 3 \
         && [[ "$(jq '[.[] | select(.is_private == true)] | length' "$BZR_STDOUT")" -ge 1 ]]; then

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -1002,16 +1002,10 @@ if [[ -n "$BUG1" ]]; then
         --summary "patch test" --is-patch
     if assert_success; then
         run_bzr attachment list "$BUG1"
-        if assert_success; then
-            IS_PATCH=$(jq -r '[.[] | select(.summary == "patch test")][-1].is_patch' "$BZR_STDOUT" 2>/dev/null || echo "")
-            if [[ "$IS_PATCH" == "true" ]]; then
-                test_pass
-            else
-                test_fail "newly uploaded attachment should have is_patch=true (got: $IS_PATCH)"
-            fi
+        if assert_success \
+            && assert_json '[.[] | select(.summary == "patch test")][-1].is_patch' "true"; then
+            test_pass
         fi
-    else
-        test_fail "upload with --is-patch failed"
     fi
 else test_skip "no BUG1"; fi
 
@@ -1039,9 +1033,9 @@ else test_skip "no BUG1"; fi
 test_begin "100b. attachment list returns private attachment in Hybrid mode"
 if [[ -n "$BUG1" ]]; then
     run_bzr --api hybrid attachment list "$BUG1"
-    # Earlier Phase 10 tests uploaded several public attachments and this
-    # phase adds 1 private; the list must include ≥3 total AND the private
-    # one must be visible (is_private: true present).
+    # Several public attachments are uploaded earlier in the run and this
+    # section adds one private; the list must include ≥3 total AND the
+    # private one must be visible (is_private: true present).
     if assert_success \
         && assert_json_array_min_length '.' 3 \
         && [[ "$(jq '[.[] | select(.is_private == true)] | length' "$BZR_STDOUT")" -ge 1 ]]; then

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -860,6 +860,7 @@ async fn attachment_upload_integration() {
         summary: Some("Test upload".to_string()),
         content_type: Some("text/plain".to_string()),
         private: false,
+        is_patch: false,
         comment: None,
         flag: vec![],
     };
@@ -900,6 +901,7 @@ async fn attachment_upload_with_comment_integration() {
         summary: Some("Test upload".to_string()),
         content_type: Some("text/plain".to_string()),
         private: false,
+        is_patch: false,
         comment: Some("see #6789 for context".to_string()),
         flag: vec![],
     };
@@ -914,6 +916,85 @@ async fn attachment_upload_with_comment_integration() {
         result.is_ok(),
         "upload with --comment should succeed: {result:?}"
     );
+}
+
+#[tokio::test]
+async fn attachment_upload_with_is_patch_integration() {
+    use wiremock::matchers::body_string_contains;
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    let upload_file = tmp.path().join("fix.patch");
+    std::fs::write(&upload_file, "diff --git a/x b/x").unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/42/attachment"))
+        .and(body_string_contains("\"is_patch\":true"))
+        .and(body_string_contains("\"content_type\":\"text/plain\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [103]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = bzr::cli::AttachmentAction::Upload {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: Some("Test patch".to_string()),
+        content_type: None,
+        private: false,
+        is_patch: true,
+        comment: None,
+        flag: vec![],
+    };
+    let result = bzr::commands::attachment::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "upload with --is-patch should succeed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn attachment_list_returns_is_patch_field_integration() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42/attachment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": {
+                "42": [{
+                    "id": 100,
+                    "bug_id": 42,
+                    "file_name": "fix.patch",
+                    "summary": "patch",
+                    "content_type": "text/plain",
+                    "creation_time": "2026-05-06T00:00:00Z",
+                    "is_obsolete": false,
+                    "is_private": false,
+                    "is_patch": true,
+                    "size": 12
+                }]
+            }
+        })))
+        .mount(&mock)
+        .await;
+
+    let action = bzr::cli::AttachmentAction::List { bug_id: 42 };
+    // Capture stdout in JSON mode and assert is_patch field is present.
+    let (result, output) = capture_stdout(bzr::commands::attachment::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+    ))
+    .await;
+    assert!(result.is_ok(), "list should succeed: {result:?}");
+    let parsed = extract_json(&output);
+    assert_eq!(parsed[0]["is_patch"], true);
 }
 
 // ── Attachment update ────────────────────────────────────────────────

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -984,7 +984,6 @@ async fn attachment_list_returns_is_patch_field_integration() {
         .await;
 
     let action = bzr::cli::AttachmentAction::List { bug_id: 42 };
-    // Capture stdout in JSON mode and assert is_patch field is present.
     let (result, output) = capture_stdout(bzr::commands::attachment::execute(
         &action,
         Some("test"),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -860,6 +860,7 @@ async fn attachment_upload_integration() {
         summary: Some("Test upload".to_string()),
         content_type: Some("text/plain".to_string()),
         private: false,
+        comment: None,
         flag: vec![],
     };
     let result = bzr::commands::attachment::execute(
@@ -872,6 +873,46 @@ async fn attachment_upload_integration() {
     assert!(
         result.is_ok(),
         "attachment upload should succeed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn attachment_upload_with_comment_integration() {
+    use wiremock::matchers::body_string_contains;
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    let upload_file = tmp.path().join("upload.txt");
+    std::fs::write(&upload_file, "test content").unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/42/attachment"))
+        .and(body_string_contains(
+            "\"comment\":\"see #6789 for context\"",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [102]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = bzr::cli::AttachmentAction::Upload {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: Some("Test upload".to_string()),
+        content_type: Some("text/plain".to_string()),
+        private: false,
+        comment: Some("see #6789 for context".to_string()),
+        flag: vec![],
+    };
+    let result = bzr::commands::attachment::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "upload with --comment should succeed: {result:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

Adds two flags to `bzr attachment upload` so common workflows that previously took two API calls now take one.

- `--comment <BODY>` — posts a comment alongside the attachment in the same `Bug.add_attachment` request. The attachment and comment share a creation timestamp and audience. Closes #165.
- `--is-patch` — marks the attachment as a patch at upload time, replacing the previous `upload` + `attachment update --is-patch true` two-call pattern. When `--content-type` is not supplied, `--is-patch` defaults the type to `text/plain`, matching `bzl-attachment-add`. Also exposes `is_patch` on the read-side `Attachment` struct so `bzr attachment list --json` includes the field, and surfaces `[PATCH]` (cyan, informational) in table-mode output alongside `[OBSOLETE]` and `[PRIVATE]` (red, warning). Closes #166.

Both `Attachment` and `UploadAttachmentParams` field additions follow the existing `bool_from_int_or_bool` deserializer pattern. The XML-RPC adapter (`src/xmlrpc/client.rs`) was updated to populate `is_patch` consistently with the existing `is_obsolete` / `is_private` handling.

## Out of scope: `--comment-private`

`Bug.add_attachment` accepts `comment` only as a flat string with no privacy field — `bzl-attachment-add` has the same limitation. The bzl precedent for private comments lives in `bzl-update`/`Bug.update`, a different endpoint with a structured `{body, is_private}` comment object. Implementing `--comment-private` as a useful CLI feature requires a two-call workflow (`add_attachment` → `Bug.update` with `comment_is_private`) and a read-side addition to expose `Comment.attachment_id` for unambiguous comment identification. Tracked in #170.

## Test plan

- [x] `cargo test` — 1040 tests passing (960 lib + 21 mod_tests + 59 integration), 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `make check-test-layout` — clean (no new inline `mod tests`)
- [x] `bzr attachment upload --help` — confirms both `--comment <BODY>` and `--is-patch` appear with full doc paragraphs and example invocations
- [ ] `make functional-test-all` — pending; new tests `100f` (`--comment` round-trips a comment count increment) and `100g` (`--is-patch` round-trips through `attachment list --json`) added to `tests/functional/run-tests.sh`

## Commits

- `feat(attachment upload): add --comment for single-call attachment+comment`
- `feat(attachment upload): add --is-patch for single-call patch upload`
- `docs(functional-tests): refresh test 100b comment for upload count drift`
- `refactor(attachment): /simplify cleanups from review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)