### PR TITLE
feat(bug list): --created-since / --changed-since date filters (closes #157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   matching `bzl-attachment-add`. The read-side `Attachment` struct
   also exposes `is_patch` so `bzr attachment list --json` includes the
   field. Closes #166.
+- `bzr bug list`, `bzr query save`, and `bzr query run` accept
+  `--created-since <DATE>` and `--changed-since <DATE>` filters
+  for Bugzilla's `creation_time` and `last_change_time` fields.
+  Inputs are ISO 8601 (`YYYY-MM-DDTHH:MM:SS[Z|±HH:MM]`) or a bare
+  `YYYY-MM-DD` (canonicalized to `T00:00:00Z`); malformed values
+  exit 7 before any network call. `bzr query run` accepts the same
+  flags as per-invocation overrides matching the existing
+  `--limit` / `--fields` convention. `bzr query show` and the
+  one-line `bzr query list` summary surface both filters when set.
+  Closes #157.
 
 ### Fixed
 
@@ -82,6 +92,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   template description is now used as the editor buffer's pre-fill
   only. Pass `--description`, `--description-file`, or pipe a
   description via stdin to use a non-template body. Refs: #159, #160.
+- `bzr bug history --since` and `bzr comment list --since` now
+  validate their input client-side via the same shared validator
+  introduced for `--created-since` / `--changed-since`. Malformed
+  dates exit 7 instead of being forwarded to the server. Bare
+  dates (`YYYY-MM-DD`) are now canonicalized to `T00:00:00Z` on
+  the wire; previously the bare form was passed through verbatim.
+  Refs: #157.
 
 ## [0.3.0] - 2026-05-05
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -84,6 +84,7 @@ bzr [--server <NAME>] [--output table|json] [--json] [--no-color] [--quiet] [--a
 │   ├── list [--product <P>...] [--component <C>...] [--status <S>...] [--assignee <A>...]
 │   │        [--creator <C>...] [--priority <P>...] [--severity <S>...] [--id <ID>...]
 │   │        [--alias <A>] [--summary <S>] [--limit <N>] [--fields <F>] [--exclude-fields <F>]
+│   │        [--created-since <D>] [--changed-since <D>]
 │   ├── view <ID> [--fields <F>] [--exclude-fields <F>]
 │   ├── search [<QUERY>] [--from-url <URL>] [--save-as [NAME]] [--limit <N>] [--fields <F>] [--exclude-fields <F>]
 │   ├── history <ID> [--since <DATE>]
@@ -161,10 +162,12 @@ bzr [--server <NAME>] [--output table|json] [--json] [--no-color] [--quiet] [--a
     ├── save <NAME> (--from-url <URL> | [--product <P>...] [--component <C>...] [--status <S>...]
     │               [--assignee <A>...] [--creator <C>...] [--priority <P>...] [--severity <S>...]
     │               [--search <Q>]) [--limit <N>] [--fields <F>] [--exclude-fields <F>]
+    │               [--created-since <D>] [--changed-since <D>]
     ├── list
     ├── show <NAME>
     ├── delete <NAME>
     └── run <NAME> [--limit <N>] [--fields <F>] [--exclude-fields <F>] [--server <NAME>]
+                   [--created-since <D>] [--changed-since <D>]
 ```
 
 ---
@@ -184,6 +187,7 @@ bzr bug list --status NEW --status ASSIGNED          # OR: match either status
 bzr bug list --status '!CLOSED'                      # NOT: exclude CLOSED
 bzr bug list --status NEW --status '!VERIFIED'       # mixed positive and negated
 bzr bug list --summary "kernel panic" --product Kernel  # substring on summary
+bzr bug list --product Firefox --changed-since 2026-04-01  # filter by date range
 ```
 
 Filter flags (`--product`, `--component`, `--status`, `--assignee`, `--creator`, `--priority`, `--severity`) are repeatable for OR semantics and support a `!` prefix for negation (NOT).
@@ -205,6 +209,12 @@ Filter flags (`--product`, `--component`, `--status`, `--assignee`, `--creator`,
 | `--limit <N>` | No | 50 | Max results |
 | `--fields <F>` | No | | Only return these fields (comma-separated) |
 | `--exclude-fields <F>` | No | | Exclude these fields (comma-separated) |
+| `--created-since <DATE>` | No | | Filter to bugs whose `creation_time` is `>= DATE`. See [Date format](#date-format) below. |
+| `--changed-since <DATE>` | No | | Filter to bugs whose `last_change_time` is `>= DATE`. See [Date format](#date-format) below. |
+
+#### Date format
+
+`--created-since` and `--changed-since` accept ISO 8601 datetimes (`YYYY-MM-DDTHH:MM:SS`, `YYYY-MM-DDTHH:MM:SSZ`, or `YYYY-MM-DDTHH:MM:SS±HH:MM`) or a bare `YYYY-MM-DD`. Bare dates are treated as `00:00:00 UTC`. Fractional seconds, week dates, and ordinal dates are rejected with exit code 7. The same validator is used by `bzr bug history --since` and `bzr comment list --since`.
 
 ### `bzr bug view`
 
@@ -1133,6 +1143,9 @@ bzr query save my-p1 --assignee me@example.com --priority P1 --status NEW --stat
 
 # Import a query from a Bugzilla URL
 bzr query save my-query --from-url "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW"
+
+# Save a date-range query (recent activity)
+bzr query save recent-firefox --product Firefox --changed-since 2026-04-01
 ```
 
 `--from-url` and manual filter flags (`--search`, `--product`, `--component`, etc.) are mutually exclusive.
@@ -1152,6 +1165,8 @@ bzr query save my-query --from-url "https://bugzilla.example.com/buglist.cgi?pro
 | `--limit <N>` | No | Max results |
 | `--fields <F>` | No | Only return these fields when the query runs (comma-separated) |
 | `--exclude-fields <F>` | No | Exclude these fields when the query runs (comma-separated) |
+| `--created-since <DATE>` | No | Save a `creation_time >= DATE` filter into the query. Same accepted forms as [`bzr bug list --created-since`](#date-format). |
+| `--changed-since <DATE>` | No | Save a `last_change_time >= DATE` filter into the query. Same accepted forms as [`bzr bug list --changed-since`](#date-format). |
 
 At least one filter must be set. Use either `--from-url` or one or more manual filter flags.
 
@@ -1203,6 +1218,9 @@ bzr query run firefox-new --fields id,summary,status
 
 # Run against a different server
 bzr query run my-query --server other-server --limit 50
+
+# Run with a different date cutoff
+bzr query run recent-firefox --changed-since 2026-05-01
 ```
 
 | Option | Required | Description |
@@ -1212,6 +1230,8 @@ bzr query run my-query --server other-server --limit 50
 | `--fields <F>` | No | Only return these fields (comma-separated) |
 | `--exclude-fields <F>` | No | Exclude these fields (comma-separated) |
 | `--server <NAME>` | No | Override the server to run the query against. Takes precedence over the server stored in the saved query. The global `--server` flag takes precedence over this flag. |
+| `--created-since <DATE>` | No | Override the saved `creation_time` filter for this run. Same accepted forms as [`bzr bug list --created-since`](#date-format). |
+| `--changed-since <DATE>` | No | Override the saved `last_change_time` filter for this run. Same accepted forms as [`bzr bug list --changed-since`](#date-format). |
 
 ---
 

--- a/docs/superpowers/specs/2026-05-06-issue-157-bug-list-date-filters-design.md
+++ b/docs/superpowers/specs/2026-05-06-issue-157-bug-list-date-filters-design.md
@@ -1,0 +1,333 @@
+# Issue #157: `bug list` date-range filters
+
+**Date:** 2026-05-06
+**Issue:** [#157](https://github.com/randomparity/bzr/issues/157)
+**Surfaced by:** `docs/superpowers/specs/2026-05-06-bzl-parity-review-design.md` (Issue B)
+
+## 1. Summary
+
+Add `--created-since` and `--changed-since` ISO-8601 date filters to
+`bzr bug list`, and the matching pair to `bzr query save` and
+`bzr query run` (override). Filters are validated client-side and
+rejected with exit code 7 on malformed input. While building the
+shared validator, retrofit the existing `bzr bug history --since`
+and `bzr comment list --since` flags to use it.
+
+## 2. Motivation
+
+Common tester workflow: "find bugs filed/modified since DATE."
+`bzl-search` exposes both filters
+(`reference/bzl/bzl-search:77-93`); `bzr bug list` has neither.
+Without them, testers fall back to ad-hoc `--from-url` parsing or
+client-side filtering of the full result set.
+
+## 3. Scope
+
+In scope:
+
+- Two new CLI flags on `bzr bug list`, `bzr query save`, and
+  `bzr query run` (the last as overrides).
+- A shared client-side validator for ISO-8601 dates.
+- Retrofit of `bzr bug history --since` and
+  `bzr comment list --since` to use the same validator.
+- REST and XML-RPC encoding for both new `SearchParams` fields.
+- Unit, integration, and one functional test.
+- `docs/bzr-cli.md` and `CHANGELOG.md` updates.
+
+Out of scope:
+
+- Mapping `chfieldfrom`/`chfieldto` from URL imports (`--from-url`)
+  to the new structured fields. URL imports continue to pass these
+  through `SavedQuery.raw_params` verbatim, as today.
+- The other field filters surfaced under bzl-parity Issue C
+  (`--whiteboard`, `--target-milestone`, etc.).
+- Any new date-handling crate dependency. The validator is
+  hand-rolled (~30 lines) and accepts only the two forms below.
+
+## 4. CLI surface
+
+### 4.1 New flags
+
+```
+--created-since <DATE>   Filter to bugs created at or after DATE
+--changed-since <DATE>   Filter to bugs last modified at or after DATE
+```
+
+Both are single-value `Option<String>`. Both apply to:
+
+- `bzr bug list` — primary surface.
+- `bzr query save` — stores them on the saved query.
+- `bzr query run` — overrides whatever the saved query carries.
+  Override semantics match the existing `--limit` / `--fields` /
+  `--exclude-fields` / `--server` overrides: `Some(_)` from the CLI
+  replaces the saved value; `None` keeps the saved value. There is
+  no "clear" sentinel.
+
+The two filters AND with each other and with all existing filters.
+Either, both, or neither may be set.
+
+### 4.2 Accepted DATE formats
+
+Validated client-side, before any network call:
+
+1. `YYYY-MM-DD` — bare date. Canonicalized to
+   `YYYY-MM-DDT00:00:00Z` before being sent.
+2. `YYYY-MM-DDTHH:MM:SS` — no zone. Sent verbatim; the server
+   treats it as UTC.
+3. `YYYY-MM-DDTHH:MM:SSZ` — sent verbatim.
+4. `YYYY-MM-DDTHH:MM:SS+HH:MM` (or `-HH:MM`) — sent verbatim.
+
+The `T` separator is required when a time component is present
+(no space). Fractional seconds, week dates (`2026-W18-3`), and
+ordinal dates (`2026-128`) are rejected — they are valid ISO-8601
+but the server isn't guaranteed to accept them, and we'd rather
+fail fast at the CLI than ship a malformed payload.
+
+### 4.3 Error message shape
+
+Validator failures produce `BzrError::InputValidation` (exit
+code 7) with this shape:
+
+```
+--created-since: 'tomorrow' is not a valid ISO-8601 date or datetime.
+Expected: YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, YYYY-MM-DDTHH:MM:SSZ, or YYYY-MM-DDTHH:MM:SS±HH:MM
+```
+
+The flag name is included so the message is self-locating when the
+caller passes multiple date flags.
+
+## 5. Implementation
+
+### 5.1 Validator module
+
+New module `src/validation/datetime.rs` with sibling
+`datetime_tests.rs`:
+
+```rust
+/// Validate an ISO-8601 datetime or bare date for use as a Bugzilla
+/// search filter. On success, returns the canonical form sent to the
+/// server (bare dates are expanded to `YYYY-MM-DDT00:00:00Z`).
+///
+/// `flag` is the CLI flag name (e.g. "--created-since") and is
+/// included in the error message so callers can locate the offending
+/// input when multiple date flags are in play.
+pub fn parse_iso8601_or_date(s: &str, flag: &str) -> Result<String>;
+```
+
+The implementation uses byte-level matching against the four accepted
+shapes — no regex crate, no date crate. Roughly:
+
+1. Length-check against the four valid lengths (10, 19, 20, 25).
+2. Pattern-match the digit/separator positions.
+3. Range-check month (1–12), day (1–31; no per-month or leap-year
+   logic — the server validates exact day validity).
+4. For datetime forms, range-check hour (0–23), minute (0–59),
+   second (0–60 to allow a leap second).
+5. For zone-offset forms, range-check the offset hours/minutes.
+
+A new top-level module `src/validation/mod.rs` re-exports
+`parse_iso8601_or_date` (no logic in `mod.rs`, so no sibling
+test file is needed there). The module is named `validation`
+rather than `datetime` because it is the obvious home for any
+future input-validators that aren't tied to a single command
+(e.g. email shape, alias shape).
+
+### 5.2 Type changes
+
+**`src/types/bug.rs::SearchParams`** gains two fields:
+
+```rust
+pub creation_time: Option<String>,     // server-canonical form
+pub last_change_time: Option<String>,  // server-canonical form
+```
+
+Field names match the Bugzilla REST API (and the existing `Bug`
+struct's `creation_time`/`last_change_time`). The CLI flags
+(`--created-since` / `--changed-since`) and struct fields are
+deliberately different: flags follow the user-facing "since" idiom;
+struct fields follow the API.
+
+Both `has_filters()` and `has_structured_filters()` gain checks for
+the two new fields.
+
+**`src/types/bug.rs::SavedQuery`** gains two fields with the same
+names and `#[serde(default, skip_serializing_if = "Option::is_none")]`
+so existing TOML configs without these keys deserialize unchanged:
+
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub creation_time: Option<String>,
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub last_change_time: Option<String>,
+```
+
+`SavedQuery::into_search_params()` and `to_search_params()` forward
+both fields.
+
+`SavedQuery::has_filters()` also gains checks for both new fields.
+Without this update, `bzr query save my-recent --created-since
+2026-04-01` (date filter as the *only* filter) would be rejected
+with the existing "query must have at least one filter set"
+error, even though the date filter alone is a meaningful query.
+
+**`SearchParams::apply_overrides`** signature grows by two
+parameters:
+
+```rust
+pub fn apply_overrides(
+    &mut self,
+    limit: Option<u32>,
+    fields: Option<&str>,
+    exclude_fields: Option<&str>,
+    creation_time: Option<&str>,
+    last_change_time: Option<&str>,
+);
+```
+
+The total reaches the project's 5-positional-param limit (the
+`&mut self` does not count). At one more, the function would need
+to take an `Overrides` struct; for now the direct shape is
+preserved.
+
+### 5.3 REST encoding
+
+`src/client/bug.rs::append_option_params` gains two entries in its
+`option_fields` table:
+
+```rust
+("creation_time", &params.creation_time),
+("last_change_time", &params.last_change_time),
+```
+
+Result: `&creation_time=2026-04-01T00:00:00Z&last_change_time=...`
+on the request URL when set.
+
+### 5.4 XML-RPC encoding
+
+`src/xmlrpc/client.rs::search_bugs` gains two entries in its
+matching `option_fields` table. Both serialize as `Value::String`
+in the RPC params map.
+
+### 5.5 Command wiring
+
+**`src/commands/bug/list.rs`** validates both flags before
+constructing `SearchParams`. Validator failure bails with exit
+code 7 before any network call.
+
+**`src/commands/bug/history.rs`** and
+**`src/commands/comment.rs`** call the validator on `--since` and
+forward the canonical form to the existing `new_since` server
+parameter.
+
+**`src/commands/query.rs::handle_save`** validates both flags
+before storing on `SavedQuery`. **`handle_run`** validates the
+override flags and forwards them via the extended
+`apply_overrides`.
+
+### 5.6 Output module
+
+`bzr query show` (and the JSON form) lists the two new fields when
+present. `bzr query list` summary is unchanged unless the brief
+view already names every set field — confirm during implementation
+and add the fields to the summary if so.
+
+### 5.7 Documentation
+
+`docs/bzr-cli.md` gains entries for the new flags under `bug list`,
+`query save`, and `query run`. The canonicalization rule
+(`YYYY-MM-DD` → `T00:00:00Z`) is documented once, in the
+`bug list` section, and referenced from the others.
+
+`CHANGELOG.md` gains an entry under the current `## [0.4.0-dev]`
+section:
+
+```
+### Added
+- `bzr bug list` and `bzr query save`/`run` accept `--created-since`
+  and `--changed-since` ISO-8601 date filters. Closes #157.
+
+### Changed
+- `bzr bug history --since` and `bzr comment list --since` now
+  validate their input client-side (exit code 7 on malformed
+  dates), matching the new `--created-since` / `--changed-since`
+  behavior.
+```
+
+## 6. Testing
+
+### 6.1 Unit tests (sibling `_tests.rs` files)
+
+- `src/validation/datetime_tests.rs` — table-driven coverage of
+  every accepted form, every rejected form, and the bare-date →
+  `T00:00:00Z` canonicalization. Verifies the error message
+  contains the flag name and the offending input.
+- `src/types/bug_tests.rs` — `SearchParams::has_filters()` and
+  `has_structured_filters()` return `true` when only `creation_time`
+  is set. `SavedQuery::has_filters()` returns `true` when only
+  `creation_time` (or only `last_change_time`) is set, so a
+  date-only `bzr query save` is accepted.
+  `SavedQuery::into_search_params()` forwards both new fields.
+  Round-trip TOML preserves both fields with default-shape configs.
+- `src/client/bug_tests.rs` — wiremock asserts the REST request
+  URL contains `creation_time=...` and `last_change_time=...` when
+  the corresponding `SearchParams` field is set.
+- `src/xmlrpc/client_tests.rs` — RPC params map contains
+  `creation_time` and `last_change_time` string entries.
+- `src/commands/bug/list_tests.rs` — invalid `--created-since`
+  surfaces as `BzrError::InputValidation` (exit code 7) with no
+  network call (no wiremock expectation).
+- `src/commands/bug/history_tests.rs` and
+  `src/commands/comment_tests.rs` — same exit-code-7 check for the
+  retrofitted `--since` flag.
+- `src/commands/query_tests.rs` — `query save` rejects malformed
+  dates; `query run` overrides replace saved values; round-trip
+  TOML preserves both fields.
+- `src/cli/mod_tests.rs` — clap parses the new flags with the
+  expected types on every affected subcommand.
+
+### 6.2 Integration test
+
+`tests/integration.rs` gains one wiremock end-to-end run of
+`bzr bug list --product P --changed-since 2026-04-01` asserting
+the outgoing query string carries
+`last_change_time=2026-04-01T00:00:00Z`.
+
+### 6.3 Functional test
+
+`tests/functional/run-tests.sh` (Phase 8 — Bugs) gains the test
+plan from the issue verbatim:
+
+```sh
+# Setup: create two bugs, modify one, capture timestamp between
+#        the two events.
+# Action: bzr bug list --product <P> --changed-since <ts> --json
+# Assert: only the modified bug appears (jq verifies bug id
+#         present/absent).
+```
+
+Slots into the existing fixture pattern; ~25 added lines.
+
+## 7. Migration & compatibility
+
+- `SavedQuery` gains two `#[serde(default)]` fields. Existing
+  configs deserialize unchanged. No migration step required.
+- `SearchParams` is `#[non_exhaustive]`; new fields do not break
+  external callers.
+- `apply_overrides`'s expanded signature is a breaking API change
+  for any external caller — there are none in tree.
+- `bug history --since` and `comment list --since` change from
+  "always accepted, server validates" to "client-validates first."
+  Strings the server previously accepted but our validator now
+  rejects (e.g. fractional seconds, week dates) become exit-code-7
+  failures. The CHANGELOG entry calls this out.
+
+## 8. Out of scope (revisitable)
+
+- URL imports (`--from-url`) currently route `chfieldfrom` /
+  `chfieldto` through `raw_params`. Mapping them to the new
+  structured fields would lose the `chfieldto` upper-bound (we
+  expose only `since`, not a range), so a partial mapping risks
+  silently dropping query semantics. Revisit if a tester files a
+  workflow gap on URL-imported date queries specifically.
+- A future date-range filter (`--created-between A B`) is a
+  different shape and isn't pre-empted by this design.

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -24,12 +24,19 @@ pub enum BugAction {
     /// return a truncated list. Use `--fields` / `--exclude-fields` to
     /// trim the response payload.
     ///
+    /// `--created-since` / `--changed-since` filter by Bugzilla's
+    /// `creation_time` / `last_change_time` fields. Both accept ISO
+    /// 8601 (`YYYY-MM-DDTHH:MM:SSZ`) or a bare `YYYY-MM-DD` (treated
+    /// as 00:00:00 UTC). Malformed input exits 7 before any network
+    /// call.
+    ///
     /// Examples:
     ///
     ///   bzr bug list --product Firefox --status NEW --limit 25
     ///   bzr bug list --assignee me@example.com --status '!CLOSED'
     ///   bzr bug list --summary "kernel panic" --product Kernel
     ///   bzr bug list --id 100,101,102
+    ///   bzr bug list --product Firefox --changed-since 2026-04-01
     ///
     /// See bzr-bug-search(1) for free-text search, bzr-bug-my(1) for
     /// caller-relative views, and bzr-query(1) for saving a filter
@@ -75,6 +82,18 @@ pub enum BugAction {
         /// Exclude these fields (comma-separated)
         #[arg(long)]
         exclude_fields: Option<String>,
+        /// Filter to bugs created at or after this date.
+        ///
+        /// Accepts `YYYY-MM-DD` (interpreted as 00:00:00 UTC),
+        /// `YYYY-MM-DDTHH:MM:SS`, `YYYY-MM-DDTHH:MM:SSZ`, or
+        /// `YYYY-MM-DDTHH:MM:SS±HH:MM`. Malformed input exits 7.
+        #[arg(long, value_name = "DATE")]
+        created_since: Option<String>,
+        /// Filter to bugs last modified at or after this date.
+        ///
+        /// Same accepted forms as `--created-since`.
+        #[arg(long, value_name = "DATE")]
+        changed_since: Option<String>,
     },
     /// View one or more bugs by ID or alias.
     ///

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -1224,3 +1224,32 @@ fn parse_template_delete() {
         _ => panic!("expected Template Delete"),
     }
 }
+
+#[test]
+fn bug_list_parses_created_since_and_changed_since() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "bug",
+        "list",
+        "--product",
+        "Firefox",
+        "--created-since",
+        "2026-04-01",
+        "--changed-since",
+        "2026-04-15T12:00:00Z",
+    ])
+    .unwrap();
+    let Commands::Bug {
+        action:
+            BugAction::List {
+                created_since,
+                changed_since,
+                ..
+            },
+    } = cli.command
+    else {
+        panic!("expected Bug::List variant");
+    };
+    assert_eq!(created_since.as_deref(), Some("2026-04-01"));
+    assert_eq!(changed_since.as_deref(), Some("2026-04-15T12:00:00Z"));
+}

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -5,6 +5,10 @@ use clap::Subcommand;
     clippy::doc_markdown,
     reason = "doc examples are literal shell commands; wrapping URLs in <> or identifiers in backticks would degrade copy-paste UX"
 )]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "only constructed once from CLI args"
+)]
 pub enum QueryAction {
     /// Save a named query (filter flags or a Bugzilla URL) for later reuse.
     ///
@@ -20,12 +24,18 @@ pub enum QueryAction {
     /// overridden per invocation by the matching flags on
     /// `bzr query run`.
     ///
+    /// `--created-since` / `--changed-since` save Bugzilla
+    /// `creation_time` / `last_change_time` filters into the
+    /// query. Same accepted forms as `bzr bug list --created-since`.
+    /// Validated at save time; malformed input exits 7.
+    ///
     /// Examples:
     ///
     ///   bzr query save firefox-new --product Firefox --status NEW
     ///   bzr query save crashes --search "crash in tab"
     ///   bzr query save my-saved \
     ///     --from-url 'https://bz/buglist.cgi?product=Firefox'
+    ///   bzr query save recent-firefox --product Firefox --changed-since 2026-04-01
     ///
     /// See bzr-query-run(1) to execute a saved query,
     /// bzr-query-list(1) for the inventory, and bzr-bug-list(1) for
@@ -80,6 +90,16 @@ pub enum QueryAction {
         /// Exclude these fields (comma-separated)
         #[arg(long)]
         exclude_fields: Option<String>,
+        /// Filter to bugs created at or after this date (saved into the query).
+        ///
+        /// Accepts the same forms as `bzr bug list --created-since`.
+        #[arg(long, value_name = "DATE")]
+        created_since: Option<String>,
+        /// Filter to bugs last modified at or after this date (saved into the query).
+        ///
+        /// Accepts the same forms as `bzr bug list --changed-since`.
+        #[arg(long, value_name = "DATE")]
+        changed_since: Option<String>,
     },
     /// List all saved queries.
     ///

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -5,10 +5,6 @@ use clap::Subcommand;
     clippy::doc_markdown,
     reason = "doc examples are literal shell commands; wrapping URLs in <> or identifiers in backticks would degrade copy-paste UX"
 )]
-#[expect(
-    clippy::large_enum_variant,
-    reason = "only constructed once from CLI args"
-)]
 pub enum QueryAction {
     /// Save a named query (filter flags or a Bugzilla URL) for later reuse.
     ///
@@ -166,11 +162,17 @@ pub enum QueryAction {
     /// The output format matches `bzr bug list` (table by default,
     /// JSON with `--json`).
     ///
+    /// `--created-since` / `--changed-since` override the saved
+    /// query's date filters for this run; passing them clears
+    /// nothing (`None` keeps the saved value), matching the
+    /// existing `--limit` / `--fields` override convention.
+    ///
     /// Examples:
     ///
     ///   bzr query run firefox-new
     ///   bzr query run firefox-new --limit 10
     ///   bzr query run firefox-new --server staging
+    ///   bzr query run recent-firefox --changed-since 2026-05-01
     ///
     /// See bzr-query-save(1) to define a query, bzr-query-show(1)
     /// to inspect what will run, and bzr-bug-list(1) for ad-hoc
@@ -191,5 +193,15 @@ pub enum QueryAction {
         /// Override the server to run against
         #[arg(long)]
         server: Option<String>,
+        /// Override the saved `creation_time` filter for this run.
+        ///
+        /// Same accepted forms as `bzr bug list --created-since`.
+        #[arg(long, value_name = "DATE")]
+        created_since: Option<String>,
+        /// Override the saved `last_change_time` filter for this run.
+        ///
+        /// Same accepted forms as `bzr bug list --changed-since`.
+        #[arg(long, value_name = "DATE")]
+        changed_since: Option<String>,
     },
 }

--- a/src/client/bug.rs
+++ b/src/client/bug.rs
@@ -91,6 +91,8 @@ fn append_option_params(
         ("quicksearch", &params.quicksearch),
         ("include_fields", &params.include_fields),
         ("exclude_fields", &params.exclude_fields),
+        ("creation_time", &params.creation_time),
+        ("last_change_time", &params.last_change_time),
     ];
     for &(key, value) in option_fields {
         if let Some(v) = value {

--- a/src/client/bug_tests.rs
+++ b/src/client/bug_tests.rs
@@ -801,3 +801,41 @@ async fn search_bugs_all_fields_reach_server() {
     let bugs = client.search_bugs(&params).await.unwrap();
     assert_eq!(bugs.len(), 1);
 }
+
+#[tokio::test]
+async fn search_bugs_sends_creation_time_query_param() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("creation_time", "2026-04-01T00:00:00Z"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let params = SearchParams {
+        creation_time: Some("2026-04-01T00:00:00Z".into()),
+        ..Default::default()
+    };
+    let bugs = client.search_bugs(&params).await.unwrap();
+    assert!(bugs.is_empty());
+}
+
+#[tokio::test]
+async fn search_bugs_sends_last_change_time_query_param() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("last_change_time", "2026-04-15T00:00:00Z"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let params = SearchParams {
+        last_change_time: Some("2026-04-15T00:00:00Z".into()),
+        ..Default::default()
+    };
+    let bugs = client.search_bugs(&params).await.unwrap();
+    assert!(bugs.is_empty());
+}

--- a/src/commands/bug/history.rs
+++ b/src/commands/bug/history.rs
@@ -5,6 +5,7 @@ use crate::client::BugzillaClient;
 use crate::error::Result;
 use crate::output;
 use crate::types::OutputFormat;
+use crate::validation::parse_iso8601_or_date;
 
 pub(super) async fn handle(
     client: &BugzillaClient,
@@ -15,7 +16,14 @@ pub(super) async fn handle(
         unreachable!()
     };
 
-    let history = client.get_bug_history_since(*id, since.as_deref()).await?;
+    let canonical_since = since
+        .as_deref()
+        .map(|s| parse_iso8601_or_date(s, "--since"))
+        .transpose()?;
+
+    let history = client
+        .get_bug_history_since(*id, canonical_since.as_deref())
+        .await?;
     if history.is_empty() {
         let _ = writeln!(io::stdout(), "No history for bug #{id}.");
     } else {

--- a/src/commands/bug/history.rs
+++ b/src/commands/bug/history.rs
@@ -5,7 +5,7 @@ use crate::client::BugzillaClient;
 use crate::error::Result;
 use crate::output;
 use crate::types::OutputFormat;
-use crate::validation::parse_iso8601_or_date;
+use crate::validation::parse_optional_date;
 
 pub(super) async fn handle(
     client: &BugzillaClient,
@@ -16,10 +16,7 @@ pub(super) async fn handle(
         unreachable!()
     };
 
-    let canonical_since = since
-        .as_deref()
-        .map(|s| parse_iso8601_or_date(s, "--since"))
-        .transpose()?;
+    let canonical_since = parse_optional_date(since.as_deref(), "--since")?;
 
     let history = client
         .get_bug_history_since(*id, canonical_since.as_deref())

--- a/src/commands/bug/history_tests.rs
+++ b/src/commands/bug/history_tests.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used)]
+
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
@@ -33,5 +35,24 @@ async fn bug_history_empty_prints_no_history_message() {
     assert!(
         output.contains("No history for bug #42."),
         "expected empty-history message, got: {output}"
+    );
+}
+
+#[tokio::test]
+async fn bug_history_rejects_malformed_since_with_exit_code_7() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let action = BugAction::History {
+        id: 42,
+        since: Some("yesterday".into()),
+    };
+    let result = crate::commands::bug::execute(&action, None, OutputFormat::Table, None).await;
+    let err = result.unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+    let msg = err.to_string();
+    assert!(msg.contains("--since"), "error should name the flag: {msg}");
+    assert!(
+        msg.contains("yesterday"),
+        "error should echo the offending input: {msg}"
     );
 }

--- a/src/commands/bug/list.rs
+++ b/src/commands/bug/list.rs
@@ -3,6 +3,7 @@ use crate::client::BugzillaClient;
 use crate::error::Result;
 use crate::output;
 use crate::types::{OutputFormat, SearchParams};
+use crate::validation::parse_iso8601_or_date;
 
 pub(super) async fn handle(
     client: &BugzillaClient,
@@ -23,10 +24,21 @@ pub(super) async fn handle(
         limit,
         fields,
         exclude_fields,
+        created_since,
+        changed_since,
     } = action
     else {
         unreachable!()
     };
+
+    let creation_time = created_since
+        .as_deref()
+        .map(|s| parse_iso8601_or_date(s, "--created-since"))
+        .transpose()?;
+    let last_change_time = changed_since
+        .as_deref()
+        .map(|s| parse_iso8601_or_date(s, "--changed-since"))
+        .transpose()?;
 
     let params = SearchParams {
         product: product.clone(),
@@ -42,6 +54,8 @@ pub(super) async fn handle(
         limit: Some(*limit),
         include_fields: fields.clone(),
         exclude_fields: exclude_fields.clone(),
+        creation_time,
+        last_change_time,
         ..Default::default()
     };
     let bugs = client.search_bugs(&params).await?;

--- a/src/commands/bug/list.rs
+++ b/src/commands/bug/list.rs
@@ -3,7 +3,7 @@ use crate::client::BugzillaClient;
 use crate::error::Result;
 use crate::output;
 use crate::types::{OutputFormat, SearchParams};
-use crate::validation::parse_iso8601_or_date;
+use crate::validation::parse_optional_date;
 
 pub(super) async fn handle(
     client: &BugzillaClient,
@@ -31,14 +31,8 @@ pub(super) async fn handle(
         unreachable!()
     };
 
-    let creation_time = created_since
-        .as_deref()
-        .map(|s| parse_iso8601_or_date(s, "--created-since"))
-        .transpose()?;
-    let last_change_time = changed_since
-        .as_deref()
-        .map(|s| parse_iso8601_or_date(s, "--changed-since"))
-        .transpose()?;
+    let creation_time = parse_optional_date(created_since.as_deref(), "--created-since")?;
+    let last_change_time = parse_optional_date(changed_since.as_deref(), "--changed-since")?;
 
     let params = SearchParams {
         product: product.clone(),

--- a/src/commands/bug/list_tests.rs
+++ b/src/commands/bug/list_tests.rs
@@ -22,6 +22,8 @@ fn empty_list_action() -> BugAction {
         limit: 50,
         fields: None,
         exclude_fields: None,
+        created_since: None,
+        changed_since: None,
     }
 }
 
@@ -86,6 +88,8 @@ async fn bug_list_passes_every_field_through_to_search_params() {
         .and(query_param("limit", "5"))
         .and(query_param("include_fields", "id,summary"))
         .and(query_param("exclude_fields", "comments"))
+        .and(query_param("creation_time", "2026-04-01T00:00:00Z"))
+        .and(query_param("last_change_time", "2026-04-15T00:00:00Z"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
         .expect(1)
         .mount(&mock)
@@ -105,6 +109,8 @@ async fn bug_list_passes_every_field_through_to_search_params() {
         limit: 5,
         fields: Some("id,summary".into()),
         exclude_fields: Some("comments".into()),
+        created_since: Some("2026-04-01".into()),
+        changed_since: Some("2026-04-15T00:00:00Z".into()),
     };
     let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
     assert!(
@@ -149,6 +155,8 @@ async fn bug_list_summary_only_sends_substring_filter() {
         limit: 50,
         fields: None,
         exclude_fields: None,
+        created_since: None,
+        changed_since: None,
     };
     let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
     assert!(result.is_ok(), "bug list --summary failed: {result:?}");
@@ -187,4 +195,46 @@ async fn bug_list_malformed_json_returns_error() {
     let action = empty_list_action();
     let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
     assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn bug_list_rejects_malformed_created_since_with_exit_code_7() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let mut action = empty_list_action();
+    if let BugAction::List { created_since, .. } = &mut action {
+        *created_since = Some("not-a-date".into());
+    }
+
+    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.exit_code(),
+        7,
+        "expected exit code 7 for input validation, got {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("--created-since"),
+        "error should name the flag: {msg}"
+    );
+    assert!(
+        msg.contains("not-a-date"),
+        "error should echo the offending input: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn bug_list_rejects_malformed_changed_since_with_exit_code_7() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let mut action = empty_list_action();
+    if let BugAction::List { changed_since, .. } = &mut action {
+        *changed_since = Some("2026-13-99".into());
+    }
+
+    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let err = result.unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+    assert!(err.to_string().contains("--changed-since"));
 }

--- a/src/commands/bug/search.rs
+++ b/src/commands/bug/search.rs
@@ -40,7 +40,7 @@ fn build_params_from_url(
     if params.limit.is_none() && limit.is_none() {
         params.limit = Some(50);
     }
-    params.apply_overrides(limit, fields, exclude_fields);
+    params.apply_overrides(limit, fields, exclude_fields, None, None);
     params
 }
 

--- a/src/commands/comment.rs
+++ b/src/commands/comment.rs
@@ -17,10 +17,8 @@ pub async fn execute(
 
     match action {
         CommentAction::List { bug_id, since } => {
-            let canonical_since = since
-                .as_deref()
-                .map(|s| crate::validation::parse_iso8601_or_date(s, "--since"))
-                .transpose()?;
+            let canonical_since =
+                crate::validation::parse_optional_date(since.as_deref(), "--since")?;
             let comments = client
                 .get_comments_since(*bug_id, canonical_since.as_deref())
                 .await?;

--- a/src/commands/comment.rs
+++ b/src/commands/comment.rs
@@ -17,7 +17,13 @@ pub async fn execute(
 
     match action {
         CommentAction::List { bug_id, since } => {
-            let comments = client.get_comments_since(*bug_id, since.as_deref()).await?;
+            let canonical_since = since
+                .as_deref()
+                .map(|s| crate::validation::parse_iso8601_or_date(s, "--since"))
+                .transpose()?;
+            let comments = client
+                .get_comments_since(*bug_id, canonical_since.as_deref())
+                .await?;
             output::print_comments(&comments, format);
         }
         CommentAction::Add {

--- a/src/commands/comment_tests.rs
+++ b/src/commands/comment_tests.rs
@@ -144,3 +144,22 @@ async fn comment_add_api_error_returns_error() {
     let result = super::execute(&action, None, OutputFormat::Json, None).await;
     assert!(result.is_err());
 }
+
+#[tokio::test]
+async fn comment_list_rejects_malformed_since_with_exit_code_7() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let action = CommentAction::List {
+        bug_id: 42,
+        since: Some("nope".into()),
+    };
+    let result = crate::commands::comment::execute(&action, None, OutputFormat::Json, None).await;
+    let err = result.unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+    let msg = err.to_string();
+    assert!(msg.contains("--since"), "error should name the flag: {msg}");
+    assert!(
+        msg.contains("nope"),
+        "error should echo the offending input: {msg}"
+    );
+}

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -162,7 +162,13 @@ async fn handle_run(
         .or(saved.server.as_deref());
 
     let mut params = saved.to_search_params();
-    params.apply_overrides(*limit, fields.as_deref(), exclude_fields.as_deref());
+    params.apply_overrides(
+        *limit,
+        fields.as_deref(),
+        exclude_fields.as_deref(),
+        None,
+        None,
+    );
 
     let client = super::shared::connect_and_configure(effective_server, api).await?;
     let bugs = client.search_bugs(&params).await?;

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -46,14 +46,10 @@ fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
         unreachable!()
     };
 
-    let creation_time = created_since
-        .as_deref()
-        .map(|s| crate::validation::parse_iso8601_or_date(s, "--created-since"))
-        .transpose()?;
-    let last_change_time = changed_since
-        .as_deref()
-        .map(|s| crate::validation::parse_iso8601_or_date(s, "--changed-since"))
-        .transpose()?;
+    let creation_time =
+        crate::validation::parse_optional_date(created_since.as_deref(), "--created-since")?;
+    let last_change_time =
+        crate::validation::parse_optional_date(changed_since.as_deref(), "--changed-since")?;
 
     let (query, preloaded_config) = if let Some(url_str) = from_url {
         let config = Config::load()?;
@@ -69,10 +65,10 @@ fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
             query.exclude_fields = Some(ef.clone());
         }
         if creation_time.is_some() {
-            query.creation_time.clone_from(&creation_time);
+            query.creation_time = creation_time;
         }
         if last_change_time.is_some() {
-            query.last_change_time.clone_from(&last_change_time);
+            query.last_change_time = last_change_time;
         }
         (query, Some(config))
     } else {
@@ -172,14 +168,10 @@ async fn handle_run(
         unreachable!()
     };
 
-    let creation_time_override = created_since
-        .as_deref()
-        .map(|s| crate::validation::parse_iso8601_or_date(s, "--created-since"))
-        .transpose()?;
-    let last_change_time_override = changed_since
-        .as_deref()
-        .map(|s| crate::validation::parse_iso8601_or_date(s, "--changed-since"))
-        .transpose()?;
+    let creation_time_override =
+        crate::validation::parse_optional_date(created_since.as_deref(), "--created-since")?;
+    let last_change_time_override =
+        crate::validation::parse_optional_date(changed_since.as_deref(), "--changed-since")?;
 
     let config = Config::load()?;
     let saved = config

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -39,10 +39,21 @@ fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
         limit,
         fields,
         exclude_fields,
+        created_since,
+        changed_since,
     } = action
     else {
         unreachable!()
     };
+
+    let creation_time = created_since
+        .as_deref()
+        .map(|s| crate::validation::parse_iso8601_or_date(s, "--created-since"))
+        .transpose()?;
+    let last_change_time = changed_since
+        .as_deref()
+        .map(|s| crate::validation::parse_iso8601_or_date(s, "--changed-since"))
+        .transpose()?;
 
     let (query, preloaded_config) = if let Some(url_str) = from_url {
         let config = Config::load()?;
@@ -56,6 +67,12 @@ fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
         }
         if let Some(ef) = exclude_fields {
             query.exclude_fields = Some(ef.clone());
+        }
+        if creation_time.is_some() {
+            query.creation_time.clone_from(&creation_time);
+        }
+        if last_change_time.is_some() {
+            query.last_change_time.clone_from(&last_change_time);
         }
         (query, Some(config))
     } else {
@@ -77,6 +94,8 @@ fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
             limit: *limit,
             fields: fields.clone(),
             exclude_fields: exclude_fields.clone(),
+            creation_time,
+            last_change_time,
             ..SavedQuery::default()
         };
         (query, None)

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -165,10 +165,21 @@ async fn handle_run(
         fields,
         exclude_fields,
         server: server_override,
+        created_since,
+        changed_since,
     } = action
     else {
         unreachable!()
     };
+
+    let creation_time_override = created_since
+        .as_deref()
+        .map(|s| crate::validation::parse_iso8601_or_date(s, "--created-since"))
+        .transpose()?;
+    let last_change_time_override = changed_since
+        .as_deref()
+        .map(|s| crate::validation::parse_iso8601_or_date(s, "--changed-since"))
+        .transpose()?;
 
     let config = Config::load()?;
     let saved = config
@@ -185,8 +196,8 @@ async fn handle_run(
         *limit,
         fields.as_deref(),
         exclude_fields.as_deref(),
-        None,
-        None,
+        creation_time_override.as_deref(),
+        last_change_time_override.as_deref(),
     );
 
     let client = super::shared::connect_and_configure(effective_server, api).await?;

--- a/src/commands/query_tests.rs
+++ b/src/commands/query_tests.rs
@@ -22,6 +22,8 @@ fn save_action(name: &str) -> QueryAction {
         limit: Some(25),
         fields: None,
         exclude_fields: None,
+        created_since: None,
+        changed_since: None,
     }
 }
 
@@ -41,6 +43,8 @@ fn product_save_action(name: &str, product: &str, limit: u32) -> QueryAction {
         limit: Some(limit),
         fields: None,
         exclude_fields: None,
+        created_since: None,
+        changed_since: None,
     }
 }
 
@@ -59,6 +63,8 @@ fn empty_save_action(name: &str, search: Option<String>) -> QueryAction {
         limit: None,
         fields: None,
         exclude_fields: None,
+        created_since: None,
+        changed_since: None,
     }
 }
 
@@ -77,6 +83,8 @@ fn url_save_action(name: &str, url: String) -> QueryAction {
         limit: None,
         fields: None,
         exclude_fields: None,
+        created_since: None,
+        changed_since: None,
     }
 }
 
@@ -131,6 +139,8 @@ async fn query_save_persists_every_field() {
         limit: Some(7),
         fields: Some("id,summary".into()),
         exclude_fields: Some("comments".into()),
+        created_since: None,
+        changed_since: None,
     };
     let (result, _) = capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
     result.unwrap();
@@ -324,6 +334,8 @@ async fn query_save_existing_entry_reports_updated() {
         limit: Some(10),
         fields: None,
         exclude_fields: None,
+        created_since: None,
+        changed_since: None,
     };
     let (result, _) =
         capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
@@ -343,6 +355,8 @@ async fn query_save_existing_entry_reports_updated() {
         limit: Some(5),
         fields: None,
         exclude_fields: None,
+        created_since: None,
+        changed_since: None,
     };
     let (result, output) = capture_stdout(super::execute(
         &update_action,
@@ -414,6 +428,8 @@ async fn query_run_applies_field_overrides() {
         limit: Some(10),
         fields: Some("id,status".into()),
         exclude_fields: Some("cc".into()),
+        created_since: None,
+        changed_since: None,
     };
     let (result, _) =
         capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
@@ -564,4 +580,91 @@ async fn query_save_from_url() {
     assert_eq!(saved.product, vec!["TestProduct"]);
     assert!(!saved.raw_params.is_empty());
     assert!(saved.source_url.is_some());
+}
+
+#[tokio::test]
+async fn query_save_rejects_malformed_created_since() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let action = QueryAction::Save {
+        name: "bad".into(),
+        from_url: None,
+        search: None,
+        product: vec!["Firefox".into()],
+        component: vec![],
+        status: vec![],
+        assignee: vec![],
+        creator: vec![],
+        priority: vec![],
+        severity: vec![],
+        limit: None,
+        fields: None,
+        exclude_fields: None,
+        created_since: Some("garbage".into()),
+        changed_since: None,
+    };
+
+    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let err = result.unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+    assert!(err.to_string().contains("--created-since"));
+}
+
+#[tokio::test]
+async fn query_save_stores_canonical_date_forms() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let action = QueryAction::Save {
+        name: "recent".into(),
+        from_url: None,
+        search: None,
+        product: vec!["Firefox".into()],
+        component: vec![],
+        status: vec![],
+        assignee: vec![],
+        creator: vec![],
+        priority: vec![],
+        severity: vec![],
+        limit: None,
+        fields: None,
+        exclude_fields: None,
+        created_since: Some("2026-04-01".into()),
+        changed_since: Some("2026-04-15T12:00:00Z".into()),
+    };
+    let (result, _) = capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    result.unwrap();
+
+    let cfg = Config::load().unwrap();
+    let q = cfg.queries.get("recent").unwrap();
+    assert_eq!(q.creation_time.as_deref(), Some("2026-04-01T00:00:00Z"));
+    assert_eq!(q.last_change_time.as_deref(), Some("2026-04-15T12:00:00Z"));
+}
+
+#[tokio::test]
+async fn query_save_accepts_date_only_query() {
+    // SavedQuery::has_filters() must recognize date-only queries so the
+    // "query must have at least one filter set" rejection does not fire.
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let action = QueryAction::Save {
+        name: "date-only".into(),
+        from_url: None,
+        search: None,
+        product: vec![],
+        component: vec![],
+        status: vec![],
+        assignee: vec![],
+        creator: vec![],
+        priority: vec![],
+        severity: vec![],
+        limit: None,
+        fields: None,
+        exclude_fields: None,
+        created_since: Some("2026-04-01".into()),
+        changed_since: None,
+    };
+    let (result, _) = capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    result.unwrap();
+    let cfg = Config::load().unwrap();
+    assert!(cfg.queries.contains_key("date-only"));
 }

--- a/src/commands/query_tests.rs
+++ b/src/commands/query_tests.rs
@@ -95,6 +95,8 @@ fn run_action(name: &str) -> QueryAction {
         fields: None,
         exclude_fields: None,
         server: None,
+        created_since: None,
+        changed_since: None,
     }
 }
 
@@ -310,6 +312,8 @@ async fn query_run_with_limit_override() {
         fields: None,
         exclude_fields: None,
         server: None,
+        created_since: None,
+        changed_since: None,
     };
     let (result, _) =
         capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
@@ -450,6 +454,8 @@ async fn query_run_applies_field_overrides() {
         fields: Some("id,summary".into()),
         exclude_fields: Some("comments".into()),
         server: None,
+        created_since: None,
+        changed_since: None,
     };
     let (result, _) =
         capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
@@ -549,6 +555,8 @@ async fn query_run_with_server_override() {
         fields: None,
         exclude_fields: None,
         server: Some("test".into()),
+        created_since: None,
+        changed_since: None,
     };
     let (result, _) =
         capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
@@ -667,4 +675,34 @@ async fn query_save_accepts_date_only_query() {
     result.unwrap();
     let cfg = Config::load().unwrap();
     assert!(cfg.queries.contains_key("date-only"));
+}
+
+#[tokio::test]
+async fn query_run_rejects_malformed_created_since_override() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    // Pre-seed a saved query so the not-found branch doesn't fire first.
+    let mut cfg = Config::load().unwrap();
+    cfg.queries.insert(
+        "recent".into(),
+        crate::types::SavedQuery {
+            product: vec!["Firefox".into()],
+            ..crate::types::SavedQuery::default()
+        },
+    );
+    cfg.save().unwrap();
+
+    let action = QueryAction::Run {
+        name: "recent".into(),
+        limit: None,
+        fields: None,
+        exclude_fields: None,
+        server: None,
+        created_since: Some("not-a-date".into()),
+        changed_since: None,
+    };
+    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let err = result.unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+    assert!(err.to_string().contains("--created-since"));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub(crate) mod output;
 pub(crate) mod tls;
 pub mod types;
 pub mod url_parser;
+pub mod validation;
 pub mod xmlrpc;
 
 /// Dispatch a parsed CLI to the appropriate command handler.

--- a/src/output/query.rs
+++ b/src/output/query.rs
@@ -30,6 +30,12 @@ fn query_summary_line(name: &str, q: &SavedQuery) -> String {
     if let Some(qs) = &q.quicksearch {
         parts.push(format!("search=\"{qs}\""));
     }
+    if let Some(ct) = &q.creation_time {
+        parts.push(format!("created>={ct}"));
+    }
+    if let Some(lct) = &q.last_change_time {
+        parts.push(format!("changed>={lct}"));
+    }
     if let Some(limit) = q.limit {
         parts.push(format!("limit={limit}"));
     }
@@ -91,6 +97,8 @@ pub fn print_query_detail(name: &str, query: &SavedQuery, format: OutputFormat) 
         }
         print_optional_field("Fields", view.query.fields.as_deref());
         print_optional_field("Exclude", view.query.exclude_fields.as_deref());
+        print_optional_field("Created since", view.query.creation_time.as_deref());
+        print_optional_field("Changed since", view.query.last_change_time.as_deref());
         if !view.query.raw_params.is_empty() {
             print_field("Raw params", &view.query.raw_params.len().to_string());
         }

--- a/src/output/query_tests.rs
+++ b/src/output/query_tests.rs
@@ -187,6 +187,60 @@ async fn print_query_detail_table_renders_url_fields() {
 
 #[cfg(unix)]
 #[tokio::test]
+async fn print_query_detail_table_shows_date_filters() {
+    let _lock = crate::ENV_LOCK.lock().await;
+    let mut query = make_list_query();
+    query.creation_time = Some("2026-04-01T00:00:00Z".into());
+    query.last_change_time = Some("2026-04-15T00:00:00Z".into());
+
+    let ((), output) = crate::test_helpers::capture_stdout(async {
+        print_query_detail("recent", &query, OutputFormat::Table);
+    })
+    .await;
+
+    assert!(output.contains("Created since"), "missing label: {output}");
+    assert!(
+        output.contains("2026-04-01T00:00:00Z"),
+        "missing creation_time value"
+    );
+    assert!(output.contains("Changed since"), "missing label: {output}");
+    assert!(
+        output.contains("2026-04-15T00:00:00Z"),
+        "missing last_change_time value"
+    );
+}
+
+#[test]
+fn query_detail_json_includes_date_filters() {
+    let mut query = make_list_query();
+    query.creation_time = Some("2026-04-01T00:00:00Z".into());
+    let view = QueryView {
+        name: "recent",
+        query: &query,
+    };
+    let json = serde_json::to_string_pretty(&view).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["creation_time"], "2026-04-01T00:00:00Z");
+}
+
+#[test]
+fn query_summary_line_renders_date_filters() {
+    let mut query = make_list_query();
+    query.creation_time = Some("2026-04-01T00:00:00Z".into());
+    query.last_change_time = Some("2026-04-15T00:00:00Z".into());
+    let line = query_summary_line("recent", &query);
+    assert!(
+        line.contains("created>=2026-04-01T00:00:00Z"),
+        "summary missing created>=: {line}"
+    );
+    assert!(
+        line.contains("changed>=2026-04-15T00:00:00Z"),
+        "summary missing changed>=: {line}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn query_list_names_sort_before_render() {
     let _lock = crate::ENV_LOCK.lock().await;
     let mut queries: HashMap<String, SavedQuery> = HashMap::new();

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -98,12 +98,16 @@ pub struct SearchParams {
 }
 
 impl SearchParams {
-    /// Apply optional runtime overrides for limit, fields, and `exclude_fields`.
+    /// Apply optional runtime overrides for limit, fields, `exclude_fields`,
+    /// and the two date filters. `Some(_)` replaces; `None` keeps the
+    /// saved value.
     pub fn apply_overrides(
         &mut self,
         limit: Option<u32>,
         fields: Option<&str>,
         exclude_fields: Option<&str>,
+        creation_time: Option<&str>,
+        last_change_time: Option<&str>,
     ) {
         if let Some(l) = limit {
             self.limit = Some(l);
@@ -113,6 +117,12 @@ impl SearchParams {
         }
         if let Some(ef) = exclude_fields {
             self.exclude_fields = Some(ef.to_string());
+        }
+        if let Some(ct) = creation_time {
+            self.creation_time = Some(ct.to_string());
+        }
+        if let Some(lct) = last_change_time {
+            self.last_change_time = Some(lct.to_string());
         }
     }
 
@@ -417,6 +427,13 @@ pub struct SavedQuery {
     /// Passed through verbatim to the Bugzilla REST API.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub raw_params: Vec<(String, String)>,
+    /// Server-canonical form (e.g. `2026-04-01T00:00:00Z`).
+    /// Validated at save time via `crate::validation::parse_iso8601_or_date`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub creation_time: Option<String>,
+    /// Server-canonical form. See `creation_time`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_change_time: Option<String>,
 }
 
 impl SavedQuery {
@@ -440,6 +457,8 @@ impl SavedQuery {
             include_fields: self.fields,
             exclude_fields: self.exclude_fields,
             raw_params: self.raw_params,
+            creation_time: self.creation_time,
+            last_change_time: self.last_change_time,
             ..Default::default()
         }
     }
@@ -474,6 +493,8 @@ impl SavedQuery {
             || !self.severity.is_empty()
             || self.quicksearch.is_some()
             || !self.raw_params.is_empty()
+            || self.creation_time.is_some()
+            || self.last_change_time.is_some()
     }
 }
 

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -88,6 +88,13 @@ pub struct SearchParams {
     /// Raw query parameters passed through verbatim to the REST API.
     /// Used for URL-imported queries with boolean chart params.
     pub raw_params: Vec<(String, String)>,
+    /// Filter to bugs created at or after this datetime (server-canonical
+    /// form: e.g. `2026-04-01T00:00:00Z`). Validated client-side at the
+    /// CLI layer via `crate::validation::parse_iso8601_or_date`.
+    pub creation_time: Option<String>,
+    /// Filter to bugs last modified at or after this datetime (server-canonical
+    /// form). Validated client-side; see `creation_time`.
+    pub last_change_time: Option<String>,
 }
 
 impl SearchParams {
@@ -150,6 +157,8 @@ impl SearchParams {
             || self.summary.is_some()
             || self.quicksearch.is_some()
             || !self.raw_params.is_empty()
+            || self.creation_time.is_some()
+            || self.last_change_time.is_some()
     }
 
     /// Returns true if any *structured* filter is set.
@@ -176,6 +185,8 @@ impl SearchParams {
             || self.alias.is_some()
             || !self.id.is_empty()
             || !self.raw_params.is_empty()
+            || self.creation_time.is_some()
+            || self.last_change_time.is_some()
     }
 }
 

--- a/src/types/bug_tests.rs
+++ b/src/types/bug_tests.rs
@@ -316,6 +316,12 @@ fn search_params_has_filters_for_each_individual_field() {
         ("raw_params", |p| {
             p.raw_params = vec![("f1".into(), "X".into())];
         }),
+        ("creation_time", |p| {
+            p.creation_time = Some("2026-04-01T00:00:00Z".into())
+        }),
+        ("last_change_time", |p| {
+            p.last_change_time = Some("2026-04-01T00:00:00Z".into())
+        }),
     ];
     for (name, setter) in cases {
         let mut p = SearchParams::default();
@@ -368,6 +374,12 @@ fn search_params_has_structured_filters_for_each_individual_field() {
         ("id", |p| p.id = vec![1]),
         ("raw_params", |p| {
             p.raw_params = vec![("f1".into(), "X".into())];
+        }),
+        ("creation_time", |p| {
+            p.creation_time = Some("2026-04-01T00:00:00Z".into())
+        }),
+        ("last_change_time", |p| {
+            p.last_change_time = Some("2026-04-01T00:00:00Z".into())
         }),
     ];
     for (name, setter) in cases {

--- a/src/types/bug_tests.rs
+++ b/src/types/bug_tests.rs
@@ -87,6 +87,8 @@ fn saved_query_list_roundtrips_json() {
         source_url: None,
         server: None,
         raw_params: vec![],
+        creation_time: None,
+        last_change_time: None,
     };
     let json = serde_json::to_string(&query).unwrap();
     let roundtripped: SavedQuery = serde_json::from_str(&json).unwrap();
@@ -317,10 +319,10 @@ fn search_params_has_filters_for_each_individual_field() {
             p.raw_params = vec![("f1".into(), "X".into())];
         }),
         ("creation_time", |p| {
-            p.creation_time = Some("2026-04-01T00:00:00Z".into())
+            p.creation_time = Some("2026-04-01T00:00:00Z".into());
         }),
         ("last_change_time", |p| {
-            p.last_change_time = Some("2026-04-01T00:00:00Z".into())
+            p.last_change_time = Some("2026-04-01T00:00:00Z".into());
         }),
     ];
     for (name, setter) in cases {
@@ -376,10 +378,10 @@ fn search_params_has_structured_filters_for_each_individual_field() {
             p.raw_params = vec![("f1".into(), "X".into())];
         }),
         ("creation_time", |p| {
-            p.creation_time = Some("2026-04-01T00:00:00Z".into())
+            p.creation_time = Some("2026-04-01T00:00:00Z".into());
         }),
         ("last_change_time", |p| {
-            p.last_change_time = Some("2026-04-01T00:00:00Z".into())
+            p.last_change_time = Some("2026-04-01T00:00:00Z".into());
         }),
     ];
     for (name, setter) in cases {
@@ -411,6 +413,12 @@ fn saved_query_has_filters_for_each_individual_field() {
         ("quicksearch", |q| q.quicksearch = Some("X".into())),
         ("raw_params", |q| {
             q.raw_params = vec![("f1".into(), "X".into())];
+        }),
+        ("creation_time", |q: &mut SavedQuery| {
+            q.creation_time = Some("2026-04-01T00:00:00Z".into());
+        }),
+        ("last_change_time", |q: &mut SavedQuery| {
+            q.last_change_time = Some("2026-04-01T00:00:00Z".into());
         }),
     ];
     for (name, setter) in cases {
@@ -481,4 +489,71 @@ fn into_search_params_moves_fields() {
     assert_eq!(params.include_fields, Some("id,summary".into()));
     assert_eq!(params.exclude_fields, Some("comments".into()));
     assert_eq!(params.raw_params, vec![("f1".into(), "qa_contact".into())]);
+}
+
+#[test]
+fn saved_query_into_search_params_forwards_date_filters() {
+    let q = SavedQuery {
+        creation_time: Some("2026-04-01T00:00:00Z".into()),
+        last_change_time: Some("2026-04-15T00:00:00Z".into()),
+        ..SavedQuery::default()
+    };
+    let p = q.into_search_params();
+    assert_eq!(p.creation_time.as_deref(), Some("2026-04-01T00:00:00Z"));
+    assert_eq!(p.last_change_time.as_deref(), Some("2026-04-15T00:00:00Z"));
+}
+
+#[test]
+fn saved_query_toml_roundtrip_preserves_date_filters() {
+    let q = SavedQuery {
+        product: vec!["Firefox".into()],
+        creation_time: Some("2026-04-01T00:00:00Z".into()),
+        last_change_time: Some("2026-04-15T00:00:00Z".into()),
+        ..SavedQuery::default()
+    };
+    let toml_str = toml::to_string(&q).unwrap();
+    let parsed: SavedQuery = toml::from_str(&toml_str).unwrap();
+    assert_eq!(
+        parsed.creation_time.as_deref(),
+        Some("2026-04-01T00:00:00Z")
+    );
+    assert_eq!(
+        parsed.last_change_time.as_deref(),
+        Some("2026-04-15T00:00:00Z")
+    );
+}
+
+#[test]
+fn saved_query_toml_legacy_without_date_filters_deserializes() {
+    // Configs written before this change must still parse — both fields
+    // are #[serde(default)] so missing keys produce None.
+    let toml_str = r#"
+product = ["Firefox"]
+"#;
+    let parsed: SavedQuery = toml::from_str(toml_str).unwrap();
+    assert_eq!(parsed.creation_time, None);
+    assert_eq!(parsed.last_change_time, None);
+}
+
+#[test]
+fn apply_overrides_replaces_date_filters_when_some() {
+    let mut p = SearchParams {
+        creation_time: Some("2026-04-01T00:00:00Z".into()),
+        last_change_time: Some("2026-04-15T00:00:00Z".into()),
+        ..Default::default()
+    };
+    p.apply_overrides(None, None, None, Some("2026-05-01T00:00:00Z"), None);
+    assert_eq!(p.creation_time.as_deref(), Some("2026-05-01T00:00:00Z"));
+    // last_change_time unchanged because we passed None.
+    assert_eq!(p.last_change_time.as_deref(), Some("2026-04-15T00:00:00Z"));
+}
+
+#[test]
+fn apply_overrides_keeps_date_filters_when_none() {
+    let mut p = SearchParams {
+        creation_time: Some("2026-04-01T00:00:00Z".into()),
+        ..Default::default()
+    };
+    p.apply_overrides(Some(10), None, None, None, None);
+    assert_eq!(p.creation_time.as_deref(), Some("2026-04-01T00:00:00Z"));
 }

--- a/src/validation/datetime.rs
+++ b/src/validation/datetime.rs
@@ -115,7 +115,8 @@ fn parse_datetime_offset(s: &str) -> Option<()> {
     if bytes[22] != b':' {
         return None;
     }
-    if !bytes[20..22].iter().all(u8::is_ascii_digit) || !bytes[23..25].iter().all(u8::is_ascii_digit)
+    if !bytes[20..22].iter().all(u8::is_ascii_digit)
+        || !bytes[23..25].iter().all(u8::is_ascii_digit)
     {
         return None;
     }

--- a/src/validation/datetime.rs
+++ b/src/validation/datetime.rs
@@ -1,0 +1,132 @@
+//! ISO-8601 date / datetime validation for Bugzilla search filters.
+//!
+//! Accepts four shapes (lengths fully constrain the format):
+//!   * `YYYY-MM-DD`            (10 chars) — canonicalized to `YYYY-MM-DDT00:00:00Z`
+//!   * `YYYY-MM-DDTHH:MM:SS`   (19 chars) — sent verbatim; server treats as UTC
+//!   * `YYYY-MM-DDTHH:MM:SSZ`  (20 chars) — sent verbatim
+//!   * `YYYY-MM-DDTHH:MM:SS±HH:MM` (25 chars) — sent verbatim
+//!
+//! Fractional seconds, week dates (`2026-W18-3`), and ordinal dates
+//! (`2026-128`) are rejected: they are valid ISO-8601 but the server
+//! is not guaranteed to accept them, and we'd rather fail fast at the
+//! CLI than ship a malformed payload.
+
+use crate::error::{BzrError, Result};
+
+/// Validate an ISO-8601 datetime or bare date for use as a Bugzilla
+/// search filter. On success, returns the canonical form sent to the
+/// server (bare dates are expanded to `YYYY-MM-DDT00:00:00Z`).
+///
+/// `flag` is the CLI flag name (e.g. "--created-since") and is
+/// included in the error message so callers can locate the offending
+/// input when multiple date flags are in play.
+pub fn parse_iso8601_or_date(s: &str, flag: &str) -> Result<String> {
+    match try_canonicalize(s) {
+        Some(canon) => Ok(canon),
+        None => Err(BzrError::InputValidation(format!(
+            "{flag}: '{s}' is not a valid ISO-8601 date or datetime.\n\
+             Expected: YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, \
+             YYYY-MM-DDTHH:MM:SSZ, or YYYY-MM-DDTHH:MM:SS±HH:MM"
+        ))),
+    }
+}
+
+fn try_canonicalize(s: &str) -> Option<String> {
+    // Length-check first; this also gates the byte-indexing below
+    // (each branch knows the input is exactly that many bytes long).
+    // ASCII-only because every accepted character is in [-+:0-9TZ].
+    if !s.is_ascii() {
+        return None;
+    }
+    match s.len() {
+        10 => parse_date(s).map(|()| format!("{s}T00:00:00Z")),
+        19 => parse_datetime_naive(s).map(|()| s.to_string()),
+        20 => parse_datetime_z(s).map(|()| s.to_string()),
+        25 => parse_datetime_offset(s).map(|()| s.to_string()),
+        _ => None,
+    }
+}
+
+fn parse_date(s: &str) -> Option<()> {
+    let bytes = s.as_bytes();
+    if bytes[4] != b'-' || bytes[7] != b'-' {
+        return None;
+    }
+    if !bytes[..4].iter().all(u8::is_ascii_digit)
+        || !bytes[5..7].iter().all(u8::is_ascii_digit)
+        || !bytes[8..10].iter().all(u8::is_ascii_digit)
+    {
+        return None;
+    }
+    let month: u32 = s[5..7].parse().ok()?;
+    let day: u32 = s[8..10].parse().ok()?;
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    Some(())
+}
+
+fn parse_time(s: &str) -> Option<()> {
+    // Expects exactly "HH:MM:SS" (8 chars).
+    let bytes = s.as_bytes();
+    if bytes.len() != 8 || bytes[2] != b':' || bytes[5] != b':' {
+        return None;
+    }
+    if !bytes[..2].iter().all(u8::is_ascii_digit)
+        || !bytes[3..5].iter().all(u8::is_ascii_digit)
+        || !bytes[6..8].iter().all(u8::is_ascii_digit)
+    {
+        return None;
+    }
+    let h: u32 = s[..2].parse().ok()?;
+    let m: u32 = s[3..5].parse().ok()?;
+    let sec: u32 = s[6..8].parse().ok()?;
+    // Allow second == 60 for leap seconds.
+    if h > 23 || m > 59 || sec > 60 {
+        return None;
+    }
+    Some(())
+}
+
+fn parse_datetime_naive(s: &str) -> Option<()> {
+    if s.as_bytes()[10] != b'T' {
+        return None;
+    }
+    parse_date(&s[..10])?;
+    parse_time(&s[11..19])?;
+    Some(())
+}
+
+fn parse_datetime_z(s: &str) -> Option<()> {
+    if !s.ends_with('Z') {
+        return None;
+    }
+    parse_datetime_naive(&s[..19])?;
+    Some(())
+}
+
+fn parse_datetime_offset(s: &str) -> Option<()> {
+    parse_datetime_naive(&s[..19])?;
+    let bytes = s.as_bytes();
+    let sign = bytes[19];
+    if sign != b'+' && sign != b'-' {
+        return None;
+    }
+    if bytes[22] != b':' {
+        return None;
+    }
+    if !bytes[20..22].iter().all(u8::is_ascii_digit) || !bytes[23..25].iter().all(u8::is_ascii_digit)
+    {
+        return None;
+    }
+    let h: u32 = s[20..22].parse().ok()?;
+    let m: u32 = s[23..25].parse().ok()?;
+    if h > 14 || m > 59 {
+        return None;
+    }
+    Some(())
+}
+
+#[cfg(test)]
+#[path = "datetime_tests.rs"]
+mod tests;

--- a/src/validation/datetime.rs
+++ b/src/validation/datetime.rs
@@ -67,9 +67,9 @@ fn parse_date(s: &str) -> Option<()> {
 }
 
 fn parse_time(s: &str) -> Option<()> {
-    // Expects exactly "HH:MM:SS" (8 chars).
+    debug_assert_eq!(s.len(), 8, "parse_time requires exactly 8 bytes (HH:MM:SS)");
     let bytes = s.as_bytes();
-    if bytes.len() != 8 || bytes[2] != b':' || bytes[5] != b':' {
+    if bytes[2] != b':' || bytes[5] != b':' {
         return None;
     }
     if !bytes[..2].iter().all(u8::is_ascii_digit)

--- a/src/validation/datetime_tests.rs
+++ b/src/validation/datetime_tests.rs
@@ -1,0 +1,156 @@
+#![expect(clippy::unwrap_used)]
+
+use super::parse_iso8601_or_date;
+
+const FLAG: &str = "--created-since";
+
+#[test]
+fn accepts_bare_date_and_canonicalizes() {
+    let canon = parse_iso8601_or_date("2026-04-01", FLAG).unwrap();
+    assert_eq!(canon, "2026-04-01T00:00:00Z");
+}
+
+#[test]
+fn accepts_naive_datetime_unchanged() {
+    let canon = parse_iso8601_or_date("2026-04-01T12:30:45", FLAG).unwrap();
+    assert_eq!(canon, "2026-04-01T12:30:45");
+}
+
+#[test]
+fn accepts_zulu_datetime_unchanged() {
+    let canon = parse_iso8601_or_date("2026-04-01T12:30:45Z", FLAG).unwrap();
+    assert_eq!(canon, "2026-04-01T12:30:45Z");
+}
+
+#[test]
+fn accepts_positive_offset_unchanged() {
+    let canon = parse_iso8601_or_date("2026-04-01T12:30:45+05:30", FLAG).unwrap();
+    assert_eq!(canon, "2026-04-01T12:30:45+05:30");
+}
+
+#[test]
+fn accepts_negative_offset_unchanged() {
+    let canon = parse_iso8601_or_date("2026-04-01T12:30:45-08:00", FLAG).unwrap();
+    assert_eq!(canon, "2026-04-01T12:30:45-08:00");
+}
+
+#[test]
+fn accepts_leap_second() {
+    // 2016-12-31T23:59:60Z was an actual leap second.
+    let canon = parse_iso8601_or_date("2016-12-31T23:59:60Z", FLAG).unwrap();
+    assert_eq!(canon, "2016-12-31T23:59:60Z");
+}
+
+#[test]
+fn rejects_empty_string() {
+    let err = parse_iso8601_or_date("", FLAG).unwrap_err();
+    assert!(err.to_string().contains(FLAG));
+}
+
+#[test]
+fn rejects_garbage_word() {
+    let err = parse_iso8601_or_date("tomorrow", FLAG).unwrap_err();
+    assert!(err.to_string().contains("tomorrow"));
+    assert!(err.to_string().contains(FLAG));
+}
+
+#[test]
+fn rejects_year_only() {
+    assert!(parse_iso8601_or_date("2026", FLAG).is_err());
+}
+
+#[test]
+fn rejects_year_month() {
+    assert!(parse_iso8601_or_date("2026-04", FLAG).is_err());
+}
+
+#[test]
+fn rejects_slash_separators() {
+    assert!(parse_iso8601_or_date("2026/04/01", FLAG).is_err());
+}
+
+#[test]
+fn rejects_space_separator_between_date_and_time() {
+    // Same length as the T form but uses space — strict T required.
+    assert!(parse_iso8601_or_date("2026-04-01 12:30:45", FLAG).is_err());
+}
+
+#[test]
+fn rejects_fractional_seconds() {
+    assert!(parse_iso8601_or_date("2026-04-01T12:30:45.123Z", FLAG).is_err());
+}
+
+#[test]
+fn rejects_week_date() {
+    assert!(parse_iso8601_or_date("2026-W18-3", FLAG).is_err());
+}
+
+#[test]
+fn rejects_ordinal_date() {
+    assert!(parse_iso8601_or_date("2026-128", FLAG).is_err());
+}
+
+#[test]
+fn rejects_zero_month() {
+    assert!(parse_iso8601_or_date("2026-00-15", FLAG).is_err());
+}
+
+#[test]
+fn rejects_month_above_twelve() {
+    assert!(parse_iso8601_or_date("2026-13-01", FLAG).is_err());
+}
+
+#[test]
+fn rejects_zero_day() {
+    assert!(parse_iso8601_or_date("2026-04-00", FLAG).is_err());
+}
+
+#[test]
+fn rejects_day_above_thirty_one() {
+    assert!(parse_iso8601_or_date("2026-04-32", FLAG).is_err());
+}
+
+#[test]
+fn rejects_hour_above_twenty_three() {
+    assert!(parse_iso8601_or_date("2026-04-01T25:00:00Z", FLAG).is_err());
+}
+
+#[test]
+fn rejects_minute_above_fifty_nine() {
+    assert!(parse_iso8601_or_date("2026-04-01T12:60:00Z", FLAG).is_err());
+}
+
+#[test]
+fn rejects_second_above_sixty() {
+    assert!(parse_iso8601_or_date("2026-04-01T12:30:61Z", FLAG).is_err());
+}
+
+#[test]
+fn rejects_offset_without_colon() {
+    assert!(parse_iso8601_or_date("2026-04-01T12:30:45+0530", FLAG).is_err());
+}
+
+#[test]
+fn rejects_offset_with_invalid_sign() {
+    assert!(parse_iso8601_or_date("2026-04-01T12:30:45 05:30", FLAG).is_err());
+}
+
+#[test]
+fn rejects_offset_hours_above_fourteen() {
+    assert!(parse_iso8601_or_date("2026-04-01T12:30:45+15:00", FLAG).is_err());
+}
+
+#[test]
+fn rejects_non_ascii_input() {
+    // 10 characters but non-ASCII — must not panic on byte indexing.
+    assert!(parse_iso8601_or_date("2026-04-0\u{00E9}", FLAG).is_err());
+}
+
+#[test]
+fn error_message_includes_expected_forms() {
+    let err = parse_iso8601_or_date("nope", FLAG).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("YYYY-MM-DD"));
+    assert!(msg.contains("YYYY-MM-DDTHH:MM:SS"));
+    assert!(msg.contains("YYYY-MM-DDTHH:MM:SSZ"));
+}

--- a/src/validation/datetime_tests.rs
+++ b/src/validation/datetime_tests.rs
@@ -141,6 +141,11 @@ fn rejects_offset_hours_above_fourteen() {
 }
 
 #[test]
+fn rejects_offset_minutes_above_fifty_nine() {
+    assert!(parse_iso8601_or_date("2026-04-01T12:30:45+05:60", FLAG).is_err());
+}
+
+#[test]
 fn rejects_non_ascii_input() {
     // 10 characters but non-ASCII — must not panic on byte indexing.
     assert!(parse_iso8601_or_date("2026-04-0\u{00E9}", FLAG).is_err());
@@ -153,4 +158,5 @@ fn error_message_includes_expected_forms() {
     assert!(msg.contains("YYYY-MM-DD"));
     assert!(msg.contains("YYYY-MM-DDTHH:MM:SS"));
     assert!(msg.contains("YYYY-MM-DDTHH:MM:SSZ"));
+    assert!(msg.contains("YYYY-MM-DDTHH:MM:SS±HH:MM"));
 }

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -1,0 +1,10 @@
+//! Shared client-side input validators.
+//!
+//! Validators here are not tied to a single command — they live in this
+//! module so that any subcommand parsing the same value-shape can call
+//! a single canonical implementation. On failure, validators return
+//! `BzrError::InputValidation`, which exits with code 7.
+
+pub mod datetime;
+
+pub use datetime::parse_iso8601_or_date;

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -8,3 +8,15 @@
 pub mod datetime;
 
 pub use datetime::parse_iso8601_or_date;
+
+use crate::error::Result;
+
+/// Validate an optional date string for use as a Bugzilla search filter.
+///
+/// `None` is passed through unchanged; `Some(s)` is canonicalized via
+/// [`parse_iso8601_or_date`]. Wraps the common
+/// `opt.as_deref().map(|s| parse_iso8601_or_date(s, flag)).transpose()`
+/// idiom used at every CLI date-flag site.
+pub fn parse_optional_date(opt: Option<&str>, flag: &str) -> Result<Option<String>> {
+    opt.map(|s| parse_iso8601_or_date(s, flag)).transpose()
+}

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -82,6 +82,8 @@ impl XmlRpcClient {
             ("alias", &params.alias),
             ("summary", &params.summary),
             ("quicksearch", &params.quicksearch),
+            ("creation_time", &params.creation_time),
+            ("last_change_time", &params.last_change_time),
         ];
         for &(key, value) in option_fields {
             if let Some(ref v) = *value {

--- a/src/xmlrpc/client_tests.rs
+++ b/src/xmlrpc/client_tests.rs
@@ -694,6 +694,36 @@ async fn xmlrpc_get_attachment_by_id_request_body_omits_exclude_fields() {
     assert_eq!(attachment.data.as_deref(), Some("YmU="));
 }
 
+#[tokio::test]
+async fn search_bugs_sends_creation_time_and_last_change_time() {
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/xmlrpc.cgi"))
+        .and(body_string_contains("<name>creation_time</name>"))
+        .and(body_string_contains(
+            "<string>2026-04-01T00:00:00Z</string>",
+        ))
+        .and(body_string_contains("<name>last_change_time</name>"))
+        .and(body_string_contains(
+            "<string>2026-04-15T00:00:00Z</string>",
+        ))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(xmlrpc_bug_response(7, "Date-filtered bug")),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let params = SearchParams {
+        creation_time: Some("2026-04-01T00:00:00Z".into()),
+        last_change_time: Some("2026-04-15T00:00:00Z".into()),
+        ..Default::default()
+    };
+    let bugs = client.search_bugs(&params).await.unwrap();
+    assert_eq!(bugs.len(), 1);
+}
+
 /// Custom wiremock matcher: body must NOT contain the given substring.
 struct NotBodyContains(&'static str);
 

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -448,6 +448,22 @@ if [[ -n "$BUG1" ]]; then
     if assert_success; then test_pass; fi
 else test_skip "no BUG1"; fi
 
+test_begin "45a. bug list --changed-since (recent activity)"
+if [[ -n "$BUG2" ]]; then
+    # Capture a timestamp safely after BUG2 was created/modified, so the
+    # filter window includes BUG2 and excludes any older fixtures. Bugzilla
+    # matches "at or after" inclusively; subtract 5 minutes to tolerate clock
+    # skew between the runner and the container.
+    SINCE_TS=$(date -u -d '5 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+                || date -u -v-5M '+%Y-%m-%dT%H:%M:%SZ')
+    run_bzr bug list --product FuncTestProd --changed-since "$SINCE_TS"
+    if assert_success && assert_json_array_min_length '.' 1; then test_pass; fi
+else test_skip "no BUG2"; fi
+
+test_begin "45b. bug list --changed-since (malformed -> exit 7)"
+run_bzr bug list --product FuncTestProd --changed-since "tomorrow"
+if assert_exit_code 7; then test_pass; fi
+
 test_begin "46. bug view 999999 (negative test)"
 run_bzr bug view 999999
 if assert_failure; then test_pass; fi

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -63,6 +63,57 @@ async fn bug_list_integration() {
 }
 
 #[tokio::test]
+async fn bug_list_changed_since_canonicalizes_bare_date_on_wire() {
+    // End-to-end: a bare-date `--changed-since` value must be canonicalized
+    // to `T00:00:00Z` by the time the REST request hits the server. Failing
+    // this test means either the validator dropped the canonicalization
+    // step or the encoder forgot to forward `last_change_time`.
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("product", "Firefox"))
+        .and(query_param("last_change_time", "2026-04-01T00:00:00Z"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = bzr::cli::BugAction::List {
+        product: vec!["Firefox".into()],
+        component: vec![],
+        status: vec![],
+        assignee: vec![],
+        creator: vec![],
+        priority: vec![],
+        severity: vec![],
+        id: vec![],
+        alias: None,
+        summary: None,
+        limit: 50,
+        fields: None,
+        exclude_fields: None,
+        created_since: None,
+        changed_since: Some("2026-04-01".into()),
+    };
+    let (result, _output) = capture_stdout(bzr::commands::bug::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+    ))
+    .await;
+    assert!(
+        result.is_ok(),
+        "bug list with --changed-since should succeed: {result:?}"
+    );
+    // wiremock's `expect(1)` enforces that exactly one request matched the
+    // canonicalized `last_change_time` query parameter; if the value were
+    // sent as bare `2026-04-01`, the matcher would fail to match and the
+    // response would be a 404, causing `result` to be `Err`.
+}
+
+#[tokio::test]
 async fn bug_view_integration() {
     let (_lock, mock, _tmp) = setup_test_env().await;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -45,6 +45,8 @@ async fn bug_list_integration() {
         limit: 50,
         fields: None,
         exclude_fields: None,
+        created_since: None,
+        changed_since: None,
     };
     let (result, output) = capture_stdout(bzr::commands::bug::execute(
         &action,
@@ -578,6 +580,8 @@ async fn command_with_unknown_server_returns_error() {
         limit: 50,
         fields: None,
         exclude_fields: None,
+        created_since: None,
+        changed_since: None,
     };
     let result = bzr::commands::bug::execute(
         &action,


### PR DESCRIPTION
## Summary

- Add `--created-since` and `--changed-since` to `bzr bug list`, `bzr query save`, and `bzr query run` (the last as overrides matching the existing `--limit` / `--fields` convention).
- New `src/validation/datetime.rs` validator: hand-rolled ISO-8601 + bare-date acceptance (`YYYY-MM-DD`, `YYYY-MM-DDTHH:MM:SS[Z|±HH:MM]`). Bare dates canonicalize to `T00:00:00Z` before being sent. Fractional seconds, week dates, and ordinal dates are rejected. No new crate dependency.
- Retrofit `bzr bug history --since` and `bzr comment list --since` to the same validator. Malformed dates now exit 7 client-side instead of being forwarded to the server.
- `bzr query show` (table + JSON) and the `bzr query list` one-line summary surface both filters when set. Date-only saved queries are now valid (`SavedQuery::has_filters` recognizes them).

## Spec

`docs/superpowers/specs/2026-05-06-issue-157-bug-list-date-filters-design.md`

## Test plan

- [x] `cargo test --workspace --all-features` — 1008 lib + 21 doc + 60 integration, all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `make check-test-layout` — clean (sibling-tests convention preserved)
- [x] Smoke test: `bzr bug list --created-since not-a-date` exits 7 with the validator message naming the flag and the offending input
- [ ] `make functional-test-all` — runs the new Phase 8 cases against a real Bugzilla container

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)