### PR TITLE
feat: bug update list-mutation flags for keywords/cc/groups/see-also

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Legacy `buglist.cgi` URL parameter names (`status_whiteboard`,
   `rep_platform`, `bug_file_loc`) are recognized by `--from-url`.
   Closes #158.
+- `bzr bug update` gains list-mutation flags for four
+  string-typed fields, mirroring the existing
+  `--blocks-add` / `--depends-on-add` convention:
+  `--keywords-add` / `--keywords-remove`,
+  `--cc-add` / `--cc-remove`,
+  `--groups-add` / `--groups-remove`,
+  `--see-also-add` / `--see-also-remove`. Comma-separated values
+  for the first three; `--see-also-*` accepts one URL per flag
+  instance (URLs may legitimately contain commas). Closes #163.
 
 ### Fixed
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -451,6 +451,10 @@ bzr bug update 12345 --status ASSIGNED --assignee dev@example.com
 bzr bug update 12345 --status RESOLVED --resolution FIXED
 bzr bug update 12345 --flag "review?(alice@example.com)"
 bzr bug update 12345 --blocks-add 100,200 --depends-on-add 50
+bzr bug update 12345 --keywords-add fix-needed,regression \
+    --cc-add alice@example.com
+bzr bug update 12345 --see-also-add https://example.com/issue/42 \
+    --see-also-add https://other.example/bug/7
 bzr bug update 100 200 300 --status RESOLVED --resolution DUPLICATE
 ```
 
@@ -469,6 +473,14 @@ bzr bug update 100 200 300 --status RESOLVED --resolution DUPLICATE
 | `--blocks-remove <IDs>` | No | Remove bug IDs from the blocks list (comma-separated) |
 | `--depends-on-add <IDs>` | No | Add bug IDs to the depends-on list (comma-separated) |
 | `--depends-on-remove <IDs>` | No | Remove bug IDs from the depends-on list (comma-separated) |
+| `--keywords-add <K>` | No | Add keywords (comma-separated) |
+| `--keywords-remove <K>` | No | Remove keywords (comma-separated) |
+| `--cc-add <U>` | No | Add CC entries (comma-separated; usernames or emails) |
+| `--cc-remove <U>` | No | Remove CC entries (comma-separated) |
+| `--groups-add <G>` | No | Add groups (comma-separated; requires permission) |
+| `--groups-remove <G>` | No | Remove groups (comma-separated; requires permission) |
+| `--see-also-add <URL>` | No | Add a see-also URL (repeat for multiple; no comma-list) |
+| `--see-also-remove <URL>` | No | Remove a see-also URL (repeat for multiple) |
 
 When updating multiple bugs, failures on individual bugs do not abort the batch. A summary is printed showing which bugs succeeded and which failed.
 

--- a/docs/superpowers/specs/2026-05-07-issue-163-bug-update-list-mutations-design.md
+++ b/docs/superpowers/specs/2026-05-07-issue-163-bug-update-list-mutations-design.md
@@ -1,0 +1,270 @@
+# Issue #163 — `bug update`: list-mutation flags for keywords / cc / groups / see-also
+
+**Date:** 2026-05-07
+**Branch:** `feat/issue-163-bug-update-list-mutations`
+**Tracking:** [#163](https://github.com/randomparity/bzr/issues/163)
+**Spec source:** [bzl-parity review, Issue H](2026-05-06-bzl-parity-review-design.md)
+
+## 1. Problem
+
+`bzl-update` supports `+` / `-` / bare-set syntax for `keywords`, `cc`,
+`groups`, and `see_also`
+(`reference/bzl/bzl-update:74-78,279-290`). `bzr bug update` only supports
+add / remove for two list-typed fields: `blocks` and `depends_on`. To
+mutate the other four list fields a tester has to fall back to the
+Bugzilla web UI.
+
+## 2. Goal
+
+Add four `*-add` / `*-remove` flag pairs to `bzr bug update`, mirroring
+the existing `--blocks-add` / `--blocks-remove` shape:
+
+- `--keywords-add` / `--keywords-remove`
+- `--cc-add` / `--cc-remove`
+- `--groups-add` / `--groups-remove`
+- `--see-also-add` / `--see-also-remove`
+
+Closes [#163](https://github.com/randomparity/bzr/issues/163).
+
+## 3. Non-goals
+
+- **Bare-set / replace syntax** (`--keywords foo,bar` to overwrite).
+  bzl supports it; this issue scopes to incremental edits only.
+- **Field-specific validation** (email regex for CC, URL parsing for
+  see-also). Light trim-and-reject-empty validation only.
+- **Pre-flight permission checks for groups.** The existing `bug update`
+  pattern trusts the server to enforce permissions and surfaces the
+  resulting error. Groups behave identically.
+- **The Issue I scalar flags** (`--alias`, `--deadline`,
+  `--estimated-time`, etc.) are tracked separately.
+
+## 4. Design
+
+### 4.1 Type changes (`src/types/bug.rs`)
+
+Add a sibling type alongside `IdListUpdate`:
+
+```rust
+/// Incremental update to a string-typed list field
+/// (keywords, cc, groups, see_also). Bugzilla accepts
+/// `{ "add": [...], "remove": [...] }` for these fields.
+#[derive(Debug, Default, Serialize)]
+#[non_exhaustive]
+pub struct StringListUpdate {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub add: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub remove: Vec<String>,
+}
+
+impl StringListUpdate {
+    pub fn is_empty(&self) -> bool {
+        self.add.is_empty() && self.remove.is_empty()
+    }
+}
+```
+
+Extend `UpdateBugParams` with four new fields, each guarded by
+`skip_serializing_if`:
+
+```rust
+#[serde(skip_serializing_if = "StringListUpdate::is_empty")]
+pub keywords: StringListUpdate,
+#[serde(skip_serializing_if = "StringListUpdate::is_empty")]
+pub cc: StringListUpdate,
+#[serde(skip_serializing_if = "StringListUpdate::is_empty")]
+pub groups: StringListUpdate,
+#[serde(skip_serializing_if = "StringListUpdate::is_empty")]
+pub see_also: StringListUpdate,
+```
+
+Re-export `StringListUpdate` from `src/types/mod.rs` next to
+`IdListUpdate`.
+
+**Why a sibling type, not a generic `ListUpdate<T>`:** the codebase
+prefers explicit types over generics; the duplication is small and the
+two concrete shapes are short.
+
+### 4.2 CLI surface (`src/cli/bug.rs`)
+
+Eight new `#[arg(long)]` fields on `BugAction::Update`. Three pairs use
+`value_delimiter = ','` matching the existing convention; `see_also`
+does not (URLs may legitimately contain commas):
+
+```rust
+/// Add keywords (comma-separated). Combine with
+/// --keywords-remove for incremental edits.
+#[arg(long, value_delimiter = ',')]
+keywords_add: Vec<String>,
+/// Remove keywords (comma-separated).
+#[arg(long, value_delimiter = ',')]
+keywords_remove: Vec<String>,
+
+/// Add CC entries (comma-separated). Accepts usernames or
+/// email addresses; format is server-defined.
+#[arg(long, value_delimiter = ',')]
+cc_add: Vec<String>,
+/// Remove CC entries (comma-separated).
+#[arg(long, value_delimiter = ',')]
+cc_remove: Vec<String>,
+
+/// Add groups (comma-separated). Group operations require
+/// permission; failures surface from the server.
+#[arg(long, value_delimiter = ',')]
+groups_add: Vec<String>,
+/// Remove groups (comma-separated).
+#[arg(long, value_delimiter = ',')]
+groups_remove: Vec<String>,
+
+/// Add a see-also URL. Repeat the flag to add multiple
+/// (URLs may contain commas, so no comma-list parsing).
+#[arg(long)]
+see_also_add: Vec<String>,
+/// Remove a see-also URL. Repeat the flag to remove multiple.
+#[arg(long)]
+see_also_remove: Vec<String>,
+```
+
+Update the `Update` variant doc comment (`src/cli/bug.rs:524-555`) to
+mention the four new list-mutation fields and add an example showing
+combined use:
+
+```text
+bzr bug update 100 --keywords-add fix-needed,regression \
+  --cc-add alice@example.com --see-also-add https://...
+```
+
+### 4.3 Command plumbing (`src/commands/bug/update.rs`)
+
+Extend `build_update_params` to destructure the eight new args. A
+single small helper performs trim-and-reject-empty validation per field:
+
+```rust
+fn clean_string_list(values: &[String]) -> Result<Vec<String>> {
+    let mut out = Vec::with_capacity(values.len());
+    for raw in values {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err(BzrError::InputValidation(
+                "list value cannot be empty or whitespace-only".to_string(),
+            ));
+        }
+        out.push(trimmed.to_string());
+    }
+    Ok(out)
+}
+```
+
+The validator runs after clap's comma-splitting, so
+`--keywords-add ",,foo"` → `["", "", "foo"]` → first empty value
+rejected. URLs in `--see-also-add` aren't comma-split, so trimming a
+single entry is the only concern there.
+
+The `UpdateBugParams` build site grows linearly; no further extraction
+needed:
+
+```rust
+let params = UpdateBugParams {
+    // ... existing fields ...
+    blocks: IdListUpdate { add: blocks_add.clone(), remove: blocks_remove.clone() },
+    depends_on: IdListUpdate { add: depends_on_add.clone(), remove: depends_on_remove.clone() },
+    keywords: StringListUpdate {
+        add: clean_string_list(keywords_add)?,
+        remove: clean_string_list(keywords_remove)?,
+    },
+    cc: StringListUpdate {
+        add: clean_string_list(cc_add)?,
+        remove: clean_string_list(cc_remove)?,
+    },
+    groups: StringListUpdate {
+        add: clean_string_list(groups_add)?,
+        remove: clean_string_list(groups_remove)?,
+    },
+    see_also: StringListUpdate {
+        add: clean_string_list(see_also_add)?,
+        remove: clean_string_list(see_also_remove)?,
+    },
+};
+```
+
+### 4.4 Client layer
+
+`src/client/bug.rs::update_bug` requires no changes. It serializes
+`UpdateBugParams` whole, and the `skip_serializing_if` guards keep the
+request body minimal when fields are unset. Empty-input case (no new
+flags supplied) sends exactly the same JSON it does today.
+
+### 4.5 Error handling
+
+Empty / whitespace-only values raise `BzrError::InputValidation`
+(exit code 7) before any network call. Server-side rejections (unknown
+keyword, no permission to set group, malformed see-also URL) propagate
+as the existing `BzrError::HttpStatus` / `BzrError::Api` would for any
+other update field — no special-casing.
+
+## 5. Testing
+
+### 5.1 Unit tests
+
+`src/types/bug_tests.rs`:
+
+- `string_list_update_serializes_with_add_and_remove`
+- `string_list_update_skips_empty_add`
+- `string_list_update_skips_empty_remove`
+- `update_bug_params_omits_empty_string_lists`
+- `update_bug_params_serializes_string_lists` — populates all four
+  fields, asserts JSON shape
+  `{"keywords":{"add":[…]},"cc":{"remove":[…]},…}`.
+
+`src/commands/bug/update_tests.rs`:
+
+- `build_update_params_populates_string_lists`
+- `build_update_params_rejects_empty_keyword`
+- `build_update_params_rejects_whitespace_only_cc`
+- `build_update_params_trims_see_also_url`
+
+`src/cli/mod_tests.rs`:
+
+- `bug_update_parses_keywords_add_comma_list`
+- `bug_update_parses_see_also_add_repeated_flag` — confirms repeated
+  `--see-also-add` accumulates without comma-splitting.
+
+### 5.2 Integration tests
+
+One wiremock test in `tests/integration.rs` that posts an update with
+all four list mutations and asserts the JSON request body shape matches
+`{"keywords":{"add":[…],"remove":[…]},…}`.
+
+### 5.3 Functional tests
+
+One scenario in `tests/functional/run-tests.sh`: create a bug, run
+`bzr bug update <id> --keywords-add fix-needed --cc-add functional@example.com`,
+then `bzr bug view <id> --json` and assert both fields appear in the
+output. Skip groups (server-permission dependent) and see-also (URL
+whitelist may be enforced) — focus on the unprivileged happy path.
+
+## 6. Documentation
+
+- `docs/bzr-cli.md` — update the `bug update` section to document the
+  eight new flags. Mirror the `--blocks-add` / `--depends-on-add`
+  style; call out that `--see-also-add` does not split on commas
+  (repeat the flag for multiple URLs).
+- `CHANGELOG.md` — add an entry under the `## [Unreleased]`
+  section: *"`bug update`: list-mutation flags for `keywords`, `cc`,
+  `groups`, `see_also` (closes #163)."*
+
+## 7. Rollout
+
+Single PR on `feat/issue-163-bug-update-list-mutations`. Spec lands in
+the same PR as the implementation.
+
+## 8. Open questions
+
+None at design time. Decisions captured during brainstorming:
+
+| Question | Decision |
+|---|---|
+| Generic vs. sibling type | Sibling `StringListUpdate` |
+| `value_delimiter` for see-also | Drop it for `--see-also-{add,remove}` only |
+| Client-side validation | Light: trim and reject empty/whitespace-only |
+| Group-permission pre-check | None — let server enforce |

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -534,9 +534,11 @@ pub enum BugAction {
     /// `name-`, `name?(user@example.com)`, or `name?,!` to clear.
     /// Repeatable.
     ///
-    /// `--blocks-add` / `--blocks-remove` and `--depends-on-add` /
-    /// `--depends-on-remove` are list-typed (comma-separated) and
-    /// modify dependency relationships incrementally.
+    /// List-typed fields support `*-add` / `*-remove` pairs for
+    /// incremental edits: `--blocks`, `--depends-on`, `--keywords`,
+    /// `--cc`, `--groups`, and `--see-also`. The first five accept
+    /// comma-separated values. `--see-also-add` / `--see-also-remove`
+    /// do not split on commas — repeat the flag to pass multiple URLs.
     ///
     /// On batch updates, partial failures (some bugs updated,
     /// others rejected) exit with code 11 (BatchPartialFailure) and
@@ -548,6 +550,9 @@ pub enum BugAction {
     ///   bzr bug update 100 200 300 --priority high --flag review+
     ///   bzr bug update 100 --blocks-add 200,201 \
     ///     --depends-on-remove 99
+    ///   bzr bug update 100 --keywords-add fix-needed,regression \
+    ///     --cc-add alice@example.com \
+    ///     --see-also-add https://example.com/issue/42
     ///
     /// See bzr-bug-create(1) for new bugs, bzr-bug-clone(1) for
     /// cloning, and bzr-comment-add(1) for adding a comment as part
@@ -618,5 +623,42 @@ pub enum BugAction {
         /// Remove bug IDs from the depends-on list (comma-separated).
         #[arg(long, value_delimiter = ',')]
         depends_on_remove: Vec<u64>,
+        /// Add keywords (comma-separated).
+        ///
+        /// Combine with `--keywords-remove` for incremental edits.
+        #[arg(long, value_delimiter = ',')]
+        keywords_add: Vec<String>,
+        /// Remove keywords (comma-separated).
+        #[arg(long, value_delimiter = ',')]
+        keywords_remove: Vec<String>,
+        /// Add CC entries (comma-separated).
+        ///
+        /// Accepts usernames or email addresses; format is
+        /// server-defined.
+        #[arg(long, value_delimiter = ',')]
+        cc_add: Vec<String>,
+        /// Remove CC entries (comma-separated).
+        #[arg(long, value_delimiter = ',')]
+        cc_remove: Vec<String>,
+        /// Add groups (comma-separated).
+        ///
+        /// Group operations require permission; failures surface
+        /// from the server.
+        #[arg(long, value_delimiter = ',')]
+        groups_add: Vec<String>,
+        /// Remove groups (comma-separated).
+        #[arg(long, value_delimiter = ',')]
+        groups_remove: Vec<String>,
+        /// Add a see-also URL.
+        ///
+        /// Repeat the flag to add multiple URLs (URLs may contain
+        /// commas, so no comma-list parsing is performed).
+        #[arg(long)]
+        see_also_add: Vec<String>,
+        /// Remove a see-also URL.
+        ///
+        /// Repeat the flag to remove multiple URLs.
+        #[arg(long)]
+        see_also_remove: Vec<String>,
     },
 }

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -1441,3 +1441,92 @@ fn query_run_parses_158_field_filter_overrides() {
     assert_eq!(qa_contact, vec!["newqa@example.com"]);
     assert_eq!(url, vec!["gitlab.com/x"]);
 }
+
+#[test]
+fn parse_bug_update_keywords_add_comma_list() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "bug",
+        "update",
+        "100",
+        "--keywords-add",
+        "fix-needed,regression",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Bug {
+            action: BugAction::Update { keywords_add, .. },
+        } => {
+            assert_eq!(keywords_add, vec!["fix-needed", "regression"]);
+        }
+        _ => panic!("expected Bug Update"),
+    }
+}
+
+#[test]
+fn parse_bug_update_cc_add_comma_list() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "bug",
+        "update",
+        "100",
+        "--cc-add",
+        "a@example.com,b@example.com",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Bug {
+            action: BugAction::Update { cc_add, .. },
+        } => {
+            assert_eq!(cc_add, vec!["a@example.com", "b@example.com"]);
+        }
+        _ => panic!("expected Bug Update"),
+    }
+}
+
+#[test]
+fn parse_bug_update_groups_remove_comma_list() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "bug",
+        "update",
+        "100",
+        "--groups-remove",
+        "secret,internal",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Bug {
+            action: BugAction::Update { groups_remove, .. },
+        } => {
+            assert_eq!(groups_remove, vec!["secret", "internal"]);
+        }
+        _ => panic!("expected Bug Update"),
+    }
+}
+
+#[test]
+fn parse_bug_update_see_also_add_repeated_flag() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "bug",
+        "update",
+        "100",
+        "--see-also-add",
+        "https://a.example/?x=1,y=2",
+        "--see-also-add",
+        "https://b.example/issue/3",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Bug {
+            action: BugAction::Update { see_also_add, .. },
+        } => {
+            assert_eq!(
+                see_also_add,
+                vec!["https://a.example/?x=1,y=2", "https://b.example/issue/3"]
+            );
+        }
+        _ => panic!("expected Bug Update"),
+    }
+}

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -42,6 +42,7 @@ fn build_update_params(action: &BugAction) -> Result<(Vec<u64>, UpdateBugParams)
             add: depends_on_add.clone(),
             remove: depends_on_remove.clone(),
         },
+        ..Default::default()
     };
     Ok((ids.clone(), params))
 }

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -19,6 +19,14 @@ fn build_update_params(action: &BugAction) -> Result<(Vec<u64>, UpdateBugParams)
         blocks_remove,
         depends_on_add,
         depends_on_remove,
+        keywords_add: _keywords_add,
+        keywords_remove: _keywords_remove,
+        cc_add: _cc_add,
+        cc_remove: _cc_remove,
+        groups_add: _groups_add,
+        groups_remove: _groups_remove,
+        see_also_add: _see_also_add,
+        see_also_remove: _see_also_remove,
     } = action
     else {
         unreachable!()

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -2,7 +2,21 @@ use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
 use crate::output::{self, ActionResult, BatchFailure, BatchResult, ResourceKind};
-use crate::types::{IdListUpdate, OutputFormat, UpdateBugParams};
+use crate::types::{IdListUpdate, OutputFormat, StringListUpdate, UpdateBugParams};
+
+fn clean_string_list(values: &[String]) -> Result<Vec<String>> {
+    let mut out = Vec::with_capacity(values.len());
+    for raw in values {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err(crate::error::BzrError::InputValidation(
+                "list value cannot be empty or whitespace-only".to_string(),
+            ));
+        }
+        out.push(trimmed.to_string());
+    }
+    Ok(out)
+}
 
 fn build_update_params(action: &BugAction) -> Result<(Vec<u64>, UpdateBugParams)> {
     let BugAction::Update {
@@ -19,14 +33,14 @@ fn build_update_params(action: &BugAction) -> Result<(Vec<u64>, UpdateBugParams)
         blocks_remove,
         depends_on_add,
         depends_on_remove,
-        keywords_add: _keywords_add,
-        keywords_remove: _keywords_remove,
-        cc_add: _cc_add,
-        cc_remove: _cc_remove,
-        groups_add: _groups_add,
-        groups_remove: _groups_remove,
-        see_also_add: _see_also_add,
-        see_also_remove: _see_also_remove,
+        keywords_add,
+        keywords_remove,
+        cc_add,
+        cc_remove,
+        groups_add,
+        groups_remove,
+        see_also_add,
+        see_also_remove,
     } = action
     else {
         unreachable!()
@@ -50,7 +64,22 @@ fn build_update_params(action: &BugAction) -> Result<(Vec<u64>, UpdateBugParams)
             add: depends_on_add.clone(),
             remove: depends_on_remove.clone(),
         },
-        ..Default::default()
+        keywords: StringListUpdate {
+            add: clean_string_list(keywords_add)?,
+            remove: clean_string_list(keywords_remove)?,
+        },
+        cc: StringListUpdate {
+            add: clean_string_list(cc_add)?,
+            remove: clean_string_list(cc_remove)?,
+        },
+        groups: StringListUpdate {
+            add: clean_string_list(groups_add)?,
+            remove: clean_string_list(groups_remove)?,
+        },
+        see_also: StringListUpdate {
+            add: clean_string_list(see_also_add)?,
+            remove: clean_string_list(see_also_remove)?,
+        },
     };
     Ok((ids.clone(), params))
 }

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -20,6 +20,14 @@ fn make_update_action(ids: Vec<u64>) -> BugAction {
         blocks_remove: vec![],
         depends_on_add: vec![],
         depends_on_remove: vec![],
+        keywords_add: vec![],
+        keywords_remove: vec![],
+        cc_add: vec![],
+        cc_remove: vec![],
+        groups_add: vec![],
+        groups_remove: vec![],
+        see_also_add: vec![],
+        see_also_remove: vec![],
     }
 }
 

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::unwrap_used)]
+
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
@@ -27,6 +29,38 @@ fn make_update_action(ids: Vec<u64>) -> BugAction {
         groups_add: vec![],
         groups_remove: vec![],
         see_also_add: vec![],
+        see_also_remove: vec![],
+    }
+}
+
+fn make_update_action_with_lists(
+    keywords_add: Vec<&str>,
+    cc_add: Vec<&str>,
+    groups_remove: Vec<&str>,
+    see_also_add: Vec<&str>,
+) -> BugAction {
+    let to_strings = |v: Vec<&str>| v.into_iter().map(String::from).collect();
+    BugAction::Update {
+        ids: vec![1],
+        status: None,
+        resolution: None,
+        assignee: None,
+        priority: None,
+        severity: None,
+        summary: None,
+        whiteboard: None,
+        flag: vec![],
+        blocks_add: vec![],
+        blocks_remove: vec![],
+        depends_on_add: vec![],
+        depends_on_remove: vec![],
+        keywords_add: to_strings(keywords_add),
+        keywords_remove: vec![],
+        cc_add: to_strings(cc_add),
+        cc_remove: vec![],
+        groups_add: vec![],
+        groups_remove: to_strings(groups_remove),
+        see_also_add: to_strings(see_also_add),
         see_also_remove: vec![],
     }
 }
@@ -116,4 +150,47 @@ async fn bug_update_batch_table_format_all_succeed() {
     assert!(output.contains("Updated bugs:"));
     assert!(output.contains("#1"));
     assert!(output.contains("#2"));
+}
+
+#[test]
+fn build_update_params_populates_string_lists() {
+    let action = make_update_action_with_lists(
+        vec!["fix-needed"],
+        vec!["alice@example.com"],
+        vec!["secret"],
+        vec!["https://example.com/issue/1"],
+    );
+    let (ids, params) = super::build_update_params(&action).unwrap();
+    assert_eq!(ids, vec![1]);
+    assert_eq!(params.keywords.add, vec!["fix-needed"]);
+    assert_eq!(params.cc.add, vec!["alice@example.com"]);
+    assert_eq!(params.groups.remove, vec!["secret"]);
+    assert_eq!(params.see_also.add, vec!["https://example.com/issue/1"]);
+}
+
+#[test]
+fn build_update_params_trims_string_list_values() {
+    let action = make_update_action_with_lists(
+        vec!["  fix-needed  "],
+        vec![],
+        vec![],
+        vec!["  https://example.com/issue/1  "],
+    );
+    let (_ids, params) = super::build_update_params(&action).unwrap();
+    assert_eq!(params.keywords.add, vec!["fix-needed"]);
+    assert_eq!(params.see_also.add, vec!["https://example.com/issue/1"]);
+}
+
+#[test]
+fn build_update_params_rejects_empty_keyword() {
+    let action = make_update_action_with_lists(vec!["", "fix-needed"], vec![], vec![], vec![]);
+    let err = super::build_update_params(&action).unwrap_err();
+    assert!(matches!(err, crate::error::BzrError::InputValidation(_)));
+}
+
+#[test]
+fn build_update_params_rejects_whitespace_only_cc() {
+    let action = make_update_action_with_lists(vec![], vec!["   "], vec![], vec![]);
+    let err = super::build_update_params(&action).unwrap_err();
+    assert!(matches!(err, crate::error::BzrError::InputValidation(_)));
 }

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -478,6 +478,24 @@ impl IdListUpdate {
     }
 }
 
+/// Represents an incremental update to a string-typed list field
+/// (keywords, cc, groups, `see_also`). Bugzilla accepts
+/// `{ "add": [...], "remove": [...] }` for these fields.
+#[derive(Debug, Default, Serialize)]
+#[non_exhaustive]
+pub struct StringListUpdate {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub add: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub remove: Vec<String>,
+}
+
+impl StringListUpdate {
+    pub fn is_empty(&self) -> bool {
+        self.add.is_empty() && self.remove.is_empty()
+    }
+}
+
 #[derive(Debug, Default, Serialize)]
 #[non_exhaustive]
 pub struct UpdateBugParams {

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -519,6 +519,14 @@ pub struct UpdateBugParams {
     pub blocks: IdListUpdate,
     #[serde(skip_serializing_if = "IdListUpdate::is_empty")]
     pub depends_on: IdListUpdate,
+    #[serde(skip_serializing_if = "StringListUpdate::is_empty")]
+    pub keywords: StringListUpdate,
+    #[serde(skip_serializing_if = "StringListUpdate::is_empty")]
+    pub cc: StringListUpdate,
+    #[serde(skip_serializing_if = "StringListUpdate::is_empty")]
+    pub groups: StringListUpdate,
+    #[serde(skip_serializing_if = "StringListUpdate::is_empty")]
+    pub see_also: StringListUpdate,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/types/bug_tests.rs
+++ b/src/types/bug_tests.rs
@@ -751,3 +751,63 @@ fn apply_overrides_default_is_noop() {
     assert_eq!(p.whiteboard, vec!["wip"]);
     assert_eq!(p.creation_time.as_deref(), Some("2026-04-01T00:00:00Z"));
 }
+
+#[test]
+fn string_list_update_is_empty_when_both_empty() {
+    let upd = StringListUpdate {
+        add: vec![],
+        remove: vec![],
+    };
+    assert!(upd.is_empty());
+}
+
+#[test]
+fn string_list_update_not_empty_when_only_add() {
+    let upd = StringListUpdate {
+        add: vec!["fix-needed".to_string()],
+        remove: vec![],
+    };
+    assert!(!upd.is_empty());
+}
+
+#[test]
+fn string_list_update_not_empty_when_only_remove() {
+    let upd = StringListUpdate {
+        add: vec![],
+        remove: vec!["regression".to_string()],
+    };
+    assert!(!upd.is_empty());
+}
+
+#[test]
+fn string_list_update_serializes_with_add_and_remove() {
+    let upd = StringListUpdate {
+        add: vec!["a".to_string(), "b".to_string()],
+        remove: vec!["c".to_string()],
+    };
+    let json = serde_json::to_value(&upd).unwrap();
+    assert_eq!(
+        json,
+        serde_json::json!({"add": ["a", "b"], "remove": ["c"]})
+    );
+}
+
+#[test]
+fn string_list_update_skips_empty_add() {
+    let upd = StringListUpdate {
+        add: vec![],
+        remove: vec!["c".to_string()],
+    };
+    let json = serde_json::to_value(&upd).unwrap();
+    assert_eq!(json, serde_json::json!({"remove": ["c"]}));
+}
+
+#[test]
+fn string_list_update_skips_empty_remove() {
+    let upd = StringListUpdate {
+        add: vec!["a".to_string()],
+        remove: vec![],
+    };
+    let json = serde_json::to_value(&upd).unwrap();
+    assert_eq!(json, serde_json::json!({"add": ["a"]}));
+}

--- a/src/types/bug_tests.rs
+++ b/src/types/bug_tests.rs
@@ -811,3 +811,50 @@ fn string_list_update_skips_empty_remove() {
     let json = serde_json::to_value(&upd).unwrap();
     assert_eq!(json, serde_json::json!({"add": ["a"]}));
 }
+
+#[test]
+fn update_bug_params_omits_empty_string_lists() {
+    let params = UpdateBugParams::default();
+    let json = serde_json::to_value(&params).unwrap();
+    assert!(json.get("keywords").is_none());
+    assert!(json.get("cc").is_none());
+    assert!(json.get("groups").is_none());
+    assert!(json.get("see_also").is_none());
+}
+
+#[test]
+fn update_bug_params_serializes_string_lists() {
+    let params = UpdateBugParams {
+        keywords: StringListUpdate {
+            add: vec!["fix-needed".to_string()],
+            remove: vec!["wontfix".to_string()],
+        },
+        cc: StringListUpdate {
+            add: vec!["alice@example.com".to_string()],
+            remove: vec![],
+        },
+        groups: StringListUpdate {
+            add: vec![],
+            remove: vec!["secret".to_string()],
+        },
+        see_also: StringListUpdate {
+            add: vec!["https://example.com/issue/1".to_string()],
+            remove: vec![],
+        },
+        ..Default::default()
+    };
+    let json = serde_json::to_value(&params).unwrap();
+    assert_eq!(
+        json["keywords"],
+        serde_json::json!({"add": ["fix-needed"], "remove": ["wontfix"]})
+    );
+    assert_eq!(
+        json["cc"],
+        serde_json::json!({"add": ["alice@example.com"]})
+    );
+    assert_eq!(json["groups"], serde_json::json!({"remove": ["secret"]}));
+    assert_eq!(
+        json["see_also"],
+        serde_json::json!({"add": ["https://example.com/issue/1"]})
+    );
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,7 +10,7 @@ pub use attachment::{Attachment, UpdateAttachmentParams, UploadAttachmentParams}
 pub use bug::{
     partition_filters, Bug, BugTemplate, CreateBugParams, FieldChange, FieldMapping, FieldValue,
     HistoryEntry, IdListUpdate, NegationOp, Overrides, QueryKind, SavedQuery, SearchParams,
-    StatusTransition, UpdateBugParams, FIELD_MAPPINGS,
+    StatusTransition, StringListUpdate, UpdateBugParams, FIELD_MAPPINGS,
 };
 pub use comment::{Comment, UpdateCommentTagsParams};
 pub use common::{

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -660,6 +660,36 @@ if [[ -n "$BUG3" ]] && [[ -n "$BUG2" ]]; then
     if assert_success; then test_pass; fi
 else test_skip "no BUG3/BUG2"; fi
 
+test_begin "53a. bug update --keywords-add (single keyword)"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug update "$BUG1" --keywords-add "fix-needed"
+    if assert_success; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "53b. bug view shows new keyword"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug view "$BUG1" --json
+    if assert_success && assert_stdout_contains "fix-needed"; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "53c. bug update --keywords-remove"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug update "$BUG1" --keywords-remove "fix-needed"
+    if assert_success; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "53d. bug update --cc-add (single user)"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug update "$BUG1" --cc-add "testuser@test.bzr"
+    if assert_success; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "53e. bug update --cc-remove"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug update "$BUG1" --cc-remove "testuser@test.bzr"
+    if assert_success; then test_pass; fi
+else test_skip "no BUG1"; fi
+
 echo ""
 
 # ══════════════════════════════════════════════════════════════════════

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -712,10 +712,18 @@ async fn bug_history_integration() {
 
 #[tokio::test]
 async fn bug_update_integration() {
+    use wiremock::matchers::body_partial_json;
+
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("PUT"))
         .and(path("/rest/bug/42"))
+        .and(body_partial_json(serde_json::json!({
+            "keywords": {"add": ["fix-needed"], "remove": ["wontfix"]},
+            "cc": {"add": ["alice@example.com"]},
+            "groups": {"remove": ["secret"]},
+            "see_also": {"add": ["https://example.com/issue/1"]},
+        })))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "bugs": [{"id": 42, "changes": {}}]
         })))
@@ -737,13 +745,13 @@ async fn bug_update_integration() {
         blocks_remove: vec![],
         depends_on_add: vec![],
         depends_on_remove: vec![],
-        keywords_add: vec![],
-        keywords_remove: vec![],
-        cc_add: vec![],
+        keywords_add: vec!["fix-needed".to_string()],
+        keywords_remove: vec!["wontfix".to_string()],
+        cc_add: vec!["alice@example.com".to_string()],
         cc_remove: vec![],
         groups_add: vec![],
-        groups_remove: vec![],
-        see_also_add: vec![],
+        groups_remove: vec!["secret".to_string()],
+        see_also_add: vec!["https://example.com/issue/1".to_string()],
         see_also_remove: vec![],
     };
     let (result, output) = capture_stdout(bzr::commands::bug::execute(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -737,6 +737,14 @@ async fn bug_update_integration() {
         blocks_remove: vec![],
         depends_on_add: vec![],
         depends_on_remove: vec![],
+        keywords_add: vec![],
+        keywords_remove: vec![],
+        cc_add: vec![],
+        cc_remove: vec![],
+        groups_add: vec![],
+        groups_remove: vec![],
+        see_also_add: vec![],
+        see_also_remove: vec![],
     };
     let (result, output) = capture_stdout(bzr::commands::bug::execute(
         &action,


### PR DESCRIPTION
## Summary

- Adds `*-add` / `*-remove` flag pairs to `bzr bug update` for four string-typed list fields (`--keywords`, `--cc`, `--groups`, `--see-also`), mirroring the existing `--blocks-add` / `--depends-on-add` convention.
- Comma-separated values for keywords/cc/groups; `--see-also-*` accepts one URL per flag instance (URLs may legitimately contain commas).
- Trim-and-reject-empty validation runs before the network call, returning `BzrError::InputValidation` (exit code 7) on whitespace-only values.

Closes #163.

## Design

Spec: [`docs/superpowers/specs/2026-05-07-issue-163-bug-update-list-mutations-design.md`](docs/superpowers/specs/2026-05-07-issue-163-bug-update-list-mutations-design.md)

A new `StringListUpdate` type sits next to the existing `IdListUpdate` in `src/types/bug.rs` (`{ add: Vec<String>, remove: Vec<String> }` with `skip_serializing_if`). `UpdateBugParams` gains four fields wired to it. `build_update_params` in `src/commands/bug/update.rs` routes each through a small `clean_string_list` helper that trims and rejects empty values.

## Test plan

- [x] `cargo test` — 1150 tests (1068 unit + 21 + 61 integration), all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `make lint && make check-test-layout` clean
- [x] `bzr bug update --help` shows all 8 new flags
- [x] Integration test asserts wire-level request body shape via `body_partial_json` (5 of 8 list fields populated, 3 explicitly empty)
- [x] Functional tests 53a–53e exercise `--keywords-add/-remove` and `--cc-add/-remove` against a live Bugzilla container (groups/see-also intentionally omitted: deployment-permission and URL-whitelist sensitivities)

## Follow-ups

Three non-blocking observations from final review have been filed as separate issues:

- #174 — `clean_string_list` error should identify which flag failed
- #175 — functional test should round-trip-assert cc add/remove
- #176 — symmetric unit-test coverage for `_remove` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)