### PR TITLE
feat(bug update): atomic --comment / --comment-file / --comment-private (closes #161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `--see-also-add` / `--see-also-remove`. Comma-separated values
   for the first three; `--see-also-*` accepts one URL per flag
   instance (URLs may legitimately contain commas). Closes #163.
+- `bzr bug update --comment <BODY>` (or `--comment-file <PATH>`)
+  posts a comment atomically with the field changes — a single
+  `Bug.update` REST call instead of a separate `bzr comment add`.
+  `--comment-private` marks the comment private. Mutually exclusive
+  with each other; `--comment-private` requires one of the body
+  flags. Empty / whitespace-only bodies are rejected (exit 7).
+  Closes #161.
 
 ### Fixed
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -446,6 +446,8 @@ Agent note: cloning without overrides copies metadata from the source bug, which
 
 Modify fields on an existing bug. Supports multiple IDs for batch updates.
 
+A comment may be posted atomically with the update via `--comment` or `--comment-file`; this avoids the need for a separate `bzr comment add` call.
+
 ```bash
 bzr bug update 12345 --status ASSIGNED --assignee dev@example.com
 bzr bug update 12345 --status RESOLVED --resolution FIXED
@@ -455,6 +457,8 @@ bzr bug update 12345 --keywords-add fix-needed,regression \
     --cc-add alice@example.com
 bzr bug update 12345 --see-also-add https://example.com/issue/42 \
     --see-also-add https://other.example/bug/7
+bzr bug update 12345 --status RESOLVED --resolution FIXED \
+    --comment "Fixed by patch in #200"
 bzr bug update 100 200 300 --status RESOLVED --resolution DUPLICATE
 ```
 
@@ -481,6 +485,9 @@ bzr bug update 100 200 300 --status RESOLVED --resolution DUPLICATE
 | `--groups-remove <G>` | No | Remove groups (comma-separated; requires permission) |
 | `--see-also-add <URL>` | No | Add a see-also URL (repeat for multiple; no comma-list) |
 | `--see-also-remove <URL>` | No | Remove a see-also URL (repeat for multiple) |
+| `--comment <BODY>` | No | Post a comment atomically with the field changes (mutually exclusive with `--comment-file`) |
+| `--comment-file <PATH>` | No | Read the comment body from a UTF-8 file (mutually exclusive with `--comment`; missing or non-UTF-8 paths exit 7) |
+| `--comment-private` | No | Mark the comment private (requires `--comment` or `--comment-file`) |
 
 When updating multiple bugs, failures on individual bugs do not abort the batch. A summary is printed showing which bugs succeeded and which failed.
 

--- a/docs/superpowers/specs/2026-05-07-bug-update-comment-design.md
+++ b/docs/superpowers/specs/2026-05-07-bug-update-comment-design.md
@@ -1,0 +1,282 @@
+# `bzr bug update`: post a comment atomically with field changes
+
+**Date:** 2026-05-07
+**Issue:** [#161](https://github.com/randomparity/bzr/issues/161)
+**Parent spec:** `docs/superpowers/specs/2026-05-06-bzl-parity-review-design.md` (Issue F)
+**Status:** approved, pending implementation plan
+
+## 1. Summary
+
+Add `--comment <BODY>`, `--comment-file <PATH>`, and `--comment-private` to
+`bzr bug update`. The comment is folded into the same `Bug.update` request
+payload, so a status-change-with-explanation closes in one round-trip
+instead of two (`bzr bug update` followed by `bzr comment add`). This is
+the most common tester workflow regression flagged by the bzl-parity
+review.
+
+## 2. Background
+
+Bugzilla's REST `PUT /rest/bug/{id}` accepts a nested `comment: {body,
+is_private}` sub-object on the request body. `bzl-update` exploits this
+(`reference/bzl/bzl-update:288-309`); `bzr bug update` does not. Today
+testers must run two commands and there is no atomicity guarantee — the
+field change can land while the comment fails (or vice versa).
+
+`bzr` already has all the supporting machinery:
+
+- `UpdateBugParams` (`src/types/bug.rs:501`) is the typed request body
+  for `update_bug`.
+- `BugzillaClient::update_bug` (`src/client/bug.rs:365`) does the PUT.
+- `bzr bug create --description-file` (`src/cli/bug.rs:362-370`) is a
+  precedent for file→string CLI input.
+- `bzr comment add` (`src/commands/comment.rs:36-39`) is the precedent
+  for empty-body rejection.
+
+## 3. Scope
+
+### In scope
+
+- New CLI flags `--comment`, `--comment-file`, `--comment-private` on
+  `bzr bug update`.
+- New `CommentUpdate` type in `src/types/bug.rs`, plus a
+  `comment: Option<CommentUpdate>` field on `UpdateBugParams`.
+- Validation: file must exist and be UTF-8; empty / whitespace-only
+  bodies rejected; `--comment-private` alone (no body source) rejected;
+  `--comment` and `--comment-file` mutually exclusive.
+- Batch behavior: the comment ships in every per-bug `PUT`, so each
+  successful bug receives the same comment (matches bzl semantics).
+- Output: table-mode success line gains a `(with comment)` suffix when
+  a comment was posted; JSON output is unchanged.
+- Tests: sibling unit tests in `update_tests.rs`, `bug_tests.rs`, and
+  `bug_tests.rs` (client); functional tests in `tests/functional/` for
+  Phase 9 (Comments).
+- Docs: `docs/bzr-cli.md` updated with the three new flags;
+  `CHANGELOG.md` entry under the next unreleased version.
+
+### Out of scope
+
+- `--private-comment <BODY>` (bzl shorthand) — superseded by
+  `--comment X --comment-private`.
+- `comment-is-private` — a separate bzl flag for *editing the privacy
+  of existing comments*; different REST endpoint.
+- Stdin / `$EDITOR` fallback for the comment body. `bzr bug update` is
+  heavily scripted and a silent EDITOR launch would surprise pipelines;
+  a body must be supplied explicitly via `--comment` or
+  `--comment-file`.
+- `--dupe-of` (issue G/#162), umbrella list-mutation flags (issue H),
+  and other `bug update` field gaps — tracked separately.
+
+## 4. CLI surface
+
+Three new flags on `BugAction::Update` in `src/cli/bug.rs`:
+
+```rust
+/// Post a comment atomically with the field changes.
+///
+/// Mutually exclusive with `--comment-file`. Use `--comment-private`
+/// to mark the comment private.
+#[arg(long, value_name = "BODY", conflicts_with = "comment_file")]
+comment: Option<String>,
+
+/// Read the comment body from a UTF-8 file.
+///
+/// Mutually exclusive with `--comment`. The file must exist and be
+/// readable; non-existent paths or non-UTF-8 contents fail with
+/// exit code 7. Empty / whitespace-only contents are also rejected.
+#[arg(long, value_name = "PATH", conflicts_with = "comment")]
+comment_file: Option<std::path::PathBuf>,
+
+/// Mark the comment private (visible only to users with elevated
+/// permissions on the server).
+///
+/// Requires `--comment` or `--comment-file`; using `--comment-private`
+/// alone is a usage error (exit 7).
+#[arg(long)]
+comment_private: bool,
+```
+
+The verbatim doc-comment on `Update` gains a paragraph between the
+flag-syntax paragraph and the list-mutation paragraph:
+
+> `--comment <BODY>` (or `--comment-file <PATH>`) posts a comment
+> atomically with the field changes — a single `Bug.update` round-trip
+> rather than a separate `bzr comment add` call. `--comment-private`
+> marks it private. Empty / whitespace-only bodies are rejected
+> (exit 7).
+
+The "See also" footer drops the `bzr-comment-add(1) for adding a comment
+as part of a status change` framing — the gap is closed; that page now
+covers stand-alone comments only.
+
+A new example is added to the verbatim doc-comment:
+
+```text
+bzr bug update 100 --status RESOLVED --resolution FIXED \
+  --comment "Fixed by patch in #200"
+```
+
+## 5. Types
+
+Add to `src/types/bug.rs`:
+
+```rust
+/// A comment to post atomically with a `Bug.update` call.
+///
+/// Serializes as `{"body": "...", "is_private": <bool>}`. Bugzilla's
+/// REST `Bug.update` accepts this as a sub-object on the request,
+/// which delivers the field changes and the comment in one round-trip.
+#[derive(Debug, Default, Serialize)]
+#[non_exhaustive]
+pub struct CommentUpdate {
+    pub body: String,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub is_private: bool,
+}
+```
+
+Extend `UpdateBugParams`:
+
+```rust
+#[serde(skip_serializing_if = "Option::is_none")]
+pub comment: Option<CommentUpdate>,
+```
+
+Re-export in `src/types/mod.rs` next to `UpdateBugParams`:
+
+```rust
+StatusTransition, StringListUpdate, UpdateBugParams, CommentUpdate, FIELD_MAPPINGS,
+```
+
+Notes:
+
+- `is_private: false` is skipped on the wire so request bodies stay
+  minimal — matches how `StringListUpdate`'s empty fields are skipped
+  today.
+- `body` is owned `String` (not `&str`) so the lifetime survives batch
+  iteration through `client.update_bug`.
+
+## 6. Command wiring
+
+Changes in `src/commands/bug/update.rs`:
+
+1. **Destructure** `comment`, `comment_file`, `comment_private` in the
+   pattern at the top of `build_update_params`.
+2. **Resolve the body source** before constructing `UpdateBugParams`:
+   - Both `comment` and `comment_file` are `None` and
+     `comment_private` is `true` → `BzrError::InputValidation(
+     "--comment-private requires --comment or --comment-file")`.
+   - `comment` is `Some(s)` → use `s` directly.
+   - `comment_file` is `Some(path)` → read via
+     `std::fs::read_to_string(path)`. Map `io::Error` and non-UTF-8
+     errors to `BzrError::InputValidation` with a path-bearing
+     message (mirrors `--description-file` behavior in
+     `bzr bug create`). The read helper is a 5-line local function
+     in `update.rs` — not extracted to a shared module yet (we'll
+     extract when a third consumer appears, e.g. `attachment upload
+     --comment-file` from issue J).
+   - Whitespace-only body → `BzrError::InputValidation(
+     "empty comment, aborting")` (same wording as `bzr comment add`).
+3. **Build `Option<CommentUpdate>`** and assign to `params.comment`.
+   `is_private` comes from `comment_private`.
+
+Output handling:
+
+- `update_single`: when `params.comment.is_some()`, the table-mode
+  message becomes `Updated bug #N (with comment)`. JSON output remains
+  `ActionResult::updated(id, ResourceKind::Bug)` (no schema churn — the
+  Bugzilla REST response does not return a comment ID for the inline
+  comment, so a structured field would be a meaningless boolean).
+- `update_batch`: in `print_batch_result`'s table branch, when a
+  comment was posted, the existing `Updated bugs: #1, #2` line gains a
+  ` (with comment)` suffix. Failed-bug lines are unchanged. Per-bug
+  failures still surface with exit code 11.
+
+## 7. Error handling and exit codes
+
+No new `BzrError` variants. Existing variants cover all paths:
+
+| Condition | Variant | Exit code |
+| --- | --- | --- |
+| `--comment` and `--comment-file` together | clap usage error | 2 |
+| `--comment-private` without body source | `InputValidation` | 7 |
+| `--comment-file` path missing | `InputValidation` | 7 |
+| `--comment-file` not UTF-8 | `InputValidation` | 7 |
+| Empty / whitespace body | `InputValidation` | 7 |
+| Server rejects the comment (permissions, locked bug, etc.) | `Api` / `HttpStatus` | 4 / per-status |
+| Batch: some bugs succeed, some fail | `BatchPartialFailure` | 11 |
+| Batch: all bugs fail | first error's exit code | as today |
+
+## 8. Tests
+
+### Sibling unit tests — `src/commands/bug/update_tests.rs`
+
+1. `build_update_params` carries the comment when `--comment "hi"` is
+   passed (`params.comment == Some(CommentUpdate { body: "hi",
+   is_private: false })`).
+2. `--comment "hi" --comment-private` → `is_private: true`.
+3. `--comment-file` with a UTF-8 tempfile → body equals contents.
+4. `--comment-file` with a missing path → `BzrError::InputValidation`,
+   path included in the message.
+5. `--comment-file` with non-UTF-8 contents (`[0xff, 0xfe, 0xfd]`) →
+   `InputValidation`.
+6. Empty / whitespace-only body rejected (`--comment "   "` and
+   `--comment-file` pointing at a whitespace file).
+7. `--comment-private` alone → `InputValidation(
+   "--comment-private requires --comment or --comment-file")`.
+8. `--comment` and `--comment-file` together rejected at clap level
+   (`Cli::try_parse_from` style if used elsewhere in the file).
+
+### Sibling unit tests — `src/types/bug_tests.rs`
+
+9. `CommentUpdate { body: "hi", is_private: false }` serializes to
+   `{"body":"hi"}` (no `is_private` key).
+10. `CommentUpdate { body: "hi", is_private: true }` serializes to
+    `{"body":"hi","is_private":true}`.
+11. `UpdateBugParams::default()` (with `comment: None`) emits no
+    `comment` key.
+12. `UpdateBugParams` with both `summary` and `comment` set emits both
+    keys, no extras.
+
+### Sibling unit test — `src/client/bug_tests.rs`
+
+13. `update_bug` with a comment in params: wiremock matches `PUT
+    /bug/{id}` with the nested `comment` object in the body; response
+    success → `Ok(())`.
+
+### Functional tests — `tests/functional/`
+
+14. **Atomic field + comment** (Phase 9): `bzr bug update <id> --status
+    RESOLVED --resolution FIXED --comment "see #other"`. Assert
+    `bzr bug view <id>` shows `RESOLVED`/`FIXED` AND `bzr comment list
+    <id>` shows the new comment, with a creation timestamp matching
+    the update. This is the literal test plan from the issue.
+15. **Private comment** (Phase 9): `bzr bug update <id> --comment "hi"
+    --comment-private`. Assert `bzr comment list <id> --json |
+    jq '.comments[-1].is_private'` is `true`.
+16. **Batch atomicity** (Phase 9): `bzr bug update <id1> <id2>
+    --comment "batch"`. Assert each bug's comment list grew by one.
+
+## 9. Documentation
+
+- `docs/bzr-cli.md` — `bzr bug update` section gains the three new
+  flags and a short paragraph about atomicity.
+- `CHANGELOG.md` — entry under the next unreleased `[X.Y.Z]`:
+  `bug update: post a comment atomically with field changes via
+  --comment/--comment-file/--comment-private (#161)`. Per the
+  CLAUDE.md convention, the entry lands in the implementation PR
+  alongside the code, not in a later release-prep commit.
+- The verbatim doc-comment on `Update` (Section 4) is the
+  authoritative source for `--help` and the generated man page.
+
+## 10. Open questions
+
+None. All design questions resolved during brainstorming:
+
+- Q1 (stdin/`$EDITOR` fallback): no — strictly opt-in.
+- Q2 (comment-only update with no field changes): allowed.
+- Q3 (output): table-mode tag only; JSON unchanged.
+- Q4 (file validation): mirrors `--description-file` behavior.
+- Approach selection: nested `CommentUpdate` struct on
+  `UpdateBugParams` (Approach 1).
+- Helper extraction: keep the file-read helper local until a third
+  consumer appears.

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -534,6 +534,12 @@ pub enum BugAction {
     /// `name-`, `name?(user@example.com)`, or `name?,!` to clear.
     /// Repeatable.
     ///
+    /// `--comment <BODY>` (or `--comment-file <PATH>`) posts a comment
+    /// atomically with the field changes — a single `Bug.update`
+    /// round-trip rather than a separate `bzr comment add` call.
+    /// `--comment-private` marks it private. Empty / whitespace-only
+    /// bodies are rejected (exit 7).
+    ///
     /// List-typed fields support `*-add` / `*-remove` pairs for
     /// incremental edits: `--blocks`, `--depends-on`, `--keywords`,
     /// `--cc`, `--groups`, and `--see-also`. The first five accept
@@ -548,6 +554,8 @@ pub enum BugAction {
     ///
     ///   bzr bug update 100 --status RESOLVED --resolution FIXED
     ///   bzr bug update 100 200 300 --priority high --flag review+
+    ///   bzr bug update 100 --status RESOLVED --resolution FIXED \
+    ///     --comment "Fixed by patch in #200"
     ///   bzr bug update 100 --blocks-add 200,201 \
     ///     --depends-on-remove 99
     ///   bzr bug update 100 --keywords-add fix-needed,regression \
@@ -596,6 +604,28 @@ pub enum BugAction {
         /// Whiteboard
         #[arg(long)]
         whiteboard: Option<String>,
+        /// Post a comment atomically with the field changes.
+        ///
+        /// Mutually exclusive with `--comment-file`. Use
+        /// `--comment-private` to mark the comment private. Empty /
+        /// whitespace-only bodies are rejected (exit 7).
+        #[arg(long, value_name = "BODY", conflicts_with = "comment_file")]
+        comment: Option<String>,
+        /// Read the comment body from a UTF-8 file.
+        ///
+        /// Mutually exclusive with `--comment`. The file must exist
+        /// and be readable; non-existent paths or non-UTF-8 contents
+        /// fail with exit code 7. Empty / whitespace-only contents
+        /// are also rejected.
+        #[arg(long, value_name = "PATH", conflicts_with = "comment")]
+        comment_file: Option<std::path::PathBuf>,
+        /// Mark the comment private (visible only to users with
+        /// elevated permissions on the server).
+        ///
+        /// Requires `--comment` or `--comment-file`; using
+        /// `--comment-private` alone is a usage error (exit 7).
+        #[arg(long)]
+        comment_private: bool,
         /// Set, request, or clear a flag using Bugzilla flag syntax.
         ///
         /// Repeatable. Accepted forms:

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -353,6 +353,80 @@ fn parse_bug_update_with_flags() {
 }
 
 #[test]
+fn parse_bug_update_with_comment() {
+    let cli = Cli::try_parse_from(["bzr", "bug", "update", "42", "--comment", "see #99"]).unwrap();
+    match cli.command {
+        Commands::Bug {
+            action:
+                BugAction::Update {
+                    ids,
+                    comment,
+                    comment_file,
+                    comment_private,
+                    ..
+                },
+        } => {
+            assert_eq!(ids, vec![42]);
+            assert_eq!(comment.as_deref(), Some("see #99"));
+            assert!(comment_file.is_none());
+            assert!(!comment_private);
+        }
+        _ => panic!("expected Bug Update"),
+    }
+}
+
+#[test]
+fn parse_bug_update_with_comment_file_and_private() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "bug",
+        "update",
+        "42",
+        "--comment-file",
+        "/tmp/body.txt",
+        "--comment-private",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Bug {
+            action:
+                BugAction::Update {
+                    comment,
+                    comment_file,
+                    comment_private,
+                    ..
+                },
+        } => {
+            assert!(comment.is_none());
+            assert_eq!(
+                comment_file.as_deref(),
+                Some(std::path::Path::new("/tmp/body.txt"))
+            );
+            assert!(comment_private);
+        }
+        _ => panic!("expected Bug Update"),
+    }
+}
+
+#[test]
+fn parse_bug_update_rejects_comment_and_comment_file_together() {
+    let result = Cli::try_parse_from([
+        "bzr",
+        "bug",
+        "update",
+        "42",
+        "--comment",
+        "x",
+        "--comment-file",
+        "/tmp/body.txt",
+    ]);
+    assert!(
+        result.is_err(),
+        "clap should reject mutually-exclusive flags"
+    );
+}
+
+#[test]
 fn parse_comment_list() {
     let cli = Cli::try_parse_from(["bzr", "comment", "list", "99"]).unwrap();
     match cli.command {

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -50,6 +50,9 @@ fn build_update_params(action: &BugAction) -> Result<(Vec<u64>, UpdateBugParams)
         groups_remove,
         see_also_add,
         see_also_remove,
+        comment: _,
+        comment_file: _,
+        comment_private: _,
     } = action
     else {
         unreachable!()

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -13,6 +13,16 @@ const FLAG_GROUPS_REMOVE: &str = "--groups-remove";
 const FLAG_SEE_ALSO_ADD: &str = "--see-also-add";
 const FLAG_SEE_ALSO_REMOVE: &str = "--see-also-remove";
 
+const COMMENT_SUFFIX: &str = " (with comment)";
+
+fn comment_suffix(present: bool) -> &'static str {
+    if present {
+        COMMENT_SUFFIX
+    } else {
+        ""
+    }
+}
+
 fn clean_string_list(field: &str, values: &[String]) -> Result<Vec<String>> {
     let mut out = Vec::with_capacity(values.len());
     for raw in values {
@@ -42,7 +52,11 @@ fn resolve_comment(
     comment_private: bool,
 ) -> Result<Option<crate::types::CommentUpdate>> {
     let body = match (comment, comment_file) {
-        (Some(_), Some(_)) => unreachable!("clap conflicts_with prevents this"),
+        (Some(_), Some(_)) => {
+            return Err(crate::error::BzrError::InputValidation(
+                "--comment and --comment-file are mutually exclusive".into(),
+            ));
+        }
         (Some(s), None) => Some(s.to_string()),
         (None, Some(path)) => Some(read_comment_file(path)?),
         (None, None) => None,
@@ -148,16 +162,12 @@ async fn update_single(
 ) -> Result<()> {
     use std::io::Write;
     client.update_bug(id, params).await?;
-    let suffix = if params.comment.is_some() {
-        " (with comment)"
-    } else {
-        ""
-    };
     match format {
         OutputFormat::Json => {
             output::print_result(&ActionResult::updated(id, ResourceKind::Bug), "", format);
         }
         OutputFormat::Table => {
+            let suffix = comment_suffix(params.comment.is_some());
             let _ = writeln!(std::io::stdout(), "Updated bug #{id}{suffix}");
         }
     }
@@ -174,7 +184,7 @@ fn print_batch_result(batch: &BatchResult, format: OutputFormat, with_comment: b
             if !batch.succeeded.is_empty() {
                 let ids_str: Vec<String> =
                     batch.succeeded.iter().map(|id| format!("#{id}")).collect();
-                let suffix = if with_comment { " (with comment)" } else { "" };
+                let suffix = comment_suffix(with_comment);
                 let _ = writeln!(
                     std::io::stdout(),
                     "Updated bugs: {}{suffix}",

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -146,16 +146,25 @@ async fn update_single(
     params: &UpdateBugParams,
     format: OutputFormat,
 ) -> Result<()> {
+    use std::io::Write;
     client.update_bug(id, params).await?;
-    output::print_result(
-        &ActionResult::updated(id, ResourceKind::Bug),
-        &format!("Updated bug #{id}"),
-        format,
-    );
+    let suffix = if params.comment.is_some() {
+        " (with comment)"
+    } else {
+        ""
+    };
+    match format {
+        OutputFormat::Json => {
+            output::print_result(&ActionResult::updated(id, ResourceKind::Bug), "", format);
+        }
+        OutputFormat::Table => {
+            let _ = writeln!(std::io::stdout(), "Updated bug #{id}{suffix}");
+        }
+    }
     Ok(())
 }
 
-fn print_batch_result(batch: &BatchResult, format: OutputFormat) {
+fn print_batch_result(batch: &BatchResult, format: OutputFormat, with_comment: bool) {
     use std::io::Write;
     match format {
         OutputFormat::Json => {
@@ -165,7 +174,12 @@ fn print_batch_result(batch: &BatchResult, format: OutputFormat) {
             if !batch.succeeded.is_empty() {
                 let ids_str: Vec<String> =
                     batch.succeeded.iter().map(|id| format!("#{id}")).collect();
-                let _ = writeln!(std::io::stdout(), "Updated bugs: {}", ids_str.join(", "));
+                let suffix = if with_comment { " (with comment)" } else { "" };
+                let _ = writeln!(
+                    std::io::stdout(),
+                    "Updated bugs: {}{suffix}",
+                    ids_str.join(", ")
+                );
             }
             for f in &batch.failed {
                 let _ = writeln!(
@@ -197,7 +211,7 @@ async fn update_batch(
         }
     }
     let batch = BatchResult::new(succeeded, failed);
-    print_batch_result(&batch, format);
+    print_batch_result(&batch, format, params.comment.is_some());
     if !batch.failed.is_empty() {
         return Err(crate::error::BzrError::BatchPartialFailure {
             succeeded: batch.succeeded.len(),

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -27,6 +27,40 @@ fn clean_string_list(field: &str, values: &[String]) -> Result<Vec<String>> {
     Ok(out)
 }
 
+fn resolve_comment(
+    comment: Option<&str>,
+    comment_file: Option<&std::path::Path>,
+    comment_private: bool,
+) -> Result<Option<crate::types::CommentUpdate>> {
+    let body = match (comment, comment_file) {
+        (Some(_), Some(_)) => unreachable!("clap conflicts_with prevents this"),
+        (Some(s), None) => Some(s.to_string()),
+        (None, Some(_path)) => {
+            return Err(crate::error::BzrError::InputValidation(
+                "--comment-file not yet implemented".into(),
+            ));
+        }
+        (None, None) => None,
+    };
+    if body.is_none() && comment_private {
+        return Err(crate::error::BzrError::InputValidation(
+            "--comment-private requires --comment or --comment-file".into(),
+        ));
+    }
+    let Some(text) = body else {
+        return Ok(None);
+    };
+    if text.trim().is_empty() {
+        return Err(crate::error::BzrError::InputValidation(
+            "empty comment, aborting".into(),
+        ));
+    }
+    Ok(Some(crate::types::CommentUpdate {
+        body: text,
+        is_private: comment_private,
+    }))
+}
+
 fn build_update_params(action: &BugAction) -> Result<(Vec<u64>, UpdateBugParams)> {
     let BugAction::Update {
         ids,
@@ -50,9 +84,9 @@ fn build_update_params(action: &BugAction) -> Result<(Vec<u64>, UpdateBugParams)
         groups_remove,
         see_also_add,
         see_also_remove,
-        comment: _,
-        comment_file: _,
-        comment_private: _,
+        comment,
+        comment_file,
+        comment_private,
     } = action
     else {
         unreachable!()
@@ -92,7 +126,11 @@ fn build_update_params(action: &BugAction) -> Result<(Vec<u64>, UpdateBugParams)
             add: clean_string_list(FLAG_SEE_ALSO_ADD, see_also_add)?,
             remove: clean_string_list(FLAG_SEE_ALSO_REMOVE, see_also_remove)?,
         },
-        comment: None,
+        comment: resolve_comment(
+            comment.as_deref(),
+            comment_file.as_deref(),
+            *comment_private,
+        )?,
     };
     Ok((ids.clone(), params))
 }

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -89,6 +89,7 @@ fn build_update_params(action: &BugAction) -> Result<(Vec<u64>, UpdateBugParams)
             add: clean_string_list(FLAG_SEE_ALSO_ADD, see_also_add)?,
             remove: clean_string_list(FLAG_SEE_ALSO_REMOVE, see_also_remove)?,
         },
+        comment: None,
     };
     Ok((ids.clone(), params))
 }

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -27,6 +27,15 @@ fn clean_string_list(field: &str, values: &[String]) -> Result<Vec<String>> {
     Ok(out)
 }
 
+fn read_comment_file(path: &std::path::Path) -> Result<String> {
+    std::fs::read_to_string(path).map_err(|e| {
+        crate::error::BzrError::InputValidation(format!(
+            "cannot read --comment-file {}: {e}",
+            path.display()
+        ))
+    })
+}
+
 fn resolve_comment(
     comment: Option<&str>,
     comment_file: Option<&std::path::Path>,
@@ -35,11 +44,7 @@ fn resolve_comment(
     let body = match (comment, comment_file) {
         (Some(_), Some(_)) => unreachable!("clap conflicts_with prevents this"),
         (Some(s), None) => Some(s.to_string()),
-        (None, Some(_path)) => {
-            return Err(crate::error::BzrError::InputValidation(
-                "--comment-file not yet implemented".into(),
-            ));
-        }
+        (None, Some(path)) => Some(read_comment_file(path)?),
         (None, None) => None,
     };
     if body.is_none() && comment_private {

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -373,3 +373,62 @@ fn build_update_params_rejects_whitespace_only_comment() {
         crate::error::BzrError::InputValidation(ref m) if m.contains("empty comment")
     ));
 }
+
+#[test]
+fn build_update_params_reads_comment_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("body.txt");
+    std::fs::write(&path, "from a file").unwrap();
+    let action = make_update_action_with_comment(None, Some(&path), false);
+    let (_ids, params) = super::build_update_params(&action).unwrap();
+    let comment = params.comment.expect("comment populated");
+    assert_eq!(comment.body, "from a file");
+    assert!(!comment.is_private);
+}
+
+#[test]
+fn build_update_params_comment_file_with_private() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("body.txt");
+    std::fs::write(&path, "private body").unwrap();
+    let action = make_update_action_with_comment(None, Some(&path), true);
+    let (_ids, params) = super::build_update_params(&action).unwrap();
+    let comment = params.comment.expect("comment populated");
+    assert!(comment.is_private);
+}
+
+#[test]
+fn build_update_params_rejects_missing_comment_file() {
+    let path = std::path::Path::new("/nonexistent/bzr-issue-161-test.txt");
+    let action = make_update_action_with_comment(None, Some(path), false);
+    let err = super::build_update_params(&action).unwrap_err();
+    let msg = err.to_string();
+    assert!(matches!(err, crate::error::BzrError::InputValidation(_)));
+    assert!(
+        msg.contains("/nonexistent/bzr-issue-161-test.txt"),
+        "error should include path: {msg}"
+    );
+}
+
+#[test]
+fn build_update_params_rejects_non_utf8_comment_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("body.bin");
+    std::fs::write(&path, [0xff_u8, 0xfe, 0xfd]).unwrap();
+    let action = make_update_action_with_comment(None, Some(&path), false);
+    let err = super::build_update_params(&action).unwrap_err();
+    assert!(matches!(err, crate::error::BzrError::InputValidation(_)));
+}
+
+#[test]
+fn build_update_params_rejects_whitespace_only_comment_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("body.txt");
+    std::fs::write(&path, "   \n\t  \n").unwrap();
+    let action = make_update_action_with_comment(None, Some(&path), false);
+    let err = super::build_update_params(&action).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::error::BzrError::InputValidation(ref m) if m.contains("empty comment")
+    ));
+}

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -432,3 +432,114 @@ fn build_update_params_rejects_whitespace_only_comment_file() {
         crate::error::BzrError::InputValidation(ref m) if m.contains("empty comment")
     ));
 }
+
+#[tokio::test]
+async fn bug_update_table_output_with_comment_single() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mock_put_bug_ok(&mock, 42).await;
+
+    let mut action = make_update_action(vec![42]);
+    if let BugAction::Update {
+        ref mut comment, ..
+    } = action
+    {
+        *comment = Some("hi".into());
+    } else {
+        unreachable!();
+    }
+
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+    ))
+    .await;
+    assert!(result.is_ok());
+    assert!(
+        output.contains("Updated bug #42 (with comment)"),
+        "expected '(with comment)' suffix; got: {output}"
+    );
+}
+
+#[tokio::test]
+async fn bug_update_table_output_no_comment_single() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mock_put_bug_ok(&mock, 42).await;
+
+    let action = make_update_action(vec![42]);
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+    ))
+    .await;
+    assert!(result.is_ok());
+    assert!(output.contains("Updated bug #42"));
+    assert!(
+        !output.contains("(with comment)"),
+        "no comment was posted; suffix should be absent: {output}"
+    );
+}
+
+#[tokio::test]
+async fn bug_update_table_output_with_comment_batch_all_succeed() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mock_put_bug_ok(&mock, 1).await;
+    mock_put_bug_ok(&mock, 2).await;
+
+    let mut action = make_update_action(vec![1, 2]);
+    if let BugAction::Update {
+        ref mut comment, ..
+    } = action
+    {
+        *comment = Some("batch comment".into());
+    } else {
+        unreachable!();
+    }
+
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+    ))
+    .await;
+    assert!(result.is_ok());
+    assert!(output.contains("Updated bugs:"));
+    assert!(output.contains("(with comment)"));
+}
+
+#[tokio::test]
+async fn bug_update_json_output_unchanged_with_comment() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mock_put_bug_ok(&mock, 42).await;
+
+    let mut action = make_update_action(vec![42]);
+    if let BugAction::Update {
+        ref mut comment, ..
+    } = action
+    {
+        *comment = Some("hi".into());
+    } else {
+        unreachable!();
+    }
+
+    let (result, output) = capture_stdout(crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+    ))
+    .await;
+    assert!(result.is_ok());
+    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    // JSON schema must NOT change (spec section 6).
+    assert_eq!(parsed["action"], "updated");
+    assert_eq!(parsed["id"], 42);
+    assert!(
+        parsed.get("comment").is_none() && parsed.get("with_comment").is_none(),
+        "JSON schema should not gain a comment-related key: {parsed}"
+    );
+}

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -1,4 +1,4 @@
-#![expect(clippy::unwrap_used)]
+#![expect(clippy::unwrap_used, clippy::expect_used)]
 
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
@@ -292,4 +292,84 @@ fn build_update_params_rejects_whitespace_only_see_also_remove() {
         "expected InputValidation naming {}, got {err:?}",
         super::FLAG_SEE_ALSO_REMOVE
     );
+}
+
+fn make_update_action_with_comment(
+    comment: Option<&str>,
+    comment_file: Option<&std::path::Path>,
+    comment_private: bool,
+) -> BugAction {
+    BugAction::Update {
+        ids: vec![1],
+        status: None,
+        resolution: None,
+        assignee: None,
+        priority: None,
+        severity: None,
+        summary: None,
+        whiteboard: None,
+        flag: vec![],
+        blocks_add: vec![],
+        blocks_remove: vec![],
+        depends_on_add: vec![],
+        depends_on_remove: vec![],
+        keywords_add: vec![],
+        keywords_remove: vec![],
+        cc_add: vec![],
+        cc_remove: vec![],
+        groups_add: vec![],
+        groups_remove: vec![],
+        see_also_add: vec![],
+        see_also_remove: vec![],
+        comment: comment.map(String::from),
+        comment_file: comment_file.map(std::path::PathBuf::from),
+        comment_private,
+    }
+}
+
+#[test]
+fn build_update_params_carries_public_comment() {
+    let action = make_update_action_with_comment(Some("hello"), None, false);
+    let (_ids, params) = super::build_update_params(&action).unwrap();
+    let comment = params.comment.expect("comment populated");
+    assert_eq!(comment.body, "hello");
+    assert!(!comment.is_private);
+}
+
+#[test]
+fn build_update_params_carries_private_comment() {
+    let action = make_update_action_with_comment(Some("secret"), None, true);
+    let (_ids, params) = super::build_update_params(&action).unwrap();
+    let comment = params.comment.expect("comment populated");
+    assert_eq!(comment.body, "secret");
+    assert!(comment.is_private);
+}
+
+#[test]
+fn build_update_params_omits_comment_when_unspecified() {
+    let action = make_update_action_with_comment(None, None, false);
+    let (_ids, params) = super::build_update_params(&action).unwrap();
+    assert!(params.comment.is_none());
+}
+
+#[test]
+fn build_update_params_rejects_private_without_body() {
+    let action = make_update_action_with_comment(None, None, true);
+    let err = super::build_update_params(&action).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("--comment-private"),
+        "error should mention the flag: {msg}"
+    );
+    assert!(matches!(err, crate::error::BzrError::InputValidation(_)));
+}
+
+#[test]
+fn build_update_params_rejects_whitespace_only_comment() {
+    let action = make_update_action_with_comment(Some("   \n\t"), None, false);
+    let err = super::build_update_params(&action).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::error::BzrError::InputValidation(ref m) if m.contains("empty comment")
+    ));
 }

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -295,12 +295,13 @@ fn build_update_params_rejects_whitespace_only_see_also_remove() {
 }
 
 fn make_update_action_with_comment(
+    ids: Vec<u64>,
     comment: Option<&str>,
     comment_file: Option<&std::path::Path>,
     comment_private: bool,
 ) -> BugAction {
     BugAction::Update {
-        ids: vec![1],
+        ids,
         status: None,
         resolution: None,
         assignee: None,
@@ -329,7 +330,7 @@ fn make_update_action_with_comment(
 
 #[test]
 fn build_update_params_carries_public_comment() {
-    let action = make_update_action_with_comment(Some("hello"), None, false);
+    let action = make_update_action_with_comment(vec![1], Some("hello"), None, false);
     let (_ids, params) = super::build_update_params(&action).unwrap();
     let comment = params.comment.expect("comment populated");
     assert_eq!(comment.body, "hello");
@@ -338,7 +339,7 @@ fn build_update_params_carries_public_comment() {
 
 #[test]
 fn build_update_params_carries_private_comment() {
-    let action = make_update_action_with_comment(Some("secret"), None, true);
+    let action = make_update_action_with_comment(vec![1], Some("secret"), None, true);
     let (_ids, params) = super::build_update_params(&action).unwrap();
     let comment = params.comment.expect("comment populated");
     assert_eq!(comment.body, "secret");
@@ -347,14 +348,14 @@ fn build_update_params_carries_private_comment() {
 
 #[test]
 fn build_update_params_omits_comment_when_unspecified() {
-    let action = make_update_action_with_comment(None, None, false);
+    let action = make_update_action_with_comment(vec![1], None, None, false);
     let (_ids, params) = super::build_update_params(&action).unwrap();
     assert!(params.comment.is_none());
 }
 
 #[test]
 fn build_update_params_rejects_private_without_body() {
-    let action = make_update_action_with_comment(None, None, true);
+    let action = make_update_action_with_comment(vec![1], None, None, true);
     let err = super::build_update_params(&action).unwrap_err();
     let msg = err.to_string();
     assert!(
@@ -366,7 +367,7 @@ fn build_update_params_rejects_private_without_body() {
 
 #[test]
 fn build_update_params_rejects_whitespace_only_comment() {
-    let action = make_update_action_with_comment(Some("   \n\t"), None, false);
+    let action = make_update_action_with_comment(vec![1], Some("   \n\t"), None, false);
     let err = super::build_update_params(&action).unwrap_err();
     assert!(matches!(
         err,
@@ -379,7 +380,7 @@ fn build_update_params_reads_comment_file() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("body.txt");
     std::fs::write(&path, "from a file").unwrap();
-    let action = make_update_action_with_comment(None, Some(&path), false);
+    let action = make_update_action_with_comment(vec![1], None, Some(&path), false);
     let (_ids, params) = super::build_update_params(&action).unwrap();
     let comment = params.comment.expect("comment populated");
     assert_eq!(comment.body, "from a file");
@@ -391,7 +392,7 @@ fn build_update_params_comment_file_with_private() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("body.txt");
     std::fs::write(&path, "private body").unwrap();
-    let action = make_update_action_with_comment(None, Some(&path), true);
+    let action = make_update_action_with_comment(vec![1], None, Some(&path), true);
     let (_ids, params) = super::build_update_params(&action).unwrap();
     let comment = params.comment.expect("comment populated");
     assert!(comment.is_private);
@@ -400,7 +401,7 @@ fn build_update_params_comment_file_with_private() {
 #[test]
 fn build_update_params_rejects_missing_comment_file() {
     let path = std::path::Path::new("/nonexistent/bzr-issue-161-test.txt");
-    let action = make_update_action_with_comment(None, Some(path), false);
+    let action = make_update_action_with_comment(vec![1], None, Some(path), false);
     let err = super::build_update_params(&action).unwrap_err();
     let msg = err.to_string();
     assert!(matches!(err, crate::error::BzrError::InputValidation(_)));
@@ -415,7 +416,7 @@ fn build_update_params_rejects_non_utf8_comment_file() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("body.bin");
     std::fs::write(&path, [0xff_u8, 0xfe, 0xfd]).unwrap();
-    let action = make_update_action_with_comment(None, Some(&path), false);
+    let action = make_update_action_with_comment(vec![1], None, Some(&path), false);
     let err = super::build_update_params(&action).unwrap_err();
     assert!(matches!(err, crate::error::BzrError::InputValidation(_)));
 }
@@ -425,7 +426,7 @@ fn build_update_params_rejects_whitespace_only_comment_file() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("body.txt");
     std::fs::write(&path, "   \n\t  \n").unwrap();
-    let action = make_update_action_with_comment(None, Some(&path), false);
+    let action = make_update_action_with_comment(vec![1], None, Some(&path), false);
     let err = super::build_update_params(&action).unwrap_err();
     assert!(matches!(
         err,
@@ -438,16 +439,7 @@ async fn bug_update_table_output_with_comment_single() {
     let (_lock, mock, _tmp) = setup_test_env().await;
     mock_put_bug_ok(&mock, 42).await;
 
-    let mut action = make_update_action(vec![42]);
-    if let BugAction::Update {
-        ref mut comment, ..
-    } = action
-    {
-        *comment = Some("hi".into());
-    } else {
-        unreachable!();
-    }
-
+    let action = make_update_action_with_comment(vec![42], Some("hi"), None, false);
     let (result, output) = capture_stdout(crate::commands::bug::execute(
         &action,
         None,
@@ -489,16 +481,7 @@ async fn bug_update_table_output_with_comment_batch_all_succeed() {
     mock_put_bug_ok(&mock, 1).await;
     mock_put_bug_ok(&mock, 2).await;
 
-    let mut action = make_update_action(vec![1, 2]);
-    if let BugAction::Update {
-        ref mut comment, ..
-    } = action
-    {
-        *comment = Some("batch comment".into());
-    } else {
-        unreachable!();
-    }
-
+    let action = make_update_action_with_comment(vec![1, 2], Some("batch comment"), None, false);
     let (result, output) = capture_stdout(crate::commands::bug::execute(
         &action,
         None,
@@ -516,16 +499,7 @@ async fn bug_update_json_output_unchanged_with_comment() {
     let (_lock, mock, _tmp) = setup_test_env().await;
     mock_put_bug_ok(&mock, 42).await;
 
-    let mut action = make_update_action(vec![42]);
-    if let BugAction::Update {
-        ref mut comment, ..
-    } = action
-    {
-        *comment = Some("hi".into());
-    } else {
-        unreachable!();
-    }
-
+    let action = make_update_action_with_comment(vec![42], Some("hi"), None, false);
     let (result, output) = capture_stdout(crate::commands::bug::execute(
         &action,
         None,
@@ -535,7 +509,6 @@ async fn bug_update_json_output_unchanged_with_comment() {
     .await;
     assert!(result.is_ok());
     let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
-    // JSON schema must NOT change (spec section 6).
     assert_eq!(parsed["action"], "updated");
     assert_eq!(parsed["id"], 42);
     assert!(

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -30,6 +30,9 @@ fn make_update_action(ids: Vec<u64>) -> BugAction {
         groups_remove: vec![],
         see_also_add: vec![],
         see_also_remove: vec![],
+        comment: None,
+        comment_file: None,
+        comment_private: false,
     }
 }
 
@@ -69,6 +72,9 @@ fn make_update_action_with_lists(lists: UpdateLists<'_>) -> BugAction {
         groups_remove: to_strings(lists.groups_remove),
         see_also_add: to_strings(lists.see_also_add),
         see_also_remove: to_strings(lists.see_also_remove),
+        comment: None,
+        comment_file: None,
+        comment_private: false,
     }
 }
 

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -502,14 +502,6 @@ impl StringListUpdate {
 /// REST `Bug.update` accepts this as a sub-object on the request,
 /// which delivers the field changes and the comment in one
 /// round-trip.
-// Wired into `UpdateBugParams` and the CLI in subsequent tasks of issue #161.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "wired into UpdateBugParams in a follow-up task of #161"
-    )
-)]
 #[derive(Debug, Default, Serialize)]
 #[non_exhaustive]
 pub struct CommentUpdate {
@@ -549,6 +541,8 @@ pub struct UpdateBugParams {
     pub groups: StringListUpdate,
     #[serde(skip_serializing_if = "StringListUpdate::is_empty")]
     pub see_also: StringListUpdate,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<CommentUpdate>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -496,6 +496,28 @@ impl StringListUpdate {
     }
 }
 
+/// A comment to post atomically with a `Bug.update` call.
+///
+/// Serializes as `{"body": "...", "is_private": <bool>}`. Bugzilla's
+/// REST `Bug.update` accepts this as a sub-object on the request,
+/// which delivers the field changes and the comment in one
+/// round-trip.
+// Wired into `UpdateBugParams` and the CLI in subsequent tasks of issue #161.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "wired into UpdateBugParams in a follow-up task of #161"
+    )
+)]
+#[derive(Debug, Default, Serialize)]
+#[non_exhaustive]
+pub struct CommentUpdate {
+    pub body: String,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub is_private: bool,
+}
+
 #[derive(Debug, Default, Serialize)]
 #[non_exhaustive]
 pub struct UpdateBugParams {

--- a/src/types/bug_tests.rs
+++ b/src/types/bug_tests.rs
@@ -878,3 +878,44 @@ fn comment_update_serializes_private_body() {
     let json = serde_json::to_value(&upd).unwrap();
     assert_eq!(json, serde_json::json!({"body": "hi", "is_private": true}));
 }
+
+#[test]
+fn update_bug_params_omits_comment_when_none() {
+    let params = UpdateBugParams::default();
+    let json = serde_json::to_value(&params).unwrap();
+    assert!(
+        json.get("comment").is_none(),
+        "expected no comment key when None, got: {json}"
+    );
+}
+
+#[test]
+fn update_bug_params_serializes_comment_when_some() {
+    let params = UpdateBugParams {
+        summary: Some("new summary".into()),
+        comment: Some(CommentUpdate {
+            body: "see #other".into(),
+            is_private: false,
+        }),
+        ..Default::default()
+    };
+    let json = serde_json::to_value(&params).unwrap();
+    assert_eq!(json["summary"], "new summary");
+    assert_eq!(json["comment"], serde_json::json!({"body": "see #other"}));
+}
+
+#[test]
+fn update_bug_params_serializes_private_comment() {
+    let params = UpdateBugParams {
+        comment: Some(CommentUpdate {
+            body: "secret".into(),
+            is_private: true,
+        }),
+        ..Default::default()
+    };
+    let json = serde_json::to_value(&params).unwrap();
+    assert_eq!(
+        json["comment"],
+        serde_json::json!({"body": "secret", "is_private": true})
+    );
+}

--- a/src/types/bug_tests.rs
+++ b/src/types/bug_tests.rs
@@ -858,3 +858,23 @@ fn update_bug_params_serializes_string_lists() {
         serde_json::json!({"add": ["https://example.com/issue/1"]})
     );
 }
+
+#[test]
+fn comment_update_serializes_public_body() {
+    let upd = CommentUpdate {
+        body: "hi".into(),
+        is_private: false,
+    };
+    let json = serde_json::to_value(&upd).unwrap();
+    assert_eq!(json, serde_json::json!({"body": "hi"}));
+}
+
+#[test]
+fn comment_update_serializes_private_body() {
+    let upd = CommentUpdate {
+        body: "hi".into(),
+        is_private: true,
+    };
+    let json = serde_json::to_value(&upd).unwrap();
+    assert_eq!(json, serde_json::json!({"body": "hi", "is_private": true}));
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -8,9 +8,9 @@ mod user;
 
 pub use attachment::{Attachment, UpdateAttachmentParams, UploadAttachmentParams};
 pub use bug::{
-    partition_filters, Bug, BugTemplate, CreateBugParams, FieldChange, FieldMapping, FieldValue,
-    HistoryEntry, IdListUpdate, NegationOp, Overrides, QueryKind, SavedQuery, SearchParams,
-    StatusTransition, StringListUpdate, UpdateBugParams, FIELD_MAPPINGS,
+    partition_filters, Bug, BugTemplate, CommentUpdate, CreateBugParams, FieldChange, FieldMapping,
+    FieldValue, HistoryEntry, IdListUpdate, NegationOp, Overrides, QueryKind, SavedQuery,
+    SearchParams, StatusTransition, StringListUpdate, UpdateBugParams, FIELD_MAPPINGS,
 };
 pub use comment::{Comment, UpdateCommentTagsParams};
 pub use common::{

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -972,6 +972,57 @@ run_bzr comment search-tags important
 # May return empty if tag was fully removed, but should succeed
 if assert_success; then test_pass; fi
 
+# ─ Issue #161: bug update --comment / --comment-file / --comment-private ─
+
+test_begin "94d. bug update --comment posts atomically"
+if [[ -n "$BUG1" ]]; then
+    # Capture pre-update comment count.
+    run_bzr comment list "$BUG1"
+    pre_count=$(jq '. | length' "$BZR_STDOUT")
+    run_bzr bug update "$BUG1" --whiteboard "atomic-comment-test" \
+        --comment "atomic comment from #161 test"
+    if assert_success; then
+        run_bzr comment list "$BUG1"
+        post_count=$(jq '. | length' "$BZR_STDOUT")
+        if [[ "$post_count" -eq $((pre_count + 1)) ]] \
+            && jq -e '.[-1].text == "atomic comment from #161 test"' "$BZR_STDOUT" >/dev/null; then
+            test_pass
+        else
+            test_fail "comment not appended atomically (pre=$pre_count post=$post_count)"
+        fi
+    fi
+else test_skip "no BUG1"; fi
+
+test_begin "94e. bug update --comment --comment-private"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug update "$BUG1" --comment "private atomic comment" --comment-private
+    if assert_success; then
+        run_bzr --api hybrid comment list "$BUG1"
+        if jq -e '.[-1].is_private == true' "$BZR_STDOUT" >/dev/null \
+            && jq -e '.[-1].text == "private atomic comment"' "$BZR_STDOUT" >/dev/null; then
+            test_pass
+        else
+            test_fail "last comment not private or text mismatch"
+        fi
+    fi
+else test_skip "no BUG1"; fi
+
+test_begin "94f. bug update --comment-file"
+if [[ -n "$BUG1" ]]; then
+    tmpfile=$(mktemp)
+    printf 'comment from file\nsecond line\n' > "$tmpfile"
+    run_bzr bug update "$BUG1" --comment-file "$tmpfile"
+    if assert_success; then
+        run_bzr comment list "$BUG1"
+        if jq -e '.[-1].text | contains("comment from file")' "$BZR_STDOUT" >/dev/null; then
+            test_pass
+        else
+            test_fail "file comment not posted"
+        fi
+    fi
+    rm -f "$tmpfile"
+else test_skip "no BUG1"; fi
+
 echo ""
 
 # ══════════════════════════════════════════════════════════════════════

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -753,6 +753,9 @@ async fn bug_update_integration() {
         groups_remove: vec!["secret".to_string()],
         see_also_add: vec!["https://example.com/issue/1".to_string()],
         see_also_remove: vec![],
+        comment: None,
+        comment_file: None,
+        comment_private: false,
     };
     let (result, output) = capture_stdout(bzr::commands::bug::execute(
         &action,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -770,6 +770,68 @@ async fn bug_update_integration() {
     assert_eq!(parsed["action"], "updated");
 }
 
+#[tokio::test]
+async fn bug_update_with_comment_integration() {
+    use wiremock::matchers::body_partial_json;
+
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/42"))
+        .and(body_partial_json(serde_json::json!({
+            "status": "RESOLVED",
+            "resolution": "FIXED",
+            "comment": {
+                "body": "see #other",
+                "is_private": true,
+            },
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 42, "changes": {}}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = bzr::cli::BugAction::Update {
+        ids: vec![42],
+        status: Some("RESOLVED".to_string()),
+        resolution: Some("FIXED".to_string()),
+        assignee: None,
+        priority: None,
+        severity: None,
+        summary: None,
+        whiteboard: None,
+        flag: vec![],
+        blocks_add: vec![],
+        blocks_remove: vec![],
+        depends_on_add: vec![],
+        depends_on_remove: vec![],
+        keywords_add: vec![],
+        keywords_remove: vec![],
+        cc_add: vec![],
+        cc_remove: vec![],
+        groups_add: vec![],
+        groups_remove: vec![],
+        see_also_add: vec![],
+        see_also_remove: vec![],
+        comment: Some("see #other".to_string()),
+        comment_file: None,
+        comment_private: true,
+    };
+    let (result, _output) = capture_stdout(bzr::commands::bug::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+    ))
+    .await;
+    assert!(
+        result.is_ok(),
+        "bug update with comment should succeed: {result:?}"
+    );
+}
+
 // ── Comment add ──────────────────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds `--comment <BODY>`, `--comment-file <PATH>`, and `--comment-private` to `bzr bug update`. The comment is folded into the same `Bug.update` REST call instead of requiring a separate `bzr comment add`.
- `--comment` and `--comment-file` are mutually exclusive; `--comment-private` requires one of them. Empty / whitespace-only bodies are rejected with exit 7.
- Table-mode success line gains a `(with comment)` suffix; JSON output schema is unchanged (regression-tested).
- Closes the Issue F gap from the bzl-parity review (#155).

Closes #161.

## Design

Spec: [`docs/superpowers/specs/2026-05-07-bug-update-comment-design.md`](docs/superpowers/specs/2026-05-07-bug-update-comment-design.md)

A new `CommentUpdate { body, is_private }` type sits next to `IdListUpdate` / `StringListUpdate` in `src/types/bug.rs` and serializes as `{"body": "...", "is_private": <bool>}` (with `is_private: false` skipped on the wire). `UpdateBugParams` gains a `comment: Option<CommentUpdate>` field guarded by `skip_serializing_if = "Option::is_none"`. CLI parses → `commands/bug/update.rs::resolve_comment` validates and constructs the value → existing `client.update_bug` does the PUT. The client layer is unchanged.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` — 1179 tests (1096 lib + 21 binary + 62 integration), all green
- [x] CLI parse tests for the three flags + mutual-exclusion (`src/cli/mod_tests.rs`)
- [x] Unit tests for `CommentUpdate` serde shape (skip-on-false `is_private`) and `UpdateBugParams.comment` skip-on-None
- [x] `build_update_params` validation: missing body with `--comment-private`, whitespace-only body, missing file, non-UTF-8 file, file with whitespace-only contents
- [x] Output: table-mode `(with comment)` suffix in single + batch modes; JSON output schema asserted unchanged
- [x] Integration test (`tests/integration.rs`) asserts the nested `comment: {body, is_private}` object lands in the PUT body via `body_partial_json`
- [x] Functional tests 94d/94e/94f exercise atomic field+comment, `--comment-private`, and `--comment-file` against a real Bugzilla container

## Follow-ups (not blocking)

Two minor observations surfaced during review, neither worth addressing in-PR:

- The `read_comment_file` error wording (`"cannot read --comment-file {}: {e}"`) differs slightly from the older `read_description_file` (`"--description-file could not be read ({}): {e}"`). Each is correct; aligning both sites is a small follow-up if a third file-reading flag (e.g. `attachment upload --comment-file`) lands.
- `output::print_result`'s table branch uses `println!`, which bypasses `capture_stdout`'s `dup2`-based fd1 redirection — pre-existing and tracked as a separate cleanup; this PR works around it locally in `update_single` to keep the new output tests honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)