### PR TITLE
feat(attachment upload): --comment-private two-call workflow (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   with each other; `--comment-private` requires one of the body
   flags. Empty / whitespace-only bodies are rejected (exit 7).
   Closes #161.
+- `bzr attachment upload --comment-private` marks the comment posted
+  alongside the attachment as private. Bugzilla's `Bug.add_attachment`
+  endpoint does not accept a privacy flag on the embedded comment, so
+  the upload is followed by a targeted `Bug.update` that flips the
+  newly created comment's `is_private` to `true`. Requires `--comment`
+  or `--comment-file`. Closes #170.
 
 ### Fixed
 
@@ -132,6 +138,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `--groups-add/-remove`, or `--see-also-add/-remove` produces
   `<flag>: list value cannot be empty or whitespace-only` instead
   of a bare message. Closes #174.
+- `Comment` JSON output now includes `attachment_id` (set when the
+  comment was created alongside an attachment, otherwise `null`).
+  Existing fields are unchanged; the field is also populated by the
+  XML-RPC fallback path. Refs: #170.
 
 ## [0.3.0] - 2026-05-05
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -599,6 +599,7 @@ bzr attachment upload 12345 data.csv --summary "Performance data" --content-type
 bzr attachment upload 12345 patch.diff --flag "review?(alice@example.com)"
 bzr attachment upload 12345 secret.bin --summary "internal trace" --private
 bzr attachment upload 12345 fix.patch --comment "see #6789 for context"
+bzr attachment upload 12345 patch.diff --comment "sensitive context" --comment-private
 bzr attachment upload 12345 fix.patch --is-patch
 ```
 
@@ -611,6 +612,7 @@ bzr attachment upload 12345 fix.patch --is-patch
 | `--private` | No | Mark the attachment as private (visible only to users with elevated permissions) |
 | `--is-patch` | No | Mark the attachment as a patch; defaults `--content-type` to `text/plain` |
 | `--comment <BODY>` | No | Post a comment alongside the attachment in the same API call |
+| `--comment-private` | No | Mark the comment posted via `--comment` private. Issues a follow-up `Bug.update` call (two API round-trips). Requires `--comment`. |
 | `--flag <F>` | No | Set flags (repeatable; see [Flag Syntax](#flag-syntax)) |
 
 Agent note: for clearer audit trails, agents should usually pass `--summary` explicitly instead of relying on the filename-derived default.

--- a/src/cli/attachment.rs
+++ b/src/cli/attachment.rs
@@ -58,6 +58,11 @@ pub enum AttachmentAction {
     /// in a single API call. Use this when the attachment needs
     /// explanatory context — typical for patches.
     ///
+    /// `--comment-private` (used together with `--comment`) marks the
+    /// new comment private after upload. This requires `editbugs`
+    /// permission. Permission errors leave the attachment uploaded and
+    /// the comment public; rerun privacy via the web UI.
+    ///
     /// `--flag` accepts Bugzilla flag syntax (`name?`, `name+`,
     /// `name-`, `name?(user@example.com)`) and is repeatable.
     /// Requires credentials with attach-file permission on the
@@ -71,6 +76,8 @@ pub enum AttachmentAction {
     ///   bzr attachment upload 12345 fix.patch \
     ///     --flag 'review?(maintainer@example.com)'
     ///   bzr attachment upload 12345 fix.patch --comment "see #4567 for context"
+    ///   bzr attachment upload 12345 patch.diff \
+    ///     --comment "private context" --comment-private
     ///   bzr attachment upload 12345 fix.patch --is-patch
     ///
     /// See bzr-attachment-update(1) to modify metadata after upload.
@@ -105,11 +112,25 @@ pub enum AttachmentAction {
         /// Folded into the underlying `Bug.add_attachment` API call so
         /// the comment and attachment share a creation timestamp and
         /// are visible to the same audience as the bug. The comment
-        /// inherits the bug's default privacy; there is no Bugzilla
-        /// API for marking an `add_attachment` comment private — use
-        /// `bzr comment add --private` separately if needed.
+        /// inherits the bug's default privacy unless `--comment-private`
+        /// is also set, in which case a follow-up `Bug.update` call
+        /// flips the new comment private (two API round-trips total).
         #[arg(long)]
         comment: Option<String>,
+        /// Mark the comment posted via `--comment` private.
+        ///
+        /// Issues a follow-up `Bug.update` call after the upload to flip
+        /// the just-created comment's `is_private` flag. The Bugzilla
+        /// `Bug.add_attachment` API does not accept comment privacy in
+        /// the upload itself, so this is a two-call workflow internally.
+        ///
+        /// Requires `--comment <BODY>`; using `--comment-private` alone
+        /// is a usage error (exit 7). Marking a comment private requires
+        /// `editbugs` permission or insidergroup membership; on 403 the
+        /// attachment remains uploaded but the comment stays public, and
+        /// the command exits non-zero with a stderr warning.
+        #[arg(long)]
+        comment_private: bool,
         /// Set, request, or clear a flag using Bugzilla flag syntax.
         ///
         /// Repeatable. Accepted forms:

--- a/src/cli/attachment.rs
+++ b/src/cli/attachment.rs
@@ -126,7 +126,7 @@ pub enum AttachmentAction {
         ///
         /// Requires `--comment <BODY>`; using `--comment-private` alone
         /// is a usage error (exit 7). Marking a comment private requires
-        /// `editbugs` permission or insidergroup membership; on 403 the
+        /// `editbugs` permission or `insider` group membership; on 403 the
         /// attachment remains uploaded but the comment stays public, and
         /// the command exits non-zero with a stderr warning.
         #[arg(long)]

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -1289,6 +1289,53 @@ fn parse_attachment_upload_without_is_patch_defaults_to_false() {
 }
 
 #[test]
+fn parse_attachment_upload_with_comment_private() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "attachment",
+        "upload",
+        "42",
+        "patch.diff",
+        "--comment",
+        "sensitive",
+        "--comment-private",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action:
+                AttachmentAction::Upload {
+                    bug_id,
+                    comment,
+                    comment_private,
+                    ..
+                },
+        } => {
+            assert_eq!(bug_id, 42);
+            assert_eq!(comment.as_deref(), Some("sensitive"));
+            assert!(comment_private, "--comment-private should set the flag");
+        }
+        _ => panic!("expected Attachment Upload"),
+    }
+}
+
+#[test]
+fn parse_attachment_upload_without_comment_private_defaults_to_false() {
+    let cli = Cli::try_parse_from(["bzr", "attachment", "upload", "42", "f.txt"]).unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action: AttachmentAction::Upload {
+                comment_private, ..
+            },
+        } => assert!(
+            !comment_private,
+            "--comment-private absent should default to false"
+        ),
+        _ => panic!("expected Attachment Upload"),
+    }
+}
+
+#[test]
 fn parse_template_delete() {
     let cli = Cli::try_parse_from(["bzr", "template", "delete", "security-bug"]).unwrap();
     match cli.command {

--- a/src/client/comment_tests.rs
+++ b/src/client/comment_tests.rs
@@ -444,3 +444,48 @@ async fn get_comments_since_rest_returns_empty_when_bug_acknowledged_with_no_com
         .unwrap();
     assert!(comments.is_empty(), "no comments expected: {comments:?}");
 }
+
+#[tokio::test]
+async fn get_comments_since_rest_propagates_attachment_id() {
+    // Regression guard for issue #170: the REST envelope path must preserve
+    // `Comment.attachment_id` end-to-end so `flip_new_comment_private` can
+    // identify the auto-generated upload comment. A wrapper that strips
+    // unknown fields before deserialization would pass the type-level unit
+    // test in `src/types/comment_tests.rs` while breaking this round trip.
+    use crate::client::test_helpers::test_client;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": {
+                "42": {
+                    "comments": [
+                        {
+                            "id": 7,
+                            "bug_id": 42,
+                            "creator": "alice@example.com",
+                            "time": "2026-01-01T00:00:00Z",
+                            "creation_time": "2026-01-01T00:00:00Z",
+                            "text": "Created attachment 99",
+                            "is_private": false,
+                            "count": 1,
+                            "attachment_id": 99
+                        }
+                    ]
+                }
+            }
+        })))
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let comments = client
+        .get_comments_since_rest_for_test(42, None)
+        .await
+        .unwrap();
+    assert_eq!(comments.len(), 1);
+    assert_eq!(comments[0].attachment_id, Some(99));
+}

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -16,6 +16,7 @@ pub async fn execute(
     format: OutputFormat,
     api: Option<ApiMode>,
 ) -> Result<()> {
+    validate_action(action)?;
     let client = super::shared::connect_and_configure(server, api).await?;
 
     match action {
@@ -47,11 +48,6 @@ pub async fn execute(
             comment_private,
             flag,
         } => {
-            if *comment_private && comment.is_none() {
-                return Err(crate::error::BzrError::InputValidation(
-                    "--comment-private requires --comment".into(),
-                ));
-            }
             let path = Path::new(file);
             let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or(file);
             let data = std::fs::read(path)?;
@@ -115,6 +111,20 @@ pub async fn execute(
     Ok(())
 }
 
+fn validate_action(action: &AttachmentAction) -> Result<()> {
+    if let AttachmentAction::Upload {
+        comment_private: true,
+        comment: None,
+        ..
+    } = action
+    {
+        return Err(crate::error::BzrError::InputValidation(
+            "--comment-private requires --comment".into(),
+        ));
+    }
+    Ok(())
+}
+
 fn guess_content_type(filename: &str) -> &'static str {
     match filename
         .rsplit('.')
@@ -144,7 +154,7 @@ fn guess_content_type(filename: &str) -> &'static str {
 /// Flip the privacy of the comment that `Bug.add_attachment` just
 /// created. Identifies the comment by its `attachment_id` field —
 /// Bugzilla sets that to the new attachment ID when the comment was
-/// posted alongside the upload (#170).
+/// posted alongside the upload.
 ///
 /// On any failure between upload and the privacy flip, prints a stderr
 /// warning naming the attachment ID and the underlying error, then

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -156,16 +156,14 @@ async fn flip_new_comment_private(
     bug_id: u64,
     new_attachment_id: u64,
 ) -> Result<()> {
-    let comments = match client.get_comments_since(bug_id, None).await {
-        Ok(comments) => comments,
-        Err(e) => {
-            warn_partial(new_attachment_id, &e);
-            return Err(e);
-        }
-    };
+    let comments = client
+        .get_comments_since(bug_id, None)
+        .await
+        .inspect_err(|e| warn_partial(new_attachment_id, e))?;
+    // `attachment_id` is unique per bug: Bugzilla sets it on exactly one
+    // comment when `Bug.add_attachment` includes a `comment` body.
     let Some(comment_id) = comments
         .iter()
-        .rev()
         .find(|c| c.attachment_id == Some(new_attachment_id))
         .map(|c| c.id)
     else {
@@ -182,11 +180,10 @@ async fn flip_new_comment_private(
         comment_is_private: map,
         ..Default::default()
     };
-    if let Err(e) = client.update_bug(bug_id, &params).await {
-        warn_partial(new_attachment_id, &e);
-        return Err(e);
-    }
-    Ok(())
+    client
+        .update_bug(bug_id, &params)
+        .await
+        .inspect_err(|e| warn_partial(new_attachment_id, e))
 }
 
 fn warn_partial(att_id: u64, err: &crate::error::BzrError) {

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
+use std::io::Write as _;
 use std::path::Path;
 
 use crate::cli::AttachmentAction;
+use crate::client::BugzillaClient;
 use crate::error::Result;
 use crate::output::{self, ActionResult, DownloadResult, ResourceKind, UploadResult};
 use crate::types::ApiMode;
@@ -41,9 +44,14 @@ pub async fn execute(
             private,
             is_patch,
             comment,
-            comment_private: _,
+            comment_private,
             flag,
         } => {
+            if *comment_private && comment.is_none() {
+                return Err(crate::error::BzrError::InputValidation(
+                    "--comment-private requires --comment".into(),
+                ));
+            }
             let path = Path::new(file);
             let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or(file);
             let data = std::fs::read(path)?;
@@ -67,6 +75,9 @@ pub async fn execute(
                 is_patch: *is_patch,
             };
             let att_id = client.upload_attachment(&upload_params).await?;
+            if *comment_private {
+                flip_new_comment_private(&client, *bug_id, att_id).await?;
+            }
             output::print_result(
                 &UploadResult::new(att_id, *bug_id, size),
                 &format!("Uploaded attachment #{att_id} to bug #{bug_id} ({size} bytes)"),
@@ -128,6 +139,65 @@ fn guess_content_type(filename: &str) -> &'static str {
         Some("patch" | "diff") => "text/x-diff",
         _ => "application/octet-stream",
     }
+}
+
+/// Flip the privacy of the comment that `Bug.add_attachment` just
+/// created. Identifies the comment by its `attachment_id` field —
+/// Bugzilla sets that to the new attachment ID when the comment was
+/// posted alongside the upload (#170).
+///
+/// On any failure between upload and the privacy flip, prints a stderr
+/// warning naming the attachment ID and the underlying error, then
+/// propagates the original error so the exit code reflects the failure.
+/// The attachment is **not** deleted on partial failure (destructive
+/// rollback is worse than a public comment the user can re-target).
+async fn flip_new_comment_private(
+    client: &BugzillaClient,
+    bug_id: u64,
+    new_attachment_id: u64,
+) -> Result<()> {
+    let comments = match client.get_comments_since(bug_id, None).await {
+        Ok(comments) => comments,
+        Err(e) => {
+            warn_partial(new_attachment_id, &e);
+            return Err(e);
+        }
+    };
+    let Some(comment_id) = comments
+        .iter()
+        .rev()
+        .find(|c| c.attachment_id == Some(new_attachment_id))
+        .map(|c| c.id)
+    else {
+        let err = crate::error::BzrError::DataIntegrity(format!(
+            "could not locate the new attachment-bound comment on bug #{bug_id} \
+             (no comment with attachment_id={new_attachment_id})",
+        ));
+        warn_partial(new_attachment_id, &err);
+        return Err(err);
+    };
+    let mut map = HashMap::new();
+    map.insert(comment_id, true);
+    let params = crate::types::UpdateBugParams {
+        comment_is_private: map,
+        ..Default::default()
+    };
+    if let Err(e) = client.update_bug(bug_id, &params).await {
+        warn_partial(new_attachment_id, &e);
+        return Err(e);
+    }
+    Ok(())
+}
+
+fn warn_partial(att_id: u64, err: &crate::error::BzrError) {
+    let _ = writeln!(
+        std::io::stderr(),
+        "warning: attachment #{att_id} uploaded but comment privacy flip failed: {err}",
+    );
+    let _ = writeln!(
+        std::io::stderr(),
+        "  the comment was created public; mark it private via the Bugzilla web UI or with elevated credentials",
+    );
 }
 
 #[cfg(test)]

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -41,6 +41,7 @@ pub async fn execute(
             private,
             is_patch,
             comment,
+            comment_private: _,
             flag,
         } => {
             let path = Path::new(file);

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -84,6 +84,7 @@ async fn attachment_upload_api_error_propagates() {
         private: false,
         is_patch: false,
         comment: None,
+        comment_private: false,
         flag: vec![],
     };
     let result = super::execute(&action, None, OutputFormat::Json, None).await;
@@ -135,6 +136,7 @@ async fn attachment_upload_returns_id() {
         private: false,
         is_patch: false,
         comment: None,
+        comment_private: false,
         flag: vec![],
     };
     let (result, output) =
@@ -168,6 +170,7 @@ async fn attachment_upload_with_comment_includes_comment_in_request() {
         private: false,
         is_patch: false,
         comment: Some("see this".into()),
+        comment_private: false,
         flag: vec![],
     };
     let result = super::execute(&action, None, OutputFormat::Json, None).await;
@@ -202,6 +205,7 @@ async fn attachment_upload_with_is_patch_defaults_content_type_to_text_plain() {
         private: false,
         is_patch: true,
         comment: None,
+        comment_private: false,
         flag: vec![],
     };
     let result = super::execute(&action, None, OutputFormat::Json, None).await;
@@ -238,6 +242,7 @@ async fn attachment_upload_is_patch_with_explicit_content_type_keeps_content_typ
         private: false,
         is_patch: true,
         comment: None,
+        comment_private: false,
         flag: vec![],
     };
     let result = super::execute(&action, None, OutputFormat::Json, None).await;

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -432,7 +432,6 @@ async fn attachment_upload_comment_private_without_comment_is_input_error() {
 
 #[tokio::test]
 async fn attachment_upload_comment_private_partial_failure_propagates_error() {
-    use wiremock::matchers::{method, path};
     let (_lock, mock, tmp) = setup_test_env().await;
 
     let upload_file = tmp.path().join("p.diff");
@@ -481,7 +480,6 @@ async fn attachment_upload_comment_private_partial_failure_propagates_error() {
 
 #[tokio::test]
 async fn attachment_upload_comment_private_no_matching_comment_is_data_integrity_error() {
-    use wiremock::matchers::{method, path};
     let (_lock, mock, tmp) = setup_test_env().await;
 
     let upload_file = tmp.path().join("p.diff");

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -343,3 +343,138 @@ fn guess_content_type_case_insensitive() {
     assert_eq!(guess_content_type("image.PNG"), "image/png");
     assert_eq!(guess_content_type("data.JSON"), "application/json");
 }
+
+#[tokio::test]
+async fn attachment_upload_with_comment_private_flips_privacy() {
+    use wiremock::matchers::body_string_contains;
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    let upload_file = tmp.path().join("p.diff");
+    std::fs::write(&upload_file, "diff --git a/x b/x").unwrap();
+
+    // Step 1: POST /rest/bug/42/attachment → returns attachment id 200
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/42/attachment"))
+        .and(body_string_contains("\"comment\":\"sensitive\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [200]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    // Step 2: GET /rest/bug/42/comment → returns comments with one matching attachment_id=200
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": {
+                "42": {
+                    "comments": [
+                        {"id": 554, "bug_id": 42, "text": "old", "is_private": false},
+                        {"id": 555, "bug_id": 42, "text": "sensitive", "is_private": false, "attachment_id": 200}
+                    ]
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    // Step 3: PUT /rest/bug/42 with comment_is_private: {"555": true}
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/42"))
+        .and(body_string_contains("\"comment_is_private\""))
+        .and(body_string_contains("\"555\":true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = AttachmentAction::Upload {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: Some("test".into()),
+        content_type: Some("text/x-diff".into()),
+        private: false,
+        is_patch: false,
+        comment: Some("sensitive".into()),
+        comment_private: true,
+        flag: vec![],
+    };
+    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(
+        result.is_ok(),
+        "two-call workflow should succeed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn attachment_upload_comment_private_without_comment_is_input_error() {
+    let (_lock, _mock, tmp) = setup_test_env().await;
+    let upload_file = tmp.path().join("p.diff");
+    std::fs::write(&upload_file, "x").unwrap();
+
+    let action = AttachmentAction::Upload {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: None,
+        content_type: None,
+        private: false,
+        is_patch: false,
+        comment: None,
+        comment_private: true,
+        flag: vec![],
+    };
+    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(matches!(
+        result,
+        Err(crate::error::BzrError::InputValidation(_))
+    ));
+}
+
+#[tokio::test]
+async fn attachment_upload_comment_private_partial_failure_propagates_error() {
+    use wiremock::matchers::{method, path};
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    let upload_file = tmp.path().join("p.diff");
+    std::fs::write(&upload_file, "x").unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/42/attachment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [200]})))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": {
+                "42": {
+                    "comments": [
+                        {"id": 555, "bug_id": 42, "text": "x", "is_private": false, "attachment_id": 200}
+                    ]
+                }
+            }
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/42"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("Forbidden: editbugs required"))
+        .mount(&mock)
+        .await;
+
+    let action = AttachmentAction::Upload {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: None,
+        content_type: None,
+        private: false,
+        is_patch: false,
+        comment: Some("x".into()),
+        comment_private: true,
+        flag: vec![],
+    };
+    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(result.is_err(), "step-2 failure should propagate");
+}

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -478,3 +478,53 @@ async fn attachment_upload_comment_private_partial_failure_propagates_error() {
     let result = super::execute(&action, None, OutputFormat::Json, None).await;
     assert!(result.is_err(), "step-2 failure should propagate");
 }
+
+#[tokio::test]
+async fn attachment_upload_comment_private_no_matching_comment_is_data_integrity_error() {
+    use wiremock::matchers::{method, path};
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    let upload_file = tmp.path().join("p.diff");
+    std::fs::write(&upload_file, "x").unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/42/attachment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [200]})))
+        .mount(&mock)
+        .await;
+
+    // Comments fetched successfully, but none has attachment_id matching
+    // the just-uploaded attachment. This is a Bugzilla server invariant
+    // violation — Bug.add_attachment with a `comment` body must create a
+    // comment whose `attachment_id` equals the new attachment's id.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": {
+                "42": {
+                    "comments": [
+                        {"id": 999, "bug_id": 42, "text": "unrelated", "is_private": false}
+                    ]
+                }
+            }
+        })))
+        .mount(&mock)
+        .await;
+
+    let action = AttachmentAction::Upload {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: None,
+        content_type: None,
+        private: false,
+        is_patch: false,
+        comment: Some("x".into()),
+        comment_private: true,
+        flag: vec![],
+    };
+    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(matches!(
+        result,
+        Err(crate::error::BzrError::DataIntegrity(_))
+    ));
+}

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -150,6 +150,7 @@ fn build_update_params(action: &BugAction) -> Result<(Vec<u64>, UpdateBugParams)
             comment_file.as_deref(),
             *comment_private,
         )?,
+        comment_is_private: std::collections::HashMap::new(),
     };
     Ok((ids.clone(), params))
 }

--- a/src/output/comment_tests.rs
+++ b/src/output/comment_tests.rs
@@ -12,6 +12,7 @@ fn make_comment(count: u64, text: &str) -> Comment {
         creation_time: Some("2025-02-01T08:00:00Z".into()),
         count,
         is_private: false,
+        attachment_id: None,
     }
 }
 
@@ -101,6 +102,7 @@ async fn print_comments_table_handles_missing_creator_and_unicode() {
         creation_time: None,
         count: 0,
         is_private: false,
+        attachment_id: None,
     }];
     let ((), output) = crate::test_helpers::capture_stdout(async {
         print_comments(&comments, OutputFormat::Table);

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -543,6 +543,13 @@ pub struct UpdateBugParams {
     pub see_also: StringListUpdate,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<CommentUpdate>,
+    /// Edit the privacy of comments that are already on the bug.
+    /// Keys are comment IDs; values are `true` (mark private) or
+    /// `false` (mark public). Used by `attachment upload
+    /// --comment-private` to flip the privacy of the comment created
+    /// by `Bug.add_attachment`.
+    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub comment_is_private: std::collections::HashMap<u64, bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/types/bug_tests.rs
+++ b/src/types/bug_tests.rs
@@ -919,3 +919,29 @@ fn update_bug_params_serializes_private_comment() {
         serde_json::json!({"body": "secret", "is_private": true})
     );
 }
+
+#[test]
+fn update_bug_params_default_omits_comment_is_private() {
+    let params = UpdateBugParams::default();
+    let json = serde_json::to_value(&params).unwrap();
+    assert!(
+        !json.as_object().unwrap().contains_key("comment_is_private"),
+        "empty comment_is_private map should be skipped on the wire, got {json}"
+    );
+}
+
+#[test]
+fn update_bug_params_serializes_comment_is_private_map() {
+    use std::collections::HashMap;
+    let mut map = HashMap::new();
+    map.insert(5678u64, true);
+    let params = UpdateBugParams {
+        comment_is_private: map,
+        ..Default::default()
+    };
+    let json = serde_json::to_value(&params).unwrap();
+    assert_eq!(
+        json["comment_is_private"]["5678"],
+        serde_json::Value::Bool(true)
+    );
+}

--- a/src/types/comment.rs
+++ b/src/types/comment.rs
@@ -25,6 +25,11 @@ pub struct Comment {
     pub count: u64,
     #[serde(default)]
     pub is_private: bool,
+    /// Set when the comment was created alongside an attachment via
+    /// `Bug.add_attachment`. Used by `attachment upload --comment-private`
+    /// to identify the just-created comment.
+    #[serde(default)]
+    pub attachment_id: Option<u64>,
 }
 
 #[cfg(test)]

--- a/src/types/comment_tests.rs
+++ b/src/types/comment_tests.rs
@@ -23,3 +23,19 @@ fn comment_deserializes_full() {
     assert_eq!(comment.count, 3);
     assert!(comment.is_private);
 }
+
+#[test]
+fn comment_deserializes_with_attachment_id() {
+    let json = r#"{"id": 7, "attachment_id": 99}"#;
+    let comment: Comment = serde_json::from_str(json).unwrap();
+    assert_eq!(comment.id, 7);
+    assert_eq!(comment.attachment_id, Some(99));
+}
+
+#[test]
+fn comment_deserializes_without_attachment_id_defaults_to_none() {
+    let json = r#"{"id": 8}"#;
+    let comment: Comment = serde_json::from_str(json).unwrap();
+    assert_eq!(comment.id, 8);
+    assert!(comment.attachment_id.is_none());
+}

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -390,6 +390,7 @@ fn value_to_comment(val: &Value) -> Result<crate::types::Comment> {
         creation_time: get_datetime_str(m, "creation_time"),
         count,
         is_private: get_bool_flag(m, "is_private"),
+        attachment_id: None,
     })
 }
 

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -390,7 +390,10 @@ fn value_to_comment(val: &Value) -> Result<crate::types::Comment> {
         creation_time: get_datetime_str(m, "creation_time"),
         count,
         is_private: get_bool_flag(m, "is_private"),
-        attachment_id: None,
+        attachment_id: m
+            .get("attachment_id")
+            .and_then(Value::as_i64)
+            .and_then(|v| u64::try_from(v).ok()),
     })
 }
 

--- a/src/xmlrpc/client_tests.rs
+++ b/src/xmlrpc/client_tests.rs
@@ -374,6 +374,33 @@ fn value_to_comment_parses_int_is_private() {
     assert!(parsed.is_private);
 }
 
+#[test]
+fn comments_with_attachment_id_propagates_field() {
+    let mut comment = BTreeMap::new();
+    comment.insert("id".into(), Value::Int(1002));
+    comment.insert("bug_id".into(), Value::Int(42));
+    comment.insert("count".into(), Value::Int(2));
+    comment.insert("text".into(), Value::String("see attachment".into()));
+    comment.insert("creator".into(), Value::String("alice@test".into()));
+    comment.insert("attachment_id".into(), Value::Int(99));
+
+    let parsed = value_to_comment(&Value::Struct(comment)).unwrap();
+    assert_eq!(parsed.attachment_id, Some(99));
+}
+
+#[test]
+fn comments_without_attachment_id_yields_none() {
+    let mut comment = BTreeMap::new();
+    comment.insert("id".into(), Value::Int(1003));
+    comment.insert("bug_id".into(), Value::Int(42));
+    comment.insert("count".into(), Value::Int(3));
+    comment.insert("text".into(), Value::String("plain comment".into()));
+    comment.insert("creator".into(), Value::String("alice@test".into()));
+
+    let parsed = value_to_comment(&Value::Struct(comment)).unwrap();
+    assert_eq!(parsed.attachment_id, None);
+}
+
 #[tokio::test]
 async fn create_user_returns_id_from_response() {
     let mock = MockServer::start().await;

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -1151,6 +1151,31 @@ if [[ -n "$BUG1" ]]; then
     fi
 else test_skip "no BUG1"; fi
 
+test_begin "100h. attachment upload --comment-private flips comment privacy"
+if [[ -n "$BUG1" ]]; then
+    run_bzr attachment upload "$BUG1" /tmp/bzr-func-test.txt \
+        --summary "private comment test" \
+        --comment "sensitive context for #170" \
+        --comment-private
+    if assert_success && assert_json_exists '.id'; then
+        ATTACH_PRIV_ID=$(jq -r '.id' "$BZR_STDOUT" 2>/dev/null || echo "")
+        run_bzr comment list "$BUG1"
+        if assert_success; then
+            # The new comment is the one whose attachment_id matches
+            # the just-uploaded attachment. Assert it's marked private.
+            MATCHED=$(jq --arg a "$ATTACH_PRIV_ID" \
+                '[.[] | select(.attachment_id == ($a | tonumber))] | last' \
+                "$BZR_STDOUT" 2>/dev/null || echo "")
+            IS_PRIVATE=$(echo "$MATCHED" | jq -r '.is_private' 2>/dev/null || echo "")
+            if [[ "$IS_PRIVATE" == "true" ]]; then
+                test_pass
+            else
+                test_fail "comment matching attachment #${ATTACH_PRIV_ID} not marked private (is_private=${IS_PRIVATE})"
+            fi
+        fi
+    fi
+else test_skip "no BUG1"; fi
+
 echo ""
 
 # ══════════════════════════════════════════════════════════════════════

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1090,6 +1090,70 @@ async fn attachment_upload_with_is_patch_integration() {
 }
 
 #[tokio::test]
+async fn attachment_upload_with_comment_private_integration() {
+    use wiremock::matchers::body_string_contains;
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    let upload_file = tmp.path().join("upload.txt");
+    std::fs::write(&upload_file, "test content").unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/42/attachment"))
+        .and(body_string_contains("\"comment\":\"sensitive\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [202]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": {
+                "42": {
+                    "comments": [
+                        {"id": 800, "bug_id": 42, "text": "sensitive", "attachment_id": 202}
+                    ]
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/42"))
+        .and(body_string_contains("\"comment_is_private\""))
+        .and(body_string_contains("\"800\":true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = bzr::cli::AttachmentAction::Upload {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: Some("test".into()),
+        content_type: Some("text/plain".into()),
+        private: false,
+        is_patch: false,
+        comment: Some("sensitive".into()),
+        comment_private: true,
+        flag: vec![],
+    };
+    let result = bzr::commands::attachment::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "upload --comment-private should drive POST→GET→PUT to success: {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn attachment_list_returns_is_patch_field_integration() {
     let (_lock, mock, _tmp) = setup_test_env().await;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -990,6 +990,7 @@ async fn attachment_upload_integration() {
         private: false,
         is_patch: false,
         comment: None,
+        comment_private: false,
         flag: vec![],
     };
     let result = bzr::commands::attachment::execute(
@@ -1031,6 +1032,7 @@ async fn attachment_upload_with_comment_integration() {
         private: false,
         is_patch: false,
         comment: Some("see #6789 for context".to_string()),
+        comment_private: false,
         flag: vec![],
     };
     let result = bzr::commands::attachment::execute(
@@ -1071,6 +1073,7 @@ async fn attachment_upload_with_is_patch_integration() {
         private: false,
         is_patch: true,
         comment: None,
+        comment_private: false,
         flag: vec![],
     };
     let result = bzr::commands::attachment::execute(


### PR DESCRIPTION
## Summary

- Adds `--comment-private` to `bzr attachment upload`. The flag posts the comment via `Bug.add_attachment`, then issues a follow-up `Bug.update` with `comment_is_private` to flip the just-created comment private.
- Identifies the new comment by `Comment.attachment_id`, a field newly surfaced on the `Comment` type (REST + XML-RPC).
- On partial failure (upload succeeds, privacy flip fails) the command emits a stderr warning naming the attachment ID and propagates the original error. The attachment is not deleted.

Closes #170.

## Test plan

- [x] \`cargo test --lib\` green (1109 passed)
- [x] \`cargo test --test integration\` green (63 passed)
- [x] \`make lint\` green (fmt + clippy)
- [x] \`make check-test-layout\` green
- [x] Functional test \`100h\` added; verification deferred to CI (no local container)
- [x] Manual: \`bzr attachment upload <bug> /tmp/x.txt --comment-private\` (no \`--comment\`) exits 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)