### PR TITLE
feat(attachment download): bulk by --bug or attachment-id list (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   matching `bzl-attachment-add`. The read-side `Attachment` struct
   also exposes `is_patch` so `bzr attachment list --json` includes the
   field. Closes #166.
+- `bzr attachment download` accepts multiple attachment IDs and
+  `--bug <ID>` (repeatable) for bulk downloads into per-bug
+  subdirectories at `<out-dir>/<bug-id>/<att-id>.<file_name>`. New
+  `--out-dir` flag (default `./attachments`). Legacy single-ID `--out`
+  shape unchanged. (#167)
 - `bzr bug list`, `bzr query save`, and `bzr query run` accept
   `--created-since <DATE>` and `--changed-since <DATE>` filters
   for Bugzilla's `creation_time` and `last_change_time` fields.

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -575,19 +575,59 @@ bzr --json attachment list 12345
 
 ### `bzr attachment download`
 
-Download an attachment by its ID. Saves to the original filename by default.
+Download one or more attachments to disk.
 
-```bash
-bzr attachment download 67890
-bzr attachment download 67890 -o /tmp/patch.diff
+**Synopsis:**
+
+```
+bzr attachment download <ID>...
+bzr attachment download <ID> --out <PATH>
+bzr attachment download [<ID>...] --bug <BUG_ID>... [--out-dir <DIR>]
 ```
 
-| Option | Required | Description |
-|--------|----------|-------------|
-| `<ATTACHMENT_ID>` | Yes | Attachment ID |
-| `-o, --out <FILE>` | No | Output file path (default: original filename) |
+**Arguments and flags:**
 
-Agent note: omit `-o` only when the current working directory and original filename are acceptable. For automation, prefer an explicit path such as `-o /tmp/patch.diff`.
+| flag | description |
+|---|---|
+| `<ID>` | Attachment ID(s). Repeatable as positional arguments. |
+| `--bug <BUG_ID>` | Download every attachment for the given bug. Repeatable. |
+| `-o`, `--out <PATH>` | Output file path. Single-attachment shape only; conflicts with `--out-dir` and `--bug`. |
+| `--out-dir <DIR>` | Output directory for batch downloads. Default: `./attachments`. Files land at `<out-dir>/<bug-id>/<att-id>.<file_name>`. |
+
+**Examples:**
+
+```bash
+# Single attachment, original filename in cwd
+bzr attachment download 9876
+
+# Single attachment, custom path
+bzr attachment download 9876 --out patch.diff
+
+# Multiple attachment IDs into a directory
+bzr attachment download 9876 9877 9878 --out-dir /tmp/patches
+
+# Every attachment of one or more bugs
+bzr attachment download --bug 12345 --bug 67890 --out-dir /tmp/all
+
+# Mixed: per-bug + explicit attachment ID
+bzr attachment download --bug 12345 9876 --out-dir /tmp/mixed
+```
+
+**Output:**
+
+The single-attachment shape emits a one-line `Downloaded attachment #N to PATH (BYTES bytes)` summary or a `DownloadResult` JSON object.
+
+The bulk shapes emit an `AttachmentBatchResult` (table or JSON): per-bug success rows with each saved file, per-attachment rows for positional IDs, and a `Summary: X succeeded, Y failed, Z total bytes` trailer. Bug-level and per-attachment failures are written to stderr in table mode.
+
+**Exit codes:**
+
+- `0` — every target succeeded
+- `6` — `--out-dir` could not be created (pre-flight)
+- `7` — input validation (no IDs and no `--bug`; `--out` with `--bug` or with multiple IDs; `--out` paired with `--out-dir`)
+- `11` — at least one target failed (`BatchPartialFailure`)
+- other — see the global exit-code table
+
+**See also:** `bzr attachment list` (discover IDs).
 
 ### `bzr attachment upload`
 

--- a/docs/superpowers/specs/2026-05-07-issue-167-attachment-download-bulk-design.md
+++ b/docs/superpowers/specs/2026-05-07-issue-167-attachment-download-bulk-design.md
@@ -1,0 +1,443 @@
+# `bzr attachment download`: bulk download by bug or by attachment-id list
+
+**Date:** 2026-05-07
+**Issue:** [#167](https://github.com/randomparity/bzr/issues/167)
+**Parent spec:** `docs/superpowers/specs/2026-05-06-bzl-parity-review-design.md` (Issue L)
+**Status:** approved, pending implementation plan
+
+## 1. Summary
+
+Extend `bzr attachment download` to download every attachment of one or
+more bugs in a single command, optionally mixed with explicit
+attachment IDs. The current command takes exactly one attachment ID;
+saving "every attachment of bug 12345 into a directory" requires
+`bzr attachment list --json | jq | xargs` plumbing today. After this
+change, `bzr attachment download --bug 12345 --out-dir /tmp/att`
+produces `/tmp/att/12345/<att-id>.<file_name>` files directly.
+
+The legacy single-ID shape (`bzr attachment download 9876 --out
+patch.diff`) is preserved unchanged.
+
+## 2. Background
+
+`bzl-attachment-get` (`reference/bzl/bzl-attachment-get:51-91`) accepts
+a mix of bug IDs and attachment IDs in one call and saves every matched
+attachment into per-bug subdirectories, prefixing each filename with
+the attachment ID. Bzr's `attachment download` accepts a single
+attachment ID with an optional `--out` path. Issue #167 is filed as
+part of the bzl→bzr workflow-parity review (Issue L).
+
+Bzr already has the supporting machinery:
+
+- `BugzillaClient::get_attachments(bug_id)` (`src/client/attachment.rs:54`)
+  lists every attachment for a bug, including the API mode dispatch
+  that handles Bugzilla 5.0.x's REST private-attachment filtering
+  (issue #133).
+- `BugzillaClient::get_attachment(id)` and
+  `BugzillaClient::download_attachment(id)` (`src/client/attachment.rs:90,130`)
+  fetch a single attachment by ID, returning the `bug_id` field on the
+  payload.
+- The `Attachment` type (`src/types/attachment.rs`) has
+  `bug_id: u64`, `file_name: String`, `is_obsolete: bool`, and
+  `data: Option<String>` (base64).
+- `BzrError::BatchPartialFailure { succeeded, failed }`
+  (`src/error.rs:46`, exit code 11) and the `BatchResult` plumbing in
+  `bug update --batch` (`src/commands/bug/update.rs:207`) are the
+  precedent for multi-target operations.
+
+## 3. Scope
+
+### In scope
+
+- Extend `AttachmentAction::Download` to accept repeatable positional
+  attachment IDs and repeatable `--bug <BUG_ID>` flags.
+- Add `--out-dir <DIR>` (default `./attachments`) for the batch shape.
+- Preserve the legacy single-ID shape with `--out <PATH>` unchanged.
+- Validation: `--out` and `--out-dir` mutually exclusive; `--out` only
+  valid with exactly one positional ID and zero `--bug` flags; at
+  least one positional ID *or* one `--bug` is required.
+- Per-target failure isolation: bug-level errors (404, auth) and
+  per-attachment errors (decode, write, missing data) are recorded as
+  failures in the batch result; the loop continues. Top-level
+  `--out-dir` write failure (EACCES on `create_dir_all(out_dir)`) is
+  pre-flight checked and fails fast as `BzrError::Io` (exit 6).
+- New `AttachmentBatchResult` typed payload in
+  `src/output/attachment.rs`, plus a renderer for human and JSON
+  output.
+- Sequential downloads (one HTTP fetch and one disk write at a time).
+- Includes obsolete attachments (bzl parity).
+- Logging: `info!` per file written.
+- Tests: sibling unit tests in `src/commands/attachment_tests.rs` and
+  `src/cli/mod_tests.rs`; one happy-path integration test in
+  `tests/integration.rs`; functional tests in `tests/functional/`.
+- Docs: `docs/bzr-cli.md` updated with all three argument shapes;
+  `CHANGELOG.md` entry under the next unreleased version.
+
+### Out of scope
+
+- `--include-obsolete` / obsolete-filtering flag — bzl parity is to
+  download all; obsolete-filtering can be a follow-up issue.
+- `--concurrency N` — sequential matches `bug update --batch` and bzl;
+  follow-up if testers report bulk runs are too slow.
+- `--overwrite` flag — existing single-attachment behavior silently
+  overwrites; we keep that for the batch shape too.
+- Resume / skip-existing semantics.
+- Streaming output — the batch result is rendered after all targets
+  finish, matching `bug update --batch`.
+- Generalizing `BatchResult<T>` to a typed payload — local
+  `AttachmentBatchResult` keeps the change isolated.
+
+## 4. CLI surface
+
+`src/cli/attachment.rs`, `AttachmentAction::Download`:
+
+```rust
+/// Download one or more attachments to disk.
+///
+/// Three argument shapes are accepted:
+///
+/// 1. Single attachment, free-form path:
+///    bzr attachment download 9876 --out patch.diff
+///
+/// 2. Multiple attachment IDs (positional):
+///    bzr attachment download 9876 9877 9878 [--out-dir DIR]
+///
+/// 3. Every attachment of one or more bugs (mixable with #2):
+///    bzr attachment download --bug 12345 --bug 67890 [9876] [--out-dir DIR]
+///
+/// In shapes 2 and 3, files are written to
+/// `<out-dir>/<bug-id>/<att-id>.<file_name>`. The attachment-ID prefix
+/// avoids same-name collisions on a single bug. `--out-dir` defaults
+/// to `./attachments` and is created (recursively) on demand.
+///
+/// `--out` is only valid for shape 1.
+#[command(verbatim_doc_comment)]
+Download {
+    /// Attachment ID(s) to download. Optional when --bug is set.
+    #[arg(value_name = "ID")]
+    ids: Vec<u64>,
+
+    /// Download every attachment for the given bug. Repeatable.
+    #[arg(long = "bug", value_name = "BUG_ID")]
+    bug_ids: Vec<u64>,
+
+    /// Output file path (single-attachment shape only).
+    #[arg(short = 'o', long = "out", id = "out_file",
+          conflicts_with_all = ["out_dir", "bug_ids"])]
+    out: Option<String>,
+
+    /// Output directory for batch downloads.
+    #[arg(long = "out-dir", default_value = "./attachments")]
+    out_dir: String,
+},
+```
+
+Validation rules (all `BzrError::InputValidation`, exit 7) — enforced
+in `validate_action`:
+
+- `ids` empty *and* `bug_ids` empty → "specify at least one attachment
+  ID or `--bug <ID>`".
+- `out.is_some()` and `ids.len() != 1` → "`--out` requires exactly one
+  attachment ID".
+- (The `--out` vs `--out-dir`/`--bug` conflicts are enforced at the
+  clap layer via `conflicts_with_all`.)
+
+## 5. Types
+
+`src/output/attachment.rs` — new typed payload for the batch shape:
+
+```rust
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct AttachmentBatchResult {
+    pub out_dir: String,
+    pub bug_results: Vec<BugDownloadResult>,
+    pub attachment_results: Vec<AttachmentDownloadResult>,
+    pub summary: BatchSummary,
+}
+
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct BugDownloadResult {
+    pub bug_id: u64,
+    pub status: TargetStatus,            // ok | error
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<DownloadedFile>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct AttachmentDownloadResult {
+    pub attachment_id: u64,
+    pub status: TargetStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bug_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct DownloadedFile {
+    pub attachment_id: u64,
+    pub path: String,
+    pub bytes: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct BatchSummary {
+    pub succeeded: usize,
+    pub failed: usize,
+    pub total_bytes: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "lowercase")]
+pub enum TargetStatus { Ok, Error }
+```
+
+The legacy single-ID shape continues to use the existing
+`output::DownloadResult` (`src/output/result_types.rs:86`).
+
+## 6. Command wiring
+
+`src/commands/attachment.rs`, replacing the existing `Download` arm:
+
+```text
+execute()
+└── match AttachmentAction::Download { ids, bug_ids, out, out_dir }:
+    ├── validate_action(...)                    // rules from §4
+    ├── if is_legacy_single(ids, bug_ids, out): // ids.len()==1 && bug_ids empty && (out.is_some() || …)
+    │     download_single_legacy(client, ids[0], out, format)
+    │   else:
+    │     download_batch(client, ids, bug_ids, out_dir, format)
+```
+
+`download_single_legacy` is the existing code path, factored into its
+own helper for clarity. Behavior is byte-for-byte identical to today:
+`client.download_attachment(id)` → `fs::write(out.unwrap_or(filename),
+bytes)` → `output::print_result(DownloadResult, ...)`.
+
+`download_batch`:
+
+```text
+download_batch(client, ids, bug_ids, out_dir, format) -> Result<()>
+├── fs::create_dir_all(&out_dir)?              // pre-flight, fail fast as Io / exit 6
+├── let mut bug_results = Vec::new();
+├── let mut attachment_results = Vec::new();
+├── for &bug_id in bug_ids:
+│     match client.get_attachments(bug_id).await {
+│       Ok(atts) => {
+│         let mut files = Vec::new();
+│         let mut first_error: Option<String> = None;
+│         for att in atts {
+│           match write_one_attachment(client, &att, &out_dir).await {
+│             Ok(file) => files.push(file),
+│             Err(e) => {
+│               if first_error.is_none() { first_error = Some(e.to_string()); }
+│               // continue to next attachment — partial bug success is allowed
+│             }
+│           }
+│         }
+│         let bug_status = if first_error.is_some() { TargetStatus::Error }
+│                          else { TargetStatus::Ok };
+│         bug_results.push(BugDownloadResult { bug_id, status: bug_status,
+│                                              files, error: first_error });
+│       }
+│       Err(e) => bug_results.push(BugDownloadResult {
+│           bug_id, status: TargetStatus::Error, files: vec![], error: Some(e.to_string()),
+│       }),
+│     }
+├── for &att_id in ids:
+│     match client.get_attachment(att_id).await {
+│       Ok(att) => match write_one_attachment_from_record(&att, &out_dir).await {
+│         Ok(file) => attachment_results.push(AttachmentDownloadResult {
+│           attachment_id: att_id, status: TargetStatus::Ok,
+│           bug_id: Some(att.bug_id), path: Some(file.path), bytes: Some(file.bytes),
+│           error: None,
+│         }),
+│         Err(e) => attachment_results.push(AttachmentDownloadResult {
+│           attachment_id: att_id, status: TargetStatus::Error,
+│           bug_id: Some(att.bug_id), path: None, bytes: None,
+│           error: Some(e.to_string()),
+│         }),
+│       },
+│       Err(e) => attachment_results.push(AttachmentDownloadResult {
+│           attachment_id: att_id, status: TargetStatus::Error,
+│           bug_id: None, path: None, bytes: None, error: Some(e.to_string()),
+│       }),
+│     }
+├── let summary = compute_summary(&bug_results, &attachment_results);
+├── output::print_attachment_batch(&AttachmentBatchResult{...}, format);
+└── if summary.failed > 0:
+       return Err(BzrError::BatchPartialFailure {
+           succeeded: summary.succeeded, failed: summary.failed
+       });
+    Ok(())
+```
+
+`write_one_attachment(client, att, out_dir)`:
+
+1. Resolve bytes:
+   - If `att.data` is `Some(b64)`, base64-decode.
+   - Else fall back to `client.download_attachment(att.id).await` (which
+     re-fetches via `bug/attachment/<id>` and decodes).
+2. `fs::create_dir_all(<out_dir>/<att.bug_id>)`.
+3. `fs::write(<out_dir>/<att.bug_id>/<att.id>.<att.file_name>, &bytes)`.
+4. `tracing::info!(att_id = att.id, path = %dest, bytes = bytes.len(),
+   "downloaded attachment")`.
+5. Return `DownloadedFile { attachment_id: att.id, path, bytes:
+   bytes.len() }`.
+
+The fallback in step 1 makes the bulk path robust to Bugzilla
+configurations where `Bug.attachments` omits the `data` field; we never
+silently drop an attachment.
+
+The hybrid REST/XML-RPC dispatch happens transparently inside
+`get_attachments` and `get_attachment` — no new API mode logic.
+
+## 7. Error handling and exit codes
+
+| failure | type | exit |
+|---|---|---|
+| no IDs and no `--bug` | `InputValidation` | 7 |
+| `--out` with `--bug` or with multiple positional IDs | `InputValidation` | 7 |
+| `--out` and `--out-dir` both set explicitly | `InputValidation` (clap) | 7 |
+| `create_dir_all(out_dir)` fails (pre-flight) | `Io` | 6 |
+| `--bug X` returns 404 / auth-denied | recorded as bug-level failure | 11 |
+| HTTP transport mid-batch | recorded as target failure | 11 |
+| attachment has no `data` and re-fetch fails | recorded as per-attachment failure | 11 |
+| base64 decode failure | recorded as per-attachment failure | 11 |
+| per-bug subdir `create_dir_all` fails | recorded as per-attachment failure | 11 |
+| `fs::write` fails mid-batch | recorded as per-attachment failure | 11 |
+| any failures alongside any successes | `BatchPartialFailure` | 11 |
+| **all** targets fail | `BatchPartialFailure` (deliberately *not* downgraded to a more specific code — matches `bug update --batch`) | 11 |
+| legacy single-ID path: any of the above | propagated unchanged | as today (2/4/5/6/8/9/10) |
+
+**Per-attachment failure within a bug.** When a single attachment
+within a bug fails (decode, write, etc.), we continue to the next
+attachment rather than abandoning the bug. This matches the user's
+intent for bulk mode: `bug_results[].files` reflects exactly what
+landed on disk, while `bug_results[].error` captures the first error
+encountered. The bug's `status` is `error` if any attachment failed,
+even when others succeeded — this lets the failure surface in the
+batch summary while preserving the partial-success disk state.
+
+**Per-attachment count semantics.** `summary.succeeded` counts
+*attachments* written to disk, not *targets* succeeded.
+`summary.failed` counts the sum of bug-level errors and
+attachment-level errors. A bug with three attachments (two written,
+one failed) contributes 2 to `succeeded` and 1 to `failed`. A bug
+that 404s contributes 0 to `succeeded` and 1 to `failed`. This is
+how the user-facing "X succeeded, Y failed" line is most useful, and
+matches what they'd count manually after the run.
+
+**Stderr behavior:** `output::print_attachment_batch` mirrors the
+existing `BatchResult` text renderer — successes and per-target
+failures are printed to stderr in human format with `id: error` lines.
+JSON output is emitted as a single object on stdout with the shape
+in §5. No partial-success warnings; overwrite-silently semantics from
+Q5 mean re-runs are idempotent.
+
+## 8. Tests
+
+### Sibling unit tests — `src/commands/attachment_tests.rs`
+
+- `validate_download_args_rejects_no_ids_no_bugs` — `InputValidation`,
+  exit 7.
+- `validate_download_args_rejects_out_with_bug` — mutual exclusion via
+  clap.
+- `validate_download_args_rejects_out_with_multi_ids` —
+  `--out` requires single positional.
+- `validate_download_args_rejects_out_and_out_dir_both_set` — clap
+  conflict.
+- `download_legacy_single_unchanged_with_out` — regression: existing
+  shape writes to `--out` path, prints `DownloadResult`.
+- `download_legacy_single_unchanged_no_out` — regression: defaults to
+  original filename in cwd.
+- `download_batch_one_bug_two_attachments` — wiremock: bug with two
+  attachments → both files at `<dir>/<bug>/<att>.<name>`.
+- `download_batch_collision_filenames_resolved_by_att_id` — two atts
+  with the same `file_name` on one bug → both written, distinguished
+  by attachment-ID prefix.
+- `download_batch_mixed_bug_and_attachment_ids` — `--bug X` + positional
+  Y → both land in `<dir>/<bug-of-Y>/...`, attachment Y's directory
+  derived from its `bug_id` field.
+- `download_batch_bug_not_found_partial_failure` — one bug 404s, others
+  succeed → `BatchPartialFailure`, exit 11, JSON has correct rows.
+- `download_batch_obsolete_attachments_included` — obsolete atts still
+  downloaded (bzl parity).
+- `download_batch_empty_bug_zero_files_success` — bug with no atts →
+  success row with `files: []`, no warning.
+- `download_batch_top_level_out_dir_unwritable_fails_fast` — EACCES on
+  `create_dir_all(out_dir)` → `Io` (exit 6), no batch loop entered.
+- `download_batch_per_bug_subdir_failure_recorded_as_target_failure` —
+  mid-batch failure isolation.
+- `download_batch_overwrites_existing_file_silently` — regression:
+  re-run idempotent.
+- `download_batch_json_output_shape` — snapshot against the JSON
+  shape from §5.
+- `download_batch_attachment_data_missing_falls_back_to_get` — when
+  `Bug.attachments` returns `data: None`, the bulk path re-fetches
+  via `download_attachment(id)` rather than silently skipping.
+
+### Sibling unit tests — `src/cli/mod_tests.rs`
+
+- `download_parses_single_id` — positional shape parses.
+- `download_parses_multiple_ids` — `Vec<u64>` accepts >1.
+- `download_parses_bug_flag_repeatable` — `--bug 1 --bug 2` parses.
+- `download_parses_mixed_bug_and_ids` — `--bug 1 9876` parses.
+- `download_parses_out_dir_default` — defaults to `./attachments`.
+- `download_clap_conflict_out_with_out_dir_explicit` — clap rejects
+  `--out X --out-dir Y`.
+- `download_clap_conflict_out_with_bug` — clap rejects `--out X --bug 1`.
+
+### Integration test — `tests/integration.rs`
+
+One happy-path bulk download against a wiremock-served Bugzilla,
+asserting on-disk file layout (`<out-dir>/<bug-id>/<att-id>.<file_name>`
+exists with expected bytes).
+
+### Functional tests — `tests/functional/`
+
+Extend `run-tests.sh` with the test plan from issue #167:
+
+```bash
+# bug with two attachments
+bzr attachment download --bug "$BUG_ID" --out-dir "/tmp/att_$$"
+[[ -f "/tmp/att_$$/$BUG_ID/${ATT1_ID}.file1" ]]
+[[ -f "/tmp/att_$$/$BUG_ID/${ATT2_ID}.file2" ]]
+
+# mixed shape
+bzr attachment download --bug "$BUG_ID" "$POSITIONAL_ATT_ID" \
+    --out-dir "/tmp/att_mix_$$"
+```
+
+## 9. Documentation
+
+- `docs/bzr-cli.md` — rewrite the `attachment download` section to
+  cover all three shapes with examples.
+- `CHANGELOG.md` — entry under the next unreleased version, section
+  "Added": "`bzr attachment download` accepts multiple attachment IDs
+  and `--bug <ID>` (repeatable) for bulk downloads into per-bug
+  subdirectories (#167)."
+
+## 10. Open questions
+
+None blocking. Two non-blocking implementation notes:
+
+- Whether `Bug.attachments` returns `data` by default depends on
+  Bugzilla version and the `exclude_fields` query parameter. The
+  fallback in `write_one_attachment` covers either behavior; no
+  design change needed.
+- Wiremock fixtures may need to be extended to include obsolete
+  attachments and missing-`data` responses to cover the new test
+  cases. This is fixture-level work, not design.

--- a/src/cli/attachment.rs
+++ b/src/cli/attachment.rs
@@ -22,28 +22,56 @@ pub enum AttachmentAction {
         bug_id: u64,
     },
 
-    /// Download an attachment to a local file.
+    /// Download attachments to disk.
     ///
-    /// Fetches the attachment by ID and writes the decoded bytes to
-    /// disk. With `--out`/`-o`, the file is written to the given
-    /// path; otherwise the attachment's stored file name is used in
-    /// the current directory. Base64 decoding is handled transparently;
-    /// the on-disk file is the original binary.
+    /// Three argument shapes are accepted:
+    ///
+    /// 1. Single attachment, free-form path:
+    ///    bzr attachment download 9876 --out patch.diff
+    ///
+    /// 2. Multiple attachment IDs (positional):
+    ///    bzr attachment download 9876 9877 9878 [--out-dir DIR]
+    ///
+    /// 3. Every attachment of one or more bugs (mixable with #2):
+    ///    bzr attachment download --bug 12345 [--bug 67890] [9876] [--out-dir DIR]
+    ///
+    /// In shapes 2 and 3, files are written to
+    /// `<out-dir>/<bug-id>/<att-id>.<file_name>`. The attachment-ID
+    /// prefix avoids same-name collisions on a single bug. `--out-dir`
+    /// defaults to `./attachments` and is created (recursively) on
+    /// demand. `--out` is only valid for shape 1.
     ///
     /// Examples:
     ///
     ///   bzr attachment download 9876
     ///   bzr attachment download 9876 --out patch.diff
-    ///   bzr attachment download 9876 -o /tmp/sample.bin
+    ///   bzr attachment download 9876 9877 9878 --out-dir /tmp/patches
+    ///   bzr attachment download --bug 12345 --bug 67890 --out-dir /tmp/all
+    ///   bzr attachment download --bug 12345 9876 --out-dir /tmp/mixed
     ///
     /// See bzr-attachment-list(1) to discover IDs for a bug.
     #[command(verbatim_doc_comment)]
     Download {
-        /// Attachment ID
-        id: u64,
-        /// Output file path (defaults to original filename)
-        #[arg(short = 'o', long = "out", id = "out_file")]
+        /// Attachment ID(s) to download. Optional when --bug is set.
+        #[arg(value_name = "ID")]
+        ids: Vec<u64>,
+
+        /// Download every attachment for the given bug. Repeatable.
+        #[arg(long = "bug", value_name = "BUG_ID")]
+        bug_ids: Vec<u64>,
+
+        /// Output file path (single-attachment shape only).
+        #[arg(
+            short = 'o',
+            long = "out",
+            id = "out_file",
+            conflicts_with_all = ["out_dir", "bug_ids"],
+        )]
         out: Option<String>,
+
+        /// Output directory for batch downloads.
+        #[arg(long = "out-dir", default_value = "./attachments")]
+        out_dir: String,
     },
 
     /// Upload a file as an attachment on a bug.

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -499,17 +499,159 @@ fn parse_attachment_list() {
 }
 
 #[test]
-fn parse_attachment_download() {
+fn parse_attachment_download_single_id_legacy() {
     let cli = Cli::try_parse_from(["bzr", "attachment", "download", "100"]).unwrap();
     match cli.command {
         Commands::Attachment {
-            action: AttachmentAction::Download { id, out },
+            action:
+                AttachmentAction::Download {
+                    ids,
+                    bug_ids,
+                    out,
+                    out_dir,
+                },
         } => {
-            assert_eq!(id, 100);
+            assert_eq!(ids, vec![100]);
+            assert!(bug_ids.is_empty());
             assert!(out.is_none());
+            assert_eq!(out_dir, "./attachments");
         }
         _ => panic!("expected Attachment Download"),
     }
+}
+
+#[test]
+fn parse_attachment_download_with_out() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "attachment",
+        "download",
+        "100",
+        "--out",
+        "patch.diff",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action: AttachmentAction::Download { ids, out, .. },
+        } => {
+            assert_eq!(ids, vec![100]);
+            assert_eq!(out.as_deref(), Some("patch.diff"));
+        }
+        _ => panic!("expected Attachment Download"),
+    }
+}
+
+#[test]
+fn parse_attachment_download_multiple_positional_ids() {
+    let cli = Cli::try_parse_from(["bzr", "attachment", "download", "100", "200", "300"]).unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action: AttachmentAction::Download { ids, bug_ids, .. },
+        } => {
+            assert_eq!(ids, vec![100, 200, 300]);
+            assert!(bug_ids.is_empty());
+        }
+        _ => panic!("expected Attachment Download"),
+    }
+}
+
+#[test]
+fn parse_attachment_download_bug_flag_repeatable() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "attachment",
+        "download",
+        "--bug",
+        "12345",
+        "--bug",
+        "67890",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action: AttachmentAction::Download { ids, bug_ids, .. },
+        } => {
+            assert!(ids.is_empty());
+            assert_eq!(bug_ids, vec![12345, 67890]);
+        }
+        _ => panic!("expected Attachment Download"),
+    }
+}
+
+#[test]
+fn parse_attachment_download_mixed_bug_and_positional() {
+    let cli =
+        Cli::try_parse_from(["bzr", "attachment", "download", "--bug", "12345", "9876"]).unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action: AttachmentAction::Download { ids, bug_ids, .. },
+        } => {
+            assert_eq!(ids, vec![9876]);
+            assert_eq!(bug_ids, vec![12345]);
+        }
+        _ => panic!("expected Attachment Download"),
+    }
+}
+
+#[test]
+fn parse_attachment_download_out_dir_default() {
+    let cli = Cli::try_parse_from(["bzr", "attachment", "download", "--bug", "12345"]).unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action: AttachmentAction::Download { out_dir, .. },
+        } => assert_eq!(out_dir, "./attachments"),
+        _ => panic!("expected Attachment Download"),
+    }
+}
+
+#[test]
+fn parse_attachment_download_out_dir_explicit() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "attachment",
+        "download",
+        "--bug",
+        "12345",
+        "--out-dir",
+        "/tmp/att",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action: AttachmentAction::Download { out_dir, .. },
+        } => assert_eq!(out_dir, "/tmp/att"),
+        _ => panic!("expected Attachment Download"),
+    }
+}
+
+#[test]
+fn parse_attachment_download_clap_conflict_out_with_out_dir() {
+    let result = Cli::try_parse_from([
+        "bzr",
+        "attachment",
+        "download",
+        "100",
+        "--out",
+        "x",
+        "--out-dir",
+        "y",
+    ]);
+    assert!(result.is_err(), "clap should reject --out with --out-dir");
+}
+
+#[test]
+fn parse_attachment_download_clap_conflict_out_with_bug() {
+    let result = Cli::try_parse_from([
+        "bzr",
+        "attachment",
+        "download",
+        "--bug",
+        "12345",
+        "--out",
+        "x",
+    ]);
+    assert!(result.is_err(), "clap should reject --out with --bug");
 }
 
 #[test]

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -26,19 +26,20 @@ pub async fn execute(
         }
         AttachmentAction::Download {
             ids,
-            bug_ids: _,
+            bug_ids,
             out,
             out_dir: _,
         } => {
-            // Bulk routing wired in Task 6. For now: legacy single-ID
-            // path only — the new validation rules in `validate_action`
-            // ensure exactly one positional ID and no `--bug` here.
-            let id = ids.first().copied().ok_or_else(|| {
-                crate::error::BzrError::InputValidation(
-                    "specify at least one attachment ID or --bug <ID>".into(),
-                )
-            })?;
-            download_single_legacy(&client, id, out.as_deref(), format).await?;
+            // Bulk dispatch (multi-ID and/or `--bug`) lands in Task 6;
+            // for this intermediate commit it returns a clear "not yet
+            // implemented" error rather than silently calling into the
+            // legacy single-ID path with the wrong arguments.
+            if !bug_ids.is_empty() || ids.len() != 1 {
+                return Err(crate::error::BzrError::Other(
+                    "bulk attachment download dispatch not yet wired (lands in Task 6)".into(),
+                ));
+            }
+            download_single_legacy(&client, ids[0], out.as_deref(), format).await?;
         }
         AttachmentAction::Upload {
             bug_id,

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -8,7 +8,8 @@ use crate::cli::AttachmentAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
 use crate::output::{
-    self, ActionResult, DownloadResult, DownloadedFile, ResourceKind, UploadResult,
+    self, ActionResult, AttachmentBatchResult, AttachmentDownloadResult, BatchSummary,
+    BugDownloadResult, DownloadResult, DownloadedFile, ResourceKind, TargetStatus, UploadResult,
 };
 use crate::types::ApiMode;
 use crate::types::Attachment;
@@ -33,18 +34,15 @@ pub async fn execute(
             ids,
             bug_ids,
             out,
-            out_dir: _,
+            out_dir,
         } => {
-            // Bulk dispatch (multi-ID and/or `--bug`) lands in Task 6;
-            // for this intermediate commit it returns a clear "not yet
-            // implemented" error rather than silently calling into the
-            // legacy single-ID path with the wrong arguments.
-            if !bug_ids.is_empty() || ids.len() != 1 {
-                return Err(crate::error::BzrError::Other(
-                    "bulk attachment download dispatch not yet wired (lands in Task 6)".into(),
-                ));
+            if bug_ids.is_empty() && ids.len() == 1 {
+                // Legacy single shape — validation already ensured `--out`
+                // is not paired with `--bug` or with multiple IDs.
+                download_single_legacy(&client, ids[0], out.as_deref(), format).await?;
+            } else {
+                download_batch(&client, ids, bug_ids, out_dir, format).await?;
             }
-            download_single_legacy(&client, ids[0], out.as_deref(), format).await?;
         }
         AttachmentAction::Upload {
             bug_id,
@@ -253,10 +251,6 @@ async fn download_single_legacy(
 /// `<out_dir>/<bug_id>/<att_id>.<file_name>`. Surfaces any failure
 /// back to the caller as `BzrError`; the caller decides whether to
 /// abort or record-and-continue.
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "consumed by download_batch in Task 6")
-)]
 async fn write_one_attachment(
     client: &BugzillaClient,
     att: &Attachment,
@@ -295,6 +289,163 @@ async fn write_one_attachment(
         path: dest_str,
         bytes: bytes.len(),
     })
+}
+
+/// Bulk attachment download: walks every `--bug <ID>` then every
+/// positional attachment ID, recording successes and per-target
+/// failures. On any failure, returns `BatchPartialFailure` (exit 11).
+///
+/// Pre-flight: creates `out_dir` itself once. If that fails (e.g. an
+/// unwritable parent), returns `Io` (exit 6) without entering the
+/// loop — better than burying the same error in N per-attachment rows.
+async fn download_batch(
+    client: &BugzillaClient,
+    ids: &[u64],
+    bug_ids: &[u64],
+    out_dir: &str,
+    format: OutputFormat,
+) -> Result<()> {
+    std::fs::create_dir_all(out_dir)?;
+
+    let mut bug_results: Vec<BugDownloadResult> = Vec::new();
+    let mut attachment_results: Vec<AttachmentDownloadResult> = Vec::new();
+    let mut total_bytes: usize = 0;
+
+    for &bug_id in bug_ids {
+        bug_results.push(download_bug_target(client, bug_id, out_dir, &mut total_bytes).await);
+    }
+
+    for &att_id in ids {
+        attachment_results
+            .push(download_attachment_target(client, att_id, out_dir, &mut total_bytes).await);
+    }
+
+    let succeeded: usize = bug_results.iter().map(|b| b.files.len()).sum::<usize>()
+        + attachment_results
+            .iter()
+            .filter(|a| a.status == TargetStatus::Ok)
+            .count();
+    let failed: usize = bug_results
+        .iter()
+        .filter(|b| b.status == TargetStatus::Error)
+        .count()
+        + attachment_results
+            .iter()
+            .filter(|a| a.status == TargetStatus::Error)
+            .count();
+
+    let result = AttachmentBatchResult {
+        out_dir: out_dir.to_string(),
+        bug_results,
+        attachment_results,
+        summary: BatchSummary {
+            succeeded,
+            failed,
+            total_bytes,
+        },
+    };
+
+    output::print_attachment_batch(&result, format);
+
+    if failed > 0 {
+        return Err(crate::error::BzrError::BatchPartialFailure { succeeded, failed });
+    }
+    Ok(())
+}
+
+/// Download every attachment for one `--bug <ID>` target. Returns a
+/// `BugDownloadResult` describing the per-bug outcome — even on a
+/// listing-API failure (in which case `files` is empty and `error` is
+/// populated).
+async fn download_bug_target(
+    client: &BugzillaClient,
+    bug_id: u64,
+    out_dir: &str,
+    total_bytes: &mut usize,
+) -> BugDownloadResult {
+    let atts = match client.get_attachments(bug_id).await {
+        Ok(atts) => atts,
+        Err(e) => {
+            return BugDownloadResult {
+                bug_id,
+                status: TargetStatus::Error,
+                files: vec![],
+                error: Some(e.to_string()),
+            };
+        }
+    };
+
+    let mut files = Vec::new();
+    let mut first_error: Option<String> = None;
+    for att in &atts {
+        match write_one_attachment(client, att, out_dir).await {
+            Ok(file) => {
+                *total_bytes += file.bytes;
+                files.push(file);
+            }
+            Err(e) => {
+                if first_error.is_none() {
+                    first_error = Some(e.to_string());
+                }
+            }
+        }
+    }
+    let status = if first_error.is_some() {
+        TargetStatus::Error
+    } else {
+        TargetStatus::Ok
+    };
+    BugDownloadResult {
+        bug_id,
+        status,
+        files,
+        error: first_error,
+    }
+}
+
+/// Download one positional attachment-ID target. The returned record
+/// retains `bug_id` whenever the metadata fetch succeeds, so users can
+/// correlate post-fetch (e.g. write) failures back to a bug.
+async fn download_attachment_target(
+    client: &BugzillaClient,
+    att_id: u64,
+    out_dir: &str,
+    total_bytes: &mut usize,
+) -> AttachmentDownloadResult {
+    let att = match client.get_attachment(att_id).await {
+        Ok(att) => att,
+        Err(e) => {
+            return AttachmentDownloadResult {
+                attachment_id: att_id,
+                status: TargetStatus::Error,
+                bug_id: None,
+                path: None,
+                bytes: None,
+                error: Some(e.to_string()),
+            };
+        }
+    };
+    match write_one_attachment(client, &att, out_dir).await {
+        Ok(file) => {
+            *total_bytes += file.bytes;
+            AttachmentDownloadResult {
+                attachment_id: att_id,
+                status: TargetStatus::Ok,
+                bug_id: Some(att.bug_id),
+                path: Some(file.path),
+                bytes: Some(file.bytes),
+                error: None,
+            }
+        }
+        Err(e) => AttachmentDownloadResult {
+            attachment_id: att_id,
+            status: TargetStatus::Error,
+            bug_id: Some(att.bug_id),
+            path: None,
+            bytes: None,
+            error: Some(e.to_string()),
+        },
+    }
 }
 
 #[cfg(test)]

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -24,8 +24,21 @@ pub async fn execute(
             let attachments = client.get_attachments(*bug_id).await?;
             output::print_attachments(&attachments, format);
         }
-        AttachmentAction::Download { id, out } => {
-            download_single_legacy(&client, *id, out.as_deref(), format).await?;
+        AttachmentAction::Download {
+            ids,
+            bug_ids: _,
+            out,
+            out_dir: _,
+        } => {
+            // Bulk routing wired in Task 6. For now: legacy single-ID
+            // path only — the new validation rules in `validate_action`
+            // ensure exactly one positional ID and no `--bug` here.
+            let id = ids.first().copied().ok_or_else(|| {
+                crate::error::BzrError::InputValidation(
+                    "specify at least one attachment ID or --bug <ID>".into(),
+                )
+            })?;
+            download_single_legacy(&client, id, out.as_deref(), format).await?;
         }
         AttachmentAction::Upload {
             bug_id,
@@ -102,17 +115,26 @@ pub async fn execute(
 }
 
 fn validate_action(action: &AttachmentAction) -> Result<()> {
-    if let AttachmentAction::Upload {
-        comment_private: true,
-        comment: None,
-        ..
-    } = action
-    {
-        return Err(crate::error::BzrError::InputValidation(
+    match action {
+        AttachmentAction::Upload {
+            comment_private: true,
+            comment: None,
+            ..
+        } => Err(crate::error::BzrError::InputValidation(
             "--comment-private requires --comment".into(),
-        ));
+        )),
+        AttachmentAction::Download { ids, bug_ids, .. } if ids.is_empty() && bug_ids.is_empty() => {
+            Err(crate::error::BzrError::InputValidation(
+                "specify at least one attachment ID or --bug <ID>".into(),
+            ))
+        }
+        AttachmentAction::Download {
+            ids, out: Some(_), ..
+        } if ids.len() != 1 => Err(crate::error::BzrError::InputValidation(
+            "--out requires exactly one attachment ID".into(),
+        )),
+        _ => Ok(()),
     }
-    Ok(())
 }
 
 fn guess_content_type(filename: &str) -> &'static str {

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -2,11 +2,16 @@ use std::collections::HashMap;
 use std::io::Write as _;
 use std::path::Path;
 
+use base64::Engine;
+
 use crate::cli::AttachmentAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output::{self, ActionResult, DownloadResult, ResourceKind, UploadResult};
+use crate::output::{
+    self, ActionResult, DownloadResult, DownloadedFile, ResourceKind, UploadResult,
+};
 use crate::types::ApiMode;
+use crate::types::Attachment;
 use crate::types::OutputFormat;
 use crate::types::{UpdateAttachmentParams, UploadAttachmentParams};
 
@@ -242,6 +247,54 @@ async fn download_single_legacy(
         format,
     );
     Ok(())
+}
+
+/// Decode (or re-fetch) one attachment's bytes and write them to
+/// `<out_dir>/<bug_id>/<att_id>.<file_name>`. Surfaces any failure
+/// back to the caller as `BzrError`; the caller decides whether to
+/// abort or record-and-continue.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "consumed by download_batch in Task 6")
+)]
+async fn write_one_attachment(
+    client: &BugzillaClient,
+    att: &Attachment,
+    out_dir: &str,
+) -> Result<DownloadedFile> {
+    let bytes = if let Some(b64) = att.data.as_deref() {
+        base64::engine::general_purpose::STANDARD
+            .decode(b64)
+            .map_err(|e| {
+                crate::error::BzrError::DataIntegrity(format!(
+                    "failed to decode attachment #{}: {e}",
+                    att.id,
+                ))
+            })?
+    } else {
+        let (_, fetched) = client.download_attachment(att.id).await?;
+        fetched
+    };
+
+    let bug_subdir = Path::new(out_dir).join(att.bug_id.to_string());
+    std::fs::create_dir_all(&bug_subdir)?;
+    let dest = bug_subdir.join(format!("{}.{}", att.id, att.file_name));
+    let dest_str = dest.to_string_lossy().into_owned();
+    std::fs::write(&dest, &bytes)?;
+
+    tracing::info!(
+        att_id = att.id,
+        bug_id = att.bug_id,
+        path = %dest_str,
+        bytes = bytes.len(),
+        "downloaded attachment",
+    );
+
+    Ok(DownloadedFile {
+        attachment_id: att.id,
+        path: dest_str,
+        bytes: bytes.len(),
+    })
 }
 
 #[cfg(test)]

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -25,17 +25,7 @@ pub async fn execute(
             output::print_attachments(&attachments, format);
         }
         AttachmentAction::Download { id, out } => {
-            let (filename, data) = client.download_attachment(*id).await?;
-            let dest = out.as_deref().unwrap_or(&filename);
-            std::fs::write(dest, &data)?;
-            output::print_result(
-                &DownloadResult::new(*id, dest, data.len()),
-                &format!(
-                    "Downloaded attachment #{id} to {dest} ({} bytes)",
-                    data.len()
-                ),
-                format,
-            );
+            download_single_legacy(&client, *id, out.as_deref(), format).await?;
         }
         AttachmentAction::Upload {
             bug_id,
@@ -205,6 +195,30 @@ fn warn_partial(att_id: u64, err: &crate::error::BzrError) {
         std::io::stderr(),
         "  the comment was created public; mark it private via the Bugzilla web UI or with elevated credentials",
     );
+}
+
+/// Single-attachment download: writes one decoded blob to `out` (if
+/// supplied) or to the attachment's stored `file_name` in the current
+/// directory. Behavior matches the original inline arm — the function
+/// exists to keep `execute()` readable when the bulk path is added.
+async fn download_single_legacy(
+    client: &BugzillaClient,
+    id: u64,
+    out: Option<&str>,
+    format: OutputFormat,
+) -> Result<()> {
+    let (filename, data) = client.download_attachment(id).await?;
+    let dest = out.unwrap_or(&filename);
+    std::fs::write(dest, &data)?;
+    output::print_result(
+        &DownloadResult::new(id, dest, data.len()),
+        &format!(
+            "Downloaded attachment #{id} to {dest} ({} bytes)",
+            data.len(),
+        ),
+        format,
+    );
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -37,8 +37,6 @@ pub async fn execute(
             out_dir,
         } => {
             if bug_ids.is_empty() && ids.len() == 1 {
-                // Legacy single shape — validation already ensured `--out`
-                // is not paired with `--bug` or with multiple IDs.
                 download_single(&client, ids[0], out.as_deref(), format).await?;
             } else {
                 download_batch(&client, ids, bug_ids, out_dir, format).await?;
@@ -318,38 +316,15 @@ async fn download_batch(
         attachment_results.push(download_attachment_target(client, att_id, out_dir).await);
     }
 
-    let succeeded: usize = bug_results.iter().map(|b| b.files.len()).sum::<usize>()
-        + attachment_results
-            .iter()
-            .filter(|a| a.status == TargetStatus::Ok)
-            .count();
-    let failed: usize = bug_results
-        .iter()
-        .filter(|b| b.status == TargetStatus::Error)
-        .count()
-        + attachment_results
-            .iter()
-            .filter(|a| a.status == TargetStatus::Error)
-            .count();
-    let total_bytes: usize = bug_results
-        .iter()
-        .flat_map(|b| &b.files)
-        .map(|f| f.bytes)
-        .sum::<usize>()
-        + attachment_results
-            .iter()
-            .filter_map(|a| a.bytes)
-            .sum::<usize>();
+    let summary = BatchSummary::from_results(&bug_results, &attachment_results);
+    let succeeded = summary.succeeded;
+    let failed = summary.failed;
 
     let result = AttachmentBatchResult {
         out_dir: out_dir.to_string(),
         bug_results,
         attachment_results,
-        summary: BatchSummary {
-            succeeded,
-            failed,
-            total_bytes,
-        },
+        summary,
     };
 
     output::print_attachment_batch(&result, format);

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -39,7 +39,7 @@ pub async fn execute(
             if bug_ids.is_empty() && ids.len() == 1 {
                 // Legacy single shape — validation already ensured `--out`
                 // is not paired with `--bug` or with multiple IDs.
-                download_single_legacy(&client, ids[0], out.as_deref(), format).await?;
+                download_single(&client, ids[0], out.as_deref(), format).await?;
             } else {
                 download_batch(&client, ids, bug_ids, out_dir, format).await?;
             }
@@ -225,9 +225,9 @@ fn warn_partial(att_id: u64, err: &crate::error::BzrError) {
 
 /// Single-attachment download: writes one decoded blob to `out` (if
 /// supplied) or to the attachment's stored `file_name` in the current
-/// directory. Behavior matches the original inline arm — the function
-/// exists to keep `execute()` readable when the bulk path is added.
-async fn download_single_legacy(
+/// directory. Paired with `download_batch` for bulk shapes; both paths
+/// are first-class.
+async fn download_single(
     client: &BugzillaClient,
     id: u64,
     out: Option<&str>,
@@ -309,15 +309,13 @@ async fn download_batch(
 
     let mut bug_results: Vec<BugDownloadResult> = Vec::new();
     let mut attachment_results: Vec<AttachmentDownloadResult> = Vec::new();
-    let mut total_bytes: usize = 0;
 
     for &bug_id in bug_ids {
-        bug_results.push(download_bug_target(client, bug_id, out_dir, &mut total_bytes).await);
+        bug_results.push(download_bug_target(client, bug_id, out_dir).await);
     }
 
     for &att_id in ids {
-        attachment_results
-            .push(download_attachment_target(client, att_id, out_dir, &mut total_bytes).await);
+        attachment_results.push(download_attachment_target(client, att_id, out_dir).await);
     }
 
     let succeeded: usize = bug_results.iter().map(|b| b.files.len()).sum::<usize>()
@@ -333,6 +331,15 @@ async fn download_batch(
             .iter()
             .filter(|a| a.status == TargetStatus::Error)
             .count();
+    let total_bytes: usize = bug_results
+        .iter()
+        .flat_map(|b| &b.files)
+        .map(|f| f.bytes)
+        .sum::<usize>()
+        + attachment_results
+            .iter()
+            .filter_map(|a| a.bytes)
+            .sum::<usize>();
 
     let result = AttachmentBatchResult {
         out_dir: out_dir.to_string(),
@@ -361,7 +368,6 @@ async fn download_bug_target(
     client: &BugzillaClient,
     bug_id: u64,
     out_dir: &str,
-    total_bytes: &mut usize,
 ) -> BugDownloadResult {
     let atts = match client.get_attachments(bug_id).await {
         Ok(atts) => atts,
@@ -380,7 +386,6 @@ async fn download_bug_target(
     for att in &atts {
         match write_one_attachment(client, att, out_dir).await {
             Ok(file) => {
-                *total_bytes += file.bytes;
                 files.push(file);
             }
             Err(e) => {
@@ -410,7 +415,6 @@ async fn download_attachment_target(
     client: &BugzillaClient,
     att_id: u64,
     out_dir: &str,
-    total_bytes: &mut usize,
 ) -> AttachmentDownloadResult {
     let att = match client.get_attachment(att_id).await {
         Ok(att) => att,
@@ -426,17 +430,14 @@ async fn download_attachment_target(
         }
     };
     match write_one_attachment(client, &att, out_dir).await {
-        Ok(file) => {
-            *total_bytes += file.bytes;
-            AttachmentDownloadResult {
-                attachment_id: att_id,
-                status: TargetStatus::Ok,
-                bug_id: Some(att.bug_id),
-                path: Some(file.path),
-                bytes: Some(file.bytes),
-                error: None,
-            }
-        }
+        Ok(file) => AttachmentDownloadResult {
+            attachment_id: att_id,
+            status: TargetStatus::Ok,
+            bug_id: Some(att.bug_id),
+            path: Some(file.path),
+            bytes: Some(file.bytes),
+            error: None,
+        },
         Err(e) => AttachmentDownloadResult {
             attachment_id: att_id,
             status: TargetStatus::Error,

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -907,3 +907,210 @@ async fn attachment_download_batch_legacy_single_id_unchanged() {
     assert!(out_path.exists());
     assert_eq!(std::fs::read(&out_path).unwrap(), b"legacy");
 }
+
+#[tokio::test]
+async fn attachment_download_batch_bug_not_found_partial_failure() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/12345/attachment"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(bug_attachments_response(
+                12345,
+                &serde_json::json!([one_att(9876, 12345, "patch.diff", b"ok")]),
+            )),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/99999/attachment"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "error": true,
+            "code": 101,
+            "message": "Bug 99999 does not exist."
+        })))
+        .mount(&mock)
+        .await;
+
+    let out_dir = tmp.path().to_string_lossy().into_owned();
+    let action = AttachmentAction::Download {
+        ids: vec![],
+        bug_ids: vec![12345, 99999],
+        out: None,
+        out_dir,
+    };
+
+    let (result, output) =
+        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    assert!(result.is_err(), "expected BatchPartialFailure");
+    let err = result.unwrap_err();
+    let exit = err.exit_code();
+    assert_eq!(exit, 11, "expected exit 11, got {exit}: {err}");
+
+    let parsed = extract_json(&output);
+    assert_eq!(parsed["summary"]["succeeded"], 1);
+    assert_eq!(parsed["summary"]["failed"], 1);
+    let bugs = parsed["bug_results"].as_array().unwrap();
+    assert_eq!(bugs[0]["bug_id"], 12345);
+    assert_eq!(bugs[0]["status"], "ok");
+    assert_eq!(bugs[1]["bug_id"], 99999);
+    assert_eq!(bugs[1]["status"], "error");
+}
+
+#[tokio::test]
+async fn attachment_download_batch_all_targets_fail_still_exit_11() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/99999/attachment"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "error": true,
+            "code": 101,
+            "message": "Bug 99999 does not exist."
+        })))
+        .mount(&mock)
+        .await;
+
+    let out_dir = tmp.path().to_string_lossy().into_owned();
+    let action = AttachmentAction::Download {
+        ids: vec![],
+        bug_ids: vec![99999],
+        out: None,
+        out_dir,
+    };
+    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(result.is_err(), "expected BatchPartialFailure");
+    let err = result.unwrap_err();
+    let exit = err.exit_code();
+    assert_eq!(exit, 11, "all-fail still uses BatchPartialFailure: {err}");
+}
+
+#[tokio::test]
+async fn attachment_download_batch_obsolete_attachments_included() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    let mut obsolete = one_att(9876, 12345, "old.patch", b"obsolete content");
+    obsolete["is_obsolete"] = serde_json::json!(true);
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/12345/attachment"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(bug_attachments_response(
+                12345,
+                &serde_json::json!([obsolete]),
+            )),
+        )
+        .mount(&mock)
+        .await;
+
+    let out_dir = tmp.path().to_string_lossy().into_owned();
+    let action = AttachmentAction::Download {
+        ids: vec![],
+        bug_ids: vec![12345],
+        out: None,
+        out_dir: out_dir.clone(),
+    };
+
+    let (result, _) = capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    assert!(result.is_ok(), "expected ok, got {result:?}");
+    assert!(tmp.path().join("12345").join("9876.old.patch").exists());
+}
+
+#[tokio::test]
+async fn attachment_download_batch_data_missing_falls_back_via_get() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    // Listing returns the attachment metadata WITHOUT data.
+    let mut att = one_att(9876, 12345, "patch.diff", b"x");
+    att["data"] = serde_json::Value::Null;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/12345/attachment"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(bug_attachments_response(12345, &serde_json::json!([att]))),
+        )
+        .mount(&mock)
+        .await;
+
+    // Fallback fetch DOES return data.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/9876"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "attachments": {
+                "9876": one_att(9876, 12345, "patch.diff", b"fallback"),
+            }
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let out_dir = tmp.path().to_string_lossy().into_owned();
+    let action = AttachmentAction::Download {
+        ids: vec![],
+        bug_ids: vec![12345],
+        out: None,
+        out_dir,
+    };
+
+    let (result, _) = capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    assert!(result.is_ok(), "expected ok, got {result:?}");
+    let written = std::fs::read(tmp.path().join("12345").join("9876.patch.diff")).unwrap();
+    assert_eq!(written, b"fallback");
+}
+
+#[tokio::test]
+async fn attachment_download_batch_top_level_out_dir_unwritable_fails_fast() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    // /dev/null/attachments — create_dir_all on a path under /dev/null
+    // (which is a character device, not a directory) → ENOTDIR.
+    let action = AttachmentAction::Download {
+        ids: vec![],
+        bug_ids: vec![12345],
+        out: None,
+        out_dir: "/dev/null/attachments".into(),
+    };
+    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(result.is_err(), "expected Io");
+    let err = result.unwrap_err();
+    let exit = err.exit_code();
+    assert_eq!(exit, 6, "expected Io exit 6 (fail-fast), got {exit}: {err}");
+}
+
+#[tokio::test]
+async fn write_one_attachment_invalid_base64_returns_data_integrity() {
+    let (_lock, _mock, tmp) = setup_test_env().await;
+    let client = super::super::shared::connect_and_configure(None, None)
+        .await
+        .unwrap();
+
+    let att = crate::types::Attachment {
+        id: 9876,
+        bug_id: 12345,
+        file_name: "patch.diff".into(),
+        summary: "broken".into(),
+        content_type: "text/plain".into(),
+        creator: None,
+        creation_time: None,
+        last_change_time: None,
+        size: 0,
+        is_obsolete: false,
+        is_private: false,
+        is_patch: false,
+        data: Some("not valid base64 !!".into()),
+    };
+    let out_dir = tmp.path().to_string_lossy().into_owned();
+
+    let result = super::write_one_attachment(&client, &att, &out_dir).await;
+    assert!(result.is_err(), "expected DataIntegrity for invalid base64");
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, crate::error::BzrError::DataIntegrity(_)),
+        "expected DataIntegrity, got {err}",
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("decode attachment #9876"),
+        "expected decode error message including att-id, got: {msg}",
+    );
+}

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -565,3 +565,131 @@ async fn attachment_download_validation_rejects_out_with_multiple_ids() {
         "unexpected error: {msg}",
     );
 }
+
+fn b64(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+#[tokio::test]
+async fn write_one_attachment_writes_inline_data_with_att_id_prefix() {
+    let (_lock, _mock, tmp) = setup_test_env().await;
+    let client = super::super::shared::connect_and_configure(None, None)
+        .await
+        .unwrap();
+
+    let att = crate::types::Attachment {
+        id: 9876,
+        bug_id: 12345,
+        file_name: "patch.diff".into(),
+        summary: "Fix patch".into(),
+        content_type: "text/x-diff".into(),
+        creator: None,
+        creation_time: None,
+        last_change_time: None,
+        size: 11,
+        is_obsolete: false,
+        is_private: false,
+        is_patch: true,
+        data: Some(b64(b"Hello world")),
+    };
+    let out_dir = tmp.path().to_string_lossy().into_owned();
+
+    let file = super::write_one_attachment(&client, &att, &out_dir)
+        .await
+        .unwrap();
+
+    let expected_path = tmp.path().join("12345").join("9876.patch.diff");
+    assert!(expected_path.exists(), "{expected_path:?} not found");
+    assert_eq!(std::fs::read(&expected_path).unwrap(), b"Hello world");
+    assert_eq!(file.attachment_id, 9876);
+    assert_eq!(file.bytes, 11);
+}
+
+#[tokio::test]
+async fn write_one_attachment_falls_back_when_data_missing() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/9876"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "attachments": {
+                "9876": {
+                    "id": 9876,
+                    "bug_id": 12345,
+                    "file_name": "patch.diff",
+                    "summary": "Fix patch",
+                    "content_type": "text/plain",
+                    "size": 11,
+                    "data": b64(b"Hello world")
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = super::super::shared::connect_and_configure(None, None)
+        .await
+        .unwrap();
+
+    let att = crate::types::Attachment {
+        id: 9876,
+        bug_id: 12345,
+        file_name: "patch.diff".into(),
+        summary: "Fix patch".into(),
+        content_type: "text/plain".into(),
+        creator: None,
+        creation_time: None,
+        last_change_time: None,
+        size: 11,
+        is_obsolete: false,
+        is_private: false,
+        is_patch: false,
+        data: None,
+    };
+    let out_dir = tmp.path().to_string_lossy().into_owned();
+
+    let file = super::write_one_attachment(&client, &att, &out_dir)
+        .await
+        .unwrap();
+
+    assert_eq!(file.bytes, 11);
+    let expected_path = tmp.path().join("12345").join("9876.patch.diff");
+    assert!(expected_path.exists());
+}
+
+#[tokio::test]
+async fn write_one_attachment_overwrites_existing_file() {
+    let (_lock, _mock, tmp) = setup_test_env().await;
+    let client = super::super::shared::connect_and_configure(None, None)
+        .await
+        .unwrap();
+
+    let dir = tmp.path().join("12345");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("9876.patch.diff"), b"OLD CONTENT").unwrap();
+
+    let att = crate::types::Attachment {
+        id: 9876,
+        bug_id: 12345,
+        file_name: "patch.diff".into(),
+        summary: "v2".into(),
+        content_type: "text/plain".into(),
+        creator: None,
+        creation_time: None,
+        last_change_time: None,
+        size: 11,
+        is_obsolete: false,
+        is_private: false,
+        is_patch: false,
+        data: Some(b64(b"NEW CONTENT")),
+    };
+    let out_dir = tmp.path().to_string_lossy().into_owned();
+
+    super::write_one_attachment(&client, &att, &out_dir)
+        .await
+        .unwrap();
+
+    let written = std::fs::read(dir.join("9876.patch.diff")).unwrap();
+    assert_eq!(written, b"NEW CONTENT");
+}

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -693,3 +693,217 @@ async fn write_one_attachment_overwrites_existing_file() {
     let written = std::fs::read(dir.join("9876.patch.diff")).unwrap();
     assert_eq!(written, b"NEW CONTENT");
 }
+
+fn bug_attachments_response(bug_id: u64, atts: &serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "bugs": { bug_id.to_string(): atts },
+    })
+}
+
+fn one_att(id: u64, bug_id: u64, file_name: &str, body: &[u8]) -> serde_json::Value {
+    serde_json::json!({
+        "id": id,
+        "bug_id": bug_id,
+        "file_name": file_name,
+        "summary": file_name,
+        "content_type": "text/plain",
+        "creator": "dev@test.com",
+        "creation_time": "2025-01-01T00:00:00Z",
+        "last_change_time": "2025-01-01T00:00:00Z",
+        "is_obsolete": false,
+        "is_patch": false,
+        "is_private": false,
+        "size": body.len(),
+        "data": b64(body),
+    })
+}
+
+#[tokio::test]
+async fn attachment_download_batch_per_bug_writes_per_bug_subdir() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/12345/attachment"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(bug_attachments_response(
+                12345,
+                &serde_json::json!([
+                    one_att(9876, 12345, "patch.diff", b"alpha"),
+                    one_att(9877, 12345, "trace.log", b"bravo charlie"),
+                ]),
+            )),
+        )
+        .mount(&mock)
+        .await;
+
+    let out_dir = tmp.path().to_string_lossy().into_owned();
+    let action = AttachmentAction::Download {
+        ids: vec![],
+        bug_ids: vec![12345],
+        out: None,
+        out_dir: out_dir.clone(),
+    };
+
+    let (result, output) =
+        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    assert!(result.is_ok(), "expected ok, got {result:?}");
+
+    let parsed = extract_json(&output);
+    assert_eq!(parsed["summary"]["succeeded"], 2);
+    assert_eq!(parsed["summary"]["failed"], 0);
+    assert_eq!(parsed["summary"]["total_bytes"], 5 + 13);
+    assert_eq!(parsed["bug_results"][0]["bug_id"], 12345);
+    assert_eq!(parsed["bug_results"][0]["status"], "ok");
+
+    assert!(tmp.path().join("12345").join("9876.patch.diff").exists());
+    assert!(tmp.path().join("12345").join("9877.trace.log").exists());
+    let p1 = std::fs::read(tmp.path().join("12345").join("9876.patch.diff")).unwrap();
+    assert_eq!(p1, b"alpha");
+}
+
+#[tokio::test]
+async fn attachment_download_batch_collision_filenames_resolved_by_att_id_prefix() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/12345/attachment"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(bug_attachments_response(
+                12345,
+                &serde_json::json!([
+                    one_att(9876, 12345, "trace.log", b"first"),
+                    one_att(9877, 12345, "trace.log", b"second"),
+                ]),
+            )),
+        )
+        .mount(&mock)
+        .await;
+
+    let out_dir = tmp.path().to_string_lossy().into_owned();
+    let action = AttachmentAction::Download {
+        ids: vec![],
+        bug_ids: vec![12345],
+        out: None,
+        out_dir,
+    };
+
+    let (result, _) = capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    assert!(result.is_ok(), "expected ok, got {result:?}");
+
+    let p1 = tmp.path().join("12345").join("9876.trace.log");
+    let p2 = tmp.path().join("12345").join("9877.trace.log");
+    assert_eq!(std::fs::read(&p1).unwrap(), b"first");
+    assert_eq!(std::fs::read(&p2).unwrap(), b"second");
+}
+
+#[tokio::test]
+async fn attachment_download_batch_mixed_bug_and_positional_ids() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/12345/attachment"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(bug_attachments_response(
+                12345,
+                &serde_json::json!([one_att(9876, 12345, "patch.diff", b"from bug")]),
+            )),
+        )
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/4242"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "attachments": {
+                "4242": one_att(4242, 67890, "extra.bin", b"from positional"),
+            }
+        })))
+        .mount(&mock)
+        .await;
+
+    let out_dir = tmp.path().to_string_lossy().into_owned();
+    let action = AttachmentAction::Download {
+        ids: vec![4242],
+        bug_ids: vec![12345],
+        out: None,
+        out_dir: out_dir.clone(),
+    };
+
+    let (result, output) =
+        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    assert!(result.is_ok(), "expected ok, got {result:?}");
+
+    let parsed = extract_json(&output);
+    assert_eq!(parsed["summary"]["succeeded"], 2);
+    assert_eq!(parsed["bug_results"][0]["bug_id"], 12345);
+    assert_eq!(parsed["attachment_results"][0]["attachment_id"], 4242);
+    assert_eq!(parsed["attachment_results"][0]["bug_id"], 67890);
+
+    assert!(tmp.path().join("12345").join("9876.patch.diff").exists());
+    assert!(tmp.path().join("67890").join("4242.extra.bin").exists());
+}
+
+#[tokio::test]
+async fn attachment_download_batch_empty_bug_zero_files_success() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/12345/attachment"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(bug_attachments_response(12345, &serde_json::json!([]))),
+        )
+        .mount(&mock)
+        .await;
+
+    let out_dir = tmp.path().to_string_lossy().into_owned();
+    let action = AttachmentAction::Download {
+        ids: vec![],
+        bug_ids: vec![12345],
+        out: None,
+        out_dir,
+    };
+
+    let (result, output) =
+        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    assert!(result.is_ok(), "expected ok, got {result:?}");
+    let parsed = extract_json(&output);
+    assert_eq!(parsed["bug_results"][0]["status"], "ok");
+    assert_eq!(parsed["summary"]["succeeded"], 0);
+    assert_eq!(parsed["summary"]["failed"], 0);
+}
+
+#[tokio::test]
+async fn attachment_download_batch_legacy_single_id_unchanged() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/9876"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "attachments": {
+                "9876": one_att(9876, 12345, "patch.diff", b"legacy"),
+            }
+        })))
+        .mount(&mock)
+        .await;
+
+    let out_path = tmp.path().join("downloaded.bin");
+    let action = AttachmentAction::Download {
+        ids: vec![9876],
+        bug_ids: vec![],
+        out: Some(out_path.to_string_lossy().into_owned()),
+        out_dir: "./attachments".into(),
+    };
+
+    let (result, output) =
+        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    assert!(result.is_ok(), "expected ok, got {result:?}");
+
+    // Legacy path emits DownloadResult, not AttachmentBatchResult — the
+    // JSON has `id` at the top level, not `summary`.
+    let parsed = extract_json(&output);
+    assert_eq!(parsed["id"], 9876);
+    assert_eq!(parsed["size"].as_u64().unwrap_or(0), 6);
+    assert!(out_path.exists());
+    assert_eq!(std::fs::read(&out_path).unwrap(), b"legacy");
+}

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -110,7 +110,12 @@ async fn attachment_download_api_error_propagates() {
         .mount(&mock)
         .await;
 
-    let action = AttachmentAction::Download { id: 404, out: None };
+    let action = AttachmentAction::Download {
+        ids: vec![404],
+        bug_ids: vec![],
+        out: None,
+        out_dir: "./attachments".into(),
+    };
     let result = super::execute(&action, None, OutputFormat::Json, None).await;
     assert!(result.is_err());
 }
@@ -525,4 +530,38 @@ async fn attachment_upload_comment_private_no_matching_comment_is_data_integrity
         result,
         Err(crate::error::BzrError::DataIntegrity(_))
     ));
+}
+
+#[tokio::test]
+async fn attachment_download_validation_rejects_no_ids_no_bugs() {
+    let action = AttachmentAction::Download {
+        ids: vec![],
+        bug_ids: vec![],
+        out: None,
+        out_dir: "./attachments".into(),
+    };
+    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(result.is_err(), "expected InputValidation");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("specify at least one attachment ID"),
+        "unexpected error: {msg}",
+    );
+}
+
+#[tokio::test]
+async fn attachment_download_validation_rejects_out_with_multiple_ids() {
+    let action = AttachmentAction::Download {
+        ids: vec![100, 200],
+        bug_ids: vec![],
+        out: Some("file.bin".into()),
+        out_dir: "./attachments".into(),
+    };
+    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    assert!(result.is_err(), "expected InputValidation");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("--out requires exactly one attachment ID"),
+        "unexpected error: {msg}",
+    );
 }

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -1058,6 +1058,7 @@ async fn attachment_download_batch_data_missing_falls_back_via_get() {
     assert_eq!(written, b"fallback");
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn attachment_download_batch_top_level_out_dir_unwritable_fails_fast() {
     let (_lock, _mock, _tmp) = setup_test_env().await;

--- a/src/output/attachment.rs
+++ b/src/output/attachment.rs
@@ -39,7 +39,7 @@ pub fn print_attachments(attachments: &[Attachment], format: OutputFormat) {
 
 /// Top-level payload for `bzr attachment download` in bulk mode.
 ///
-/// Single-ID legacy mode continues to use [`super::DownloadResult`].
+/// Single-ID mode continues to use [`super::DownloadResult`].
 #[derive(Debug, Serialize)]
 #[non_exhaustive]
 pub struct AttachmentBatchResult {
@@ -95,16 +95,55 @@ pub struct DownloadedFile {
 
 /// Aggregate counters for the batch run.
 ///
-/// `succeeded` counts attachments written to disk; `failed` counts the
-/// sum of bug-level errors and per-attachment failures. A bug with
-/// three attachments where two are written and one fails contributes
-/// 2 to `succeeded` and 1 to `failed`.
+/// `succeeded` counts attachments successfully written to disk
+/// (across both `--bug` and positional-ID targets). `failed` counts
+/// failed *targets* — each `--bug <ID>` whose result is `Error` plus
+/// each positional attachment-ID whose result is `Error`. A bug whose
+/// listing succeeds but where some internal writes fail contributes
+/// each successful write to `succeeded` and one to `failed` for the
+/// bug itself.
 #[derive(Debug, Serialize)]
 #[non_exhaustive]
 pub struct BatchSummary {
     pub succeeded: usize,
     pub failed: usize,
     pub total_bytes: usize,
+}
+
+impl BatchSummary {
+    /// Compute the summary post-hoc from the populated result lists.
+    pub fn from_results(
+        bug_results: &[BugDownloadResult],
+        attachment_results: &[AttachmentDownloadResult],
+    ) -> Self {
+        let succeeded = bug_results.iter().map(|b| b.files.len()).sum::<usize>()
+            + attachment_results
+                .iter()
+                .filter(|a| a.status == TargetStatus::Ok)
+                .count();
+        let failed = bug_results
+            .iter()
+            .filter(|b| b.status == TargetStatus::Error)
+            .count()
+            + attachment_results
+                .iter()
+                .filter(|a| a.status == TargetStatus::Error)
+                .count();
+        let total_bytes = bug_results
+            .iter()
+            .flat_map(|b| &b.files)
+            .map(|f| f.bytes)
+            .sum::<usize>()
+            + attachment_results
+                .iter()
+                .filter_map(|a| a.bytes)
+                .sum::<usize>();
+        Self {
+            succeeded,
+            failed,
+            total_bytes,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]

--- a/src/output/attachment.rs
+++ b/src/output/attachment.rs
@@ -162,69 +162,76 @@ pub enum TargetStatus {
 /// JSON mode emits a single object on stdout — no stderr writes.
 pub fn print_attachment_batch(result: &AttachmentBatchResult, format: OutputFormat) {
     print_formatted(result, format, |r| {
-        for bug in &r.bug_results {
-            match bug.status {
-                TargetStatus::Ok => {
-                    let _ = writeln!(
-                        io::stdout(),
-                        "{} {}: {} files saved",
-                        "Bug".bold(),
-                        format!("#{}", bug.bug_id).bold(),
-                        bug.files.len(),
-                    );
-                    for file in &bug.files {
-                        let _ = writeln!(io::stdout(), "  → {} ({} bytes)", file.path, file.bytes);
-                    }
-                }
-                TargetStatus::Error => {
-                    let _ = writeln!(
-                        io::stderr(),
-                        "Bug #{}: {}",
-                        bug.bug_id,
-                        bug.error.as_deref().unwrap_or("error"),
-                    );
-                    for file in &bug.files {
-                        let _ = writeln!(
-                            io::stdout(),
-                            "  → {} ({} bytes) [partial]",
-                            file.path,
-                            file.bytes,
-                        );
-                    }
-                }
-            }
-        }
-        for att in &r.attachment_results {
-            match att.status {
-                TargetStatus::Ok => {
-                    let _ = writeln!(
-                        io::stdout(),
-                        "{} #{}: {} ({} bytes)",
-                        "Attachment".bold(),
-                        att.attachment_id,
-                        att.path.as_deref().unwrap_or("?"),
-                        att.bytes.unwrap_or(0),
-                    );
-                }
-                TargetStatus::Error => {
-                    let _ = writeln!(
-                        io::stderr(),
-                        "Attachment #{}: {}",
-                        att.attachment_id,
-                        att.error.as_deref().unwrap_or("error"),
-                    );
-                }
-            }
-        }
-        let _ = writeln!(
-            io::stdout(),
-            "{} {} succeeded, {} failed, {} total bytes",
-            "Summary:".bold(),
-            r.summary.succeeded,
-            r.summary.failed,
-            r.summary.total_bytes,
-        );
+        write_attachment_batch_table(r, &mut io::stdout(), &mut io::stderr());
     });
+}
+
+/// Render the table-mode body of an [`AttachmentBatchResult`] to the given
+/// writers. Successes go to `out`, target-level failures go to `err`.
+/// Extracted from `print_attachment_batch` so tests can inject buffers
+/// for both streams; production calls use `io::stdout()` and `io::stderr()`.
+pub(super) fn write_attachment_batch_table(
+    r: &AttachmentBatchResult,
+    out: &mut impl std::io::Write,
+    err: &mut impl std::io::Write,
+) {
+    for bug in &r.bug_results {
+        match bug.status {
+            TargetStatus::Ok => {
+                let _ = writeln!(
+                    out,
+                    "{} {}: {} files saved",
+                    "Bug".bold(),
+                    format!("#{}", bug.bug_id).bold(),
+                    bug.files.len(),
+                );
+                for file in &bug.files {
+                    let _ = writeln!(out, "  → {} ({} bytes)", file.path, file.bytes);
+                }
+            }
+            TargetStatus::Error => {
+                let _ = writeln!(
+                    err,
+                    "Bug #{}: {}",
+                    bug.bug_id,
+                    bug.error.as_deref().unwrap_or("error"),
+                );
+                for file in &bug.files {
+                    let _ = writeln!(out, "  → {} ({} bytes) [partial]", file.path, file.bytes);
+                }
+            }
+        }
+    }
+    for att in &r.attachment_results {
+        match att.status {
+            TargetStatus::Ok => {
+                let _ = writeln!(
+                    out,
+                    "{} #{}: {} ({} bytes)",
+                    "Attachment".bold(),
+                    att.attachment_id,
+                    att.path.as_deref().unwrap_or("?"),
+                    att.bytes.unwrap_or(0),
+                );
+            }
+            TargetStatus::Error => {
+                let _ = writeln!(
+                    err,
+                    "Attachment #{}: {}",
+                    att.attachment_id,
+                    att.error.as_deref().unwrap_or("error"),
+                );
+            }
+        }
+    }
+    let _ = writeln!(
+        out,
+        "{} {} succeeded, {} failed, {} total bytes",
+        "Summary:".bold(),
+        r.summary.succeeded,
+        r.summary.failed,
+        r.summary.total_bytes,
+    );
 }
 
 #[cfg(test)]

--- a/src/output/attachment.rs
+++ b/src/output/attachment.rs
@@ -50,8 +50,10 @@ pub struct AttachmentBatchResult {
 }
 
 /// Result of `--bug <ID>` for a single bug. Carries every file the
-/// bulk path successfully wrote to disk for this bug, and (if any
-/// attachment failed) the first error message encountered.
+/// bulk path successfully wrote to disk for this bug. If any
+/// attachment failed, `error` holds the first error message
+/// encountered; subsequent failures within the same bug are not
+/// retained — the renderer surfaces only one error per bug.
 #[derive(Debug, Serialize)]
 #[non_exhaustive]
 pub struct BugDownloadResult {

--- a/src/output/attachment.rs
+++ b/src/output/attachment.rs
@@ -173,7 +173,7 @@ pub fn print_attachment_batch(result: &AttachmentBatchResult, format: OutputForm
                         bug.files.len(),
                     );
                     for file in &bug.files {
-                        let _ = writeln!(io::stdout(), "  → {} ({} bytes)", file.path, file.bytes,);
+                        let _ = writeln!(io::stdout(), "  → {} ({} bytes)", file.path, file.bytes);
                     }
                 }
                 TargetStatus::Error => {

--- a/src/output/attachment.rs
+++ b/src/output/attachment.rs
@@ -42,13 +42,6 @@ pub fn print_attachments(attachments: &[Attachment], format: OutputFormat) {
 /// Single-ID legacy mode continues to use [`super::DownloadResult`].
 #[derive(Debug, Serialize)]
 #[non_exhaustive]
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "consumed by print_attachment_batch renderer (Task 4) and dispatch (Task 6)"
-    )
-)]
 pub struct AttachmentBatchResult {
     pub out_dir: String,
     pub bug_results: Vec<BugDownloadResult>,
@@ -117,14 +110,91 @@ pub struct BatchSummary {
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(
     not(test),
-    expect(
-        dead_code,
-        reason = "consumed by print_attachment_batch renderer (Task 4) and dispatch (Task 6)"
-    )
+    expect(dead_code, reason = "constructed by download_batch dispatch in Task 6")
 )]
 pub enum TargetStatus {
     Ok,
     Error,
+}
+
+/// Render an [`AttachmentBatchResult`] in the requested format.
+///
+/// Successful entries print to stdout; bug-level failures and
+/// per-attachment failures print to stderr (one line each), so
+/// `2>/dev/null` quiets warnings without losing the success listing.
+/// JSON mode emits a single object on stdout — no stderr writes.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "wired into AttachmentAction::Download dispatch by Task 6"
+    )
+)]
+pub fn print_attachment_batch(result: &AttachmentBatchResult, format: OutputFormat) {
+    print_formatted(result, format, |r| {
+        for bug in &r.bug_results {
+            match bug.status {
+                TargetStatus::Ok => {
+                    let _ = writeln!(
+                        io::stdout(),
+                        "{} {}: {} files saved",
+                        "Bug".bold(),
+                        format!("#{}", bug.bug_id).bold(),
+                        bug.files.len(),
+                    );
+                    for file in &bug.files {
+                        let _ = writeln!(io::stdout(), "  → {} ({} bytes)", file.path, file.bytes,);
+                    }
+                }
+                TargetStatus::Error => {
+                    let _ = writeln!(
+                        io::stderr(),
+                        "Bug #{}: {}",
+                        bug.bug_id,
+                        bug.error.as_deref().unwrap_or("error"),
+                    );
+                    for file in &bug.files {
+                        let _ = writeln!(
+                            io::stdout(),
+                            "  → {} ({} bytes) [partial]",
+                            file.path,
+                            file.bytes,
+                        );
+                    }
+                }
+            }
+        }
+        for att in &r.attachment_results {
+            match att.status {
+                TargetStatus::Ok => {
+                    let _ = writeln!(
+                        io::stdout(),
+                        "{} #{}: {} ({} bytes)",
+                        "Attachment".bold(),
+                        att.attachment_id,
+                        att.path.as_deref().unwrap_or("?"),
+                        att.bytes.unwrap_or(0),
+                    );
+                }
+                TargetStatus::Error => {
+                    let _ = writeln!(
+                        io::stderr(),
+                        "Attachment #{}: {}",
+                        att.attachment_id,
+                        att.error.as_deref().unwrap_or("error"),
+                    );
+                }
+            }
+        }
+        let _ = writeln!(
+            io::stdout(),
+            "{} {} succeeded, {} failed, {} total bytes",
+            "Summary:".bold(),
+            r.summary.succeeded,
+            r.summary.failed,
+            r.summary.total_bytes,
+        );
+    });
 }
 
 #[cfg(test)]

--- a/src/output/attachment.rs
+++ b/src/output/attachment.rs
@@ -108,10 +108,6 @@ pub struct BatchSummary {
 #[derive(Debug, Serialize, PartialEq, Eq)]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "constructed by download_batch dispatch in Task 6")
-)]
 pub enum TargetStatus {
     Ok,
     Error,
@@ -123,13 +119,6 @@ pub enum TargetStatus {
 /// per-attachment failures print to stderr (one line each), so
 /// `2>/dev/null` quiets warnings without losing the success listing.
 /// JSON mode emits a single object on stdout — no stderr writes.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "wired into AttachmentAction::Download dispatch by Task 6"
-    )
-)]
 pub fn print_attachment_batch(result: &AttachmentBatchResult, format: OutputFormat) {
     print_formatted(result, format, |r| {
         for bug in &r.bug_results {

--- a/src/output/attachment.rs
+++ b/src/output/attachment.rs
@@ -1,6 +1,7 @@
 use std::io::{self, Write as _};
 
 use colored::Colorize;
+use serde::Serialize;
 
 use super::formatting::{print_field, print_formatted, print_optional_field};
 use crate::types::{Attachment, OutputFormat};
@@ -34,6 +35,96 @@ pub fn print_attachments(attachments: &[Attachment], format: OutputFormat) {
             let _ = writeln!(io::stdout());
         }
     });
+}
+
+/// Top-level payload for `bzr attachment download` in bulk mode.
+///
+/// Single-ID legacy mode continues to use [`super::DownloadResult`].
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by print_attachment_batch renderer (Task 4) and dispatch (Task 6)"
+    )
+)]
+pub struct AttachmentBatchResult {
+    pub out_dir: String,
+    pub bug_results: Vec<BugDownloadResult>,
+    pub attachment_results: Vec<AttachmentDownloadResult>,
+    pub summary: BatchSummary,
+}
+
+/// Result of `--bug <ID>` for a single bug. Carries every file the
+/// bulk path successfully wrote to disk for this bug, and (if any
+/// attachment failed) the first error message encountered.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct BugDownloadResult {
+    pub bug_id: u64,
+    pub status: TargetStatus,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<DownloadedFile>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Result of a positional attachment-ID argument in bulk mode. The
+/// `bug_id` field is populated from the API response when reachable,
+/// even on per-attachment failure (so the user can correlate the
+/// failure to the bug it belongs to).
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct AttachmentDownloadResult {
+    pub attachment_id: u64,
+    pub status: TargetStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bug_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// One on-disk artifact produced by the bulk path.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct DownloadedFile {
+    pub attachment_id: u64,
+    pub path: String,
+    pub bytes: usize,
+}
+
+/// Aggregate counters for the batch run.
+///
+/// `succeeded` counts attachments written to disk; `failed` counts the
+/// sum of bug-level errors and per-attachment failures. A bug with
+/// three attachments where two are written and one fails contributes
+/// 2 to `succeeded` and 1 to `failed`.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct BatchSummary {
+    pub succeeded: usize,
+    pub failed: usize,
+    pub total_bytes: usize,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+#[serde(rename_all = "lowercase")]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by print_attachment_batch renderer (Task 4) and dispatch (Task 6)"
+    )
+)]
+pub enum TargetStatus {
+    Ok,
+    Error,
 }
 
 #[cfg(test)]

--- a/src/output/attachment_tests.rs
+++ b/src/output/attachment_tests.rs
@@ -290,3 +290,64 @@ fn target_status_serializes_lowercase() {
         "\"error\"",
     );
 }
+
+fn sample_batch_result() -> AttachmentBatchResult {
+    AttachmentBatchResult {
+        out_dir: "./attachments".into(),
+        bug_results: vec![BugDownloadResult {
+            bug_id: 12345,
+            status: TargetStatus::Ok,
+            files: vec![
+                DownloadedFile {
+                    attachment_id: 9876,
+                    path: "./attachments/12345/9876.patch.diff".into(),
+                    bytes: 4096,
+                },
+                DownloadedFile {
+                    attachment_id: 9877,
+                    path: "./attachments/12345/9877.trace.log".into(),
+                    bytes: 2048,
+                },
+            ],
+            error: None,
+        }],
+        attachment_results: vec![],
+        summary: BatchSummary {
+            succeeded: 2,
+            failed: 0,
+            total_bytes: 6144,
+        },
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn print_attachment_batch_table_includes_summary() {
+    let _lock = crate::ENV_LOCK.lock().await;
+    let result = sample_batch_result();
+    let ((), out) = crate::test_helpers::capture_stdout(async {
+        print_attachment_batch(&result, OutputFormat::Table);
+    })
+    .await;
+    assert!(out.contains("Bug #12345"), "missing bug header: {out}");
+    assert!(
+        out.contains("./attachments/12345/9876.patch.diff"),
+        "missing file path: {out}",
+    );
+    assert!(out.contains("2 succeeded"), "missing summary line: {out}",);
+    assert!(out.contains("6144"), "missing total_bytes: {out}");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn print_attachment_batch_json_emits_typed_payload() {
+    let _lock = crate::ENV_LOCK.lock().await;
+    let result = sample_batch_result();
+    let ((), out) = crate::test_helpers::capture_stdout(async {
+        print_attachment_batch(&result, OutputFormat::Json);
+    })
+    .await;
+    let parsed: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(parsed["summary"]["succeeded"], 2);
+    assert_eq!(parsed["bug_results"][0]["files"][0]["attachment_id"], 9876);
+}

--- a/src/output/attachment_tests.rs
+++ b/src/output/attachment_tests.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::unwrap_used)]
 
-use super::print_attachments;
+use super::*;
 use crate::types::{Attachment, OutputFormat};
 
 fn make_attachment(id: u64, summary: &str) -> Attachment {
@@ -213,4 +213,80 @@ async fn print_attachments_json_one_via_print() {
     assert_eq!(parsed[0]["id"], 99);
     assert_eq!(parsed[0]["summary"], "Json patch");
     assert_eq!(parsed[0]["file_name"], "file_99.patch");
+}
+
+#[test]
+fn attachment_batch_result_json_shape() {
+    let result = AttachmentBatchResult {
+        out_dir: "./attachments".into(),
+        bug_results: vec![BugDownloadResult {
+            bug_id: 12345,
+            status: TargetStatus::Ok,
+            files: vec![DownloadedFile {
+                attachment_id: 9876,
+                path: "./attachments/12345/9876.patch.diff".into(),
+                bytes: 4096,
+            }],
+            error: None,
+        }],
+        attachment_results: vec![],
+        summary: BatchSummary {
+            succeeded: 1,
+            failed: 0,
+            total_bytes: 4096,
+        },
+    };
+
+    let json = serde_json::to_value(&result).unwrap();
+    assert_eq!(json["out_dir"], "./attachments");
+    assert_eq!(json["bug_results"][0]["bug_id"], 12345);
+    assert_eq!(json["bug_results"][0]["status"], "ok");
+    assert_eq!(json["bug_results"][0]["files"][0]["attachment_id"], 9876);
+    assert_eq!(json["bug_results"][0]["files"][0]["bytes"], 4096);
+    assert_eq!(json["summary"]["succeeded"], 1);
+    assert_eq!(json["summary"]["total_bytes"], 4096);
+}
+
+#[test]
+fn attachment_batch_result_omits_empty_optional_fields() {
+    let result = AttachmentBatchResult {
+        out_dir: "./attachments".into(),
+        bug_results: vec![BugDownloadResult {
+            bug_id: 12345,
+            status: TargetStatus::Ok,
+            files: vec![],
+            error: None,
+        }],
+        attachment_results: vec![AttachmentDownloadResult {
+            attachment_id: 999,
+            status: TargetStatus::Error,
+            bug_id: None,
+            path: None,
+            bytes: None,
+            error: Some("not found".into()),
+        }],
+        summary: BatchSummary {
+            succeeded: 0,
+            failed: 1,
+            total_bytes: 0,
+        },
+    };
+    let json = serde_json::to_value(&result).unwrap();
+    let bug = &json["bug_results"][0];
+    assert!(bug.get("files").is_none(), "files should skip when empty");
+    assert!(bug.get("error").is_none(), "error should skip when None");
+    let att = &json["attachment_results"][0];
+    assert!(att.get("path").is_none());
+    assert!(att.get("bytes").is_none());
+    assert!(att.get("bug_id").is_none());
+    assert_eq!(att["error"], "not found");
+}
+
+#[test]
+fn target_status_serializes_lowercase() {
+    assert_eq!(serde_json::to_string(&TargetStatus::Ok).unwrap(), "\"ok\"");
+    assert_eq!(
+        serde_json::to_string(&TargetStatus::Error).unwrap(),
+        "\"error\"",
+    );
 }

--- a/src/output/attachment_tests.rs
+++ b/src/output/attachment_tests.rs
@@ -351,3 +351,179 @@ async fn print_attachment_batch_json_emits_typed_payload() {
     assert_eq!(parsed["summary"]["succeeded"], 2);
     assert_eq!(parsed["bug_results"][0]["files"][0]["attachment_id"], 9876);
 }
+
+#[test]
+fn write_attachment_batch_table_bug_error_writes_to_err() {
+    let result = AttachmentBatchResult {
+        out_dir: "./attachments".into(),
+        bug_results: vec![BugDownloadResult {
+            bug_id: 99999,
+            status: TargetStatus::Error,
+            files: vec![],
+            error: Some("bug not found".into()),
+        }],
+        attachment_results: vec![],
+        summary: BatchSummary {
+            succeeded: 0,
+            failed: 1,
+            total_bytes: 0,
+        },
+    };
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    write_attachment_batch_table(&result, &mut out, &mut err);
+    let err_str = String::from_utf8(err).unwrap();
+    let out_str = String::from_utf8(out).unwrap();
+    assert!(
+        err_str.contains("Bug #99999: bug not found"),
+        "stderr should carry bug-error: {err_str}",
+    );
+    assert!(out_str.contains("0 succeeded, 1 failed"));
+}
+
+#[test]
+fn write_attachment_batch_table_bug_error_with_partial_files() {
+    let result = AttachmentBatchResult {
+        out_dir: "./attachments".into(),
+        bug_results: vec![BugDownloadResult {
+            bug_id: 12345,
+            status: TargetStatus::Error,
+            files: vec![DownloadedFile {
+                attachment_id: 9876,
+                path: "./attachments/12345/9876.a.txt".into(),
+                bytes: 5,
+            }],
+            error: Some("write failed for #9877".into()),
+        }],
+        attachment_results: vec![],
+        summary: BatchSummary {
+            succeeded: 1,
+            failed: 1,
+            total_bytes: 5,
+        },
+    };
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    write_attachment_batch_table(&result, &mut out, &mut err);
+    let out_str = String::from_utf8(out).unwrap();
+    let err_str = String::from_utf8(err).unwrap();
+    assert!(
+        err_str.contains("Bug #12345: write failed for #9877"),
+        "stderr should carry bug-error: {err_str}",
+    );
+    assert!(
+        out_str.contains("./attachments/12345/9876.a.txt") && out_str.contains("[partial]"),
+        "stdout should list partial file with [partial] tag: {out_str}",
+    );
+}
+
+#[test]
+fn write_attachment_batch_table_attachment_error_writes_to_err() {
+    let result = AttachmentBatchResult {
+        out_dir: "./attachments".into(),
+        bug_results: vec![],
+        attachment_results: vec![AttachmentDownloadResult {
+            attachment_id: 4242,
+            status: TargetStatus::Error,
+            bug_id: None,
+            path: None,
+            bytes: None,
+            error: Some("attachment 4242 not found".into()),
+        }],
+        summary: BatchSummary {
+            succeeded: 0,
+            failed: 1,
+            total_bytes: 0,
+        },
+    };
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    write_attachment_batch_table(&result, &mut out, &mut err);
+    let err_str = String::from_utf8(err).unwrap();
+    assert!(
+        err_str.contains("Attachment #4242: attachment 4242 not found"),
+        "stderr should carry attachment-error: {err_str}",
+    );
+}
+
+#[test]
+fn write_attachment_batch_table_attachment_ok_writes_path_and_bytes() {
+    let result = AttachmentBatchResult {
+        out_dir: "./attachments".into(),
+        bug_results: vec![],
+        attachment_results: vec![AttachmentDownloadResult {
+            attachment_id: 4242,
+            status: TargetStatus::Ok,
+            bug_id: Some(67890),
+            path: Some("./attachments/67890/4242.extra.bin".into()),
+            bytes: Some(256),
+            error: None,
+        }],
+        summary: BatchSummary {
+            succeeded: 1,
+            failed: 0,
+            total_bytes: 256,
+        },
+    };
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    write_attachment_batch_table(&result, &mut out, &mut err);
+    let out_str = String::from_utf8(out).unwrap();
+    assert!(
+        out_str.contains("Attachment") && out_str.contains("#4242"),
+        "stdout should include attachment header: {out_str}",
+    );
+    assert!(out_str.contains("./attachments/67890/4242.extra.bin"));
+    assert!(out_str.contains("256"));
+}
+
+#[test]
+fn batch_summary_from_results_aggregates_correctly() {
+    let bug_results = vec![
+        BugDownloadResult {
+            bug_id: 1,
+            status: TargetStatus::Ok,
+            files: vec![
+                DownloadedFile {
+                    attachment_id: 10,
+                    path: "p1".into(),
+                    bytes: 100,
+                },
+                DownloadedFile {
+                    attachment_id: 11,
+                    path: "p2".into(),
+                    bytes: 200,
+                },
+            ],
+            error: None,
+        },
+        BugDownloadResult {
+            bug_id: 2,
+            status: TargetStatus::Error,
+            files: vec![],
+            error: Some("missing".into()),
+        },
+    ];
+    let attachment_results = vec![
+        AttachmentDownloadResult {
+            attachment_id: 30,
+            status: TargetStatus::Ok,
+            bug_id: Some(3),
+            path: Some("p3".into()),
+            bytes: Some(50),
+            error: None,
+        },
+        AttachmentDownloadResult {
+            attachment_id: 31,
+            status: TargetStatus::Error,
+            bug_id: None,
+            path: None,
+            bytes: None,
+            error: Some("missing".into()),
+        },
+    ];
+    let summary = BatchSummary::from_results(&bug_results, &attachment_results);
+    assert_eq!(summary.succeeded, 3);
+    assert_eq!(summary.failed, 2);
+    assert_eq!(summary.total_bytes, 350);
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -27,10 +27,6 @@ pub use result_types::{
 };
 
 // Re-export all public items from submodules.
-#[expect(
-    unused_imports,
-    reason = "wired into AttachmentAction::Download dispatch by Task 6"
-)]
 pub use attachment::{
     print_attachment_batch, print_attachments, AttachmentBatchResult, AttachmentDownloadResult,
     BatchSummary, BugDownloadResult, DownloadedFile, TargetStatus,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -28,6 +28,14 @@ pub use result_types::{
 
 // Re-export all public items from submodules.
 pub use attachment::print_attachments;
+#[expect(
+    unused_imports,
+    reason = "consumed by print_attachment_batch renderer (Task 4) and dispatch (Task 6)"
+)]
+pub use attachment::{
+    AttachmentBatchResult, AttachmentDownloadResult, BatchSummary, BugDownloadResult,
+    DownloadedFile, TargetStatus,
+};
 pub use bug::{print_bug_detail, print_bugs, print_history, print_multi_bug_view, MultiBugRow};
 pub use classification::print_classification;
 pub use comment::print_comments;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -27,14 +27,13 @@ pub use result_types::{
 };
 
 // Re-export all public items from submodules.
-pub use attachment::print_attachments;
 #[expect(
     unused_imports,
-    reason = "consumed by print_attachment_batch renderer (Task 4) and dispatch (Task 6)"
+    reason = "wired into AttachmentAction::Download dispatch by Task 6"
 )]
 pub use attachment::{
-    AttachmentBatchResult, AttachmentDownloadResult, BatchSummary, BugDownloadResult,
-    DownloadedFile, TargetStatus,
+    print_attachment_batch, print_attachments, AttachmentBatchResult, AttachmentDownloadResult,
+    BatchSummary, BugDownloadResult, DownloadedFile, TargetStatus,
 };
 pub use bug::{print_bug_detail, print_bugs, print_history, print_multi_bug_view, MultiBugRow};
 pub use classification::print_classification;

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -1176,6 +1176,56 @@ if [[ -n "$BUG1" ]]; then
     fi
 else test_skip "no BUG1"; fi
 
+test_begin "100i. attachment download --bug bulk into per-bug subdir"
+if [[ -n "$BUG1" ]]; then
+    BULK_DIR="$(mktemp -d /tmp/bzr-func-bulk.XXXXXX)"
+    run_bzr attachment download --bug "$BUG1" --out-dir "$BULK_DIR"
+    if assert_success; then
+        # Per-bug subdir must exist
+        if [[ -d "$BULK_DIR/$BUG1" ]]; then
+            # Bug had at least 5 attachments uploaded earlier in Phase 15;
+            # require ≥2 to be safe against per-deployment fixture drift.
+            NUM_FILES=$(find "$BULK_DIR/$BUG1" -type f | wc -l | tr -d ' ')
+            if [[ "$NUM_FILES" -ge 2 ]]; then
+                test_pass
+            else
+                test_fail "expected ≥2 files in $BULK_DIR/$BUG1, found $NUM_FILES"
+            fi
+        else
+            test_fail "expected per-bug subdir $BULK_DIR/$BUG1 not created"
+        fi
+    fi
+    rm -rf "$BULK_DIR"
+else test_skip "no BUG1"; fi
+
+test_begin "100j. attachment download mixes --bug and positional IDs"
+if [[ -n "$BUG1" ]] && [[ -n "${ATTACH_ID:-}" ]] && [[ "$ATTACH_ID" != "null" ]]; then
+    MIX_DIR="$(mktemp -d /tmp/bzr-func-mix.XXXXXX)"
+    # Use BUG1 (multi-attachment) AND a specific ATTACH_ID (which also
+    # belongs to BUG1, so positional + --bug both land in the same
+    # per-bug subdir). The test verifies the dispatch handles both
+    # input shapes; the disk layout is the same as the per-bug case.
+    run_bzr attachment download --bug "$BUG1" "$ATTACH_ID" --out-dir "$MIX_DIR"
+    if assert_success; then
+        if [[ -d "$MIX_DIR/$BUG1" ]]; then
+            # The positional ATTACH_ID's file must exist with the att-id
+            # prefix even though it would have been included by --bug too.
+            # The per-bug walk runs first, then positional — silent
+            # overwrite means the second write wins, but the file must
+            # exist either way.
+            POS_FILE_COUNT=$(find "$MIX_DIR/$BUG1" -name "${ATTACH_ID}.*" -type f | wc -l | tr -d ' ')
+            if [[ "$POS_FILE_COUNT" -ge 1 ]]; then
+                test_pass
+            else
+                test_fail "expected file ${ATTACH_ID}.* in $MIX_DIR/$BUG1, found $POS_FILE_COUNT"
+            fi
+        else
+            test_fail "expected per-bug subdir $MIX_DIR/$BUG1 not created"
+        fi
+    fi
+    rm -rf "$MIX_DIR"
+else test_skip "no BUG1 or no ATTACH_ID"; fi
+
 echo ""
 
 # ══════════════════════════════════════════════════════════════════════

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -967,6 +967,74 @@ async fn attachment_download_integration() {
     assert_eq!(content, "Hello world");
 }
 
+#[tokio::test]
+async fn attachment_download_bulk_per_bug_integration() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/77/attachment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": {
+                "77": [
+                    {
+                        "id": 1001,
+                        "bug_id": 77,
+                        "file_name": "a.txt",
+                        "summary": "first",
+                        "content_type": "text/plain",
+                        "size": 5,
+                        "is_obsolete": false,
+                        "is_patch": false,
+                        "is_private": false,
+                        "data": "QUFBQUE="
+                    },
+                    {
+                        "id": 1002,
+                        "bug_id": 77,
+                        "file_name": "b.txt",
+                        "summary": "second",
+                        "content_type": "text/plain",
+                        "size": 4,
+                        "is_obsolete": false,
+                        "is_patch": false,
+                        "is_private": false,
+                        "data": "QkJCQg=="
+                    }
+                ]
+            }
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let out_dir = tmp.path().to_string_lossy().into_owned();
+    let action = bzr::cli::AttachmentAction::Download {
+        ids: vec![],
+        bug_ids: vec![77],
+        out: None,
+        out_dir,
+    };
+    let result = bzr::commands::attachment::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+    )
+    .await;
+    assert!(result.is_ok(), "expected ok: {result:?}");
+
+    assert!(tmp.path().join("77").join("1001.a.txt").exists());
+    assert!(tmp.path().join("77").join("1002.b.txt").exists());
+    assert_eq!(
+        std::fs::read(tmp.path().join("77").join("1001.a.txt")).unwrap(),
+        b"AAAAA"
+    );
+    assert_eq!(
+        std::fs::read(tmp.path().join("77").join("1002.b.txt")).unwrap(),
+        b"BBBB"
+    );
+}
+
 // ── Attachment upload ────────────────────────────────────────────────
 
 #[tokio::test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -946,8 +946,10 @@ async fn attachment_download_integration() {
 
     let out_path = tmp.path().join("downloaded.txt");
     let action = bzr::cli::AttachmentAction::Download {
-        id: 99,
+        ids: vec![99],
+        bug_ids: vec![],
         out: Some(out_path.to_string_lossy().into_owned()),
+        out_dir: "./attachments".into(),
     };
     let result = bzr::commands::attachment::execute(
         &action,


### PR DESCRIPTION
## Summary

Closes #167.

Extends `bzr attachment download` to accept a single attachment ID, multiple positional attachment IDs, or one or more `--bug <ID>` flags (mixable). Bulk shapes write each file to `<out-dir>/<bug-id>/<att-id>.<file_name>`. The legacy single-ID `--out <PATH>` shape is preserved.

- Spec: `docs/superpowers/specs/2026-05-07-issue-167-attachment-download-bulk-design.md`
- Breaking change to `AttachmentAction::Download` variant shape (`feat(cli)!` in `34bc9c3`); all internal callers updated.
- Sequential dispatch (per spec Q7); concurrency deferred.
- All-fail uses `BatchPartialFailure` (exit 11); top-level `--out-dir` write failure fails fast as `Io` (exit 6).
- Obsolete attachments are downloaded (bzl parity).

## Test plan

- [x] `cargo test --lib` — 1138 pass (run with `--test-threads=1` to bypass a pre-existing `capture_stdout`/fd-1 race; see note below)
- [x] `cargo test --test integration` — 64 pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `bash -n tests/functional/run-tests.sh` clean; `shellcheck` no new warnings
- [ ] Functional suite (`make functional-test-all`) — requires Docker + Bugzilla containers; CI will exercise

## New on-disk layout

```
$OUT_DIR/
├── 12345/
│   ├── 9876.patch.diff
│   └── 9877.trace.log
└── 67890/
    └── 4242.extra.bin
```

The attachment-ID prefix on each filename eliminates same-name collisions within a bug (two attachments named `trace.log` on one bug land as `9876.trace.log` and `9877.trace.log`).

## JSON output (bulk shape)

```json
{
  "out_dir": "./attachments",
  "bug_results": [
    {"bug_id": 12345, "status": "ok", "files": [{"attachment_id": 9876, "path": "...", "bytes": 4096}]},
    {"bug_id": 99999, "status": "error", "error": "bug not found"}
  ],
  "attachment_results": [
    {"attachment_id": 4242, "status": "ok", "bug_id": 67890, "path": "...", "bytes": 256}
  ],
  "summary": {"succeeded": 2, "failed": 1, "total_bytes": 4352}
}
```

The single-ID legacy shape continues to emit the existing `DownloadResult` JSON unchanged.

## Notes for reviewer

- Pre-existing test infrastructure flake: `output::attachment::tests::print_attachment_batch_json_emits_typed_payload` occasionally fails under parallel scheduling because `capture_stdout` redirects fd 1 via `dup2` and races with sibling `capture_stdout`-using tests. Passes in isolation and with `--test-threads=1`. Not introduced by this branch — observed during multi-stage review of intermediate commits as well.
- Two follow-up issues filed during simplify-pass review:
  - #189 (low) — extract a shared `make_attachment(...)` test fixture helper.
  - #190 (medium) — avoid N+1 round-trips on Hybrid/XmlRpc bulk downloads (request `data` in XML-RPC `Bug.attachments`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)