### PR TITLE
fix(tests): unflake stdout-capture tests pending #192 migration

### DIFF
--- a/docs/superpowers/specs/2026-05-07-issue-192-stdout-capture-flakes-design.md
+++ b/docs/superpowers/specs/2026-05-07-issue-192-stdout-capture-flakes-design.md
@@ -1,0 +1,237 @@
+# Issue #192: Eliminate stdout-capture races by plumbing writers
+
+**Issue:** [#192](https://github.com/randomparity/bzr/issues/192) — *Flaky stdout-capture tests: dup2 fd-1 redirection races concurrent writers*
+**Status:** Design approved 2026-05-07
+**Branch:** `feat/issue-192-stdout-capture-migration`
+
+## Problem
+
+`test_helpers::capture_stdout` redirects file descriptor 1 process-wide via `dup`/`dup2` to capture output written during a future. Cargo runs tests in parallel by default, so during the redirection window any concurrently running test that writes to fd 1 — `writeln!(io::stdout(), …)`, ANSI escapes from `colored`, or any of the project's many `print_*` helpers — lands its bytes in the capturing test's temp file. Three CI runs in 24 hours have flaked on this race, including on `main`.
+
+The doc-comment on `capture_stdout` claims tests are serialized via `ENV_LOCK`. They are not — `ENV_LOCK` only serializes tests that explicitly take it, and most output-writing tests don't.
+
+The `extract_json` helper papered over the race for tests asserting on JSON. It cannot help two cases that have flaked recently:
+
+- `output::attachment::tests::print_attachment_batch_json_emits_typed_payload` — calls `serde_json::from_str(out.trim())` directly.
+- `commands::bug::view::tests::view_multi_strict_json_failure_emits_no_partial_json` — asserts captured stdout is *empty*, which a stray byte from a concurrent writer breaks.
+
+## Goal
+
+Eliminate the race class entirely by removing `capture_stdout`. Replace the implicit "global stdout, captured by fd redirection" model with explicit `&mut dyn Write` references plumbed from `main` through `dispatch` through `commands::*::execute()` to the output-formatter helpers. Tests construct their own buffers; nothing is process-global.
+
+## Non-goals
+
+- Refactoring `BzrError` or any error variant.
+- Changing the `tracing` subscriber, log routing, or `RUST_LOG` behavior.
+- Adding `--no-color` plumbing. The `colored` crate already disables ANSI on non-TTY writers; tests writing into `Vec<u8>` never see escape bytes.
+- Splitting oversized files or other unrelated cleanup.
+- Touching `ENV_LOCK`. It serializes `XDG_CONFIG_HOME` mutation and is unrelated to the stdout race.
+
+## Architecture
+
+A new `Writers` newtype bundles the two output streams and rides as the final argument through every command-layer signature.
+
+```rust
+// src/output/writers.rs
+pub struct Writers<'a> {
+    pub out: &'a mut dyn std::io::Write,
+    pub err: &'a mut dyn std::io::Write,
+}
+
+impl<'a> Writers<'a> {
+    pub fn new(out: &'a mut dyn Write, err: &'a mut dyn Write) -> Self {
+        Self { out, err }
+    }
+}
+```
+
+Re-exported from `src/output/mod.rs` so `crate::output::Writers` is the canonical path.
+
+A test helper replaces `capture_stdout`:
+
+```rust
+// src/test_helpers.rs
+pub struct CapturedIo { pub out: Vec<u8>, pub err: Vec<u8> }
+
+impl CapturedIo {
+    pub fn new() -> Self { Self { out: Vec::new(), err: Vec::new() } }
+    pub fn writers(&mut self) -> Writers<'_> {
+        Writers::new(&mut self.out, &mut self.err)
+    }
+    pub fn out_str(&self) -> &str { std::str::from_utf8(&self.out).unwrap_or("") }
+    pub fn err_str(&self) -> &str { std::str::from_utf8(&self.err).unwrap_or("") }
+}
+```
+
+Each test owns its own `CapturedIo`. No shared global, no fd manipulation, no lock requirement.
+
+### Writer-type rationale
+
+Three options were considered for the writer parameter shape:
+
+| Option | Shape | Pros | Cons |
+|---|---|---|---|
+| A | `&mut dyn Write` (one per stream) | One indirection; `dispatch` stays non-generic | Two parameters when both streams are needed |
+| B | `&mut impl Write` / `<W: Write>` | Monomorphized; matches existing `output/formatting.rs` | Generics propagate through 14 `execute()` signatures and `dispatch`; contagious |
+| C | `Writers<'a>` newtype with `dyn Write` inside | Single parameter; non-generic; extensible | One extra type to learn |
+
+**Selected: C.** Avoids generic contagion at the command layer, keeps `dispatch()` a plain `pub fn`, and makes "the two streams" a single concept. The leaf `output/` helpers continue using `&mut impl Write` (they're terminal — generics aren't contagious there).
+
+## Components and signatures
+
+### Layer 1 — `src/output/` formatter helpers
+
+Every `print_*` is renamed in place to `write_*` and takes `&mut impl Write` (or two `&mut impl Write` parameters when both streams are needed). This matches the existing pattern used by `output/formatting.rs::write_field`, `output/bug.rs::write_bug_detail`, and `output/attachment.rs::write_attachment_batch_table`. Generics at the leaf layer monomorphize cleanly and don't propagate contagiously, since these helpers are terminal — they call `write!`/`writeln!` and don't pass writers to anyone else. Per CLAUDE.md "replace, don't deprecate," `print_*` is not retained as a wrapper.
+
+Example:
+
+```rust
+// before
+pub fn print_attachments(items: &[Attachment], format: OutputFormat) { … }
+
+// after
+pub fn write_attachments(items: &[Attachment], format: OutputFormat, out: &mut impl Write) { … }
+```
+
+Call sites in `commands/` pass `w.out` (which is `&mut dyn Write`) — Rust accepts this because `dyn Write` itself implements `Write`, so `&mut dyn Write` satisfies `&mut impl Write` at the call boundary. No double indirection, no `Box`.
+
+`output/attachment.rs::write_attachment_batch_table` already follows this shape and is unchanged.
+
+### Layer 2 — `src/commands/*::execute()`
+
+All 14 `execute()` functions gain a final `w: &mut Writers<'_>` parameter:
+
+```rust
+pub async fn execute(
+    action: &XAction,
+    server: Option<&str>,
+    format: OutputFormat,
+    api: Option<ApiMode>,
+    w: &mut Writers<'_>,
+) -> Result<()>
+```
+
+This is 5 positional parameters — the project's hard limit. Acceptable here as a one-time tipping point. Any future addition to this signature must refactor to a context struct (out of scope).
+
+The `commands::bug` submodules (`view`, `update`, `clone`, `list`, `create`, `history`, `my`, `search`) propagate the writer through their internal call graphs.
+
+### Layer 3 — `src/lib.rs::dispatch()`
+
+`dispatch` gains `w: &mut Writers<'_>` and forwards it to each `commands::*::execute()`. Remains non-generic.
+
+### Layer 4 — `src/main.rs`
+
+Locks both streams once at the top of `main`:
+
+```rust
+let stdout = io::stdout();
+let stderr = io::stderr();
+let mut out = stdout.lock();
+let mut err = stderr.lock();
+let mut writers = Writers::new(&mut out, &mut err);
+bzr::dispatch(&cli, format, &mut writers).await
+```
+
+## Data flow (final state)
+
+```
+main.rs            : io::stdout().lock(), io::stderr().lock() → Writers
+  → dispatch(&cli, format, &mut writers)
+    → commands::X::execute(action, server, format, api, &mut writers)
+      → write_*(record, w.out)        // happy path
+      → write_*(error,  w.err)        // error/status path
+```
+
+All output flows through explicit writer references. No global fd state. No process-wide redirection. No race window.
+
+## Error handling
+
+`write!` and `writeln!` return `io::Result<()>`. Three policies were considered:
+
+| Policy | Approach | Verdict |
+|---|---|---|
+| i | Bubble through `BzrError::Io` everywhere | Noisy; every formatter signature returns `Result`, `?` peppers every helper |
+| ii | Discard at write sites: `let _ = writeln!(…)` | Matches CLAUDE.md output convention; broken pipe is `head` / `less q` exit, not a real bug |
+| iii | Discard at leaves; flush-and-error at command boundary | Over-engineered for this codebase |
+
+**Selected: ii.** Existing crate convention already discards write results at `writeln!(io::stdout(), …)` sites. The failure mode policy iii would catch (broken pipe at end of command) is not a meaningful CLI error.
+
+## Testing strategy
+
+- **Output unit tests** (`src/output/*_tests.rs`): become sync `#[test]`s, write into `&mut Vec<u8>`, assert on `String::from_utf8`. No `tokio::test`, no `ENV_LOCK`, no `#[cfg(unix)]` gate. Faster and deterministic.
+- **Command-layer tests** (`src/commands/**/*_tests.rs`): construct `CapturedIo`, pass `&mut io.writers()` to `execute()`, assert on `io.out_str()` / `io.err_str()`. Still `#[tokio::test]` because of `wiremock`. Still take `ENV_LOCK` via `setup_test_env` if they touch `XDG_CONFIG_HOME` — that concern is unchanged.
+- **Integration tests** (`tests/integration.rs`): same pattern as command tests, but called through `dispatch` rather than `execute`.
+
+### Verification gates
+
+1. `rg 'capture_stdout|extract_json' src/ tests/` returns zero hits at the end of Phase 4.
+2. `rg '#\[cfg\(unix\)\]\s*\n#\[tokio::test\]' src/output/*_tests.rs` returns zero hits — output-layer tests are now sync.
+3. `cargo test --locked` runs cleanly under load (`taskset -c 0,1` on a Linux CI runner).
+4. Stress run before merging: 50 consecutive `cargo test --locked` invocations in a draft PR. If all pass clean, the race class is empirically gone.
+
+## Phase plan
+
+Each phase leaves the tree green and lands as its own PR.
+
+### Phase 0 — Tier 1 immediate flake mitigation
+
+Lands first as a small standalone PR ahead of the migration.
+
+- `output::attachment_tests::print_attachment_batch_json_emits_typed_payload`: `serde_json::from_str(out.trim())` → `extract_json(&out)`.
+- `commands::bug::view_tests::view_multi_strict_json_failure_emits_no_partial_json`: refactor the asserting block to use a buffer (prefigures Phase 2), or fall back to an `extract_json`-based "no JSON found" probe if the refactor is non-trivial.
+- Replace the misleading `capture_stdout` doc-comment with one that accurately describes the fd-1 redirection and the deprecation path.
+
+### Phase 1 — Scaffolding
+
+- Add `src/output/writers.rs` with `Writers`.
+- Add `CapturedIo` in `src/test_helpers.rs`.
+- No callers yet. Pure additive change.
+
+### Phase 2 — Migration (output, command, dispatch, main)
+
+This is the bulk of the work and lands as a single PR so the tree never has a half-renamed surface. Within the PR, work proceeds bottom-up but the commit can be split into reviewable chunks:
+
+- Rename `print_* → write_*` across `src/output/*.rs`. New shape: `&mut impl Write` (or a pair of them for stdout/stderr-emitting helpers), matching the existing leaf-layer convention. ~14 output files, ~60–80 helper renames.
+- Update output unit tests (`src/output/*_tests.rs`) to call `write_*` directly with `&mut Vec<u8>`. Drop `capture_stdout`, `tokio::test`, and the `#[cfg(unix)]` gate from these files. ~50 tests touched.
+- Add `w: &mut Writers<'_>` to every `commands::*::execute()` (14 functions) and to internal helpers in `commands::bug` submodules that emit output.
+- Command-layer call sites previously calling `print_*` now call `write_*` with `w.out` / `w.err`.
+- `dispatch()` gains `w: &mut Writers<'_>` and forwards it.
+- `main.rs` constructs `Writers` from locked stdout/stderr.
+- Public API of the lib crate changes — acceptable per `lib.rs`'s docstring (lib crate is for integration tests, not external consumers).
+
+Command-layer tests still use `capture_stdout` at the end of Phase 2; they keep passing because the command body now writes to the locked `io::stdout()` via `w.out` constructed in `dispatch`. They migrate in Phase 3.
+
+### Phase 3 — Command-layer test migration
+
+- Migrate command-layer tests (`src/commands/**/*_tests.rs`, `src/lib_tests.rs`, `tests/integration.rs`) from `capture_stdout(execute(…))` to:
+
+```rust
+let mut io = CapturedIo::new();
+let result = execute(&action, server, format, api, &mut io.writers()).await;
+assert!(io.out_str().contains("…"));
+```
+
+### Phase 4 — Tier 2 cleanup + tier 3 collapse
+
+Delete:
+
+- `test_helpers::capture_stdout`
+- `test_helpers::extract_json` and `try_parse_from`
+- the `dup`/`dup2`/`close` extern block and `#[cfg(unix)]` gate
+- any `test_helpers_tests.rs` cases that exercised the deleted helpers
+
+Verify with `rg capture_stdout` returning zero hits across `src/` and `tests/`.
+
+The original tier 3 ("lock everything" or "single-threaded test binary") becomes structurally satisfied: there is no fd-1 redirection to race against. Hardening the construct is replaced by removing it.
+
+## Risks and rollout
+
+- **Risk: a print-helper rename misses a call site.** The compiler catches this — `print_*` no longer exists after Phase 2.
+- **Risk: a test forgets to read `io.out_str()` after the call.** Type system doesn't catch this, but the assertion patterns in migrated tests will fail visibly during Phase 3.
+- **Risk: `colored` writes ANSI escapes into `Vec<u8>`.** It does not — `colored::control::SHOULD_COLORIZE` reads `is_terminal(stdout)`, which is false for a `Vec<u8>` writer. A regression assertion in Phase 2 confirms no `\x1b` byte appears in any captured output.
+- **Risk: PR size.** Phase 2 is large by design — it touches ~14 output files, ~50 output tests, 14 `execute()` signatures, plus `dispatch` and `main`. The alternative (split across multiple PRs with transient `print_*` shims) violates "replace, don't deprecate" and leaves the tree in an awkward intermediate state. Phase 4 must remain its own PR so the deletion is reviewable in isolation.
+- **Empirical confirmation.** Phase 4 closes with the 50-iteration stress run described in *Verification gates*. If any iteration fails, the migration is not complete and the failing test must be diagnosed before issue #192 is closed.
+
+## CHANGELOG
+
+Per project convention, each phase that ships user-visible behavior writes its CHANGELOG entry as the work lands. Phases 0 and 4 are user-visible (CI flake fix; final removal of the deprecated helper); intermediate phases are internal refactors and do not require CHANGELOG entries unless they change observable CLI behavior (none expected).

--- a/docs/superpowers/specs/2026-05-07-issue-192-stdout-capture-flakes-design.md
+++ b/docs/superpowers/specs/2026-05-07-issue-192-stdout-capture-flakes-design.md
@@ -164,7 +164,7 @@ All output flows through explicit writer references. No global fd state. No proc
 
 ### Verification gates
 
-1. `rg 'capture_stdout|extract_json' src/ tests/` returns zero hits at the end of Phase 4.
+1. `rg 'capture_stdout|extract_json' src/ tests/` returns zero hits at the end of Phase 3.
 2. `rg '#\[cfg\(unix\)\]\s*\n#\[tokio::test\]' src/output/*_tests.rs` returns zero hits — output-layer tests are now sync.
 3. `cargo test --locked` runs cleanly under load (`taskset -c 0,1` on a Linux CI runner).
 4. Stress run before merging: 50 consecutive `cargo test --locked` invocations in a draft PR. If all pass clean, the race class is empirically gone.
@@ -187,9 +187,11 @@ Lands first as a small standalone PR ahead of the migration.
 - Add `CapturedIo` in `src/test_helpers.rs`.
 - No callers yet. Pure additive change.
 
-### Phase 2 — Migration (output, command, dispatch, main)
+### Phase 2 — Full migration (output, command, dispatch, main, all tests)
 
-This is the bulk of the work and lands as a single PR so the tree never has a half-renamed surface. Within the PR, work proceeds bottom-up but the commit can be split into reviewable chunks:
+This is the bulk of the work and **must land as a single PR**. The reason is structural: the moment `execute()` gains its `Writers` parameter, every `capture_stdout(execute(…))` test call breaks (signature mismatch). There is no intermediate state where output helpers, command signatures, and tests can be partially migrated — they all observe each other through the type system. Splitting into smaller PRs would require either a transient migration helper (rejected: violates "replace, don't deprecate") or transient `print_*` shims (same objection).
+
+Within the single PR, the work proceeds bottom-up and the commit history may be split into reviewable chunks:
 
 - Rename `print_* → write_*` across `src/output/*.rs`. New shape: `&mut impl Write` (or a pair of them for stdout/stderr-emitting helpers), matching the existing leaf-layer convention. ~14 output files, ~60–80 helper renames.
 - Update output unit tests (`src/output/*_tests.rs`) to call `write_*` directly with `&mut Vec<u8>`. Drop `capture_stdout`, `tokio::test`, and the `#[cfg(unix)]` gate from these files. ~50 tests touched.
@@ -197,21 +199,20 @@ This is the bulk of the work and lands as a single PR so the tree never has a ha
 - Command-layer call sites previously calling `print_*` now call `write_*` with `w.out` / `w.err`.
 - `dispatch()` gains `w: &mut Writers<'_>` and forwards it.
 - `main.rs` constructs `Writers` from locked stdout/stderr.
-- Public API of the lib crate changes — acceptable per `lib.rs`'s docstring (lib crate is for integration tests, not external consumers).
-
-Command-layer tests still use `capture_stdout` at the end of Phase 2; they keep passing because the command body now writes to the locked `io::stdout()` via `w.out` constructed in `dispatch`. They migrate in Phase 3.
-
-### Phase 3 — Command-layer test migration
-
 - Migrate command-layer tests (`src/commands/**/*_tests.rs`, `src/lib_tests.rs`, `tests/integration.rs`) from `capture_stdout(execute(…))` to:
 
-```rust
-let mut io = CapturedIo::new();
-let result = execute(&action, server, format, api, &mut io.writers()).await;
-assert!(io.out_str().contains("…"));
-```
+  ```rust
+  let mut io = CapturedIo::new();
+  let result = execute(&action, server, format, api, &mut io.writers()).await;
+  assert!(io.out_str().contains("…"));
+  ```
 
-### Phase 4 — Tier 2 cleanup + tier 3 collapse
+  ~22 test files touched.
+- Public API of the lib crate changes — acceptable per `lib.rs`'s docstring (lib crate is for integration tests, not external consumers).
+
+After Phase 2, `capture_stdout` and `extract_json` have zero call sites in `src/` and `tests/`. They survive in `test_helpers.rs` only to be deleted in Phase 3.
+
+### Phase 3 — Tier 2 cleanup + tier 3 collapse
 
 Delete:
 
@@ -227,11 +228,11 @@ The original tier 3 ("lock everything" or "single-threaded test binary") becomes
 ## Risks and rollout
 
 - **Risk: a print-helper rename misses a call site.** The compiler catches this — `print_*` no longer exists after Phase 2.
-- **Risk: a test forgets to read `io.out_str()` after the call.** Type system doesn't catch this, but the assertion patterns in migrated tests will fail visibly during Phase 3.
+- **Risk: a test forgets to read `io.out_str()` after the call.** Type system doesn't catch this, but the assertion patterns in migrated tests will fail visibly during Phase 2.
 - **Risk: `colored` writes ANSI escapes into `Vec<u8>`.** It does not — `colored::control::SHOULD_COLORIZE` reads `is_terminal(stdout)`, which is false for a `Vec<u8>` writer. A regression assertion in Phase 2 confirms no `\x1b` byte appears in any captured output.
-- **Risk: PR size.** Phase 2 is large by design — it touches ~14 output files, ~50 output tests, 14 `execute()` signatures, plus `dispatch` and `main`. The alternative (split across multiple PRs with transient `print_*` shims) violates "replace, don't deprecate" and leaves the tree in an awkward intermediate state. Phase 4 must remain its own PR so the deletion is reviewable in isolation.
-- **Empirical confirmation.** Phase 4 closes with the 50-iteration stress run described in *Verification gates*. If any iteration fails, the migration is not complete and the failing test must be diagnosed before issue #192 is closed.
+- **Risk: PR size.** Phase 2 is large by design — it touches ~14 output files, ~50 output tests, 14 `execute()` signatures, ~22 command-layer test files, plus `dispatch` and `main`. The alternative (splitting into smaller PRs) requires either transient migration helpers in `test_helpers` or transient `print_*` shims in `src/output/`, both of which violate "replace, don't deprecate" and leave the tree in an awkward intermediate state. Once `execute()` gains its `Writers` parameter, every test calling `execute()` must update in lockstep — there is no green-tree intermediate. Phase 3 (deletion) must remain its own PR so the cleanup is reviewable in isolation.
+- **Empirical confirmation.** Phase 3 closes with the 50-iteration stress run described in *Verification gates*. If any iteration fails, the migration is not complete and the failing test must be diagnosed before issue #192 is closed.
 
 ## CHANGELOG
 
-Per project convention, each phase that ships user-visible behavior writes its CHANGELOG entry as the work lands. Phases 0 and 4 are user-visible (CI flake fix; final removal of the deprecated helper); intermediate phases are internal refactors and do not require CHANGELOG entries unless they change observable CLI behavior (none expected).
+Per project convention, each phase that ships user-visible behavior writes its CHANGELOG entry as the work lands. Phases 0 and 3 are user-visible (CI flake fix; final removal of the deprecated helper); intermediate phases are internal refactors and do not require CHANGELOG entries unless they change observable CLI behavior (none expected).

--- a/src/commands/bug/view_tests.rs
+++ b/src/commands/bug/view_tests.rs
@@ -226,10 +226,12 @@ async fn view_multi_strict_json_failure_emits_no_partial_json() {
     .await;
     assert!(result.is_err());
     // No JSON should have been emitted — the buffer was discarded on Err.
-    assert!(
-        output.trim().is_empty(),
-        "expected empty stdout, got: {output}"
-    );
+    // capture_stdout's process-wide fd-1 redirection can capture stray bytes
+    // from concurrent tests, so we cannot assert the buffer is byte-empty.
+    // Instead we assert no JSON value can be parsed out of it: extract_json
+    // panics when no JSON is found, which we catch and treat as success.
+    let parsed = std::panic::catch_unwind(|| crate::test_helpers::extract_json(&output));
+    assert!(parsed.is_err(), "expected no JSON in stdout, got: {output}");
 }
 
 #[tokio::test]

--- a/src/output/attachment_tests.rs
+++ b/src/output/attachment_tests.rs
@@ -347,7 +347,7 @@ async fn print_attachment_batch_json_emits_typed_payload() {
         print_attachment_batch(&result, OutputFormat::Json);
     })
     .await;
-    let parsed: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    let parsed = crate::test_helpers::extract_json(&out);
     assert_eq!(parsed["summary"]["succeeded"], 2);
     assert_eq!(parsed["bug_results"][0]["files"][0]["attachment_id"], 9876);
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -59,9 +59,15 @@ api_mode = "rest"
 
 /// Capture stdout written during an async operation.
 ///
-/// Redirects file descriptor 1 to a temp file, runs the future, restores
-/// stdout, then returns the captured content. Must be called while holding
-/// `ENV_LOCK` (tests are single-threaded via `setup_test_env`).
+/// Redirects file descriptor 1 process-wide to a temp file via `dup2`, runs
+/// the future, restores stdout, and returns the captured content. The
+/// redirection is process-global, so any concurrently running test that
+/// writes to fd 1 during the redirection window will land its bytes in the
+/// captured file. This race is the subject of issue #192 and the helper is
+/// being phased out — see
+/// `docs/superpowers/specs/2026-05-07-issue-192-stdout-capture-flakes-design.md`.
+/// New tests should plumb output through `Writers` and capture into
+/// owned buffers instead.
 ///
 /// # Panics
 ///


### PR DESCRIPTION
## Summary

Tier 1 mitigation for #192. Two tests have flaked in CI under concurrent test load due to fd-1 redirection in `capture_stdout` racing with parallel writers. This PR makes both tests race-tolerant without changing the underlying race; phases 1–3 (separate PRs) will remove `capture_stdout` entirely.

- `output::attachment::tests::print_attachment_batch_json_emits_typed_payload`: switch from `serde_json::from_str(out.trim())` to `extract_json(&out)`, the same race-tolerant probe ~10 other JSON-asserting tests already use.
- `commands::bug::view::tests::view_multi_strict_json_failure_emits_no_partial_json`: the assertion was `output.trim().is_empty()` — too strict against fd-1 contamination from concurrent tests. Replaced with `catch_unwind(extract_json)` returning `Err`, i.e. "no parseable JSON value in the captured buffer."
- `capture_stdout` doc-comment was claiming `ENV_LOCK` serializes stdout-writing tests. It doesn't. Replaced with an accurate description of the fd-1 redirection and a pointer to the design doc for the phased removal.

The two design-doc commits on this branch describe the broader migration plan (`docs/superpowers/specs/2026-05-07-issue-192-stdout-capture-flakes-design.md`) — included here as context for the test fixes; they describe future work tracked separately.

## Test plan

- [x] `cargo test --lib` — 1143 passed
- [x] Each affected test passes 20× consecutively (no flakes locally)
- [x] cargo fmt --check clean
- [x] cargo clippy --all-targets --all-features -- -D warnings clean

## Follow-ups

- Phase 1 (separate PR): add `Writers` newtype + `CapturedIo` test helper as additive scaffolding.
- Phase 2 (separate PR): rename `print_* → write_*`, plumb `Writers` through `main → dispatch → execute`.
- Phase 3 (separate PR): delete `capture_stdout`, `extract_json`, and the `dup`/`dup2` extern block.

Refs: #192