### PR TITLE
feat(output): add Writers and CapturedIo scaffolding

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -17,6 +17,7 @@ mod result_types;
 mod server;
 mod template;
 mod user;
+mod writers;
 
 // Re-export shared types and helpers used by commands.
 pub(crate) use formatting::write_divider;
@@ -25,6 +26,14 @@ pub use result_types::{
     DownloadResult, MembershipResult, MultiBugViewResult, ResourceKind, SearchResult, TagResult,
     UploadResult,
 };
+#[cfg_attr(
+    not(any(test, feature = "test-helpers")),
+    expect(
+        unused_imports,
+        reason = "scaffolding for #192 phase 2 — re-export becomes load-bearing when commands::*::execute() gains a Writers parameter"
+    )
+)]
+pub use writers::Writers;
 
 // Re-export all public items from submodules.
 pub use attachment::{

--- a/src/output/writers.rs
+++ b/src/output/writers.rs
@@ -1,0 +1,39 @@
+//! Writer plumbing for command-layer output.
+//!
+//! The two streams are bundled into a single `Writers` parameter so command
+//! signatures stay compact (one parameter, not two). Inside the struct the
+//! streams are `&mut dyn Write` — the command layer doesn't need to care
+//! what concrete writer backs each stream. `main.rs` constructs `Writers`
+//! from locked `io::stdout()` / `io::stderr()`; tests use `CapturedIo` to
+//! own `Vec<u8>` buffers and borrow them through `Writers`.
+
+use std::io::Write;
+
+#[cfg_attr(
+    not(any(test, feature = "test-helpers")),
+    expect(
+        dead_code,
+        reason = "scaffolding for #192 phase 2 — first production caller added when commands::*::execute() gains a Writers parameter"
+    )
+)]
+pub struct Writers<'a> {
+    pub out: &'a mut dyn Write,
+    pub err: &'a mut dyn Write,
+}
+
+impl<'a> Writers<'a> {
+    #[cfg_attr(
+        not(any(test, feature = "test-helpers")),
+        expect(
+            dead_code,
+            reason = "scaffolding for #192 phase 2 — first production caller added when main constructs Writers from locked stdout/stderr"
+        )
+    )]
+    pub fn new(out: &'a mut dyn Write, err: &'a mut dyn Write) -> Self {
+        Self { out, err }
+    }
+}
+
+#[cfg(test)]
+#[path = "writers_tests.rs"]
+mod tests;

--- a/src/output/writers_tests.rs
+++ b/src/output/writers_tests.rs
@@ -1,0 +1,28 @@
+use super::Writers;
+
+#[test]
+fn writers_new_holds_two_streams_and_writes_independently() {
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    {
+        let w = Writers::new(&mut out, &mut err);
+        let _ = writeln!(w.out, "hello stdout");
+        let _ = writeln!(w.err, "hello stderr");
+    }
+    assert_eq!(out, b"hello stdout\n");
+    assert_eq!(err, b"hello stderr\n");
+}
+
+#[test]
+fn writers_out_and_err_are_independent_buffers() {
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    {
+        let w = Writers::new(&mut out, &mut err);
+        let _ = w.out.write_all(b"A");
+        let _ = w.err.write_all(b"B");
+        let _ = w.out.write_all(b"C");
+    }
+    assert_eq!(out, b"AC");
+    assert_eq!(err, b"B");
+}

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -159,6 +159,46 @@ fn try_parse_from(slice: &str, opener: char) -> Option<serde_json::Value> {
     None
 }
 
+/// Owned `Vec<u8>` buffers for capturing stdout and stderr in tests, plus
+/// a `Writers` constructor that borrows them. Replaces `capture_stdout` for
+/// tests against code that takes a `Writers` parameter.
+pub struct CapturedIo {
+    pub out: Vec<u8>,
+    pub err: Vec<u8>,
+}
+
+impl CapturedIo {
+    pub fn new() -> Self {
+        Self {
+            out: Vec::new(),
+            err: Vec::new(),
+        }
+    }
+
+    /// Construct a `Writers` borrowing this buffer pair.
+    pub fn writers(&mut self) -> crate::output::Writers<'_> {
+        crate::output::Writers::new(&mut self.out, &mut self.err)
+    }
+
+    /// View captured stdout as `&str` (non-UTF-8 bytes are replaced with the
+    /// empty string — tests should hold UTF-8 invariants and this method
+    /// makes assertion failures more readable than working in raw bytes).
+    pub fn out_str(&self) -> &str {
+        std::str::from_utf8(&self.out).unwrap_or("")
+    }
+
+    /// View captured stderr as `&str`. Same caveat as `out_str`.
+    pub fn err_str(&self) -> &str {
+        std::str::from_utf8(&self.err).unwrap_or("")
+    }
+}
+
+impl Default for CapturedIo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Build a mock XML-RPC Bug.search response containing one bug.
 pub fn xmlrpc_bug_response(id: i64, summary: &str) -> String {
     format!(

--- a/src/test_helpers_tests.rs
+++ b/src/test_helpers_tests.rs
@@ -24,3 +24,22 @@ fn xmlrpc_bug_response_contains_expected_bug_fields() {
     assert!(xml.contains("<name>status</name>"));
     assert!(xml.contains("<string>NEW</string>"));
 }
+
+#[test]
+fn captured_io_starts_empty() {
+    let io = CapturedIo::new();
+    assert!(io.out.is_empty());
+    assert!(io.err.is_empty());
+}
+
+#[test]
+fn captured_io_writers_route_to_owned_buffers() {
+    let mut io = CapturedIo::new();
+    {
+        let w = io.writers();
+        let _ = writeln!(w.out, "to stdout");
+        let _ = writeln!(w.err, "to stderr");
+    }
+    assert_eq!(io.out_str(), "to stdout\n");
+    assert_eq!(io.err_str(), "to stderr\n");
+}


### PR DESCRIPTION
## Summary

Phase 1 of the #192 migration. Pure additive scaffolding:

- `src/output/writers.rs`: `Writers<'a>` newtype with `out` and `err` as `&mut dyn Write`.
- `src/test_helpers.rs`: `CapturedIo` with owned `Vec<u8>` buffers and a `writers()` constructor.

Both come with sibling test files. No production call sites yet — phase 2 plumbs Writers through the command layer and migrates tests to CapturedIo.

The dead-code suppressions on `Writers`, `Writers::new`, and the `pub use` re-export are gated with `cfg_attr(not(any(test, feature = \"test-helpers\")))` — they only fire in lib-only / no-feature builds. The expects become unfulfilled (and trivially removable) the moment phase 2 lands a production caller.

## Test plan

- [x] cargo test --lib output::writers passes (2 tests)
- [x] cargo test --lib test_helpers passes (5 tests, +2 new)
- [x] cargo test --lib total = 1147 (1143 baseline + 4 new)
- [x] cargo clippy --lib -- -D warnings clean (matches pre-commit hook)
- [x] cargo clippy --all-targets --all-features -- -D warnings clean
- [x] cargo fmt --check clean

## Follow-ups

- Phase 2 (separate PR): rename `print_* → write_*`, plumb `Writers` through `main → dispatch → execute`, migrate command-layer tests to CapturedIo. Removes the dead-code suppressions added here.
- Phase 3 (separate PR): delete `capture_stdout`, `extract_json`, and the `dup`/`dup2` extern block.

Refs: #192