### PR TITLE
refactor(output): plumb writers through main → dispatch → execute (#192 phase 2)

### DIFF
--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::io::Write as _;
 use std::path::Path;
 
 use base64::Engine;
@@ -10,6 +9,7 @@ use crate::error::Result;
 use crate::output::{
     self, ActionResult, AttachmentBatchResult, AttachmentDownloadResult, BatchSummary,
     BugDownloadResult, DownloadResult, DownloadedFile, ResourceKind, TargetStatus, UploadResult,
+    Writers,
 };
 use crate::types::ApiMode;
 use crate::types::Attachment;
@@ -21,6 +21,7 @@ pub async fn execute(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     validate_action(action)?;
     let client = super::shared::connect_and_configure(server, api).await?;
@@ -28,7 +29,7 @@ pub async fn execute(
     match action {
         AttachmentAction::List { bug_id } => {
             let attachments = client.get_attachments(*bug_id).await?;
-            output::print_attachments(&attachments, format);
+            output::write_attachments(&attachments, format, w.out);
         }
         AttachmentAction::Download {
             ids,
@@ -37,9 +38,9 @@ pub async fn execute(
             out_dir,
         } => {
             if bug_ids.is_empty() && ids.len() == 1 {
-                download_single(&client, ids[0], out.as_deref(), format).await?;
+                download_single(&client, ids[0], out.as_deref(), format, w).await?;
             } else {
-                download_batch(&client, ids, bug_ids, out_dir, format).await?;
+                download_batch(&client, ids, bug_ids, out_dir, format, w).await?;
             }
         }
         AttachmentAction::Upload {
@@ -77,12 +78,13 @@ pub async fn execute(
             };
             let att_id = client.upload_attachment(&upload_params).await?;
             if *comment_private {
-                flip_new_comment_private(&client, *bug_id, att_id).await?;
+                flip_new_comment_private(&client, *bug_id, att_id, w).await?;
             }
-            output::print_result(
+            output::write_result(
                 &UploadResult::new(att_id, *bug_id, size),
                 &format!("Uploaded attachment #{att_id} to bug #{bug_id} ({size} bytes)"),
                 format,
+                w.out,
             );
         }
         AttachmentAction::Update {
@@ -106,10 +108,11 @@ pub async fn execute(
                 flags,
             };
             client.update_attachment(*id, &params).await?;
-            output::print_result(
+            output::write_result(
                 &ActionResult::updated(*id, ResourceKind::Attachment),
                 &format!("Updated attachment #{id}"),
                 format,
+                w.out,
             );
         }
     }
@@ -179,11 +182,12 @@ async fn flip_new_comment_private(
     client: &BugzillaClient,
     bug_id: u64,
     new_attachment_id: u64,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let comments = client
         .get_comments_since(bug_id, None)
         .await
-        .inspect_err(|e| warn_partial(new_attachment_id, e))?;
+        .inspect_err(|e| warn_partial(new_attachment_id, e, w))?;
     // `attachment_id` is unique per bug: Bugzilla sets it on exactly one
     // comment when `Bug.add_attachment` includes a `comment` body.
     let Some(comment_id) = comments
@@ -195,7 +199,7 @@ async fn flip_new_comment_private(
             "could not locate the new attachment-bound comment on bug #{bug_id} \
              (no comment with attachment_id={new_attachment_id})",
         ));
-        warn_partial(new_attachment_id, &err);
+        warn_partial(new_attachment_id, &err, w);
         return Err(err);
     };
     let mut map = HashMap::new();
@@ -207,16 +211,16 @@ async fn flip_new_comment_private(
     client
         .update_bug(bug_id, &params)
         .await
-        .inspect_err(|e| warn_partial(new_attachment_id, e))
+        .inspect_err(|e| warn_partial(new_attachment_id, e, w))
 }
 
-fn warn_partial(att_id: u64, err: &crate::error::BzrError) {
+fn warn_partial(att_id: u64, err: &crate::error::BzrError, w: &mut Writers<'_>) {
     let _ = writeln!(
-        std::io::stderr(),
+        w.err,
         "warning: attachment #{att_id} uploaded but comment privacy flip failed: {err}",
     );
     let _ = writeln!(
-        std::io::stderr(),
+        w.err,
         "  the comment was created public; mark it private via the Bugzilla web UI or with elevated credentials",
     );
 }
@@ -230,17 +234,19 @@ async fn download_single(
     id: u64,
     out: Option<&str>,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let (filename, data) = client.download_attachment(id).await?;
     let dest = out.unwrap_or(&filename);
     std::fs::write(dest, &data)?;
-    output::print_result(
+    output::write_result(
         &DownloadResult::new(id, dest, data.len()),
         &format!(
             "Downloaded attachment #{id} to {dest} ({} bytes)",
             data.len(),
         ),
         format,
+        w.out,
     );
     Ok(())
 }
@@ -302,6 +308,7 @@ async fn download_batch(
     bug_ids: &[u64],
     out_dir: &str,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     std::fs::create_dir_all(out_dir)?;
 
@@ -327,7 +334,7 @@ async fn download_batch(
         summary,
     };
 
-    output::print_attachment_batch(&result, format);
+    output::write_attachment_batch(&result, format, w.out, w.err);
 
     if failed > 0 {
         return Err(crate::error::BzrError::BatchPartialFailure { succeeded, failed });

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -5,7 +5,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::AttachmentAction;
-use crate::test_helpers::{capture_stdout, extract_json, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 #[tokio::test]
@@ -35,10 +35,18 @@ async fn attachment_list_returns_attachments() {
         .await;
 
     let action = AttachmentAction::List { bug_id: 42 };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a1 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a1.writers(),
+    )
+    .await;
+    let output = __io_a1.out_str().to_string();
     assert!(result.is_ok());
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["id"], 100);
     assert_eq!(parsed[0]["file_name"], "patch.diff");
     assert_eq!(parsed[0]["creator"], "dev@test.com");
@@ -46,6 +54,7 @@ async fn attachment_list_returns_attachments() {
 
 #[tokio::test]
 async fn attachment_list_api_error_propagates() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -55,12 +64,20 @@ async fn attachment_list_api_error_propagates() {
         .await;
 
     let action = AttachmentAction::List { bug_id: 999 };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
 }
 
 #[tokio::test]
 async fn attachment_upload_api_error_propagates() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     Mock::given(method("POST"))
@@ -87,7 +104,14 @@ async fn attachment_upload_api_error_propagates() {
         comment_private: false,
         flag: vec![],
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
@@ -98,6 +122,7 @@ async fn attachment_upload_api_error_propagates() {
 
 #[tokio::test]
 async fn attachment_download_api_error_propagates() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -116,7 +141,14 @@ async fn attachment_download_api_error_propagates() {
         out: None,
         out_dir: "./attachments".into(),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
 }
 
@@ -144,16 +176,25 @@ async fn attachment_upload_returns_id() {
         comment_private: false,
         flag: vec![],
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a2 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a2.writers(),
+    )
+    .await;
+    let output = __io_a2.out_str().to_string();
     assert!(result.is_ok());
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 200);
 }
 
 #[tokio::test]
 async fn attachment_upload_with_comment_includes_comment_in_request() {
     use wiremock::matchers::body_string_contains;
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     Mock::given(method("POST"))
@@ -178,7 +219,14 @@ async fn attachment_upload_with_comment_includes_comment_in_request() {
         comment_private: false,
         flag: vec![],
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_ok(),
         "upload with --comment should succeed: {result:?}"
@@ -188,6 +236,7 @@ async fn attachment_upload_with_comment_includes_comment_in_request() {
 #[tokio::test]
 async fn attachment_upload_with_is_patch_defaults_content_type_to_text_plain() {
     use wiremock::matchers::body_string_contains;
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     Mock::given(method("POST"))
@@ -213,7 +262,14 @@ async fn attachment_upload_with_is_patch_defaults_content_type_to_text_plain() {
         comment_private: false,
         flag: vec![],
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_ok(),
         "upload --is-patch should succeed: {result:?}"
@@ -223,6 +279,7 @@ async fn attachment_upload_with_is_patch_defaults_content_type_to_text_plain() {
 #[tokio::test]
 async fn attachment_upload_is_patch_with_explicit_content_type_keeps_content_type() {
     use wiremock::matchers::body_string_contains;
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     Mock::given(method("POST"))
@@ -250,7 +307,14 @@ async fn attachment_upload_is_patch_with_explicit_content_type_keeps_content_typ
         comment_private: false,
         flag: vec![],
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_ok(),
         "upload --is-patch with explicit ct should succeed: {result:?}"
@@ -279,10 +343,18 @@ async fn attachment_update_succeeds() {
         is_private: None,
         flag: vec![],
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a3 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a3.writers(),
+    )
+    .await;
+    let output = __io_a3.out_str().to_string();
     assert!(result.is_ok());
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 99);
     assert_eq!(parsed["action"], "updated");
 }
@@ -352,6 +424,7 @@ fn guess_content_type_case_insensitive() {
 #[tokio::test]
 async fn attachment_upload_with_comment_private_flips_privacy() {
     use wiremock::matchers::body_string_contains;
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     let upload_file = tmp.path().join("p.diff");
@@ -404,7 +477,14 @@ async fn attachment_upload_with_comment_private_flips_privacy() {
         comment_private: true,
         flag: vec![],
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_ok(),
         "two-call workflow should succeed: {result:?}"
@@ -413,6 +493,7 @@ async fn attachment_upload_with_comment_private_flips_privacy() {
 
 #[tokio::test]
 async fn attachment_upload_comment_private_without_comment_is_input_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, tmp) = setup_test_env().await;
     let upload_file = tmp.path().join("p.diff");
     std::fs::write(&upload_file, "x").unwrap();
@@ -428,7 +509,14 @@ async fn attachment_upload_comment_private_without_comment_is_input_error() {
         comment_private: true,
         flag: vec![],
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(matches!(
         result,
         Err(crate::error::BzrError::InputValidation(_))
@@ -437,6 +525,7 @@ async fn attachment_upload_comment_private_without_comment_is_input_error() {
 
 #[tokio::test]
 async fn attachment_upload_comment_private_partial_failure_propagates_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     let upload_file = tmp.path().join("p.diff");
@@ -479,12 +568,20 @@ async fn attachment_upload_comment_private_partial_failure_propagates_error() {
         comment_private: true,
         flag: vec![],
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err(), "step-2 failure should propagate");
 }
 
 #[tokio::test]
 async fn attachment_upload_comment_private_no_matching_comment_is_data_integrity_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     let upload_file = tmp.path().join("p.diff");
@@ -525,7 +622,14 @@ async fn attachment_upload_comment_private_no_matching_comment_is_data_integrity
         comment_private: true,
         flag: vec![],
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(matches!(
         result,
         Err(crate::error::BzrError::DataIntegrity(_))
@@ -534,13 +638,21 @@ async fn attachment_upload_comment_private_no_matching_comment_is_data_integrity
 
 #[tokio::test]
 async fn attachment_download_validation_rejects_no_ids_no_bugs() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let action = AttachmentAction::Download {
         ids: vec![],
         bug_ids: vec![],
         out: None,
         out_dir: "./attachments".into(),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err(), "expected InputValidation");
     let msg = result.unwrap_err().to_string();
     assert!(
@@ -551,13 +663,21 @@ async fn attachment_download_validation_rejects_no_ids_no_bugs() {
 
 #[tokio::test]
 async fn attachment_download_validation_rejects_out_with_multiple_ids() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let action = AttachmentAction::Download {
         ids: vec![100, 200],
         bug_ids: vec![],
         out: Some("file.bin".into()),
         out_dir: "./attachments".into(),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err(), "expected InputValidation");
     let msg = result.unwrap_err().to_string();
     assert!(
@@ -744,11 +864,21 @@ async fn attachment_download_batch_per_bug_writes_per_bug_subdir() {
         out_dir: out_dir.clone(),
     };
 
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a4 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a4.writers(),
+    )
+    .await;
+
+    let output = __io_a4.out_str().to_string();
     assert!(result.is_ok(), "expected ok, got {result:?}");
 
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["summary"]["succeeded"], 2);
     assert_eq!(parsed["summary"]["failed"], 0);
     assert_eq!(parsed["summary"]["total_bytes"], 5 + 13);
@@ -787,7 +917,11 @@ async fn attachment_download_batch_collision_filenames_resolved_by_att_id_prefix
         out_dir,
     };
 
-    let (result, _) = capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut __io.writers()).await;
+
+    let _ = __io.out_str().to_string();
     assert!(result.is_ok(), "expected ok, got {result:?}");
 
     let p1 = tmp.path().join("12345").join("9876.trace.log");
@@ -829,11 +963,21 @@ async fn attachment_download_batch_mixed_bug_and_positional_ids() {
         out_dir: out_dir.clone(),
     };
 
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a5 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a5.writers(),
+    )
+    .await;
+
+    let output = __io_a5.out_str().to_string();
     assert!(result.is_ok(), "expected ok, got {result:?}");
 
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["summary"]["succeeded"], 2);
     assert_eq!(parsed["bug_results"][0]["bug_id"], 12345);
     assert_eq!(parsed["attachment_results"][0]["attachment_id"], 4242);
@@ -864,10 +1008,20 @@ async fn attachment_download_batch_empty_bug_zero_files_success() {
         out_dir,
     };
 
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a6 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a6.writers(),
+    )
+    .await;
+
+    let output = __io_a6.out_str().to_string();
     assert!(result.is_ok(), "expected ok, got {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["bug_results"][0]["status"], "ok");
     assert_eq!(parsed["summary"]["succeeded"], 0);
     assert_eq!(parsed["summary"]["failed"], 0);
@@ -895,13 +1049,23 @@ async fn attachment_download_batch_legacy_single_id_unchanged() {
         out_dir: "./attachments".into(),
     };
 
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a7 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a7.writers(),
+    )
+    .await;
+
+    let output = __io_a7.out_str().to_string();
     assert!(result.is_ok(), "expected ok, got {result:?}");
 
     // Legacy path emits DownloadResult, not AttachmentBatchResult — the
     // JSON has `id` at the top level, not `summary`.
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 9876);
     assert_eq!(parsed["size"].as_u64().unwrap_or(0), 6);
     assert!(out_path.exists());
@@ -941,14 +1105,24 @@ async fn attachment_download_batch_bug_not_found_partial_failure() {
         out_dir,
     };
 
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a8 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a8.writers(),
+    )
+    .await;
+
+    let output = __io_a8.out_str().to_string();
     assert!(result.is_err(), "expected BatchPartialFailure");
     let err = result.unwrap_err();
     let exit = err.exit_code();
     assert_eq!(exit, 11, "expected exit 11, got {exit}: {err}");
 
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["summary"]["succeeded"], 1);
     assert_eq!(parsed["summary"]["failed"], 1);
     let bugs = parsed["bug_results"].as_array().unwrap();
@@ -960,6 +1134,7 @@ async fn attachment_download_batch_bug_not_found_partial_failure() {
 
 #[tokio::test]
 async fn attachment_download_batch_all_targets_fail_still_exit_11() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -979,7 +1154,14 @@ async fn attachment_download_batch_all_targets_fail_still_exit_11() {
         out: None,
         out_dir,
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err(), "expected BatchPartialFailure");
     let err = result.unwrap_err();
     let exit = err.exit_code();
@@ -1011,7 +1193,18 @@ async fn attachment_download_batch_obsolete_attachments_included() {
         out_dir: out_dir.clone(),
     };
 
-    let (result, _) = capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io2 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io2.writers(),
+    )
+    .await;
+
+    let _ = __io2.out_str().to_string();
     assert!(result.is_ok(), "expected ok, got {result:?}");
     assert!(tmp.path().join("12345").join("9876.old.patch").exists());
 }
@@ -1052,7 +1245,18 @@ async fn attachment_download_batch_data_missing_falls_back_via_get() {
         out_dir,
     };
 
-    let (result, _) = capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io3 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io3.writers(),
+    )
+    .await;
+
+    let _ = __io3.out_str().to_string();
     assert!(result.is_ok(), "expected ok, got {result:?}");
     let written = std::fs::read(tmp.path().join("12345").join("9876.patch.diff")).unwrap();
     assert_eq!(written, b"fallback");
@@ -1061,6 +1265,7 @@ async fn attachment_download_batch_data_missing_falls_back_via_get() {
 #[cfg(unix)]
 #[tokio::test]
 async fn attachment_download_batch_top_level_out_dir_unwritable_fails_fast() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     // /dev/null/attachments — create_dir_all on a path under /dev/null
@@ -1071,7 +1276,14 @@ async fn attachment_download_batch_top_level_out_dir_unwritable_fails_fast() {
         out: None,
         out_dir: "/dev/null/attachments".into(),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err(), "expected Io");
     let err = result.unwrap_err();
     let exit = err.exit_code();

--- a/src/commands/bug/clone.rs
+++ b/src/commands/bug/clone.rs
@@ -1,13 +1,14 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output::{self, ActionResult, ResourceKind};
+use crate::output::{self, ActionResult, ResourceKind, Writers};
 use crate::types::{CreateBugParams, OutputFormat};
 
 pub(super) async fn handle(
     client: &BugzillaClient,
     action: &BugAction,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let BugAction::Clone {
         id,
@@ -90,10 +91,11 @@ pub(super) async fn handle(
             .await?;
     }
 
-    output::print_result(
+    output::write_result(
         &ActionResult::created(new_id, ResourceKind::Bug),
         &format!("Cloned bug #{} → #{new_id}", source.id),
         format,
+        w.out,
     );
     Ok(())
 }

--- a/src/commands/bug/clone_tests.rs
+++ b/src/commands/bug/clone_tests.rs
@@ -1,8 +1,10 @@
+#![expect(clippy::unwrap_used)]
+
 use wiremock::matchers::{body_partial_json, method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::BugAction;
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 #[tokio::test]
@@ -97,15 +99,14 @@ async fn bug_clone_copies_fields() {
         no_cc: false,
         no_keywords: false,
     };
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
-        &action,
-        None,
-        OutputFormat::Json,
-        None,
-    ))
-    .await;
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    let output = __io.out_str().to_string();
     assert!(result.is_ok(), "bug clone failed: {result:?}");
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 200);
     assert_eq!(parsed["action"], "created");
 }
@@ -182,12 +183,15 @@ async fn bug_clone_no_comment_skips_comment() {
         no_cc: false,
         no_keywords: false,
     };
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io2 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io2.writers(),
+    )
     .await;
+    let _output = __io2.out_str().to_string();
     assert!(result.is_ok(), "bug clone --no-comment failed: {result:?}");
 }

--- a/src/commands/bug/create.rs
+++ b/src/commands/bug/create.rs
@@ -4,7 +4,7 @@ use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::commands::editor;
 use crate::error::Result;
-use crate::output::{self, ActionResult, ResourceKind};
+use crate::output::{self, ActionResult, ResourceKind, Writers};
 use crate::types::{CreateBugParams, OutputFormat};
 
 fn read_description_file(path: &std::path::Path) -> Result<String> {
@@ -57,12 +57,6 @@ impl MergedFields {
 }
 
 /// Parse the post-editor buffer into `(summary, description)`.
-///
-/// Truncates at the sentinel divider, takes the first non-empty line
-/// as the summary, and joins the remaining lines (after stripping
-/// leading and trailing blank lines) as the description. Returns
-/// `InputValidation` when no non-empty line is found above the
-/// sentinel.
 fn parse_editor_buffer(raw: &str) -> Result<(String, String)> {
     let mut iter = raw
         .lines()
@@ -88,11 +82,6 @@ fn parse_editor_buffer(raw: &str) -> Result<(String, String)> {
     Ok((summary, description))
 }
 
-/// Build the pre-filled `$EDITOR` buffer.
-///
-/// Layout: optional pre-filled summary on line 1, optional template
-/// description body, the sentinel divider, and a read-only field
-/// reminder block populated from `params`.
 fn build_editor_template(
     summary_pre_fill: Option<&str>,
     template_description: Option<&str>,
@@ -139,10 +128,6 @@ fn build_editor_template(
     buf
 }
 
-/// Resolve the description source by precedence (#1-#3): explicit
-/// `--description`, `--description-file`, or piped stdin. Returns
-/// `None` when no explicit source is supplied and stdin is a TTY --
-/// the caller then dispatches the `$EDITOR` flow (#4).
 fn resolve_description(
     description: Option<&str>,
     description_file: Option<&std::path::Path>,
@@ -166,8 +151,6 @@ fn resolve_description(
     Ok(None)
 }
 
-/// Resolve the optional `--template` reference into a cloned
-/// `BugTemplate`, surfacing a config error when the name is unknown.
 fn load_template(name: Option<&str>) -> Result<Option<crate::types::BugTemplate>> {
     let Some(name) = name else { return Ok(None) };
     let config = crate::config::Config::load()?;
@@ -178,8 +161,6 @@ fn load_template(name: Option<&str>) -> Result<Option<crate::types::BugTemplate>
     Ok(Some(t.clone()))
 }
 
-/// Drive the `$EDITOR` flow: build the pre-filled buffer from the
-/// merged field set, launch the editor, and parse the result.
 fn run_editor_flow(
     summary_pre_fill: Option<&str>,
     merged: &MergedFields,
@@ -257,6 +238,7 @@ pub(super) async fn handle(
     client: &BugzillaClient,
     action: &BugAction,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let BugAction::Create {
         template: template_name,
@@ -309,10 +291,11 @@ pub(super) async fn handle(
         keywords: vec![],
     };
     let id = client.create_bug(&params).await?;
-    output::print_result(
+    output::write_result(
         &ActionResult::created(id, ResourceKind::Bug),
         &format!("Created bug #{id}"),
         format,
+        w.out,
     );
     Ok(())
 }

--- a/src/commands/bug/create_tests.rs
+++ b/src/commands/bug/create_tests.rs
@@ -7,7 +7,7 @@ use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::{BugAction, TemplateAction};
 use crate::error::BzrError;
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 fn create_action() -> BugAction {
@@ -40,15 +40,21 @@ async fn bug_create_sends_post() {
         .mount(&mock)
         .await;
 
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io = crate::test_helpers::CapturedIo::new();
+
+    let result = crate::commands::bug::execute(
         &create_action(),
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io.writers(),
+    )
     .await;
+
+    let output = __io.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["action"], "created");
     assert_eq!(parsed["id"], 99);
 }
@@ -73,13 +79,16 @@ async fn bug_create_missing_product_returns_input_validation() {
         blocks: vec![],
         depends_on: vec![],
     };
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io2 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io2.writers(),
+    )
     .await;
+    let _output = __io2.out_str().to_string();
     let err = result.unwrap_err();
     assert!(
         matches!(&err, BzrError::InputValidation(msg) if msg.contains("--product")),
@@ -107,13 +116,16 @@ async fn bug_create_missing_component_returns_input_validation() {
         blocks: vec![],
         depends_on: vec![],
     };
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io3 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io3.writers(),
+    )
     .await;
+    let _output = __io3.out_str().to_string();
     let err = result.unwrap_err();
     assert!(
         matches!(&err, BzrError::InputValidation(msg) if msg.contains("--component")),
@@ -141,13 +153,16 @@ async fn bug_create_with_unknown_template_errors() {
         blocks: vec![],
         depends_on: vec![],
     };
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io4 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io4.writers(),
+    )
     .await;
+    let _output = __io4.out_str().to_string();
     let err = result.unwrap_err();
     assert!(
         matches!(&err, BzrError::Config(msg) if msg.contains("does-not-exist")),
@@ -173,13 +188,16 @@ async fn bug_create_with_template_fills_missing_fields() {
         rep_platform: None,
         description: Some("from template".into()),
     };
-    let (result, _) = capture_stdout(crate::commands::template::execute(
+    let mut __io5 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::template::execute(
         &save,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io5.writers(),
+    )
     .await;
+    let _ = __io5.out_str().to_string();
     assert!(result.is_ok(), "template save failed: {result:?}");
 
     // The mock should see the template's product/component/version
@@ -210,18 +228,22 @@ async fn bug_create_with_template_fills_missing_fields() {
         blocks: vec![],
         depends_on: vec![],
     };
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io6 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io6.writers(),
+    )
     .await;
+    let output = __io6.out_str().to_string();
     assert!(
         result.is_ok(),
         "bug create with template failed: {result:?}"
     );
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 7);
     assert_eq!(parsed["action"], "created");
 }
@@ -258,13 +280,16 @@ async fn bug_create_reads_description_from_file() {
         blocks: vec![],
         depends_on: vec![],
     };
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io7 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io7.writers(),
+    )
     .await;
+    let _output = __io7.out_str().to_string();
     assert!(result.is_ok(), "got {result:?}");
     let _ = std::fs::remove_file(&desc_path);
 }
@@ -289,13 +314,16 @@ async fn bug_create_description_file_missing_returns_input_validation() {
         blocks: vec![],
         depends_on: vec![],
     };
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io8 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io8.writers(),
+    )
     .await;
+    let _output = __io8.out_str().to_string();
     let err = result.unwrap_err();
     assert!(
         matches!(&err, BzrError::InputValidation(m) if m.contains("description-file")),
@@ -327,13 +355,16 @@ async fn bug_create_description_file_non_utf8_returns_input_validation() {
         blocks: vec![],
         depends_on: vec![],
     };
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io9 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io9.writers(),
+    )
     .await;
+    let _output = __io9.out_str().to_string();
     let err = result.unwrap_err();
     let _ = std::fs::remove_file(&bad_path);
     assert!(
@@ -362,13 +393,16 @@ async fn bug_create_missing_summary_without_editor_flow_is_rejected() {
         blocks: vec![],
         depends_on: vec![],
     };
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io10 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io10.writers(),
+    )
     .await;
+    let _output = __io10.out_str().to_string();
     let err = result.unwrap_err();
     assert!(
         matches!(&err, BzrError::InputValidation(m) if m.contains("--summary")),
@@ -567,13 +601,18 @@ async fn bug_create_editor_flow_resolves_via_editor_when_stdin_is_tty() {
         .mount(&mock)
         .await;
 
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io11 = crate::test_helpers::CapturedIo::new();
+
+    let result = crate::commands::bug::execute(
         &editor_action_no_summary_no_description(),
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io11.writers(),
+    )
     .await;
+
+    let _output = __io11.out_str().to_string();
 
     // SAFETY: setup_test_env holds bzr::ENV_LOCK for the duration of
     // this test, serializing env access across all tests using it.
@@ -622,13 +661,18 @@ async fn bug_create_editor_branch_unreachable_when_stdin_piped() {
         .mount(&mock)
         .await;
 
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io12 = crate::test_helpers::CapturedIo::new();
+
+    let result = crate::commands::bug::execute(
         &editor_action_no_summary_no_description(),
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io12.writers(),
+    )
     .await;
+
+    let _output = __io12.out_str().to_string();
 
     // SAFETY: setup_test_env holds bzr::ENV_LOCK for the duration of
     // this test, serializing env access across all tests using it.
@@ -665,13 +709,16 @@ async fn bug_create_template_description_does_not_fall_back_outside_editor_flow(
         rep_platform: None,
         description: Some("template body".into()),
     };
-    let (result, _) = capture_stdout(crate::commands::template::execute(
+    let mut __io13 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::template::execute(
         &save,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io13.writers(),
+    )
     .await;
+    let _ = __io13.out_str().to_string();
     assert!(result.is_ok(), "template save failed: {result:?}");
 
     // Invoke bug create with the template, no other description source,
@@ -694,13 +741,16 @@ async fn bug_create_template_description_does_not_fall_back_outside_editor_flow(
         blocks: vec![],
         depends_on: vec![],
     };
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io14 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io14.writers(),
+    )
     .await;
+    let _output = __io14.out_str().to_string();
     let err = result.unwrap_err();
     assert!(
         matches!(&err, BzrError::InputValidation(_)),

--- a/src/commands/bug/history.rs
+++ b/src/commands/bug/history.rs
@@ -1,9 +1,7 @@
-use std::io::{self, Write};
-
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output;
+use crate::output::{self, Writers};
 use crate::types::OutputFormat;
 use crate::validation::parse_optional_date;
 
@@ -11,6 +9,7 @@ pub(super) async fn handle(
     client: &BugzillaClient,
     action: &BugAction,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let BugAction::History { id, since } = action else {
         unreachable!()
@@ -22,9 +21,9 @@ pub(super) async fn handle(
         .get_bug_history_since(*id, canonical_since.as_deref())
         .await?;
     if history.is_empty() {
-        let _ = writeln!(io::stdout(), "No history for bug #{id}.");
+        let _ = writeln!(w.out, "No history for bug #{id}.");
     } else {
-        output::print_history(&history, format);
+        output::write_history(&history, format, w.out);
     }
     Ok(())
 }

--- a/src/commands/bug/history_tests.rs
+++ b/src/commands/bug/history_tests.rs
@@ -4,7 +4,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::BugAction;
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 #[tokio::test]
@@ -24,13 +24,16 @@ async fn bug_history_empty_prints_no_history_message() {
         id: 42,
         since: None,
     };
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Table,
         None,
-    ))
+        &mut __io.writers(),
+    )
     .await;
+    let output = __io.out_str().to_string();
     assert!(result.is_ok(), "bug history should succeed: {result:?}");
     assert!(
         output.contains("No history for bug #42."),
@@ -40,13 +43,21 @@ async fn bug_history_empty_prints_no_history_message() {
 
 #[tokio::test]
 async fn bug_history_rejects_malformed_since_with_exit_code_7() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = BugAction::History {
         id: 42,
         since: Some("yesterday".into()),
     };
-    let result = crate::commands::bug::execute(&action, None, OutputFormat::Table, None).await;
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     let err = result.unwrap_err();
     assert_eq!(err.exit_code(), 7);
     let msg = err.to_string();

--- a/src/commands/bug/list.rs
+++ b/src/commands/bug/list.rs
@@ -1,7 +1,7 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output;
+use crate::output::{self, Writers};
 use crate::types::{OutputFormat, SearchParams};
 use crate::validation::parse_optional_date;
 
@@ -9,6 +9,7 @@ pub(super) async fn handle(
     client: &BugzillaClient,
     action: &BugAction,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let BugAction::List {
         product,
@@ -69,7 +70,7 @@ pub(super) async fn handle(
         ..Default::default()
     };
     let bugs = client.search_bugs(&params).await?;
-    output::print_bugs(&bugs, format);
+    output::write_bugs(&bugs, format, w.out);
     Ok(())
 }
 

--- a/src/commands/bug/list_tests.rs
+++ b/src/commands/bug/list_tests.rs
@@ -4,7 +4,7 @@ use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::BugAction;
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 fn empty_list_action() -> BugAction {
@@ -60,15 +60,14 @@ async fn bug_list_returns_bugs() {
         .await;
 
     let action = empty_list_action();
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
-        &action,
-        None,
-        OutputFormat::Json,
-        None,
-    ))
-    .await;
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    let output = __io.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["id"], 1);
     assert_eq!(parsed[0]["summary"], "Test bug");
     assert_eq!(parsed[0]["status"], "NEW");
@@ -77,6 +76,7 @@ async fn bug_list_returns_bugs() {
 
 #[tokio::test]
 async fn bug_list_passes_every_field_through_to_search_params() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     // Every CLI field on `bug list` must round-trip into the search
     // query string.
     let (_lock, mock, _tmp) = setup_test_env().await;
@@ -136,7 +136,14 @@ async fn bug_list_passes_every_field_through_to_search_params() {
         qa_contact: vec!["qa@test.com".into()],
         url: vec!["github.com/foo".into()],
     };
-    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_ok(),
         "bug list with all fields failed: {result:?}"
@@ -145,6 +152,7 @@ async fn bug_list_passes_every_field_through_to_search_params() {
 
 #[tokio::test]
 async fn bug_list_summary_only_sends_substring_filter() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     // `--summary` alone must be passed verbatim as the REST `summary`
     // query parameter and must not trigger an XML-RPC fallback even
     // when the result is empty (issue #152).
@@ -190,12 +198,20 @@ async fn bug_list_summary_only_sends_substring_filter() {
         qa_contact: vec![],
         url: vec![],
     };
-    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_ok(), "bug list --summary failed: {result:?}");
 }
 
 #[tokio::test]
 async fn bug_list_http_500_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -205,7 +221,14 @@ async fn bug_list_http_500_returns_error() {
         .await;
 
     let action = empty_list_action();
-    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
@@ -216,6 +239,7 @@ async fn bug_list_http_500_returns_error() {
 
 #[tokio::test]
 async fn bug_list_malformed_json_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -225,12 +249,20 @@ async fn bug_list_malformed_json_returns_error() {
         .await;
 
     let action = empty_list_action();
-    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
 }
 
 #[tokio::test]
 async fn bug_list_rejects_malformed_created_since_with_exit_code_7() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let mut action = empty_list_action();
@@ -238,7 +270,14 @@ async fn bug_list_rejects_malformed_created_since_with_exit_code_7() {
         *created_since = Some("not-a-date".into());
     }
 
-    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     let err = result.unwrap_err();
     assert_eq!(
         err.exit_code(),
@@ -258,6 +297,7 @@ async fn bug_list_rejects_malformed_created_since_with_exit_code_7() {
 
 #[tokio::test]
 async fn bug_list_rejects_malformed_changed_since_with_exit_code_7() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let mut action = empty_list_action();
@@ -265,7 +305,14 @@ async fn bug_list_rejects_malformed_changed_since_with_exit_code_7() {
         *changed_since = Some("2026-13-99".into());
     }
 
-    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     let err = result.unwrap_err();
     assert_eq!(err.exit_code(), 7);
     assert!(err.to_string().contains("--changed-since"));
@@ -273,6 +320,7 @@ async fn bug_list_rejects_malformed_changed_since_with_exit_code_7() {
 
 #[tokio::test]
 async fn bug_list_mixed_positive_notequals_notsubstring() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     // End-to-end coverage: --product (positive), --resolution '!FIXED'
     // (notequals), --whiteboard '!wip' (notsubstring) all reach the
     // wire with the right operator.
@@ -306,6 +354,13 @@ async fn bug_list_mixed_positive_notequals_notsubstring() {
         *resolution = vec!["!FIXED".into()];
         *whiteboard = vec!["!wip".into()];
     }
-    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_ok(), "bug list failed: {result:?}");
 }

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -2,6 +2,7 @@
 
 use crate::cli::BugAction;
 use crate::error::Result;
+use crate::output::Writers;
 use crate::types::{ApiMode, OutputFormat};
 
 mod clone;
@@ -19,24 +20,25 @@ pub async fn execute(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     // Search builds its own client because --from-url may resolve a different
     // server from the URL hostname. Skip the shared connect to avoid double
     // auth/version detection on every `bug search` invocation.
     if let BugAction::Search { .. } = action {
-        return search::handle(action, server, format, api).await;
+        return search::handle(action, server, format, api, w).await;
     }
 
     let client = crate::commands::shared::connect_and_configure(server, api).await?;
 
     match action {
-        BugAction::List { .. } => list::handle(&client, action, format).await,
-        BugAction::View { .. } => view::handle(&client, action, format).await,
-        BugAction::History { .. } => history::handle(&client, action, format).await,
-        BugAction::My { .. } => my::handle(&client, action, format).await,
-        BugAction::Create { .. } => create::handle(&client, action, format).await,
-        BugAction::Clone { .. } => clone::handle(&client, action, format).await,
-        BugAction::Update { .. } => update::handle(&client, action, format).await,
+        BugAction::List { .. } => list::handle(&client, action, format, w).await,
+        BugAction::View { .. } => view::handle(&client, action, format, w).await,
+        BugAction::History { .. } => history::handle(&client, action, format, w).await,
+        BugAction::My { .. } => my::handle(&client, action, format, w).await,
+        BugAction::Create { .. } => create::handle(&client, action, format, w).await,
+        BugAction::Clone { .. } => clone::handle(&client, action, format, w).await,
+        BugAction::Update { .. } => update::handle(&client, action, format, w).await,
         BugAction::Search { .. } => unreachable!("handled above"),
     }
 }

--- a/src/commands/bug/my.rs
+++ b/src/commands/bug/my.rs
@@ -1,13 +1,14 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output;
+use crate::output::{self, Writers};
 use crate::types::{OutputFormat, SearchParams};
 
 pub(super) async fn handle(
     client: &BugzillaClient,
     action: &BugAction,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let BugAction::My {
         created,
@@ -60,7 +61,7 @@ pub(super) async fn handle(
         }
     }
 
-    output::print_bugs(&all_bugs, format);
+    output::write_bugs(&all_bugs, format, w.out);
     Ok(())
 }
 

--- a/src/commands/bug/my_tests.rs
+++ b/src/commands/bug/my_tests.rs
@@ -1,10 +1,10 @@
-#![expect(clippy::expect_used)]
+#![expect(clippy::unwrap_used, clippy::expect_used)]
 
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::cli::BugAction;
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 async fn mount_whoami(mock: &MockServer) {
@@ -50,15 +50,14 @@ async fn bug_my_returns_assigned_by_default() {
         fields: None,
         exclude_fields: None,
     };
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
-        &action,
-        None,
-        OutputFormat::Json,
-        None,
-    ))
-    .await;
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    let output = __io.out_str().to_string();
     assert!(result.is_ok(), "bug my failed: {result:?}");
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["id"], 10);
     assert_eq!(parsed[0]["summary"], "Assigned bug");
 }
@@ -90,13 +89,16 @@ async fn bug_my_passes_status_limit_and_field_filters() {
         fields: Some("id,summary".into()),
         exclude_fields: Some("comments".into()),
     };
-    let (result, _) = capture_stdout(crate::commands::bug::execute(
+    let mut __io2 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io2.writers(),
+    )
     .await;
+    let _ = __io2.out_str().to_string();
     assert!(result.is_ok(), "bug my with filters failed: {result:?}");
 }
 
@@ -124,13 +126,16 @@ async fn bug_my_created_only_runs_creator_search_not_assigned() {
         fields: None,
         exclude_fields: None,
     };
-    let (result, _) = capture_stdout(crate::commands::bug::execute(
+    let mut __io3 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io3.writers(),
+    )
     .await;
+    let _ = __io3.out_str().to_string();
     assert!(result.is_ok(), "bug my --created failed: {result:?}");
 }
 
@@ -157,13 +162,16 @@ async fn bug_my_cc_only_runs_cc_search_not_assigned_or_creator() {
         fields: None,
         exclude_fields: None,
     };
-    let (result, _) = capture_stdout(crate::commands::bug::execute(
+    let mut __io4 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io4.writers(),
+    )
     .await;
+    let _ = __io4.out_str().to_string();
     assert!(result.is_ok(), "bug my --cc failed: {result:?}");
 }
 
@@ -197,15 +205,19 @@ async fn bug_my_all_deduplicates() {
         fields: None,
         exclude_fields: None,
     };
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io5 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io5.writers(),
+    )
     .await;
+    let output = __io5.out_str().to_string();
     assert!(result.is_ok(), "bug my --all failed: {result:?}");
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     let bugs = parsed.as_array().expect("expected JSON array");
     assert_eq!(bugs.len(), 1, "duplicate bug should be deduplicated");
     assert_eq!(bugs[0]["id"], 42);

--- a/src/commands/bug/search.rs
+++ b/src/commands/bug/search.rs
@@ -1,6 +1,6 @@
 use crate::cli::BugAction;
 use crate::error::Result;
-use crate::output;
+use crate::output::{self, Writers};
 use crate::types::{ApiMode, OutputFormat, Overrides, SavedQuery, SearchParams};
 
 /// Determine the `save_as` name + query to persist after a successful URL-based
@@ -56,6 +56,7 @@ pub(super) async fn handle(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let BugAction::Search {
         query,
@@ -100,7 +101,7 @@ pub(super) async fn handle(
     };
 
     let bugs = client.search_bugs(&params).await?;
-    output::print_bugs(&bugs, format);
+    output::write_bugs(&bugs, format, w.out);
 
     if let Some((name, query)) = save_info {
         let mut config = crate::config::Config::load()?;
@@ -108,7 +109,7 @@ pub(super) async fn handle(
         config.queries.insert(name.clone(), query);
         config.save()?;
         let verb = if is_update { "Updated" } else { "Saved" };
-        crate::output::print_query_saved(&name, verb, format);
+        crate::output::write_query_saved(&name, verb, format, w.out);
     }
 
     Ok(())

--- a/src/commands/bug/search_tests.rs
+++ b/src/commands/bug/search_tests.rs
@@ -4,7 +4,7 @@ use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::BugAction;
-use crate::test_helpers::{capture_stdout, extract_json, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 fn from_url_action(url: String, save_as: Option<String>) -> BugAction {
@@ -37,15 +37,16 @@ async fn handle_search_from_url_executes() {
     let url = format!("{server_url}/buglist.cgi?product=TestProduct&limit=10");
     let action = from_url_action(url, None);
 
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
-        &action,
-        None,
-        OutputFormat::Json,
-        None,
-    ))
-    .await;
+    let mut __io = crate::test_helpers::CapturedIo::new();
+
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+
+    let output = __io.out_str().to_string();
     assert!(result.is_ok(), "from-url search failed: {result:?}");
-    let parsed: serde_json::Value = extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["id"], 1);
 }
 
@@ -68,13 +69,18 @@ async fn handle_search_from_url_preserves_url_limit_when_cli_unset() {
     let url = format!("{}/buglist.cgi?product=TestProduct&limit=10", mock.uri());
     let action = from_url_action(url, None);
 
-    let (result, _) = capture_stdout(crate::commands::bug::execute(
+    let mut __io2 = crate::test_helpers::CapturedIo::new();
+
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io2.writers(),
+    )
     .await;
+
+    let _ = __io2.out_str().to_string();
     assert!(
         result.is_ok(),
         "from-url with explicit limit failed: {result:?}"
@@ -106,13 +112,16 @@ async fn handle_search_quicksearch_passes_limit_and_field_filters() {
         fields: Some("id,summary".into()),
         exclude_fields: Some("comments".into()),
     };
-    let (result, _) = capture_stdout(crate::commands::bug::execute(
+    let mut __io3 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io3.writers(),
+    )
     .await;
+    let _ = __io3.out_str().to_string();
     assert!(
         result.is_ok(),
         "quicksearch with filters failed: {result:?}"
@@ -141,13 +150,18 @@ async fn handle_search_from_url_passes_raw_params() {
     );
     let action = from_url_action(url, None);
 
-    let (result, _) = capture_stdout(crate::commands::bug::execute(
+    let mut __io4 = crate::test_helpers::CapturedIo::new();
+
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io4.writers(),
+    )
     .await;
+
+    let _ = __io4.out_str().to_string();
     assert!(
         result.is_ok(),
         "from-url with raw params failed: {result:?}"
@@ -168,13 +182,18 @@ async fn handle_search_from_url_saves_query() {
     let url = format!("{server_url}/buglist.cgi?product=TestProduct&known_name=my-query");
     let action = from_url_action(url, Some("my-query".into()));
 
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io5 = crate::test_helpers::CapturedIo::new();
+
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io5.writers(),
+    )
     .await;
+
+    let _output = __io5.out_str().to_string();
     assert!(result.is_ok(), "from-url save failed: {result:?}");
 
     let config = crate::config::Config::load().unwrap();
@@ -198,13 +217,16 @@ async fn handle_search_from_url_auto_names_from_known_name() {
     let url =
         format!("{server_url}/buglist.cgi?product=TestProduct&known_name=my%20saved%20search");
     let action = from_url_action(url, Some(String::new()));
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io6 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io6.writers(),
+    )
     .await;
+    let _output = __io6.out_str().to_string();
     assert!(
         result.is_ok(),
         "auto-name from known_name failed: {result:?}"
@@ -225,13 +247,16 @@ async fn handle_search_save_as_no_name_no_known_name_errors() {
         "https://bugzilla.example.com/buglist.cgi?product=Firefox".into(),
         Some(String::new()),
     );
-    let (result, _output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io7 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io7.writers(),
+    )
     .await;
+    let _output = __io7.out_str().to_string();
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -1,7 +1,7 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output::{self, ActionResult, BatchFailure, BatchResult, ResourceKind};
+use crate::output::{self, ActionResult, BatchFailure, BatchResult, ResourceKind, Writers};
 use crate::types::{IdListUpdate, OutputFormat, StringListUpdate, UpdateBugParams};
 
 const FLAG_KEYWORDS_ADD: &str = "--keywords-add";
@@ -160,45 +160,45 @@ async fn update_single(
     id: u64,
     params: &UpdateBugParams,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
-    use std::io::Write;
     client.update_bug(id, params).await?;
     match format {
         OutputFormat::Json => {
-            output::print_result(&ActionResult::updated(id, ResourceKind::Bug), "", format);
+            output::write_result(
+                &ActionResult::updated(id, ResourceKind::Bug),
+                "",
+                format,
+                w.out,
+            );
         }
         OutputFormat::Table => {
             let suffix = comment_suffix(params.comment.is_some());
-            let _ = writeln!(std::io::stdout(), "Updated bug #{id}{suffix}");
+            let _ = writeln!(w.out, "Updated bug #{id}{suffix}");
         }
     }
     Ok(())
 }
 
-fn print_batch_result(batch: &BatchResult, format: OutputFormat, with_comment: bool) {
-    use std::io::Write;
+fn write_batch_result(
+    batch: &BatchResult,
+    format: OutputFormat,
+    with_comment: bool,
+    w: &mut Writers<'_>,
+) {
     match format {
         OutputFormat::Json => {
-            output::print_result(batch, "", format);
+            output::write_result(batch, "", format, w.out);
         }
         OutputFormat::Table => {
             if !batch.succeeded.is_empty() {
                 let ids_str: Vec<String> =
                     batch.succeeded.iter().map(|id| format!("#{id}")).collect();
                 let suffix = comment_suffix(with_comment);
-                let _ = writeln!(
-                    std::io::stdout(),
-                    "Updated bugs: {}{suffix}",
-                    ids_str.join(", ")
-                );
+                let _ = writeln!(w.out, "Updated bugs: {}{suffix}", ids_str.join(", "));
             }
             for f in &batch.failed {
-                let _ = writeln!(
-                    std::io::stderr(),
-                    "Failed to update bug #{}: {}",
-                    f.id,
-                    f.error
-                );
+                let _ = writeln!(w.err, "Failed to update bug #{}: {}", f.id, f.error);
             }
         }
     }
@@ -209,6 +209,7 @@ async fn update_batch(
     ids: &[u64],
     params: &UpdateBugParams,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let mut succeeded = Vec::new();
     let mut failed = Vec::new();
@@ -222,7 +223,7 @@ async fn update_batch(
         }
     }
     let batch = BatchResult::new(succeeded, failed);
-    print_batch_result(&batch, format, params.comment.is_some());
+    write_batch_result(&batch, format, params.comment.is_some(), w);
     if !batch.failed.is_empty() {
         return Err(crate::error::BzrError::BatchPartialFailure {
             succeeded: batch.succeeded.len(),
@@ -236,12 +237,13 @@ pub(super) async fn handle(
     client: &BugzillaClient,
     action: &BugAction,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let (ids, params) = build_update_params(action)?;
     if ids.len() == 1 {
-        update_single(client, ids[0], &params, format).await
+        update_single(client, ids[0], &params, format, w).await
     } else {
-        update_batch(client, &ids, &params, format).await
+        update_batch(client, &ids, &params, format, w).await
     }
 }
 

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -4,7 +4,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::BugAction;
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 fn make_update_action(ids: Vec<u64>) -> BugAction {
@@ -96,15 +96,14 @@ async fn bug_update_sends_put() {
     mock_put_bug_ok(&mock, 42).await;
 
     let action = make_update_action(vec![42]);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
-        &action,
-        None,
-        OutputFormat::Json,
-        None,
-    ))
-    .await;
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    let output = __io.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["action"], "updated");
     assert_eq!(parsed["id"], 42);
 }
@@ -124,13 +123,16 @@ async fn bug_update_batch_mixed_results() {
         .await;
 
     let action = make_update_action(vec![1, 2]);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io2 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io2.writers(),
+    )
     .await;
+    let output = __io2.out_str().to_string();
     assert!(matches!(
         result,
         Err(crate::error::BzrError::BatchPartialFailure {
@@ -138,7 +140,8 @@ async fn bug_update_batch_mixed_results() {
             failed: 1,
         })
     ));
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["succeeded"], serde_json::json!([1]));
     assert_eq!(parsed["failed"][0]["id"], 2);
 }
@@ -152,13 +155,16 @@ async fn bug_update_batch_table_format_all_succeed() {
     mock_put_bug_ok(&mock, 2).await;
 
     let action = make_update_action(vec![1, 2]);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io3 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Table,
         None,
-    ))
+        &mut __io3.writers(),
+    )
     .await;
+    let output = __io3.out_str().to_string();
     assert!(result.is_ok());
     assert!(output.contains("Updated bugs:"));
     assert!(output.contains("#1"));
@@ -440,13 +446,16 @@ async fn bug_update_table_output_with_comment_single() {
     mock_put_bug_ok(&mock, 42).await;
 
     let action = make_update_action_with_comment(vec![42], Some("hi"), None, false);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io4 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Table,
         None,
-    ))
+        &mut __io4.writers(),
+    )
     .await;
+    let output = __io4.out_str().to_string();
     assert!(result.is_ok());
     assert!(
         output.contains("Updated bug #42 (with comment)"),
@@ -460,13 +469,16 @@ async fn bug_update_table_output_no_comment_single() {
     mock_put_bug_ok(&mock, 42).await;
 
     let action = make_update_action(vec![42]);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io5 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Table,
         None,
-    ))
+        &mut __io5.writers(),
+    )
     .await;
+    let output = __io5.out_str().to_string();
     assert!(result.is_ok());
     assert!(output.contains("Updated bug #42"));
     assert!(
@@ -482,13 +494,16 @@ async fn bug_update_table_output_with_comment_batch_all_succeed() {
     mock_put_bug_ok(&mock, 2).await;
 
     let action = make_update_action_with_comment(vec![1, 2], Some("batch comment"), None, false);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io6 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Table,
         None,
-    ))
+        &mut __io6.writers(),
+    )
     .await;
+    let output = __io6.out_str().to_string();
     assert!(result.is_ok());
     assert!(output.contains("Updated bugs:"));
     assert!(output.contains("(with comment)"));
@@ -500,15 +515,19 @@ async fn bug_update_json_output_unchanged_with_comment() {
     mock_put_bug_ok(&mock, 42).await;
 
     let action = make_update_action_with_comment(vec![42], Some("hi"), None, false);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io7 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io7.writers(),
+    )
     .await;
+    let output = __io7.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["action"], "updated");
     assert_eq!(parsed["id"], 42);
     assert!(

--- a/src/commands/bug/view.rs
+++ b/src/commands/bug/view.rs
@@ -1,13 +1,16 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::{BzrError, Result};
-use crate::output::{self, print_multi_bug_view, BugViewFailure, MultiBugRow, MultiBugViewResult};
+use crate::output::{
+    self, write_multi_bug_view, BugViewFailure, MultiBugRow, MultiBugViewResult, Writers,
+};
 use crate::types::{Bug, OutputFormat};
 
 pub(super) async fn handle(
     client: &BugzillaClient,
     action: &BugAction,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let BugAction::View {
         ids,
@@ -29,11 +32,11 @@ pub(super) async fn handle(
     let exc = exclude_fields.as_deref();
 
     if ids.len() == 1 {
-        view_single(client, &ids[0], inc, exc, format).await
+        view_single(client, &ids[0], inc, exc, format, w).await
     } else if *permissive {
-        view_batch_permissive(client, ids, inc, exc, format).await
+        view_batch_permissive(client, ids, inc, exc, format, w).await
     } else {
-        view_batch_strict(client, ids, inc, exc, format).await
+        view_batch_strict(client, ids, inc, exc, format, w).await
     }
 }
 
@@ -43,35 +46,29 @@ async fn view_single(
     include_fields: Option<&str>,
     exclude_fields: Option<&str>,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let bug = client.get_bug(id, include_fields, exclude_fields).await?;
-    output::print_bug_detail(&bug, format);
+    output::write_bug_detail(&bug, format, w.out);
     Ok(())
 }
 
-/// Multi-ID strict path. On any failure, bail with that error's code.
-///
-/// Output handling differs by format:
-/// - Table: eager-print each detail block as it arrives. Preceding
-///   successes have already been written to stdout when the failure
-///   propagates.
-/// - JSON: collect all bugs in a buffer; emit nothing on failure
-///   (concatenated bare JSON objects would be invalid).
 async fn view_batch_strict(
     client: &BugzillaClient,
     ids: &[String],
     include_fields: Option<&str>,
     exclude_fields: Option<&str>,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     match format {
         OutputFormat::Table => {
             for (i, id) in ids.iter().enumerate() {
                 let bug = client.get_bug(id, include_fields, exclude_fields).await?;
                 if i > 0 {
-                    output::write_divider(&mut std::io::stdout());
+                    output::write_divider(w.out);
                 }
-                output::print_bug_detail(&bug, format);
+                output::write_bug_detail(&bug, format, w.out);
             }
             Ok(())
         }
@@ -85,25 +82,19 @@ async fn view_batch_strict(
                 bugs,
                 failed: Vec::new(),
             };
-            output::print_result(&result, "", format);
+            output::write_result(&result, "", format, w.out);
             Ok(())
         }
     }
 }
 
-/// Multi-ID permissive path.
-///
-/// Per-resource errors (`BzrError::is_bug_get_per_resource()` — i.e.
-/// `NotFound` and `Bug.get` codes 100/101/102) are recorded as inline
-/// failure rows. Anything else (transport, auth, security, server
-/// internal, unrecognized `Api` codes) bails immediately with that
-/// error's exit code.
 async fn view_batch_permissive(
     client: &BugzillaClient,
     ids: &[String],
     include_fields: Option<&str>,
     exclude_fields: Option<&str>,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     match format {
         OutputFormat::Table => {
@@ -120,7 +111,7 @@ async fn view_batch_permissive(
                     Err(e) => return Err(e),
                 }
             }
-            print_multi_bug_view(&rows);
+            write_multi_bug_view(&rows, w.out);
         }
         OutputFormat::Json => {
             let mut bugs: Vec<Bug> = Vec::with_capacity(ids.len());
@@ -137,7 +128,7 @@ async fn view_batch_permissive(
                     Err(e) => return Err(e),
                 }
             }
-            output::print_result(&MultiBugViewResult { bugs, failed }, "", format);
+            output::write_result(&MultiBugViewResult { bugs, failed }, "", format, w.out);
         }
     }
     Ok(())

--- a/src/commands/bug/view_tests.rs
+++ b/src/commands/bug/view_tests.rs
@@ -4,7 +4,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::BugAction;
-use crate::test_helpers::{capture_stdout, extract_json, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 fn make_view_action(ids: &[&str], permissive: bool) -> BugAction {
@@ -52,13 +52,16 @@ async fn view_single_unchanged_table() {
         .await;
 
     let action = make_view_action(&["42"], false);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Table,
         None,
-    ))
+        &mut __io.writers(),
+    )
     .await;
+    let output = __io.out_str().to_string();
     assert!(result.is_ok(), "{:?}", result.err());
     assert!(output.contains("Bug #42"));
     assert!(output.contains("Test bug"));
@@ -76,15 +79,19 @@ async fn view_single_unchanged_json() {
         .await;
 
     let action = make_view_action(&["42"], false);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io2 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io2.writers(),
+    )
     .await;
+    let output = __io2.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     // Single-ID JSON shape must remain a bare Bug object — no `bugs`/`failed`.
     assert_eq!(parsed["id"], 42);
     assert!(parsed.get("bugs").is_none());
@@ -93,6 +100,7 @@ async fn view_single_unchanged_json() {
 
 #[tokio::test]
 async fn view_single_failure_propagates() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
     Mock::given(method("GET"))
         .and(path("/rest/bug/999999"))
@@ -104,7 +112,14 @@ async fn view_single_failure_propagates() {
         .await;
 
     let action = make_view_action(&["999999"], false);
-    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
@@ -125,13 +140,16 @@ async fn view_multi_strict_all_succeed_table() {
     }
 
     let action = make_view_action(&["1", "2", "3"], false);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io3 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Table,
         None,
-    ))
+        &mut __io3.writers(),
+    )
     .await;
+    let output = __io3.out_str().to_string();
     assert!(result.is_ok());
     assert!(output.contains("Bug #1"));
     assert!(output.contains("Bug #2"));
@@ -160,13 +178,16 @@ async fn view_multi_strict_first_failure_bails() {
     // confirms the loop never gets that far.
 
     let action = make_view_action(&["1", "2", "3"], false);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io4 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Table,
         None,
-    ))
+        &mut __io4.writers(),
+    )
     .await;
+    let output = __io4.out_str().to_string();
     assert!(result.is_err());
     assert!(output.contains("Bug #1"));
     // Bug #3 must NOT have been fetched.
@@ -185,15 +206,19 @@ async fn view_multi_strict_json_all_succeed_emits_wrapped_shape() {
     }
 
     let action = make_view_action(&["1", "2"], false);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io5 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io5.writers(),
+    )
     .await;
+    let output = __io5.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["bugs"].as_array().unwrap().len(), 2);
     assert_eq!(parsed["failed"].as_array().unwrap().len(), 0);
     assert_eq!(parsed["bugs"][0]["id"], 1);
@@ -217,20 +242,25 @@ async fn view_multi_strict_json_failure_emits_no_partial_json() {
         .await;
 
     let action = make_view_action(&["1", "2"], false);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io6 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io6.writers(),
+    )
     .await;
+    let output = __io6.out_str().to_string();
     assert!(result.is_err());
     // No JSON should have been emitted — the buffer was discarded on Err.
     // capture_stdout's process-wide fd-1 redirection can capture stray bytes
     // from concurrent tests, so we cannot assert the buffer is byte-empty.
     // Instead we assert no JSON value can be parsed out of it: extract_json
     // panics when no JSON is found, which we catch and treat as success.
-    let parsed = std::panic::catch_unwind(|| crate::test_helpers::extract_json(&output));
+    let parsed = std::panic::catch_unwind(|| {
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap()
+    });
     assert!(parsed.is_err(), "expected no JSON in stdout, got: {output}");
 }
 
@@ -256,13 +286,16 @@ async fn view_multi_permissive_partial_table() {
         .await;
 
     let action = make_view_action(&["1", "2", "3"], true);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io7 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Table,
         None,
-    ))
+        &mut __io7.writers(),
+    )
     .await;
+    let output = __io7.out_str().to_string();
     assert!(
         result.is_ok(),
         "permissive must exit Ok, got: {:?}",
@@ -296,15 +329,19 @@ async fn view_multi_permissive_json_shape() {
         .await;
 
     let action = make_view_action(&["1", "2"], true);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io8 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io8.writers(),
+    )
     .await;
+    let output = __io8.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["bugs"].as_array().unwrap().len(), 1);
     assert_eq!(parsed["bugs"][0]["id"], 1);
     let failed = parsed["failed"].as_array().unwrap();
@@ -333,15 +370,19 @@ async fn view_multi_permissive_all_fail_returns_empty_bugs() {
     }
 
     let action = make_view_action(&["1", "2", "3"], true);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io9 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io9.writers(),
+    )
     .await;
+    let output = __io9.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["bugs"].as_array().unwrap().len(), 0);
     assert_eq!(parsed["failed"].as_array().unwrap().len(), 3);
 }
@@ -363,15 +404,19 @@ async fn view_multi_permissive_with_alias_preserves_id_string() {
         .await;
 
     let action = make_view_action(&["1", "my-alias"], true);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io10 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io10.writers(),
+    )
     .await;
+    let output = __io10.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     let failed = parsed["failed"].as_array().unwrap();
     assert_eq!(
         failed[0]["id"], "my-alias",
@@ -381,10 +426,18 @@ async fn view_multi_permissive_with_alias_preserves_id_string() {
 
 #[tokio::test]
 async fn view_permissive_single_id_rejected() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = make_view_action(&["42"], true);
-    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(matches!(err, crate::error::BzrError::InputValidation(_)));
@@ -396,6 +449,7 @@ async fn view_permissive_single_id_rejected() {
 
 #[tokio::test]
 async fn view_multi_permissive_transport_error_bails() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
     Mock::given(method("GET"))
         .and(path("/rest/bug/1"))
@@ -414,7 +468,14 @@ async fn view_multi_permissive_transport_error_bails() {
         .await;
 
     let action = make_view_action(&["1", "2", "3"], true);
-    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_err(),
         "transport error must bail despite --permissive"
@@ -425,6 +486,7 @@ async fn view_multi_permissive_transport_error_bails() {
 
 #[tokio::test]
 async fn view_multi_permissive_api_session_wide_bails() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
     Mock::given(method("GET"))
         .and(path("/rest/bug/1"))
@@ -446,7 +508,14 @@ async fn view_multi_permissive_api_session_wide_bails() {
         .await;
 
     let action = make_view_action(&["1", "2", "3"], true);
-    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_err(),
         "session-wide Api code must bail despite --permissive"
@@ -470,21 +539,26 @@ async fn view_multi_permissive_api_102_suppressed() {
         .await;
 
     let action = make_view_action(&["1", "2"], true);
-    let (result, output) = capture_stdout(crate::commands::bug::execute(
+    let mut __io11 = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
         &action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io11.writers(),
+    )
     .await;
+    let output = __io11.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["failed"].as_array().unwrap().len(), 1);
     assert_eq!(parsed["failed"][0]["id"], "2");
 }
 
 #[tokio::test]
 async fn view_multi_permissive_api_410_bails() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
     Mock::given(method("GET"))
         .and(path("/rest/bug/1"))
@@ -509,7 +583,14 @@ async fn view_multi_permissive_api_410_bails() {
         .await;
 
     let action = make_view_action(&["1", "2", "3"], true);
-    let result = crate::commands::bug::execute(&action, None, OutputFormat::Json, None).await;
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_err(),
         "auth-flavored Api code must bail despite --permissive"

--- a/src/commands/classification.rs
+++ b/src/commands/classification.rs
@@ -1,6 +1,6 @@
 use crate::cli::ClassificationAction;
 use crate::error::Result;
-use crate::output;
+use crate::output::{self, Writers};
 use crate::types::ApiMode;
 use crate::types::OutputFormat;
 
@@ -9,13 +9,14 @@ pub async fn execute(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let client = super::shared::connect_and_configure(server, api).await?;
 
     match action {
         ClassificationAction::View { name } => {
             let classification = client.get_classification(name).await?;
-            output::print_classification(&classification, format);
+            output::write_classification(&classification, format, w.out);
         }
     }
     Ok(())

--- a/src/commands/classification_tests.rs
+++ b/src/commands/classification_tests.rs
@@ -1,8 +1,10 @@
+#![expect(clippy::unwrap_used)]
+
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::ClassificationAction;
-use crate::test_helpers::{capture_stdout, extract_json, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 #[tokio::test]
@@ -25,16 +27,25 @@ async fn classification_view_returns_data() {
     let action = ClassificationAction::View {
         name: "Unclassified".to_string(),
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a1 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a1.writers(),
+    )
+    .await;
+    let output = __io_a1.out_str().to_string();
     assert!(result.is_ok());
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "Unclassified");
     assert_eq!(parsed["description"], "Not yet classified");
 }
 
 #[tokio::test]
 async fn classification_view_http_500_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -46,6 +57,13 @@ async fn classification_view_http_500_returns_error() {
     let action = ClassificationAction::View {
         name: "Missing".to_string(),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
 }

--- a/src/commands/comment.rs
+++ b/src/commands/comment.rs
@@ -3,7 +3,7 @@ use std::io::{IsTerminal, Read};
 use crate::cli::CommentAction;
 use crate::commands::editor;
 use crate::error::{BzrError, Result};
-use crate::output::{self, ActionResult, ResourceKind, SearchResult, TagResult};
+use crate::output::{self, ActionResult, ResourceKind, SearchResult, TagResult, Writers};
 use crate::types::ApiMode;
 use crate::types::{OutputFormat, UpdateCommentTagsParams};
 
@@ -12,6 +12,7 @@ pub async fn execute(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let client = super::shared::connect_and_configure(server, api).await?;
 
@@ -22,7 +23,7 @@ pub async fn execute(
             let comments = client
                 .get_comments_since(*bug_id, canonical_since.as_deref())
                 .await?;
-            output::print_comments(&comments, format);
+            output::write_comments(&comments, format, w.out);
         }
         CommentAction::Add {
             bug_id,
@@ -37,10 +38,11 @@ pub async fn execute(
                 return Err(BzrError::InputValidation("empty comment, aborting".into()));
             }
             let id = client.add_comment(*bug_id, &text, *private).await?;
-            output::print_result(
+            output::write_result(
                 &ActionResult::created(id, ResourceKind::Comment),
                 &format!("Added comment #{id} to bug #{bug_id}"),
                 format,
+                w.out,
             );
         }
         CommentAction::Tag {
@@ -58,15 +60,16 @@ pub async fn execute(
             } else {
                 tags.join(", ")
             };
-            output::print_result(
+            output::write_result(
                 &TagResult::updated(*comment_id, tags),
                 &format!("Tags on comment #{comment_id}: {display}"),
                 format,
+                w.out,
             );
         }
         CommentAction::SearchTags { query } => {
             let tags = client.search_comment_tags(query).await?;
-            output::print_result(
+            output::write_result(
                 &SearchResult::new(tags.clone()),
                 &if tags.is_empty() {
                     "No tags.".to_string()
@@ -77,6 +80,7 @@ pub async fn execute(
                         .join("\n")
                 },
                 format,
+                w.out,
             );
         }
     }

--- a/src/commands/comment_tests.rs
+++ b/src/commands/comment_tests.rs
@@ -4,7 +4,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::CommentAction;
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 #[tokio::test]
@@ -35,10 +35,19 @@ async fn comment_list_returns_comments() {
         bug_id: 42,
         since: None,
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a1 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a1.writers(),
+    )
+    .await;
+    let output = __io_a1.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["id"], 1);
     assert_eq!(parsed[0]["text"], "Hello world");
     assert_eq!(parsed[0]["creator"], "user@test.com");
@@ -46,6 +55,7 @@ async fn comment_list_returns_comments() {
 
 #[tokio::test]
 async fn comment_add_with_body() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("POST"))
@@ -59,21 +69,36 @@ async fn comment_add_with_body() {
         body: Some("Test comment".to_string()),
         private: false,
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_ok());
 }
 
 #[tokio::test]
 async fn comment_add_empty_body_is_rejected() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
-    // No mock needed — execute() should reject before making any API call
+    // No mock needed — execute(, &mut __cap_io.writers()) should reject before making any API call
     let action = CommentAction::Add {
         bug_id: 42,
         body: Some("   ".to_string()),
         private: false,
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err(), "empty body should be rejected");
     let err = result.unwrap_err().to_string();
     assert!(
@@ -101,6 +126,7 @@ fn filter_comment_body_empty_input() {
 
 #[tokio::test]
 async fn comment_list_http_500_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -113,7 +139,14 @@ async fn comment_list_http_500_returns_error() {
         bug_id: 42,
         since: None,
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
@@ -124,6 +157,7 @@ async fn comment_list_http_500_returns_error() {
 
 #[tokio::test]
 async fn comment_add_api_error_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("POST"))
@@ -141,19 +175,34 @@ async fn comment_add_api_error_returns_error() {
         body: Some("Test comment".to_string()),
         private: false,
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
 }
 
 #[tokio::test]
 async fn comment_list_rejects_malformed_since_with_exit_code_7() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = CommentAction::List {
         bug_id: 42,
         since: Some("nope".into()),
     };
-    let result = crate::commands::comment::execute(&action, None, OutputFormat::Json, None).await;
+    let result = crate::commands::comment::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     let err = result.unwrap_err();
     assert_eq!(err.exit_code(), 7);
     let msg = err.to_string();

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -1,6 +1,6 @@
 use crate::cli::ComponentAction;
 use crate::error::Result;
-use crate::output::{self, ActionResult, ResourceKind};
+use crate::output::{self, ActionResult, ResourceKind, Writers};
 use crate::types::ApiMode;
 use crate::types::OutputFormat;
 use crate::types::{CreateComponentParams, UpdateComponentParams};
@@ -10,6 +10,7 @@ pub async fn execute(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let client = super::shared::connect_and_configure(server, api).await?;
 
@@ -27,10 +28,11 @@ pub async fn execute(
                 default_assignee: default_assignee.clone(),
             };
             let id = client.create_component(&params).await?;
-            output::print_result(
+            output::write_result(
                 &ActionResult::created(id, ResourceKind::Component),
                 &format!("Created component #{id} in product '{product}'"),
                 format,
+                w.out,
             );
         }
         ComponentAction::Update {
@@ -45,10 +47,11 @@ pub async fn execute(
                 default_assignee: default_assignee.clone(),
             };
             client.update_component(*id, &params).await?;
-            output::print_result(
+            output::write_result(
                 &ActionResult::updated(*id, ResourceKind::Component),
                 &format!("Updated component #{id}"),
                 format,
+                w.out,
             );
         }
     }

--- a/src/commands/component_tests.rs
+++ b/src/commands/component_tests.rs
@@ -1,8 +1,10 @@
+#![expect(clippy::unwrap_used)]
+
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::ComponentAction;
-use crate::test_helpers::{capture_stdout, extract_json, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 #[tokio::test]
@@ -21,15 +23,24 @@ async fn component_create_succeeds() {
         description: "Backend component".to_string(),
         default_assignee: "dev@test.com".to_string(),
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a1 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a1.writers(),
+    )
+    .await;
+    let output = __io_a1.out_str().to_string();
     assert!(result.is_ok());
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 42);
 }
 
 #[tokio::test]
 async fn component_create_http_500_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("POST"))
@@ -44,7 +55,14 @@ async fn component_create_http_500_returns_error() {
         description: "Backend component".to_string(),
         default_assignee: "dev@test.com".to_string(),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
 }
 
@@ -64,10 +82,18 @@ async fn component_update_succeeds() {
         description: None,
         default_assignee: None,
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a2 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a2.writers(),
+    )
+    .await;
+    let output = __io_a2.out_str().to_string();
     assert!(result.is_ok());
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 10);
     assert_eq!(parsed["action"], "updated");
 }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -5,13 +5,12 @@
 //! sibling command modules.
 
 use std::fmt::Write as _;
-use std::io::{self, Write as _};
 use std::path::PathBuf;
 
 use crate::cli::ConfigAction;
 use crate::config::{Config, ServerConfig};
 use crate::error::Result;
-use crate::output::{self, ConfigResult};
+use crate::output::{self, ConfigResult, Writers};
 use crate::types::OutputFormat;
 
 pub async fn execute(
@@ -19,6 +18,7 @@ pub async fn execute(
     _server: Option<&str>,
     format: OutputFormat,
     _api: Option<crate::types::ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     match action {
         ConfigAction::SetServer {
@@ -49,6 +49,7 @@ pub async fn execute(
                     tls_pin_clear: *tls_pin_clear,
                 },
                 format,
+                w,
             )
             .await
         }
@@ -63,13 +64,14 @@ pub async fn execute(
             let path = Config::path()?;
             config.save()?;
 
-            output::print_result(
+            output::write_result(
                 &ConfigResult::default_set(name.as_str(), path.to_string_lossy()),
                 &format!(
                     "Default server set to '{name}'\nConfig file: {}",
                     path.display()
                 ),
                 format,
+                w.out,
             );
             Ok(())
         }
@@ -77,15 +79,15 @@ pub async fn execute(
             let config = Config::load()?;
             let path = Config::path()?;
             let view = output::ConfigView::from_config(&config, &path);
-            output::print_config(&view, format);
+            output::write_config(&view, format, w.out);
             Ok(())
         }
         ConfigAction::SetKeyring {
             name,
             service,
             account,
-        } => set_keyring(name, service.as_deref(), account.as_deref(), format),
-        ConfigAction::UnsetKeyring { name } => unset_keyring(name.as_str(), format),
+        } => set_keyring(name, service.as_deref(), account.as_deref(), format, w),
+        ConfigAction::UnsetKeyring { name } => unset_keyring(name.as_str(), format, w),
         ConfigAction::MigrateToKeyring {
             name,
             service,
@@ -97,6 +99,7 @@ pub async fn execute(
             account.as_deref(),
             *yes,
             format,
+            w,
         ),
     }
 }
@@ -115,7 +118,11 @@ struct SetServerArgs<'a> {
     tls_pin_clear: bool,
 }
 
-async fn set_server(args: &SetServerArgs<'_>, format: OutputFormat) -> Result<()> {
+async fn set_server(
+    args: &SetServerArgs<'_>,
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) -> Result<()> {
     let SetServerArgs {
         name,
         url,
@@ -138,7 +145,7 @@ async fn set_server(args: &SetServerArgs<'_>, format: OutputFormat) -> Result<()
             server.tls_pin_issuer = None;
             server.tls_pin_issuer_der = None;
             config.save()?;
-            let _ = writeln!(io::stderr(), "Certificate pin cleared for server '{name}'.");
+            let _ = writeln!(w.err, "Certificate pin cleared for server '{name}'.");
             return Ok(());
         }
         return Err(crate::error::BzrError::config(format!(
@@ -173,8 +180,8 @@ async fn set_server(args: &SetServerArgs<'_>, format: OutputFormat) -> Result<()
     if tls_pin_now {
         let (fingerprint, issuer, issuer_der) =
             crate::tls::tofu::probe_server_cert(&server_config.url).await?;
-        let _ = writeln!(io::stderr(), "Certificate fingerprint: {fingerprint}");
-        let _ = writeln!(io::stderr(), "Issuer:                  {issuer}");
+        let _ = writeln!(w.err, "Certificate fingerprint: {fingerprint}");
+        let _ = writeln!(w.err, "Issuer:                  {issuer}");
         let confirmed = crate::tls::tofu::confirm_pin()?;
         if confirmed {
             server_config.tls_pin_sha256 = Some(fingerprint);
@@ -207,10 +214,11 @@ async fn set_server(args: &SetServerArgs<'_>, format: OutputFormat) -> Result<()
     }
     let _ = write!(human, "\nConfig file: {}", path.display());
 
-    output::print_result(
+    output::write_result(
         &ConfigResult::configured(name, url, is_default, path.to_string_lossy(), is_update),
         &human,
         format,
+        w.out,
     );
     Ok(())
 }
@@ -220,6 +228,7 @@ fn set_keyring(
     service: Option<&str>,
     account: Option<&str>,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let mut config = Config::load()?;
     if !config.servers.contains_key(name) {
@@ -253,15 +262,16 @@ fn set_keyring(
          (service={service_name}, account={account_name})\nConfig file: {}",
         path.display()
     );
-    output::print_result(
+    output::write_result(
         &ConfigResult::configured(name, &server_url, false, path.to_string_lossy(), true),
         &human,
         format,
+        w.out,
     );
     Ok(())
 }
 
-fn unset_keyring(name: &str, format: OutputFormat) -> Result<()> {
+fn unset_keyring(name: &str, format: OutputFormat, w: &mut Writers<'_>) -> Result<()> {
     let mut config = Config::load()?;
     let server = config
         .servers
@@ -290,10 +300,11 @@ fn unset_keyring(name: &str, format: OutputFormat) -> Result<()> {
          `bzr config set-keyring` to re-credential.\nConfig file: {}",
         path.display()
     );
-    output::print_result(
+    output::write_result(
         &ConfigResult::configured(name, &server_url, false, path.to_string_lossy(), true),
         &human,
         format,
+        w.out,
     );
     Ok(())
 }
@@ -304,6 +315,7 @@ fn migrate_to_keyring(
     account: Option<&str>,
     yes: bool,
     format: OutputFormat,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     if !yes {
         return Err(crate::error::BzrError::InputValidation(
@@ -363,10 +375,11 @@ fn migrate_to_keyring(
         )
     };
 
-    output::print_result(
+    output::write_result(
         &ConfigResult::configured(name, &server_url, false, path.to_string_lossy(), true),
         &human,
         format,
+        w.out,
     );
     Ok(())
 }

--- a/src/commands/config_tests.rs
+++ b/src/commands/config_tests.rs
@@ -2,7 +2,6 @@
 
 use super::*;
 use crate::error::BzrError;
-use crate::test_helpers::capture_stdout;
 use crate::types::AuthMethod;
 
 async fn setup_config_env() -> (tokio::sync::MutexGuard<'static, ()>, tempfile::TempDir) {
@@ -18,6 +17,7 @@ async fn setup_config_env() -> (tokio::sync::MutexGuard<'static, ()>, tempfile::
 /// Invoke `execute` with a `SetServer` action carrying an inline
 /// `api_key` and all other optional fields at their defaults.
 async fn seed_inline_server(name: &str, url: &str, api_key: &str) {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     execute(
         &ConfigAction::SetServer {
             name: name.into(),
@@ -35,6 +35,7 @@ async fn seed_inline_server(name: &str, url: &str, api_key: &str) {
         None,
         OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await
     .unwrap();
@@ -44,6 +45,7 @@ async fn seed_inline_server(name: &str, url: &str, api_key: &str) {
 /// the `BZR_KEYRING_TEST_SECRET` test hook and running `SetKeyring`.
 #[cfg(feature = "keyring")]
 async fn seed_keyring_secret(server_name: &str, secret: &str) {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     // SAFETY: Serialized via ENV_LOCK through setup_config_env.
     unsafe { std::env::set_var("BZR_KEYRING_TEST_SECRET", secret) };
     execute(
@@ -55,6 +57,7 @@ async fn seed_keyring_secret(server_name: &str, secret: &str) {
         None,
         OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await
     .unwrap();
@@ -64,6 +67,7 @@ async fn seed_keyring_secret(server_name: &str, secret: &str) {
 
 #[tokio::test]
 async fn set_default_on_empty_config_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _tmp) = setup_config_env().await;
     let config = Config::default();
     config.save().unwrap();
@@ -74,6 +78,7 @@ async fn set_default_on_empty_config_returns_error() {
         None,
         OutputFormat::Table,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(result.is_err());
@@ -86,7 +91,8 @@ async fn set_default_on_empty_config_returns_error() {
 #[tokio::test]
 async fn first_set_server_auto_sets_default() {
     let (_lock, _tmp) = setup_config_env().await;
-    let (result, output) = capture_stdout(execute(
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = execute(
         &ConfigAction::SetServer {
             name: "first".into(),
             url: "https://first.example.com".into(),
@@ -103,8 +109,10 @@ async fn first_set_server_auto_sets_default() {
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io.writers(),
+    )
     .await;
+    let output = __io.out_str().to_string();
     result.unwrap();
     let config = Config::load().unwrap();
     assert_eq!(config.default_server.as_deref(), Some("first"));
@@ -112,12 +120,14 @@ async fn first_set_server_auto_sets_default() {
 
     // The first server set must report `is_default: true` in JSON
     // output, since there was no prior default to take precedence.
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["is_default"], true);
 }
 
 #[tokio::test]
 async fn second_set_server_does_not_override_default() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _tmp) = setup_config_env().await;
     // Set up first server
     execute(
@@ -137,6 +147,7 @@ async fn second_set_server_does_not_override_default() {
         None,
         OutputFormat::Table,
         None,
+        &mut __cap_io.writers(),
     )
     .await
     .unwrap();
@@ -158,6 +169,7 @@ async fn second_set_server_does_not_override_default() {
         None,
         OutputFormat::Table,
         None,
+        &mut __cap_io.writers(),
     )
     .await
     .unwrap();
@@ -180,7 +192,9 @@ async fn set_server_update_preserves_existing_default() {
         seed_inline_server(name, url, &format!("{name}-key-1234567890")).await;
     }
 
-    let (result, output) = capture_stdout(execute(
+    let mut __io2 = crate::test_helpers::CapturedIo::new();
+
+    let result = execute(
         &ConfigAction::SetServer {
             name: "second".into(),
             url: "https://updated.example.com".into(),
@@ -197,11 +211,14 @@ async fn set_server_update_preserves_existing_default() {
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io2.writers(),
+    )
     .await;
+
+    let output = __io2.out_str().to_string();
     assert!(result.is_ok());
 
-    let parsed = crate::test_helpers::extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "second");
     assert_eq!(parsed["action"], "updated");
 
@@ -224,18 +241,23 @@ async fn set_default_persists_selected_server() {
         seed_inline_server(name, url, &format!("{name}-key-1234567890")).await;
     }
 
-    let (result, output) = capture_stdout(execute(
+    let mut __io3 = crate::test_helpers::CapturedIo::new();
+
+    let result = execute(
         &ConfigAction::SetDefault {
             name: "second".into(),
         },
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io3.writers(),
+    )
     .await;
+
+    let output = __io3.out_str().to_string();
     assert!(result.is_ok());
 
-    let parsed = crate::test_helpers::extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "second");
     assert_eq!(parsed["action"], "updated");
     assert_eq!(
@@ -246,6 +268,7 @@ async fn set_default_persists_selected_server() {
 
 #[tokio::test]
 async fn show_json_includes_populated_server_details() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _tmp) = setup_config_env().await;
     execute(
         &ConfigAction::SetServer {
@@ -264,15 +287,26 @@ async fn show_json_includes_populated_server_details() {
         None,
         OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await
     .unwrap();
 
-    let (result, output) =
-        capture_stdout(execute(&ConfigAction::Show, None, OutputFormat::Json, None)).await;
+    let mut __io_a1 = crate::test_helpers::CapturedIo::new();
+
+    let result = execute(
+        &ConfigAction::Show,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a1.writers(),
+    )
+    .await;
+
+    let output = __io_a1.out_str().to_string();
     assert!(result.is_ok());
 
-    let parsed = crate::test_helpers::extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["default_server"], "prod");
     assert_eq!(parsed["servers"]["prod"]["url"], "https://prod.example.com");
     assert_eq!(parsed["servers"]["prod"]["email"], "admin@example.com");
@@ -284,6 +318,7 @@ async fn show_json_includes_populated_server_details() {
 
 #[tokio::test]
 async fn set_server_with_env_var_persists_env_source() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _tmp) = setup_config_env().await;
     execute(
         &ConfigAction::SetServer {
@@ -302,6 +337,7 @@ async fn set_server_with_env_var_persists_env_source() {
         None,
         OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await
     .unwrap();
@@ -342,6 +378,7 @@ async fn set_keyring_stores_secret_and_rewrites_config() {
 #[cfg(feature = "keyring")]
 #[tokio::test]
 async fn migrate_to_keyring_from_inline_rewrites_config() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     ::keyring::set_default_credential_builder(::keyring::mock::default_credential_builder());
     let (_lock, _tmp) = setup_config_env().await;
 
@@ -362,6 +399,7 @@ async fn migrate_to_keyring_from_inline_rewrites_config() {
         None,
         OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await
     .unwrap();
@@ -380,6 +418,7 @@ async fn migrate_to_keyring_from_inline_rewrites_config() {
 #[cfg(feature = "keyring")]
 #[tokio::test]
 async fn migrate_to_keyring_from_env_preserves_config() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     ::keyring::set_default_credential_builder(::keyring::mock::default_credential_builder());
     let (_lock, _tmp) = setup_config_env().await;
 
@@ -402,6 +441,7 @@ async fn migrate_to_keyring_from_env_preserves_config() {
         None,
         OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await
     .unwrap();
@@ -416,6 +456,7 @@ async fn migrate_to_keyring_from_env_preserves_config() {
         None,
         OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await
     .unwrap();
@@ -436,6 +477,7 @@ async fn migrate_to_keyring_from_env_preserves_config() {
 #[cfg(feature = "keyring")]
 #[tokio::test]
 async fn migrate_to_keyring_from_keyring_errors_before_storing() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     ::keyring::set_default_credential_builder(::keyring::mock::default_credential_builder());
     let (_lock, _tmp) = setup_config_env().await;
 
@@ -455,6 +497,7 @@ async fn migrate_to_keyring_from_keyring_errors_before_storing() {
         None,
         OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(result.is_err());
@@ -472,6 +515,7 @@ async fn migrate_to_keyring_from_keyring_errors_before_storing() {
 
 #[tokio::test]
 async fn migrate_to_keyring_without_yes_errors() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _tmp) = setup_config_env().await;
 
     seed_inline_server(
@@ -491,6 +535,7 @@ async fn migrate_to_keyring_without_yes_errors() {
         None,
         OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
 
@@ -503,6 +548,7 @@ async fn migrate_to_keyring_without_yes_errors() {
 #[cfg(feature = "keyring")]
 #[tokio::test]
 async fn unset_keyring_removes_secret_and_clears_config() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     ::keyring::set_default_credential_builder(::keyring::mock::default_credential_builder());
     let (_lock, _tmp) = setup_config_env().await;
 
@@ -519,6 +565,7 @@ async fn unset_keyring_removes_secret_and_clears_config() {
         None,
         OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await
     .unwrap();

--- a/src/commands/field.rs
+++ b/src/commands/field.rs
@@ -1,8 +1,6 @@
-use std::io::{self, Write};
-
 use crate::cli::FieldAction;
 use crate::error::Result;
-use crate::output;
+use crate::output::{self, Writers};
 use crate::types::ApiMode;
 use crate::types::OutputFormat;
 
@@ -11,19 +9,20 @@ pub async fn execute(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     match action {
         FieldAction::Aliases => {
-            output::print_field_aliases(crate::client::FIELD_ALIASES, format);
+            output::write_field_aliases(crate::client::FIELD_ALIASES, format, w.out);
             return Ok(());
         }
         FieldAction::List { name } => {
             let client = super::shared::connect_and_configure(server, api).await?;
             let values = client.get_field_values(name).await?;
             if values.is_empty() && format == OutputFormat::Table {
-                let _ = writeln!(io::stdout(), "No values for field '{name}'.");
+                let _ = writeln!(w.out, "No values for field '{name}'.");
             } else {
-                output::print_field_values(&values, format);
+                output::write_field_values(&values, format, w.out);
             }
         }
     }

--- a/src/commands/field_tests.rs
+++ b/src/commands/field_tests.rs
@@ -4,7 +4,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::FieldAction;
-use crate::test_helpers::{capture_stdout, extract_json, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 #[tokio::test]
@@ -29,10 +29,18 @@ async fn field_list_returns_values() {
     let action = FieldAction::List {
         name: "status".to_string(),
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a1 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a1.writers(),
+    )
+    .await;
+    let output = __io_a1.out_str().to_string();
     assert!(result.is_ok());
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert!(parsed.as_array().unwrap().len() >= 3);
     assert_eq!(parsed[0]["name"], "NEW");
 }
@@ -41,10 +49,18 @@ async fn field_list_returns_values() {
 async fn field_aliases_succeeds_without_server() {
     let _lock = crate::ENV_LOCK.lock().await;
     let action = FieldAction::Aliases;
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a2 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a2.writers(),
+    )
+    .await;
+    let output = __io_a2.out_str().to_string();
     assert!(result.is_ok());
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     let arr = parsed.as_array().unwrap();
     assert!(!arr.is_empty());
     assert_eq!(arr[0]["alias"], "file_loc");
@@ -64,8 +80,16 @@ async fn field_list_table_format_with_empty_values_prints_no_values_message() {
     let action = FieldAction::List {
         name: "status".to_string(),
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Table, None)).await;
+    let mut __io_a3 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+        &mut __io_a3.writers(),
+    )
+    .await;
+    let output = __io_a3.out_str().to_string();
     assert!(result.is_ok());
     assert!(
         output.contains("No values for field"),
@@ -86,19 +110,28 @@ async fn field_list_json_format_with_empty_values_emits_empty_array() {
     let action = FieldAction::List {
         name: "status".to_string(),
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a4 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a4.writers(),
+    )
+    .await;
+    let output = __io_a4.out_str().to_string();
     assert!(result.is_ok());
     assert!(
         !output.contains("No values for field"),
         "JSON format must not emit the table-style 'No values' message; got: {output:?}"
     );
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert!(parsed.as_array().unwrap().is_empty());
 }
 
 #[tokio::test]
 async fn field_list_http_500_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -110,6 +143,13 @@ async fn field_list_http_500_returns_error() {
     let action = FieldAction::List {
         name: "status".to_string(),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
 }

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -1,6 +1,6 @@
 use crate::cli::GroupAction;
 use crate::error::Result;
-use crate::output::{self, ActionResult, MembershipResult, ResourceKind};
+use crate::output::{self, ActionResult, MembershipResult, ResourceKind, Writers};
 use crate::types::ApiMode;
 use crate::types::OutputFormat;
 use crate::types::{CreateGroupParams, UpdateGroupParams};
@@ -10,37 +10,40 @@ pub async fn execute(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let client = super::shared::connect_and_configure(server, api).await?;
 
     match action {
         GroupAction::AddUser { group, user } => {
             client.add_user_to_group(user, group).await?;
-            output::print_result(
+            output::write_result(
                 &MembershipResult::added(user.as_str(), group.as_str()),
                 &format!("Added {user} to group '{group}'"),
                 format,
+                w.out,
             );
         }
         GroupAction::RemoveUser { group, user } => {
             client.remove_user_from_group(user, group).await?;
-            output::print_result(
+            output::write_result(
                 &MembershipResult::removed(user.as_str(), group.as_str()),
                 &format!("Removed {user} from group '{group}'"),
                 format,
+                w.out,
             );
         }
         GroupAction::ListUsers { group, details } => {
             let users = client.get_group_members(group, *details).await?;
             if *details {
-                output::print_users_detailed(&users, format);
+                output::write_users_detailed(&users, format, w.out);
             } else {
-                output::print_users(&users, format);
+                output::write_users(&users, format, w.out);
             }
         }
         GroupAction::View { group } => {
             let info = client.get_group(group).await?;
-            output::print_group_info(&info, format);
+            output::write_group_info(&info, format, w.out);
         }
         GroupAction::Create {
             name,
@@ -53,10 +56,11 @@ pub async fn execute(
                 is_active: *is_active,
             };
             let id = client.create_group(&params).await?;
-            output::print_result(
+            output::write_result(
                 &ActionResult::created_named(id, name.as_str(), ResourceKind::Group),
                 &format!("Created group #{id} '{name}'"),
                 format,
+                w.out,
             );
         }
         GroupAction::Update {
@@ -69,10 +73,11 @@ pub async fn execute(
                 is_active: *is_active,
             };
             client.update_group(group, &params).await?;
-            output::print_result(
+            output::write_result(
                 &ActionResult::updated_named(group.as_str(), None, ResourceKind::Group),
                 &format!("Updated group '{group}'"),
                 format,
+                w.out,
             );
         }
     }

--- a/src/commands/group_tests.rs
+++ b/src/commands/group_tests.rs
@@ -4,7 +4,7 @@ use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::GroupAction;
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 #[tokio::test]
@@ -29,10 +29,19 @@ async fn group_view_returns_info() {
     let action = GroupAction::View {
         group: "admin".to_string(),
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a1 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a1.writers(),
+    )
+    .await;
+    let output = __io_a1.out_str().to_string();
     assert!(result.is_ok(), "group_view failed: {result:?}");
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 1);
     assert_eq!(parsed["name"], "admin");
     assert_eq!(parsed["description"], "Admin group");
@@ -54,16 +63,26 @@ async fn group_create_sends_post() {
         description: "A test group".into(),
         is_active: true,
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a2 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a2.writers(),
+    )
+    .await;
+    let output = __io_a2.out_str().to_string();
     assert!(result.is_ok(), "group create failed: {result:?}");
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["action"], "created");
     assert_eq!(parsed["id"], 5);
 }
 
 #[tokio::test]
 async fn group_update_sends_put() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("PUT"))
@@ -81,12 +100,20 @@ async fn group_update_sends_put() {
         description: Some("Updated description".into()),
         is_active: None,
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_ok(), "group update failed: {result:?}");
 }
 
 #[tokio::test]
 async fn group_add_user_sends_put() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     // add_user_to_group sends PUT /rest/user/{user} with group membership body
@@ -104,12 +131,20 @@ async fn group_add_user_sends_put() {
         group: "admin".into(),
         user: "alice@test.com".into(),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_ok(), "group add_user failed: {result:?}");
 }
 
 #[tokio::test]
 async fn group_remove_user_sends_put() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("PUT"))
@@ -126,12 +161,20 @@ async fn group_remove_user_sends_put() {
         group: "admin".into(),
         user: "bob@test.com".into(),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_ok(), "group remove_user failed: {result:?}");
 }
 
 #[tokio::test]
 async fn group_list_users_returns_members() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -149,12 +192,20 @@ async fn group_list_users_returns_members() {
         group: "admin".to_string(),
         details: false,
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_ok(), "group list_users failed: {result:?}");
 }
 
 #[tokio::test]
 async fn group_list_users_with_details() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -171,7 +222,14 @@ async fn group_list_users_with_details() {
         group: "admin".to_string(),
         details: true,
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_ok(),
         "group list_users --details failed: {result:?}"
@@ -180,6 +238,7 @@ async fn group_list_users_with_details() {
 
 #[tokio::test]
 async fn group_view_http_500_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -191,7 +250,14 @@ async fn group_view_http_500_returns_error() {
     let action = GroupAction::View {
         group: "admin".to_string(),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
@@ -202,6 +268,7 @@ async fn group_view_http_500_returns_error() {
 
 #[tokio::test]
 async fn group_view_malformed_json_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("POST"))
@@ -213,6 +280,13 @@ async fn group_view_malformed_json_returns_error() {
     let action = GroupAction::View {
         group: "admin".to_string(),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
 }

--- a/src/commands/product.rs
+++ b/src/commands/product.rs
@@ -1,6 +1,6 @@
 use crate::cli::ProductAction;
 use crate::error::Result;
-use crate::output::{self, ActionResult, ResourceKind};
+use crate::output::{self, ActionResult, ResourceKind, Writers};
 use crate::types::ApiMode;
 use crate::types::OutputFormat;
 use crate::types::{CreateProductParams, UpdateProductParams};
@@ -10,17 +10,18 @@ pub async fn execute(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let client = super::shared::connect_and_configure(server, api).await?;
 
     match action {
         ProductAction::List { r#type } => {
             let products = client.list_products_by_type(*r#type).await?;
-            output::print_products(&products, format);
+            output::write_products(&products, format, w.out);
         }
         ProductAction::View { name } => {
             let product = client.get_product(name).await?;
-            output::print_product_detail(&product, format);
+            output::write_product_detail(&product, format, w.out);
         }
         ProductAction::Create {
             name,
@@ -35,10 +36,11 @@ pub async fn execute(
                 is_open: *is_open,
             };
             let id = client.create_product(&params).await?;
-            output::print_result(
+            output::write_result(
                 &ActionResult::created_named(id, name.as_str(), ResourceKind::Product),
                 &format!("Created product #{id} '{name}'"),
                 format,
+                w.out,
             );
         }
         ProductAction::Update {
@@ -53,10 +55,11 @@ pub async fn execute(
                 is_open: *is_open,
             };
             client.update_product(name, &params).await?;
-            output::print_result(
+            output::write_result(
                 &ActionResult::updated_named(name.as_str(), None, ResourceKind::Product),
                 &format!("Updated product '{name}'"),
                 format,
+                w.out,
             );
         }
     }

--- a/src/commands/product_tests.rs
+++ b/src/commands/product_tests.rs
@@ -4,7 +4,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::ProductAction;
-use crate::test_helpers::{capture_stdout, extract_json, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::{OutputFormat, ProductListType};
 
 #[tokio::test]
@@ -32,15 +32,24 @@ async fn product_list_returns_products() {
     let action = ProductAction::List {
         r#type: ProductListType::Accessible,
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a1 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a1.writers(),
+    )
+    .await;
+    let output = __io_a1.out_str().to_string();
     assert!(result.is_ok());
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["name"], "TestProduct");
 }
 
 #[tokio::test]
 async fn product_list_http_500_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -52,7 +61,14 @@ async fn product_list_http_500_returns_error() {
     let action = ProductAction::List {
         r#type: ProductListType::Accessible,
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
@@ -84,10 +100,18 @@ async fn product_view_returns_detail() {
     let action = ProductAction::View {
         name: "Firefox".to_string(),
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a2 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a2.writers(),
+    )
+    .await;
+    let output = __io_a2.out_str().to_string();
     assert!(result.is_ok());
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "Firefox");
     assert_eq!(parsed["description"], "Web browser");
 }
@@ -108,10 +132,18 @@ async fn product_create_returns_id() {
         version: "1.0".to_string(),
         is_open: true,
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a3 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a3.writers(),
+    )
+    .await;
+    let output = __io_a3.out_str().to_string();
     assert!(result.is_ok());
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 5);
 }
 
@@ -133,9 +165,17 @@ async fn product_update_succeeds() {
         default_milestone: None,
         is_open: None,
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a4 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a4.writers(),
+    )
+    .await;
+    let output = __io_a4.out_str().to_string();
     assert!(result.is_ok());
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["action"], "updated");
 }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -6,7 +6,7 @@
 use crate::cli::QueryAction;
 use crate::config::Config;
 use crate::error::{BzrError, Result};
-use crate::output;
+use crate::output::{self, Writers};
 use crate::types::{OutputFormat, QueryKind, SavedQuery};
 
 /// Translate clap's empty-Vec sentinel into `None` so
@@ -25,17 +25,18 @@ pub async fn execute(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<crate::types::ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     match action {
-        QueryAction::Save { .. } => handle_save(action, format),
-        QueryAction::List => handle_list(format),
-        QueryAction::Show { .. } => handle_show(action, format),
-        QueryAction::Delete { .. } => handle_delete(action, format),
-        QueryAction::Run { .. } => handle_run(action, server, format, api).await,
+        QueryAction::Save { .. } => handle_save(action, format, w),
+        QueryAction::List => handle_list(format, w),
+        QueryAction::Show { .. } => handle_show(action, format, w),
+        QueryAction::Delete { .. } => handle_delete(action, format, w),
+        QueryAction::Run { .. } => handle_run(action, server, format, api, w).await,
     }
 }
 
-fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
+fn handle_save(action: &QueryAction, format: OutputFormat, w: &mut Writers<'_>) -> Result<()> {
     let QueryAction::Save {
         name,
         from_url,
@@ -139,17 +140,17 @@ fn handle_save(action: &QueryAction, format: OutputFormat) -> Result<()> {
     config.save()?;
 
     let verb = if is_update { "Updated" } else { "Saved" };
-    output::print_query_saved(name, verb, format);
+    output::write_query_saved(name, verb, format, w.out);
     Ok(())
 }
 
-fn handle_list(format: OutputFormat) -> Result<()> {
+fn handle_list(format: OutputFormat, w: &mut Writers<'_>) -> Result<()> {
     let config = Config::load()?;
-    output::print_query_list(&config.queries, format);
+    output::write_query_list(&config.queries, format, w.out);
     Ok(())
 }
 
-fn handle_show(action: &QueryAction, format: OutputFormat) -> Result<()> {
+fn handle_show(action: &QueryAction, format: OutputFormat, w: &mut Writers<'_>) -> Result<()> {
     let QueryAction::Show { name } = action else {
         unreachable!()
     };
@@ -158,11 +159,11 @@ fn handle_show(action: &QueryAction, format: OutputFormat) -> Result<()> {
         .queries
         .get(name.as_str())
         .ok_or_else(|| BzrError::config(format!("query '{name}' not found")))?;
-    output::print_query_detail(name, query, format);
+    output::write_query_detail(name, query, format, w.out);
     Ok(())
 }
 
-fn handle_delete(action: &QueryAction, format: OutputFormat) -> Result<()> {
+fn handle_delete(action: &QueryAction, format: OutputFormat, w: &mut Writers<'_>) -> Result<()> {
     let QueryAction::Delete { name } = action else {
         unreachable!()
     };
@@ -172,7 +173,7 @@ fn handle_delete(action: &QueryAction, format: OutputFormat) -> Result<()> {
     }
     config.save()?;
 
-    output::print_query_saved(name, "Deleted", format);
+    output::write_query_saved(name, "Deleted", format, w.out);
     Ok(())
 }
 
@@ -181,6 +182,7 @@ async fn handle_run(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<crate::types::ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let QueryAction::Run {
         name,
@@ -237,7 +239,7 @@ async fn handle_run(
 
     let client = super::shared::connect_and_configure(effective_server, api).await?;
     let bugs = client.search_bugs(&params).await?;
-    output::print_bugs(&bugs, format);
+    output::write_bugs(&bugs, format, w.out);
     Ok(())
 }
 

--- a/src/commands/query_tests.rs
+++ b/src/commands/query_tests.rs
@@ -2,7 +2,7 @@
 
 use crate::cli::QueryAction;
 use crate::config::Config;
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, ResponseTemplate};
@@ -145,17 +145,34 @@ async fn query_save_and_show() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = save_action("test-q");
-    let (result, _output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a1 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a1.writers(),
+    )
+    .await;
+    let _output = __io_a1.out_str().to_string();
     assert!(result.is_ok(), "query save failed: {result:?}");
 
     let action = QueryAction::Show {
         name: "test-q".into(),
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a2 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a2.writers(),
+    )
+    .await;
+    let output = __io_a2.out_str().to_string();
     assert!(result.is_ok(), "query show failed: {result:?}");
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "test-q");
     assert_eq!(parsed["kind"], "list");
     assert_eq!(parsed["product"][0], "Firefox");
@@ -192,16 +209,27 @@ async fn query_save_persists_every_field() {
         qa_contact: vec![],
         url: vec![],
     };
-    let (result, _) = capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut __io.writers()).await;
+    let _ = __io.out_str().to_string();
     result.unwrap();
 
     let action = QueryAction::Show {
         name: "comprehensive".into(),
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a3 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a3.writers(),
+    )
+    .await;
+    let output = __io_a3.out_str().to_string();
     result.unwrap();
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["product"][0], "Firefox");
     assert_eq!(parsed["component"][0], "General");
     assert_eq!(parsed["status"][0], "NEW");
@@ -219,22 +247,32 @@ async fn query_list_emits_saved_query_names() {
     // Saved queries must appear in `query list` output.
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
-    let (result, _) = capture_stdout(super::execute(
+    let mut __io2 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
         &save_action("listed-query"),
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io2.writers(),
+    )
     .await;
+
+    let _ = __io2.out_str().to_string();
     result.unwrap();
 
-    let (result, output) = capture_stdout(super::execute(
+    let mut __io3 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
         &QueryAction::List,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io3.writers(),
+    )
     .await;
+
+    let output = __io3.out_str().to_string();
     result.unwrap();
     assert!(
         output.contains("listed-query"),
@@ -247,27 +285,52 @@ async fn query_save_search_kind() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = empty_save_action("crashes", Some("crash in tab".into()));
-    let (result, _output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a4 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a4.writers(),
+    )
+    .await;
+    let _output = __io_a4.out_str().to_string();
     assert!(result.is_ok(), "query save failed: {result:?}");
 
     let action = QueryAction::Show {
         name: "crashes".into(),
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a5 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a5.writers(),
+    )
+    .await;
+    let output = __io_a5.out_str().to_string();
     assert!(result.is_ok(), "query show failed: {result:?}");
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["kind"], "search");
     assert_eq!(parsed["quicksearch"], "crash in tab");
 }
 
 #[tokio::test]
 async fn query_save_requires_filter() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = empty_save_action("empty", None);
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err(), "saving empty query should fail");
     let err = result.unwrap_err().to_string();
     assert!(
@@ -278,12 +341,20 @@ async fn query_save_requires_filter() {
 
 #[tokio::test]
 async fn query_delete_unknown_errors() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = QueryAction::Delete {
         name: "nonexistent".into(),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err(), "deleting unknown query should fail");
     let err = result.unwrap_err().to_string();
     assert!(
@@ -297,8 +368,16 @@ async fn query_list_empty() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = QueryAction::List;
-    let (result, _output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a6 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a6.writers(),
+    )
+    .await;
+    let _output = __io_a6.out_str().to_string();
     assert!(result.is_ok(), "query list failed: {result:?}");
 }
 
@@ -308,8 +387,16 @@ async fn query_run_executes_saved_query() {
 
     // First, save a query
     let save_action = product_save_action("run-test", "TestProduct", 10);
-    let (result, _) =
-        capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a7 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &save_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a7.writers(),
+    )
+    .await;
+    let _ = __io_a7.out_str().to_string();
     assert!(result.is_ok(), "query save failed: {result:?}");
 
     // Mock the bug search endpoint
@@ -329,10 +416,19 @@ async fn query_run_executes_saved_query() {
 
     // Run the saved query
     let run_action = run_action("run-test");
-    let (result, output) =
-        capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a8 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &run_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a8.writers(),
+    )
+    .await;
+    let output = __io_a8.out_str().to_string();
     assert!(result.is_ok(), "query run failed: {result:?}");
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["id"], 1);
     assert_eq!(parsed[0]["product"], "TestProduct");
 }
@@ -342,8 +438,16 @@ async fn query_run_with_limit_override() {
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     let save_action = product_save_action("override-test", "TestProduct", 100);
-    let (result, _) =
-        capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a9 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &save_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a9.writers(),
+    )
+    .await;
+    let _ = __io_a9.out_str().to_string();
     assert!(result.is_ok());
 
     Mock::given(method("GET"))
@@ -371,8 +475,16 @@ async fn query_run_with_limit_override() {
         qa_contact: vec![],
         url: vec![],
     };
-    let (result, _) =
-        capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a10 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &run_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a10.writers(),
+    )
+    .await;
+    let _ = __io_a10.out_str().to_string();
     assert!(result.is_ok(), "query run with override failed: {result:?}");
 }
 
@@ -405,8 +517,16 @@ async fn query_save_existing_entry_reports_updated() {
         qa_contact: vec![],
         url: vec![],
     };
-    let (result, _) =
-        capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a11 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &save_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a11.writers(),
+    )
+    .await;
+    let _ = __io_a11.out_str().to_string();
     assert!(result.is_ok());
 
     let update_action = QueryAction::Save {
@@ -434,16 +554,19 @@ async fn query_save_existing_entry_reports_updated() {
         qa_contact: vec![],
         url: vec![],
     };
-    let (result, output) = capture_stdout(super::execute(
+    let mut __io4 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
         &update_action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io4.writers(),
+    )
     .await;
+    let output = __io4.out_str().to_string();
     assert!(result.is_ok());
 
-    let parsed = crate::test_helpers::extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "existing");
     assert_eq!(parsed["action"], "updated");
 
@@ -456,33 +579,51 @@ async fn query_save_existing_entry_reports_updated() {
 
 #[tokio::test]
 async fn query_delete_removes_saved_query() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let save_action = product_save_action("delete-me", "Firefox", 1);
-    let (result, _) =
-        capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a12 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &save_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a12.writers(),
+    )
+    .await;
+    let _ = __io_a12.out_str().to_string();
     assert!(result.is_ok());
 
     let delete_action = QueryAction::Delete {
         name: "delete-me".into(),
     };
-    let (result, output) = capture_stdout(super::execute(
+    let mut __io5 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
         &delete_action,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io5.writers(),
+    )
     .await;
+    let output = __io5.out_str().to_string();
     assert!(result.is_ok());
-    let parsed = crate::test_helpers::extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["action"], "deleted");
 
     let show_action = QueryAction::Show {
         name: "delete-me".into(),
     };
-    let err = super::execute(&show_action, None, OutputFormat::Json, None)
-        .await
-        .unwrap_err();
+    let err = super::execute(
+        &show_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await
+    .unwrap_err();
     assert!(err.to_string().contains("not found"));
 }
 
@@ -515,8 +656,16 @@ async fn query_run_applies_field_overrides() {
         qa_contact: vec![],
         url: vec![],
     };
-    let (result, _) =
-        capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a13 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &save_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a13.writers(),
+    )
+    .await;
+    let _ = __io_a13.out_str().to_string();
     assert!(result.is_ok());
 
     Mock::given(method("GET"))
@@ -545,17 +694,33 @@ async fn query_run_applies_field_overrides() {
         qa_contact: vec![],
         url: vec![],
     };
-    let (result, _) =
-        capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a14 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &run_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a14.writers(),
+    )
+    .await;
+    let _ = __io_a14.out_str().to_string();
     assert!(result.is_ok());
 }
 
 #[tokio::test]
 async fn query_run_unknown_errors() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = run_action("nonexistent");
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err(), "running unknown query should fail");
     let err = result.unwrap_err().to_string();
     assert!(
@@ -569,23 +734,31 @@ async fn query_list_table_sorts_entries_by_name() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     for name in ["zzz", "aaa"] {
-        let (result, _) = capture_stdout(super::execute(
+        let mut __io6 = crate::test_helpers::CapturedIo::new();
+        let result = super::execute(
             &save_action(name),
             None,
             OutputFormat::Json,
             None,
-        ))
+            &mut __io6.writers(),
+        )
         .await;
+        let _ = __io6.out_str().to_string();
         assert!(result.is_ok());
     }
 
-    let (result, _) = capture_stdout(super::execute(
+    let mut __io7 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
         &QueryAction::List,
         None,
         OutputFormat::Table,
         None,
-    ))
+        &mut __io7.writers(),
+    )
     .await;
+
+    let _ = __io7.out_str().to_string();
     assert!(result.is_ok());
 
     let config = Config::load().unwrap();
@@ -596,6 +769,7 @@ async fn query_list_table_sorts_entries_by_name() {
 
 #[tokio::test]
 async fn query_show_unknown_errors() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let err = super::execute(
@@ -605,6 +779,7 @@ async fn query_show_unknown_errors() {
         None,
         OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await
     .unwrap_err();
@@ -618,8 +793,16 @@ async fn query_run_with_server_override() {
 
     // Save a query that records a different server than the mock
     let save_action = save_action("server-test");
-    let (result, _) =
-        capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a15 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &save_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a15.writers(),
+    )
+    .await;
+    let _ = __io_a15.out_str().to_string();
     assert!(result.is_ok());
 
     // Patch the saved query to have a different server
@@ -654,8 +837,16 @@ async fn query_run_with_server_override() {
         qa_contact: vec![],
         url: vec![],
     };
-    let (result, _) =
-        capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a16 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &run_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a16.writers(),
+    )
+    .await;
+    let _ = __io_a16.out_str().to_string();
     assert!(
         result.is_ok(),
         "query run with server override failed: {result:?}"
@@ -674,8 +865,16 @@ async fn query_save_from_url() {
         "{server_url}/buglist.cgi?product=TestProduct&f1=qa_contact&o1=changedfrom&v1=user%40example.com"
     );
     let action = url_save_action("url-query", url);
-    let (result, _output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a17 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a17.writers(),
+    )
+    .await;
+    let _output = __io_a17.out_str().to_string();
     assert!(result.is_ok(), "query save --from-url failed: {result:?}");
 
     let config = Config::load().unwrap();
@@ -688,6 +887,7 @@ async fn query_save_from_url() {
 
 #[tokio::test]
 async fn query_save_rejects_malformed_created_since() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = QueryAction::Save {
@@ -716,7 +916,14 @@ async fn query_save_rejects_malformed_created_since() {
         url: vec![],
     };
 
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     let err = result.unwrap_err();
     assert_eq!(err.exit_code(), 7);
     assert!(err.to_string().contains("--created-since"));
@@ -751,7 +958,16 @@ async fn query_save_stores_canonical_date_forms() {
         qa_contact: vec![],
         url: vec![],
     };
-    let (result, _) = capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io8 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io8.writers(),
+    )
+    .await;
+    let _ = __io8.out_str().to_string();
     result.unwrap();
 
     let cfg = Config::load().unwrap();
@@ -791,7 +1007,16 @@ async fn query_save_accepts_date_only_query() {
         qa_contact: vec![],
         url: vec![],
     };
-    let (result, _) = capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io9 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io9.writers(),
+    )
+    .await;
+    let _ = __io9.out_str().to_string();
     result.unwrap();
     let cfg = Config::load().unwrap();
     assert!(cfg.queries.contains_key("date-only"));
@@ -799,6 +1024,7 @@ async fn query_save_accepts_date_only_query() {
 
 #[tokio::test]
 async fn query_run_rejects_malformed_created_since_override() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     // Pre-seed a saved query so the not-found branch doesn't fire first.
@@ -829,7 +1055,14 @@ async fn query_run_rejects_malformed_created_since_override() {
         qa_contact: vec![],
         url: vec![],
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     let err = result.unwrap_err();
     assert_eq!(err.exit_code(), 7);
     assert!(err.to_string().contains("--created-since"));
@@ -864,8 +1097,16 @@ async fn query_save_persists_158_field_filters() {
         qa_contact: vec!["qa@example.com".into()],
         url: vec!["github.com/foo".into()],
     };
-    let (result, _output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a18 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a18.writers(),
+    )
+    .await;
+    let _output = __io_a18.out_str().to_string();
     assert!(result.is_ok(), "save failed: {result:?}");
 
     let cfg = Config::load().unwrap();
@@ -913,8 +1154,16 @@ async fn query_save_accepts_whiteboard_only_filter() {
         qa_contact: vec![],
         url: vec![],
     };
-    let (result, _output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a19 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a19.writers(),
+    )
+    .await;
+    let _output = __io_a19.out_str().to_string();
     assert!(
         result.is_ok(),
         "save with whiteboard-only filter must succeed: {result:?}"
@@ -951,8 +1200,16 @@ async fn query_run_overrides_replace_saved_field_filters() {
         qa_contact: vec![],
         url: vec![],
     };
-    let (result, _) =
-        capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a20 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &save_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a20.writers(),
+    )
+    .await;
+    let _ = __io_a20.out_str().to_string();
     assert!(result.is_ok(), "save failed: {result:?}");
 
     // The run must hit the wire with the override values, not the saved ones.
@@ -982,8 +1239,16 @@ async fn query_run_overrides_replace_saved_field_filters() {
         qa_contact: vec![],
         url: vec![],
     };
-    let (result, _) =
-        capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a21 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &run_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a21.writers(),
+    )
+    .await;
+    let _ = __io_a21.out_str().to_string();
     assert!(result.is_ok(), "run failed: {result:?}");
 }
 
@@ -1016,8 +1281,16 @@ async fn query_run_empty_override_keeps_saved_field_filter() {
         qa_contact: vec![],
         url: vec![],
     };
-    let (result, _) =
-        capture_stdout(super::execute(&save_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a22 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &save_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a22.writers(),
+    )
+    .await;
+    let _ = __io_a22.out_str().to_string();
     assert!(result.is_ok(), "save failed: {result:?}");
 
     // No --whiteboard override on run: the saved value must reach the wire.
@@ -1030,7 +1303,15 @@ async fn query_run_empty_override_keeps_saved_field_filter() {
         .await;
 
     let run_action = run_action("saved-wb");
-    let (result, _) =
-        capture_stdout(super::execute(&run_action, None, OutputFormat::Json, None)).await;
+    let mut __io_a23 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &run_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a23.writers(),
+    )
+    .await;
+    let _ = __io_a23.out_str().to_string();
     assert!(result.is_ok(), "run failed: {result:?}");
 }

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -1,6 +1,6 @@
 use crate::cli::ServerAction;
 use crate::error::Result;
-use crate::output;
+use crate::output::{self, Writers};
 use crate::types::ApiMode;
 use crate::types::OutputFormat;
 
@@ -9,13 +9,14 @@ pub async fn execute(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let client = super::shared::connect_and_configure(server, api).await?;
 
     match action {
         ServerAction::Info => {
             let info = client.server_info().await?;
-            output::print_server_info(&info, format);
+            output::write_server_info(&info, format, w.out);
         }
     }
     Ok(())

--- a/src/commands/server_tests.rs
+++ b/src/commands/server_tests.rs
@@ -4,7 +4,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::ServerAction;
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 #[tokio::test]
@@ -27,20 +27,27 @@ async fn server_info_returns_version_and_extensions() {
         .mount(&mock)
         .await;
 
-    let (result, output) = capture_stdout(super::execute(
+    let mut __io = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
         &ServerAction::Info,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io.writers(),
+    )
     .await;
+
+    let output = __io.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["version"], "5.0.4");
 }
 
 #[tokio::test]
 async fn server_info_http_500_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -49,7 +56,14 @@ async fn server_info_http_500_returns_error() {
         .mount(&mock)
         .await;
 
-    let result = super::execute(&ServerAction::Info, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &ServerAction::Info,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(

--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -5,7 +5,7 @@
 use crate::cli::TemplateAction;
 use crate::config::Config;
 use crate::error::{BzrError, Result};
-use crate::output;
+use crate::output::{self, Writers};
 use crate::types::BugTemplate;
 use crate::types::OutputFormat;
 
@@ -18,6 +18,7 @@ pub async fn execute(
     _server: Option<&str>,
     format: OutputFormat,
     _api: Option<crate::types::ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     match action {
         TemplateAction::Save {
@@ -66,11 +67,11 @@ pub async fn execute(
             config.save()?;
 
             let verb = if is_update { "Updated" } else { "Saved" };
-            output::print_template_saved(name, verb, format);
+            output::write_template_saved(name, verb, format, w.out);
         }
         TemplateAction::List => {
             let config = Config::load()?;
-            output::print_template_list(&config.templates, format);
+            output::write_template_list(&config.templates, format, w.out);
         }
         TemplateAction::Show { name } => {
             let config = Config::load()?;
@@ -78,7 +79,7 @@ pub async fn execute(
                 .templates
                 .get(name.as_str())
                 .ok_or_else(|| BzrError::config(format!("template '{name}' not found")))?;
-            output::print_template_detail(name, template, format);
+            output::write_template_detail(name, template, format, w.out);
         }
         TemplateAction::Delete { name } => {
             let mut config = Config::load()?;
@@ -87,19 +88,12 @@ pub async fn execute(
             }
             config.save()?;
 
-            #[expect(clippy::print_stdout)]
-            match format {
-                OutputFormat::Json => {
-                    output::print_result(
-                        &serde_json::json!({"name": name, "action": "deleted"}),
-                        "",
-                        format,
-                    );
-                }
-                OutputFormat::Table => {
-                    println!("Deleted template '{name}'");
-                }
-            }
+            output::write_result(
+                &serde_json::json!({"name": name, "action": "deleted"}),
+                &format!("Deleted template '{name}'"),
+                format,
+                w.out,
+            );
         }
     }
     Ok(())

--- a/src/commands/template_tests.rs
+++ b/src/commands/template_tests.rs
@@ -2,7 +2,7 @@
 
 use crate::cli::TemplateAction;
 use crate::config::Config;
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 fn save_action(name: &str) -> TemplateAction {
@@ -26,18 +26,35 @@ async fn template_save_and_show() {
 
     // Save a template
     let action = save_action("test-tmpl");
-    let (result, _output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a1 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a1.writers(),
+    )
+    .await;
+    let _output = __io_a1.out_str().to_string();
     assert!(result.is_ok(), "template save failed: {result:?}");
 
     // Show the saved template
     let action = TemplateAction::Show {
         name: "test-tmpl".into(),
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a2 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a2.writers(),
+    )
+    .await;
+    let output = __io_a2.out_str().to_string();
     assert!(result.is_ok(), "template show failed: {result:?}");
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "test-tmpl");
     assert_eq!(parsed["product"], "TestProduct");
     assert_eq!(parsed["priority"], "P1");
@@ -45,6 +62,7 @@ async fn template_save_and_show() {
 
 #[tokio::test]
 async fn template_save_requires_field() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = TemplateAction::Save {
@@ -59,7 +77,14 @@ async fn template_save_requires_field() {
         rep_platform: None,
         description: None,
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err(), "saving empty template should fail");
     let err = result.unwrap_err().to_string();
     assert!(
@@ -86,7 +111,9 @@ async fn template_save_with_single_field_succeeds() {
         rep_platform: None,
         description: None,
     };
-    let (result, _) = capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut __io.writers()).await;
+    let _ = __io.out_str().to_string();
     assert!(
         result.is_ok(),
         "single-field template should save: {result:?}"
@@ -95,12 +122,20 @@ async fn template_save_with_single_field_succeeds() {
 
 #[tokio::test]
 async fn template_delete_unknown_errors() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = TemplateAction::Delete {
         name: "nonexistent".into(),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err(), "deleting unknown template should fail");
     let err = result.unwrap_err().to_string();
     assert!(
@@ -114,8 +149,16 @@ async fn template_list_empty() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = TemplateAction::List;
-    let (result, _output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a3 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a3.writers(),
+    )
+    .await;
+    let _output = __io_a3.out_str().to_string();
     assert!(result.is_ok(), "template list failed: {result:?}");
 }
 
@@ -123,13 +166,18 @@ async fn template_list_empty() {
 async fn template_save_existing_entry_reports_updated_and_replaces_fields() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
-    let (result, _) = capture_stdout(super::execute(
+    let mut __io2 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
         &save_action("existing"),
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io2.writers(),
+    )
     .await;
+
+    let _ = __io2.out_str().to_string();
     assert!(result.is_ok());
 
     let update = TemplateAction::Save {
@@ -144,11 +192,19 @@ async fn template_save_existing_entry_reports_updated_and_replaces_fields() {
         rep_platform: None,
         description: Some("updated".into()),
     };
-    let (result, output) =
-        capture_stdout(super::execute(&update, None, OutputFormat::Json, None)).await;
+    let mut __io_a4 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &update,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a4.writers(),
+    )
+    .await;
+    let output = __io_a4.out_str().to_string();
     assert!(result.is_ok());
 
-    let parsed = crate::test_helpers::extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "existing");
     assert_eq!(parsed["action"], "updated");
 
@@ -164,27 +220,37 @@ async fn template_save_existing_entry_reports_updated_and_replaces_fields() {
 async fn template_delete_existing_removes_entry() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
-    let (result, _) = capture_stdout(super::execute(
+    let mut __io3 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
         &save_action("delete-me"),
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io3.writers(),
+    )
     .await;
+
+    let _ = __io3.out_str().to_string();
     assert!(result.is_ok());
 
-    let (result, output) = capture_stdout(super::execute(
+    let mut __io4 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
         &TemplateAction::Delete {
             name: "delete-me".into(),
         },
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io4.writers(),
+    )
     .await;
+
+    let output = __io4.out_str().to_string();
     assert!(result.is_ok());
 
-    let parsed = crate::test_helpers::extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "delete-me");
     assert_eq!(parsed["action"], "deleted");
     assert!(!Config::load().unwrap().templates.contains_key("delete-me"));
@@ -194,24 +260,34 @@ async fn template_delete_existing_removes_entry() {
 async fn template_delete_table_prints_deleted_message() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
-    let (result, _) = capture_stdout(super::execute(
+    let mut __io5 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
         &save_action("table-delete"),
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io5.writers(),
+    )
     .await;
+
+    let _ = __io5.out_str().to_string();
     assert!(result.is_ok());
 
-    let (result, _output) = capture_stdout(super::execute(
+    let mut __io6 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
         &TemplateAction::Delete {
             name: "table-delete".into(),
         },
         None,
         OutputFormat::Table,
         None,
-    ))
+        &mut __io6.writers(),
+    )
     .await;
+
+    let _output = __io6.out_str().to_string();
     assert!(result.is_ok());
     assert!(!Config::load()
         .unwrap()
@@ -224,23 +300,31 @@ async fn template_list_table_sorts_entries_by_name() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     for name in ["zzz", "aaa"] {
-        let (result, _) = capture_stdout(super::execute(
+        let mut __io7 = crate::test_helpers::CapturedIo::new();
+        let result = super::execute(
             &save_action(name),
             None,
             OutputFormat::Json,
             None,
-        ))
+            &mut __io7.writers(),
+        )
         .await;
+        let _ = __io7.out_str().to_string();
         assert!(result.is_ok());
     }
 
-    let (result, output) = capture_stdout(super::execute(
+    let mut __io8 = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
         &TemplateAction::List,
         None,
         OutputFormat::Table,
         None,
-    ))
+        &mut __io8.writers(),
+    )
     .await;
+
+    let output = __io8.out_str().to_string();
     assert!(result.is_ok());
     assert!(output.is_empty() || output.contains("product="));
 
@@ -252,6 +336,7 @@ async fn template_list_table_sorts_entries_by_name() {
 
 #[tokio::test]
 async fn template_show_unknown_errors() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let err = super::execute(
@@ -261,6 +346,7 @@ async fn template_show_unknown_errors() {
         None,
         OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await
     .unwrap_err();

--- a/src/commands/user.rs
+++ b/src/commands/user.rs
@@ -1,6 +1,6 @@
 use crate::cli::UserAction;
 use crate::error::Result;
-use crate::output::{self, ActionResult, ResourceKind};
+use crate::output::{self, ActionResult, ResourceKind, Writers};
 use crate::types::ApiMode;
 use crate::types::OutputFormat;
 use crate::types::{CreateUserParams, UpdateUserParams};
@@ -25,6 +25,7 @@ pub async fn execute(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let client = super::shared::connect_and_configure(server, api).await?;
 
@@ -32,9 +33,9 @@ pub async fn execute(
         UserAction::Search { query, details } => {
             let users = client.search_users(query, *details).await?;
             if *details {
-                output::print_users_detailed(&users, format);
+                output::write_users_detailed(&users, format, w.out);
             } else {
-                output::print_users(&users, format);
+                output::write_users(&users, format, w.out);
             }
         }
         UserAction::Create {
@@ -50,10 +51,11 @@ pub async fn execute(
                 password: password.clone(),
             };
             let id = client.create_user(&params).await?;
-            output::print_result(
+            output::write_result(
                 &ActionResult::created_named(id, email.as_str(), ResourceKind::User),
                 &format!("Created user #{id} ({email})"),
                 format,
+                w.out,
             );
         }
         UserAction::Update {
@@ -72,10 +74,11 @@ pub async fn execute(
                 login_denied_text: denied_text,
             };
             client.update_user(user, &params).await?;
-            output::print_result(
+            output::write_result(
                 &ActionResult::updated_named(user.as_str(), None, ResourceKind::User),
                 &format!("Updated user '{user}'"),
                 format,
+                w.out,
             );
         }
     }

--- a/src/commands/user_tests.rs
+++ b/src/commands/user_tests.rs
@@ -4,7 +4,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::UserAction;
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 #[test]
@@ -64,16 +64,26 @@ async fn user_search_returns_results() {
         query: "alice".to_string(),
         details: false,
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a1 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a1.writers(),
+    )
+    .await;
+    let output = __io_a1.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["id"], 1);
     assert_eq!(parsed[0]["name"], "alice@test.com");
 }
 
 #[tokio::test]
 async fn update_user_disable_login_sends_denied_text() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("PUT"))
@@ -90,7 +100,14 @@ async fn update_user_disable_login_sends_denied_text() {
         disable_login: Some(true),
         login_denied_text: Some("Go away".to_string()),
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_ok(),
         "update with disable_login failed: {result:?}"
@@ -99,6 +116,7 @@ async fn update_user_disable_login_sends_denied_text() {
 
 #[tokio::test]
 async fn update_user_enable_login_sends_empty_denied_text() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("PUT"))
@@ -115,7 +133,14 @@ async fn update_user_enable_login_sends_empty_denied_text() {
         disable_login: Some(false),
         login_denied_text: None,
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_ok(),
         "update with enable_login failed: {result:?}"
@@ -139,16 +164,26 @@ async fn user_create_sends_post() {
         full_name: Some("New User".into()),
         password: None,
     };
-    let (result, output) =
-        capture_stdout(super::execute(&action, None, OutputFormat::Json, None)).await;
+    let mut __io_a2 = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io_a2.writers(),
+    )
+    .await;
+    let output = __io_a2.out_str().to_string();
     assert!(result.is_ok(), "user create failed: {result:?}");
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["action"], "created");
     assert_eq!(parsed["id"], 99);
 }
 
 #[tokio::test]
 async fn user_search_http_500_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -161,7 +196,14 @@ async fn user_search_http_500_returns_error() {
         query: "alice".to_string(),
         details: false,
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
@@ -172,6 +214,7 @@ async fn user_search_http_500_returns_error() {
 
 #[tokio::test]
 async fn user_search_malformed_json_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -184,6 +227,13 @@ async fn user_search_malformed_json_returns_error() {
         query: "alice".to_string(),
         details: false,
     };
-    let result = super::execute(&action, None, OutputFormat::Json, None).await;
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err());
 }

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -2,7 +2,7 @@
 
 use crate::cli::WhoamiAction;
 use crate::error::Result;
-use crate::output;
+use crate::output::{self, Writers};
 use crate::types::ApiMode;
 use crate::types::OutputFormat;
 
@@ -11,10 +11,11 @@ pub async fn execute(
     server: Option<&str>,
     format: OutputFormat,
     api: Option<ApiMode>,
+    w: &mut Writers<'_>,
 ) -> Result<()> {
     let client = super::shared::connect_and_configure(server, api).await?;
     let whoami = client.whoami().await?;
-    output::print_whoami(&whoami, format);
+    output::write_whoami(&whoami, format, w.out);
     Ok(())
 }
 

--- a/src/commands/whoami_tests.rs
+++ b/src/commands/whoami_tests.rs
@@ -1,7 +1,9 @@
+#![expect(clippy::unwrap_used)]
+
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
-use crate::test_helpers::{capture_stdout, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 #[tokio::test]
@@ -19,15 +21,21 @@ async fn whoami_returns_user_info() {
         .mount(&mock)
         .await;
 
-    let (result, output) = capture_stdout(super::execute(
+    let mut __io = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(
         &crate::cli::WhoamiAction::Show,
         None,
         OutputFormat::Json,
         None,
-    ))
+        &mut __io.writers(),
+    )
     .await;
+
+    let output = __io.out_str().to_string();
     assert!(result.is_ok());
-    let parsed: serde_json::Value = crate::test_helpers::extract_json(&output);
+    let parsed: serde_json::Value =
+        serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 1);
     assert_eq!(parsed["name"], "admin@test.com");
     assert_eq!(parsed["real_name"], "Admin User");
@@ -35,6 +43,7 @@ async fn whoami_returns_user_info() {
 
 #[tokio::test]
 async fn whoami_http_500_returns_error() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -48,6 +57,7 @@ async fn whoami_http_500_returns_error() {
         None,
         OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(result.is_err());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@ pub mod config;
 pub mod credentials;
 pub mod error;
 pub(crate) mod http;
-#[expect(clippy::print_stdout, clippy::expect_used)]
-pub(crate) mod output;
+#[expect(clippy::expect_used)]
+pub mod output;
 pub(crate) mod tls;
 pub mod types;
 pub mod url_parser;
@@ -28,51 +28,57 @@ pub mod xmlrpc;
 ///
 /// This is the shared dispatch logic used by both the binary (`main.rs`)
 /// and integration tests, ensuring they exercise the same code paths.
-pub async fn dispatch(cli: &cli::Cli, format: types::OutputFormat) -> error::Result<()> {
+pub async fn dispatch(
+    cli: &cli::Cli,
+    format: types::OutputFormat,
+    w: &mut output::Writers<'_>,
+) -> error::Result<()> {
     let api = cli.api;
     let server = cli.server.as_deref();
 
     match &cli.command {
-        cli::Commands::Bug { action } => commands::bug::execute(action, server, format, api).await,
+        cli::Commands::Bug { action } => {
+            commands::bug::execute(action, server, format, api, w).await
+        }
         cli::Commands::Comment { action } => {
-            commands::comment::execute(action, server, format, api).await
+            commands::comment::execute(action, server, format, api, w).await
         }
         cli::Commands::Attachment { action } => {
-            commands::attachment::execute(action, server, format, api).await
+            commands::attachment::execute(action, server, format, api, w).await
         }
         cli::Commands::Config { action } => {
-            commands::config::execute(action, server, format, api).await
+            commands::config::execute(action, server, format, api, w).await
         }
         cli::Commands::Product { action } => {
-            commands::product::execute(action, server, format, api).await
+            commands::product::execute(action, server, format, api, w).await
         }
         cli::Commands::Field { action } => {
-            commands::field::execute(action, server, format, api).await
+            commands::field::execute(action, server, format, api, w).await
         }
         cli::Commands::User { action } => {
-            commands::user::execute(action, server, format, api).await
+            commands::user::execute(action, server, format, api, w).await
         }
         cli::Commands::Group { action } => {
-            commands::group::execute(action, server, format, api).await
+            commands::group::execute(action, server, format, api, w).await
         }
         cli::Commands::Whoami { action } => {
             let whoami_action = action.as_ref().unwrap_or(&cli::WhoamiAction::Show);
-            commands::whoami::execute(whoami_action, server, format, api).await
+            commands::whoami::execute(whoami_action, server, format, api, w).await
         }
         cli::Commands::Server { action } => {
-            commands::server::execute(action, server, format, api).await
+            commands::server::execute(action, server, format, api, w).await
         }
         cli::Commands::Classification { action } => {
-            commands::classification::execute(action, server, format, api).await
+            commands::classification::execute(action, server, format, api, w).await
         }
         cli::Commands::Component { action } => {
-            commands::component::execute(action, server, format, api).await
+            commands::component::execute(action, server, format, api, w).await
         }
         cli::Commands::Template { action } => {
-            commands::template::execute(action, server, format, api).await
+            commands::template::execute(action, server, format, api, w).await
         }
         cli::Commands::Query { action } => {
-            commands::query::execute(action, server, format, api).await
+            commands::query::execute(action, server, format, api, w).await
         }
     }
 }

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -5,7 +5,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use super::*;
-use crate::test_helpers::{capture_stdout, extract_json, setup_test_env};
+use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
 #[tokio::test]
@@ -24,10 +24,12 @@ async fn dispatch_whoami_defaults_to_show_action() {
         .await;
 
     let cli = cli::Cli::try_parse_from(["bzr", "--server", "test", "--json", "whoami"]).unwrap();
-    let (result, output) = capture_stdout(dispatch(&cli, OutputFormat::Json)).await;
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = dispatch(&cli, OutputFormat::Json, &mut __io.writers()).await;
+    let output = __io.out_str().to_string();
     assert!(result.is_ok(), "dispatch failed: {result:?}");
 
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "admin@example.com");
 }
 
@@ -45,10 +47,12 @@ async fn dispatch_routes_local_query_commands() {
         "Firefox",
     ])
     .unwrap();
-    let (result, output) = capture_stdout(dispatch(&cli, OutputFormat::Json)).await;
+    let mut __io2 = crate::test_helpers::CapturedIo::new();
+    let result = dispatch(&cli, OutputFormat::Json, &mut __io2.writers()).await;
+    let output = __io2.out_str().to_string();
     assert!(result.is_ok(), "dispatch failed: {result:?}");
 
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "firefox-new");
     assert_eq!(parsed["action"], "saved");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,13 @@ async fn main() -> ExitCode {
         suppress_stdout();
     }
 
-    if let Err(e) = bzr::dispatch(&cli, format).await {
+    let stdout = std::io::stdout();
+    let stderr = std::io::stderr();
+    let mut out = stdout.lock();
+    let mut err = stderr.lock();
+    let mut writers = bzr::output::Writers::new(&mut out, &mut err);
+
+    if let Err(e) = bzr::dispatch(&cli, format, &mut writers).await {
         #[expect(clippy::print_stderr)]
         {
             eprintln!("{}", format_dispatch_error(&e, format));

--- a/src/output/attachment.rs
+++ b/src/output/attachment.rs
@@ -1,15 +1,19 @@
-use std::io::{self, Write as _};
+use std::io::Write;
 
 use colored::Colorize;
 use serde::Serialize;
 
-use super::formatting::{print_field, print_formatted, print_optional_field};
+use super::formatting::{write_field, write_formatted, write_optional_field};
 use crate::types::{Attachment, OutputFormat};
 
-pub fn print_attachments(attachments: &[Attachment], format: OutputFormat) {
-    print_formatted(attachments, format, |attachments| {
+pub fn write_attachments<W: Write + ?Sized>(
+    attachments: &[Attachment],
+    format: OutputFormat,
+    out: &mut W,
+) {
+    write_formatted(attachments, format, out, |attachments, out| {
         if attachments.is_empty() {
-            let _ = writeln!(io::stdout(), "No attachments.");
+            let _ = writeln!(out, "No attachments.");
             return;
         }
         for a in attachments {
@@ -17,7 +21,7 @@ pub fn print_attachments(attachments: &[Attachment], format: OutputFormat) {
             let obsolete = if a.is_obsolete { " [OBSOLETE]" } else { "" };
             let private = if a.is_private { " [PRIVATE]" } else { "" };
             let _ = writeln!(
-                io::stdout(),
+                out,
                 "{} #{} - {}{}{}{}",
                 "Attachment".bold(),
                 a.id,
@@ -26,13 +30,14 @@ pub fn print_attachments(attachments: &[Attachment], format: OutputFormat) {
                 obsolete.red(),
                 private.red(),
             );
-            print_field(
+            write_field(
+                out,
                 "File",
                 &format!("{} ({}, {} bytes)", a.file_name, a.content_type, a.size),
             );
-            print_optional_field("Creator", a.creator.as_deref());
-            print_optional_field("Created", a.creation_time.as_deref());
-            let _ = writeln!(io::stdout());
+            write_optional_field(out, "Creator", a.creator.as_deref());
+            write_optional_field(out, "Created", a.creation_time.as_deref());
+            let _ = writeln!(out);
         }
     });
 }
@@ -156,24 +161,33 @@ pub enum TargetStatus {
 
 /// Render an [`AttachmentBatchResult`] in the requested format.
 ///
-/// Successful entries print to stdout; bug-level failures and
-/// per-attachment failures print to stderr (one line each), so
+/// Successful entries print to `out`; bug-level failures and
+/// per-attachment failures print to `err` (one line each), so
 /// `2>/dev/null` quiets warnings without losing the success listing.
-/// JSON mode emits a single object on stdout — no stderr writes.
-pub fn print_attachment_batch(result: &AttachmentBatchResult, format: OutputFormat) {
-    print_formatted(result, format, |r| {
-        write_attachment_batch_table(r, &mut io::stdout(), &mut io::stderr());
-    });
+/// JSON mode emits a single object on `out` — no `err` writes.
+pub fn write_attachment_batch<O, E>(
+    result: &AttachmentBatchResult,
+    format: OutputFormat,
+    out: &mut O,
+    err: &mut E,
+) where
+    O: Write + ?Sized,
+    E: Write + ?Sized,
+{
+    match format {
+        OutputFormat::Json => super::formatting::write_json(result, out),
+        OutputFormat::Table => write_attachment_batch_table(result, out, err),
+    }
 }
 
 /// Render the table-mode body of an [`AttachmentBatchResult`] to the given
 /// writers. Successes go to `out`, target-level failures go to `err`.
-/// Extracted from `print_attachment_batch` so tests can inject buffers
-/// for both streams; production calls use `io::stdout()` and `io::stderr()`.
-pub(super) fn write_attachment_batch_table(
+/// Extracted from `write_attachment_batch` so tests can inject buffers
+/// for both streams; production calls receive `Writers::out` and `Writers::err`.
+pub(super) fn write_attachment_batch_table<O: Write + ?Sized, E: Write + ?Sized>(
     r: &AttachmentBatchResult,
-    out: &mut impl std::io::Write,
-    err: &mut impl std::io::Write,
+    out: &mut O,
+    err: &mut E,
 ) {
     for bug in &r.bug_results {
         match bug.status {

--- a/src/output/attachment_tests.rs
+++ b/src/output/attachment_tests.rs
@@ -21,15 +21,31 @@ fn make_attachment(id: u64, summary: &str) -> Attachment {
     }
 }
 
+fn capture(format: OutputFormat, attachments: &[Attachment]) -> String {
+    let mut buf = Vec::new();
+    write_attachments(attachments, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
+
+fn capture_batch(format: OutputFormat, result: &AttachmentBatchResult) -> (String, String) {
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    write_attachment_batch(result, format, &mut out, &mut err);
+    (
+        String::from_utf8(out).unwrap(),
+        String::from_utf8(err).unwrap(),
+    )
+}
+
 #[test]
-fn print_attachments_json_empty() {
+fn write_attachments_json_empty() {
     let attachments: Vec<Attachment> = vec![];
     let json = serde_json::to_string_pretty(&attachments).unwrap();
     assert_eq!(json, "[]");
 }
 
 #[test]
-fn print_attachments_json_one_attachment() {
+fn write_attachments_json_one_attachment() {
     let attachments = vec![make_attachment(10, "Fix patch")];
     let json = serde_json::to_string_pretty(&attachments).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -52,7 +68,7 @@ fn attachment_text_format_fields() {
 }
 
 #[test]
-fn print_attachments_json_obsolete_and_private() {
+fn write_attachments_json_obsolete_and_private() {
     let mut att = make_attachment(11, "Old patch");
     att.is_obsolete = true;
     att.is_private = true;
@@ -62,44 +78,26 @@ fn print_attachments_json_obsolete_and_private() {
     assert_eq!(parsed["is_private"], true);
 }
 
-// ── capture_stdout-based formatter tests ─────────────────────────
-
-#[cfg(unix)]
-#[tokio::test]
-async fn print_attachments_table_empty_says_no_attachments() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_attachments(&[], OutputFormat::Table);
-    })
-    .await;
+#[test]
+fn write_attachments_table_empty_says_no_attachments() {
+    let output = capture(OutputFormat::Table, &[]);
     assert!(output.contains("No attachments."));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_attachments_json_empty_renders_empty_array() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_attachments(&[], OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
+#[test]
+fn write_attachments_json_empty_renders_empty_array() {
+    let output = capture(OutputFormat::Json, &[]);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert!(parsed.is_array());
     assert_eq!(parsed.as_array().unwrap().len(), 0);
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_attachments_table_renders_all_fields() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_attachments_table_renders_all_fields() {
     let mut att = make_attachment(7, "Helpful patch");
     att.is_obsolete = true;
     att.is_private = true;
-    let attachments = vec![att];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_attachments(&attachments, OutputFormat::Table);
-    })
-    .await;
+    let output = capture(OutputFormat::Table, &[att]);
     assert!(output.contains("Attachment"));
     assert!(output.contains("#7"));
     assert!(output.contains("Helpful patch"));
@@ -114,10 +112,8 @@ async fn print_attachments_table_renders_all_fields() {
     assert!(output.contains("2025-03-01T09:00:00Z"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_attachments_table_missing_optional_fields_render_dash() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_attachments_table_missing_optional_fields_render_dash() {
     let attachments = vec![Attachment {
         id: 8,
         bug_id: 42,
@@ -133,16 +129,9 @@ async fn print_attachments_table_missing_optional_fields_render_dash() {
         is_patch: false,
         data: None,
     }];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_attachments(&attachments, OutputFormat::Table);
-    })
-    .await;
+    let output = capture(OutputFormat::Table, &attachments);
     assert!(output.contains("Unicode summary — é"));
     assert!(output.contains("patché.txt"));
-    // Missing creator/created render as "-" via print_optional_field's
-    // "  {label:<12}  {value}" format. Anchor to the trailing field
-    // value so the assertion fails on rendering bugs, not table-border
-    // changes.
     assert!(
         output.contains("Creator       -"),
         "expected dashed Creator field, got: {output}"
@@ -151,44 +140,30 @@ async fn print_attachments_table_missing_optional_fields_render_dash() {
         output.contains("Created       -"),
         "expected dashed Created field, got: {output}"
     );
-    // Neither flag is set
     assert!(!output.contains("[OBSOLETE]"));
     assert!(!output.contains("[PRIVATE]"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_attachments_table_renders_patch_tag() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_attachments_table_renders_patch_tag() {
     let mut att = make_attachment(12, "Patch attachment");
     att.is_patch = true;
-    let attachments = vec![att];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_attachments(&attachments, OutputFormat::Table);
-    })
-    .await;
+    let output = capture(OutputFormat::Table, &[att]);
     assert!(output.contains("Attachment"));
     assert!(output.contains("#12"));
     assert!(output.contains("Patch attachment"));
     assert!(output.contains("[PATCH]"));
-    // is_patch alone should not enable the other tags.
     assert!(!output.contains("[OBSOLETE]"));
     assert!(!output.contains("[PRIVATE]"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_attachments_table_patch_tag_precedes_obsolete_and_private() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_attachments_table_patch_tag_precedes_obsolete_and_private() {
     let mut att = make_attachment(13, "All flags");
     att.is_patch = true;
     att.is_obsolete = true;
     att.is_private = true;
-    let attachments = vec![att];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_attachments(&attachments, OutputFormat::Table);
-    })
-    .await;
+    let output = capture(OutputFormat::Table, &[att]);
     let patch_idx = output.find("[PATCH]").expect("[PATCH] tag should render");
     let obsolete_idx = output
         .find("[OBSOLETE]")
@@ -200,19 +175,22 @@ async fn print_attachments_table_patch_tag_precedes_obsolete_and_private() {
     assert!(obsolete_idx < private_idx);
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_attachments_json_one_via_print() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let attachments = vec![make_attachment(99, "Json patch")];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_attachments(&attachments, OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
+#[test]
+fn write_attachments_json_one_via_write() {
+    let output = capture(OutputFormat::Json, &[make_attachment(99, "Json patch")]);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(parsed[0]["id"], 99);
     assert_eq!(parsed[0]["summary"], "Json patch");
     assert_eq!(parsed[0]["file_name"], "file_99.patch");
+}
+
+#[test]
+fn write_attachments_does_not_emit_ansi_when_writing_to_buffer() {
+    let output = capture(OutputFormat::Table, &[make_attachment(1, "p")]);
+    assert!(
+        !output.contains('\x1b'),
+        "expected no ANSI escapes when writing to Vec<u8>: {output:?}",
+    );
 }
 
 #[test]
@@ -320,34 +298,24 @@ fn sample_batch_result() -> AttachmentBatchResult {
     }
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_attachment_batch_table_includes_summary() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_attachment_batch_table_includes_summary() {
     let result = sample_batch_result();
-    let ((), out) = crate::test_helpers::capture_stdout(async {
-        print_attachment_batch(&result, OutputFormat::Table);
-    })
-    .await;
+    let (out, _err) = capture_batch(OutputFormat::Table, &result);
     assert!(out.contains("Bug #12345"), "missing bug header: {out}");
     assert!(
         out.contains("./attachments/12345/9876.patch.diff"),
         "missing file path: {out}",
     );
-    assert!(out.contains("2 succeeded"), "missing summary line: {out}",);
+    assert!(out.contains("2 succeeded"), "missing summary line: {out}");
     assert!(out.contains("6144"), "missing total_bytes: {out}");
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_attachment_batch_json_emits_typed_payload() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_attachment_batch_json_emits_typed_payload() {
     let result = sample_batch_result();
-    let ((), out) = crate::test_helpers::capture_stdout(async {
-        print_attachment_batch(&result, OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&out);
+    let (out, _err) = capture_batch(OutputFormat::Json, &result);
+    let parsed: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
     assert_eq!(parsed["summary"]["succeeded"], 2);
     assert_eq!(parsed["bug_results"][0]["files"][0]["attachment_id"], 9876);
 }

--- a/src/output/bug.rs
+++ b/src/output/bug.rs
@@ -1,10 +1,10 @@
-use std::io::{self, Write};
+use std::io::Write;
 
 use colored::Colorize;
 use tabled::{Table, Tabled};
 
 use super::formatting::{
-    colorize_status, print_formatted, shorten_email, truncate, write_divider, write_field,
+    colorize_status, shorten_email, truncate, write_divider, write_field, write_formatted,
     write_list_field, write_optional_field,
 };
 use crate::types::{Bug, HistoryEntry, OutputFormat};
@@ -36,25 +36,25 @@ impl From<&Bug> for BugRow {
     }
 }
 
-pub fn print_bugs(bugs: &[Bug], format: OutputFormat) {
-    print_formatted(bugs, format, |bugs| {
+pub fn write_bugs<W: Write + ?Sized>(bugs: &[Bug], format: OutputFormat, out: &mut W) {
+    write_formatted(bugs, format, out, |bugs, out| {
         if bugs.is_empty() {
-            let _ = writeln!(io::stdout(), "No bugs found.");
+            let _ = writeln!(out, "No bugs found.");
             return;
         }
         let rows: Vec<BugRow> = bugs.iter().map(BugRow::from).collect();
         let table = Table::new(rows).to_string();
-        let _ = writeln!(io::stdout(), "{table}");
+        let _ = writeln!(out, "{table}");
     });
 }
 
-pub fn print_bug_detail(bug: &Bug, format: OutputFormat) {
-    print_formatted(bug, format, |bug| {
-        write_bug_detail(bug, &mut io::stdout());
+pub fn write_bug_detail<W: Write + ?Sized>(bug: &Bug, format: OutputFormat, out: &mut W) {
+    write_formatted(bug, format, out, |bug, out| {
+        write_bug_detail_table(bug, out);
     });
 }
 
-fn write_bug_detail(bug: &Bug, out: &mut impl Write) {
+fn write_bug_detail_table(bug: &Bug, out: &mut (impl Write + ?Sized)) {
     let _ = writeln!(
         out,
         "{} #{}\n{}\n",
@@ -77,7 +77,7 @@ fn write_bug_detail(bug: &Bug, out: &mut impl Write) {
     write_id_list_field(out, "Depends on", &bug.depends_on);
 }
 
-fn write_id_list_field(out: &mut impl Write, label: &str, ids: &[u64]) {
+fn write_id_list_field(out: &mut (impl Write + ?Sized), label: &str, ids: &[u64]) {
     if !ids.is_empty() {
         let id_str = ids
             .iter()
@@ -88,11 +88,15 @@ fn write_id_list_field(out: &mut impl Write, label: &str, ids: &[u64]) {
     }
 }
 
-pub fn print_history(history: &[HistoryEntry], format: OutputFormat) {
-    print_formatted(history, format, |history| {
+pub fn write_history<W: Write + ?Sized>(
+    history: &[HistoryEntry],
+    format: OutputFormat,
+    out: &mut W,
+) {
+    write_formatted(history, format, out, |history, out| {
         for entry in history {
             let _ = writeln!(
-                io::stdout(),
+                out,
                 "{} by {} ({})",
                 "Change".bold(),
                 entry.who.cyan(),
@@ -103,26 +107,22 @@ pub fn print_history(history: &[HistoryEntry], format: OutputFormat) {
                     .attachment_id
                     .map(|id| format!(" [attachment #{id}]"))
                     .unwrap_or_default();
-                let _ = writeln!(
-                    io::stdout(),
-                    "  {}{attachment_suffix}:",
-                    change.field_name.bold()
-                );
+                let _ = writeln!(out, "  {}{attachment_suffix}:", change.field_name.bold());
                 if !change.removed.is_empty() {
-                    let _ = writeln!(io::stdout(), "    - {}", change.removed.red());
+                    let _ = writeln!(out, "    - {}", change.removed.red());
                 }
                 if !change.added.is_empty() {
-                    let _ = writeln!(io::stdout(), "    + {}", change.added.green());
+                    let _ = writeln!(out, "    + {}", change.added.green());
                 }
             }
-            write_divider(&mut io::stdout());
+            write_divider(out);
         }
     });
 }
 
 /// One row in a multi-ID `bzr bug view` output stream.
 ///
-/// Used by [`print_multi_bug_view`] to interleave successful detail
+/// Used by [`write_multi_bug_view`] to interleave successful detail
 /// blocks with `UNAVAILABLE` placeholder blocks for inaccessible bugs.
 #[non_exhaustive]
 #[derive(Debug)]
@@ -134,27 +134,23 @@ pub enum MultiBugRow {
 /// Render a multi-ID `bzr bug view` result.
 ///
 /// JSON mode is **not** handled here — the caller emits a
-/// `MultiBugViewResult` via `output::print_result`. This function only
+/// `MultiBugViewResult` via `output::write_result`. This function only
 /// covers table mode: argument-order detail blocks for `Ok`, visually
 /// distinct `UNAVAILABLE` placeholder blocks for `Failed`, with a
 /// `─`-divider line between every pair of blocks (no trailing divider).
-pub fn print_multi_bug_view(rows: &[MultiBugRow]) {
-    write_multi_bug_view(rows, &mut io::stdout());
-}
-
-fn write_multi_bug_view(rows: &[MultiBugRow], out: &mut impl Write) {
+pub fn write_multi_bug_view<W: Write + ?Sized>(rows: &[MultiBugRow], out: &mut W) {
     for (i, row) in rows.iter().enumerate() {
         if i > 0 {
             write_divider(out);
         }
         match row {
-            MultiBugRow::Ok(bug) => write_bug_detail(bug, out),
+            MultiBugRow::Ok(bug) => write_bug_detail_table(bug, out),
             MultiBugRow::Failed { id, error } => write_unavailable_block(id, error, out),
         }
     }
 }
 
-fn write_unavailable_block(id: &str, error: &str, out: &mut impl Write) {
+fn write_unavailable_block(id: &str, error: &str, out: &mut (impl Write + ?Sized)) {
     let _ = writeln!(
         out,
         "{} #{} — {}",

--- a/src/output/bug_tests.rs
+++ b/src/output/bug_tests.rs
@@ -51,6 +51,24 @@ fn make_history_entry() -> HistoryEntry {
     }
 }
 
+fn capture_bugs(format: OutputFormat, bugs: &[Bug]) -> String {
+    let mut buf = Vec::new();
+    write_bugs(bugs, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
+
+fn capture_bug_detail(format: OutputFormat, bug: &Bug) -> String {
+    let mut buf = Vec::new();
+    write_bug_detail(bug, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
+
+fn capture_history(format: OutputFormat, history: &[HistoryEntry]) -> String {
+    let mut buf = Vec::new();
+    write_history(history, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
+
 // ── BugRow conversion ────────────────────────────────────────────
 
 #[test]
@@ -102,17 +120,17 @@ fn bug_row_from_bug_missing_fields() {
     assert_eq!(row.assignee, "");
 }
 
-// ── print_bugs ───────────────────────────────────────────────────
+// ── write_bugs ───────────────────────────────────────────────────
 
 #[test]
-fn print_bugs_json_empty_list() {
+fn write_bugs_json_empty_list() {
     let bugs: Vec<Bug> = vec![];
     let json = serde_json::to_string_pretty(&bugs).unwrap();
     assert_eq!(json, "[]");
 }
 
 #[test]
-fn print_bugs_json_one_bug() {
+fn write_bugs_json_one_bug() {
     let bugs = vec![make_bug(42, "Login broken", "NEW")];
     let json = serde_json::to_string_pretty(&bugs).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -121,7 +139,7 @@ fn print_bugs_json_one_bug() {
 }
 
 #[test]
-fn print_bugs_table_renders_rows() {
+fn write_bugs_table_renders_rows() {
     let bugs = [make_bug(42, "Login broken", "NEW")];
     let rows: Vec<BugRow> = bugs.iter().map(BugRow::from).collect();
     let table = Table::new(rows).to_string();
@@ -133,10 +151,50 @@ fn print_bugs_table_renders_rows() {
     assert!(table.contains("SUMMARY"));
 }
 
-// ── print_bug_detail ─────────────────────────────────────────────
+#[test]
+fn write_bugs_table_empty_says_no_bugs_found() {
+    let output = capture_bugs(OutputFormat::Table, &[]);
+    assert!(output.contains("No bugs found."));
+}
 
 #[test]
-fn print_bug_detail_json_contains_all_fields() {
+fn write_bugs_json_empty_renders_empty_array() {
+    let output = capture_bugs(OutputFormat::Json, &[]);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+    assert!(parsed.is_array());
+    assert_eq!(parsed.as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn write_bugs_table_renders_columns_and_truncates() {
+    let bugs = vec![make_bug(42, "Login broken", "NEW")];
+    let output = capture_bugs(OutputFormat::Table, &bugs);
+    assert!(output.contains("ID"));
+    assert!(output.contains("STATUS"));
+    assert!(output.contains("PRIORITY"));
+    assert!(output.contains("ASSIGNEE"));
+    assert!(output.contains("SUMMARY"));
+    assert!(output.contains("42"));
+    assert!(output.contains("NEW"));
+    assert!(output.contains("P1"));
+    assert!(output.contains("dev"));
+    assert!(output.contains("Login broken"));
+}
+
+#[test]
+fn write_bugs_json_via_write() {
+    let bugs = vec![make_bug(99, "Crash on startup", "ASSIGNED")];
+    let output = capture_bugs(OutputFormat::Json, &bugs);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+    assert_eq!(parsed[0]["id"], 99);
+    assert_eq!(parsed[0]["summary"], "Crash on startup");
+    assert_eq!(parsed[0]["status"], "ASSIGNED");
+}
+
+// ── write_bug_detail ─────────────────────────────────────────────
+
+#[test]
+fn write_bug_detail_json_contains_all_fields() {
     let bug = make_bug(42, "Detail test", "ASSIGNED");
     let json = serde_json::to_string_pretty(&bug).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -155,7 +213,7 @@ fn print_bug_detail_json_contains_all_fields() {
 }
 
 #[test]
-fn print_bug_detail_json_with_resolution() {
+fn write_bug_detail_json_with_resolution() {
     let mut bug = make_bug(42, "Fixed bug", "RESOLVED");
     bug.resolution = Some("FIXED".into());
     let json = serde_json::to_string_pretty(&bug).unwrap();
@@ -163,124 +221,11 @@ fn print_bug_detail_json_with_resolution() {
     assert_eq!(parsed["resolution"], "FIXED");
 }
 
-// ── print_json helper ────────────────────────────────────────────
-
 #[test]
-fn print_json_produces_valid_json_for_bug() {
-    let bug = make_bug(1, "Test bug", "NEW");
-    let json = serde_json::to_string_pretty(&bug).unwrap();
-    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
-    assert_eq!(parsed["id"], 1);
-    assert_eq!(parsed["summary"], "Test bug");
-    assert_eq!(parsed["status"], "NEW");
-}
-
-#[test]
-fn print_json_produces_valid_json_for_vec() {
-    let bugs = vec![make_bug(1, "A", "NEW"), make_bug(2, "B", "RESOLVED")];
-    let json = serde_json::to_string_pretty(&bugs).unwrap();
-    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
-    assert!(parsed.is_array());
-    assert_eq!(parsed.as_array().unwrap().len(), 2);
-}
-
-// ── print_history ────────────────────────────────────────────────
-
-#[test]
-fn print_history_json_one_entry() {
-    let history = vec![make_history_entry()];
-    let json = serde_json::to_string_pretty(&history).unwrap();
-    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
-    assert_eq!(parsed[0]["who"], "editor@example.com");
-    assert_eq!(parsed[0]["when"], "2025-04-01T12:00:00Z");
-    let changes = parsed[0]["changes"].as_array().unwrap();
-    assert_eq!(changes.len(), 2);
-    assert_eq!(changes[0]["field_name"], "status");
-    assert_eq!(changes[0]["removed"], "NEW");
-    assert_eq!(changes[0]["added"], "ASSIGNED");
-    assert_eq!(changes[1]["attachment_id"], 99);
-}
-
-#[test]
-fn print_history_json_empty() {
-    let history: Vec<HistoryEntry> = vec![];
-    let json = serde_json::to_string_pretty(&history).unwrap();
-    assert_eq!(json, "[]");
-}
-
-// ── capture_stdout-based formatter tests ─────────────────────────
-
-#[cfg(unix)]
-#[tokio::test]
-async fn print_bugs_table_empty_says_no_bugs_found() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_bugs(&[], OutputFormat::Table);
-    })
-    .await;
-    assert!(output.contains("No bugs found."));
-}
-
-#[cfg(unix)]
-#[tokio::test]
-async fn print_bugs_json_empty_renders_empty_array() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_bugs(&[], OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
-    assert!(parsed.is_array());
-    assert_eq!(parsed.as_array().unwrap().len(), 0);
-}
-
-#[cfg(unix)]
-#[tokio::test]
-async fn print_bugs_table_renders_columns_and_truncates() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let bugs = vec![make_bug(42, "Login broken", "NEW")];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_bugs(&bugs, OutputFormat::Table);
-    })
-    .await;
-    assert!(output.contains("ID"));
-    assert!(output.contains("STATUS"));
-    assert!(output.contains("PRIORITY"));
-    assert!(output.contains("ASSIGNEE"));
-    assert!(output.contains("SUMMARY"));
-    assert!(output.contains("42"));
-    assert!(output.contains("NEW"));
-    assert!(output.contains("P1"));
-    // Email is shortened to local part
-    assert!(output.contains("dev"));
-    assert!(output.contains("Login broken"));
-}
-
-#[cfg(unix)]
-#[tokio::test]
-async fn print_bugs_json_via_print() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let bugs = vec![make_bug(99, "Crash on startup", "ASSIGNED")];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_bugs(&bugs, OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
-    assert_eq!(parsed[0]["id"], 99);
-    assert_eq!(parsed[0]["summary"], "Crash on startup");
-    assert_eq!(parsed[0]["status"], "ASSIGNED");
-}
-
-#[cfg(unix)]
-#[tokio::test]
-async fn print_bug_detail_table_renders_all_fields() {
-    let _lock = crate::ENV_LOCK.lock().await;
+fn write_bug_detail_table_renders_all_fields() {
     let mut bug = make_bug(42, "Detail test", "ASSIGNED");
     bug.resolution = Some("FIXED".into());
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_bug_detail(&bug, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_bug_detail(OutputFormat::Table, &bug);
     assert!(output.contains("Bug"));
     assert!(output.contains("#42"));
     assert!(output.contains("Detail test"));
@@ -307,10 +252,8 @@ async fn print_bug_detail_table_renders_all_fields() {
     assert!(output.contains("100"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_bug_detail_table_handles_minimal_bug() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_bug_detail_table_handles_minimal_bug() {
     let bug = Bug {
         id: 1,
         summary: "Unicode summary — déjà vu".into(),
@@ -334,79 +277,96 @@ async fn print_bug_detail_table_handles_minimal_bug() {
         op_sys: None,
         rep_platform: None,
     };
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_bug_detail(&bug, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_bug_detail(OutputFormat::Table, &bug);
     assert!(output.contains("Unicode summary — déjà vu"));
-    // Optional fields render as "-"
     assert!(output.contains('-'));
-    // No Keywords/Blocks/Depends on lines when empty
     assert!(!output.contains("Keywords"));
     assert!(!output.contains("Blocks"));
     assert!(!output.contains("Depends on"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_bug_detail_json_via_print() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_bug_detail_json_via_write() {
     let bug = make_bug(7, "Json bug", "NEW");
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_bug_detail(&bug, OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
+    let output = capture_bug_detail(OutputFormat::Json, &bug);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(parsed["id"], 7);
     assert_eq!(parsed["summary"], "Json bug");
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_history_table_renders_changes() {
-    let _lock = crate::ENV_LOCK.lock().await;
+// ── write_json (pretty) ──────────────────────────────────────────
+
+#[test]
+fn write_json_produces_valid_json_for_bug() {
+    let bug = make_bug(1, "Test bug", "NEW");
+    let json = serde_json::to_string_pretty(&bug).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["id"], 1);
+    assert_eq!(parsed["summary"], "Test bug");
+    assert_eq!(parsed["status"], "NEW");
+}
+
+#[test]
+fn write_json_produces_valid_json_for_vec() {
+    let bugs = vec![make_bug(1, "A", "NEW"), make_bug(2, "B", "RESOLVED")];
+    let json = serde_json::to_string_pretty(&bugs).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(parsed.is_array());
+    assert_eq!(parsed.as_array().unwrap().len(), 2);
+}
+
+// ── write_history ────────────────────────────────────────────────
+
+#[test]
+fn write_history_json_one_entry() {
     let history = vec![make_history_entry()];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_history(&history, OutputFormat::Table);
-    })
-    .await;
+    let json = serde_json::to_string_pretty(&history).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed[0]["who"], "editor@example.com");
+    assert_eq!(parsed[0]["when"], "2025-04-01T12:00:00Z");
+    let changes = parsed[0]["changes"].as_array().unwrap();
+    assert_eq!(changes.len(), 2);
+    assert_eq!(changes[0]["field_name"], "status");
+    assert_eq!(changes[0]["removed"], "NEW");
+    assert_eq!(changes[0]["added"], "ASSIGNED");
+    assert_eq!(changes[1]["attachment_id"], 99);
+}
+
+#[test]
+fn write_history_json_empty() {
+    let history: Vec<HistoryEntry> = vec![];
+    let json = serde_json::to_string_pretty(&history).unwrap();
+    assert_eq!(json, "[]");
+}
+
+#[test]
+fn write_history_table_renders_changes() {
+    let history = vec![make_history_entry()];
+    let output = capture_history(OutputFormat::Table, &history);
     assert!(output.contains("Change"));
     assert!(output.contains("editor@example.com"));
     assert!(output.contains("2025-04-01T12:00:00Z"));
     assert!(output.contains("status"));
     assert!(output.contains("NEW"));
     assert!(output.contains("ASSIGNED"));
-    // Attachment-scoped change
     assert!(output.contains("flagtypes.name"));
     assert!(output.contains("[attachment #99]"));
     assert!(output.contains("review?"));
-    // Separator
     assert!(output.contains('─'));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_history_table_empty_renders_nothing() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_history(&[], OutputFormat::Table);
-    })
-    .await;
-    // No "Change", separator, or other history content
+#[test]
+fn write_history_table_empty_renders_nothing() {
+    let output = capture_history(OutputFormat::Table, &[]);
     assert!(!output.contains("Change"));
     assert!(!output.contains('─'));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_history_json_via_print() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_history_json_via_write() {
     let history = vec![make_history_entry()];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_history(&history, OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
+    let output = capture_history(OutputFormat::Json, &history);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(parsed[0]["who"], "editor@example.com");
 }
 
@@ -456,7 +416,6 @@ fn multi_bug_view_renders_success_blocks_with_dividers() {
     assert!(out.contains("Bug #1"));
     assert!(out.contains("Bug #2"));
     assert!(out.contains("Bug #3"));
-    // Three rows ⇒ exactly two dividers between them, no trailing divider.
     let divider = "─".repeat(60);
     assert_eq!(out.matches(&divider).count(), 2);
 }
@@ -471,8 +430,6 @@ fn multi_bug_view_renders_failure_block_with_unavailable_marker() {
     let mut buf = Vec::new();
     write_multi_bug_view(&rows, &mut buf);
     let out = String::from_utf8(buf).unwrap();
-    // The colored crate writes ANSI escapes around terms when a TTY is
-    // detected; tests compare on the plain substrings.
     assert!(out.contains("Bug #999"));
     assert!(out.contains("UNAVAILABLE"));
     assert!(out.contains("Error: bug not found: 999"));

--- a/src/output/classification.rs
+++ b/src/output/classification.rs
@@ -1,28 +1,27 @@
-use std::io::{self, Write as _};
+use std::io::Write;
 
 use colored::Colorize;
 
-use super::formatting::{print_formatted, truncate};
+use super::formatting::{truncate, write_formatted};
 use crate::types::{Classification, OutputFormat};
 
-pub fn print_classification(classification: &Classification, format: OutputFormat) {
-    print_formatted(classification, format, |classification| {
+pub fn write_classification<W: Write + ?Sized>(
+    classification: &Classification,
+    format: OutputFormat,
+    out: &mut W,
+) {
+    write_formatted(classification, format, out, |classification, out| {
         let _ = writeln!(
-            io::stdout(),
+            out,
             "{} {}\n{}\n",
             "Classification".bold(),
             classification.name.bold(),
             classification.description,
         );
         if !classification.products.is_empty() {
-            let _ = writeln!(io::stdout(), "{}:", "Products".bold());
+            let _ = writeln!(out, "{}:", "Products".bold());
             for p in &classification.products {
-                let _ = writeln!(
-                    io::stdout(),
-                    "  {} - {}",
-                    p.name,
-                    truncate(&p.description, 60)
-                );
+                let _ = writeln!(out, "  {} - {}", p.name, truncate(&p.description, 60));
             }
         }
     });

--- a/src/output/classification_tests.rs
+++ b/src/output/classification_tests.rs
@@ -1,9 +1,16 @@
 #![expect(clippy::unwrap_used)]
 
-use crate::types::{Classification, ClassificationProduct};
+use super::write_classification;
+use crate::types::{Classification, ClassificationProduct, OutputFormat};
+
+fn capture(format: OutputFormat, c: &Classification) -> String {
+    let mut buf = Vec::new();
+    write_classification(c, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
 
 #[test]
-fn print_classification_json() {
+fn write_classification_json() {
     let classification = Classification {
         id: 1,
         name: "Software".into(),
@@ -49,7 +56,7 @@ fn classification_text_format_fields() {
 }
 
 #[test]
-fn print_classification_json_empty_products() {
+fn write_classification_json_empty_products() {
     let classification = Classification {
         id: 2,
         name: "Empty".into(),
@@ -62,10 +69,8 @@ fn print_classification_json_empty_products() {
     assert_eq!(parsed["products"].as_array().unwrap().len(), 0);
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_classification_table_omits_products_header_when_empty() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_classification_table_omits_products_header_when_empty() {
     let with_products = Classification {
         id: 1,
         name: "Software".into(),
@@ -85,14 +90,8 @@ async fn print_classification_table_omits_products_header_when_empty() {
         products: vec![],
     };
 
-    let ((), populated) = crate::test_helpers::capture_stdout(async {
-        super::print_classification(&with_products, crate::types::OutputFormat::Table);
-    })
-    .await;
-    let ((), bare) = crate::test_helpers::capture_stdout(async {
-        super::print_classification(&empty, crate::types::OutputFormat::Table);
-    })
-    .await;
+    let populated = capture(OutputFormat::Table, &with_products);
+    let bare = capture(OutputFormat::Table, &empty);
 
     assert!(populated.contains("Products"));
     assert!(populated.contains("Widget"));

--- a/src/output/comment.rs
+++ b/src/output/comment.rs
@@ -1,19 +1,19 @@
-use std::io::{self, Write as _};
+use std::io::Write;
 
 use colored::Colorize;
 
-use super::formatting::print_formatted;
+use super::formatting::write_formatted;
 use crate::types::{Comment, OutputFormat};
 
-pub fn print_comments(comments: &[Comment], format: OutputFormat) {
-    print_formatted(comments, format, |comments| {
+pub fn write_comments<W: Write + ?Sized>(comments: &[Comment], format: OutputFormat, out: &mut W) {
+    write_formatted(comments, format, out, |comments, out| {
         if comments.is_empty() {
-            let _ = writeln!(io::stdout(), "No comments.");
+            let _ = writeln!(out, "No comments.");
             return;
         }
         for c in comments {
             let _ = writeln!(
-                io::stdout(),
+                out,
                 "{} #{} by {} ({})",
                 "Comment".bold(),
                 c.count,
@@ -21,14 +21,14 @@ pub fn print_comments(comments: &[Comment], format: OutputFormat) {
                 c.creation_time.as_deref().unwrap_or(""),
             );
             if c.is_private {
-                let _ = writeln!(io::stdout(), "  {}", "[PRIVATE]".red());
+                let _ = writeln!(out, "  {}", "[PRIVATE]".red());
             }
-            let _ = writeln!(io::stdout());
+            let _ = writeln!(out);
             for line in c.text.lines() {
-                let _ = writeln!(io::stdout(), "  {line}");
+                let _ = writeln!(out, "  {line}");
             }
-            let _ = writeln!(io::stdout());
-            let _ = writeln!(io::stdout(), "{}", "─".repeat(60));
+            let _ = writeln!(out);
+            let _ = writeln!(out, "{}", "─".repeat(60));
         }
     });
 }

--- a/src/output/comment_tests.rs
+++ b/src/output/comment_tests.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::unwrap_used)]
 
-use super::print_comments;
+use super::write_comments;
 use crate::types::{Comment, OutputFormat};
 
 fn make_comment(count: u64, text: &str) -> Comment {
@@ -16,15 +16,21 @@ fn make_comment(count: u64, text: &str) -> Comment {
     }
 }
 
+fn capture(format: OutputFormat, comments: &[Comment]) -> String {
+    let mut buf = Vec::new();
+    write_comments(comments, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
+
 #[test]
-fn print_comments_json_empty() {
+fn write_comments_json_empty() {
     let comments: Vec<Comment> = vec![];
     let json = serde_json::to_string_pretty(&comments).unwrap();
     assert_eq!(json, "[]");
 }
 
 #[test]
-fn print_comments_json_one_comment() {
+fn write_comments_json_one_comment() {
     let comments = vec![make_comment(0, "First comment text")];
     let json = serde_json::to_string_pretty(&comments).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -34,7 +40,7 @@ fn print_comments_json_one_comment() {
 }
 
 #[test]
-fn print_comments_json_private_flag() {
+fn write_comments_json_private_flag() {
     let mut comment = make_comment(1, "secret");
     comment.is_private = true;
     let json = serde_json::to_string(&comment).unwrap();
@@ -42,43 +48,25 @@ fn print_comments_json_private_flag() {
     assert_eq!(parsed["is_private"], true);
 }
 
-// ── capture_stdout-based formatter tests ─────────────────────────
-
-#[cfg(unix)]
-#[tokio::test]
-async fn print_comments_table_empty_says_no_comments() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_comments(&[], OutputFormat::Table);
-    })
-    .await;
+#[test]
+fn write_comments_table_empty_says_no_comments() {
+    let output = capture(OutputFormat::Table, &[]);
     assert!(output.contains("No comments."));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_comments_json_empty_renders_empty_array() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_comments(&[], OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
+#[test]
+fn write_comments_json_empty_renders_empty_array() {
+    let output = capture(OutputFormat::Json, &[]);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert!(parsed.is_array());
     assert_eq!(parsed.as_array().unwrap().len(), 0);
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_comments_table_renders_comment_fields() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_comments_table_renders_comment_fields() {
     let mut c = make_comment(2, "Line one\nLine two");
     c.is_private = true;
-    let comments = vec![c];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_comments(&comments, OutputFormat::Table);
-    })
-    .await;
+    let output = capture(OutputFormat::Table, &[c]);
     assert!(output.contains("Comment"));
     assert!(output.contains("#2"));
     assert!(output.contains("commenter@example.com"));
@@ -86,14 +74,11 @@ async fn print_comments_table_renders_comment_fields() {
     assert!(output.contains("[PRIVATE]"));
     assert!(output.contains("Line one"));
     assert!(output.contains("Line two"));
-    // Separator row
     assert!(output.contains('─'));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_comments_table_handles_missing_creator_and_unicode() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_comments_table_handles_missing_creator_and_unicode() {
     let comments = vec![Comment {
         id: 1,
         bug_id: 42,
@@ -104,28 +89,29 @@ async fn print_comments_table_handles_missing_creator_and_unicode() {
         is_private: false,
         attachment_id: None,
     }];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_comments(&comments, OutputFormat::Table);
-    })
-    .await;
-    // Falls back to "unknown" for missing creator and "" for missing time
+    let output = capture(OutputFormat::Table, &comments);
     assert!(output.contains("unknown"));
     assert!(output.contains("héllo, wörld"));
-    // Private flag absent — verify [PRIVATE] is NOT present
     assert!(!output.contains("[PRIVATE]"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_comments_json_one_comment_via_print() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_comments_json_one_comment_via_write() {
     let comments = vec![make_comment(7, "json body")];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_comments(&comments, OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
+    let output = capture(OutputFormat::Json, &comments);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(parsed[0]["count"], 7);
     assert_eq!(parsed[0]["text"], "json body");
     assert_eq!(parsed[0]["bug_id"], 42);
+}
+
+#[test]
+fn write_comments_table_does_not_emit_ansi_when_writing_to_buffer() {
+    // colored disables ANSI for non-TTY writers; Vec<u8> is not a TTY.
+    let comments = vec![make_comment(3, "body")];
+    let output = capture(OutputFormat::Table, &comments);
+    assert!(
+        !output.contains('\x1b'),
+        "expected no ANSI escapes when writing to Vec<u8>: {output:?}",
+    );
 }

--- a/src/output/config.rs
+++ b/src/output/config.rs
@@ -1,8 +1,8 @@
-use std::io::{self, Write};
+use std::io::Write;
 
 use serde::Serialize;
 
-use super::formatting::{mask_api_key, print_field, print_formatted, print_optional_field};
+use super::formatting::{mask_api_key, write_field, write_formatted, write_optional_field};
 use crate::config::{CredentialSource, CredentialSourceKind};
 use crate::types::{AuthMethod, OutputFormat};
 
@@ -91,46 +91,45 @@ impl ConfigView {
     }
 }
 
-fn print_api_key(s: &ServerDisplayInfo) {
+fn write_api_key(out: &mut (impl Write + ?Sized), s: &ServerDisplayInfo) {
     let label = match s.api_key_source.as_str() {
         "env" => "API Key Env",
         "keyring" => "Keyring",
         _ => "API Key",
     };
-    print_field(label, &s.api_key);
+    write_field(out, label, &s.api_key);
 }
 
-fn print_server(name: &str, s: &ServerDisplayInfo) {
-    writeln!(io::stdout(), "\n[{name}]").expect("write to output");
-    print_field("URL", &s.url);
-    print_optional_field("Email", s.email.as_deref());
-    print_api_key(s);
-    print_field("API Key Source", &s.api_key_source);
-    print_field("Auth", &auth_display(s.auth_method.as_ref()));
+fn write_server(out: &mut (impl Write + ?Sized), name: &str, s: &ServerDisplayInfo) {
+    let _ = writeln!(out, "\n[{name}]");
+    write_field(out, "URL", &s.url);
+    write_optional_field(out, "Email", s.email.as_deref());
+    write_api_key(out, s);
+    write_field(out, "API Key Source", &s.api_key_source);
+    write_field(out, "Auth", &auth_display(s.auth_method.as_ref()));
     if s.tls_insecure {
-        print_field("TLS", "insecure (certificate verification disabled)");
+        write_field(out, "TLS", "insecure (certificate verification disabled)");
     }
     if let Some(ca) = &s.tls_ca_cert {
-        print_field("TLS CA Cert", ca);
+        write_field(out, "TLS CA Cert", ca);
     }
     if let Some(pin) = &s.tls_pin {
-        print_field("TLS Pin", pin);
+        write_field(out, "TLS Pin", pin);
     }
 }
 
-pub fn print_config(view: &ConfigView, format: OutputFormat) {
-    print_formatted(view, format, |v| {
-        let mut out = io::stdout();
-        writeln!(out, "Config file: {}\n", v.config_file).expect("write to output");
+pub fn write_config<W: Write + ?Sized>(view: &ConfigView, format: OutputFormat, out: &mut W) {
+    write_formatted(view, format, out, |v, out| {
+        let _ = writeln!(out, "Config file: {}\n", v.config_file);
         if let Some(ref def) = v.default_server {
-            writeln!(out, "Default server: {def}").expect("write to output");
+            let _ = writeln!(out, "Default server: {def}");
         }
         if v.servers.is_empty() {
-            writeln!(out, "No servers configured.").expect("write to output");
+            let _ = writeln!(out, "No servers configured.");
             return;
         }
         for (name, s) in &v.servers {
-            print_server(name, s);
+            write_server(out, name, s);
         }
     });
 }

--- a/src/output/config_tests.rs
+++ b/src/output/config_tests.rs
@@ -190,19 +190,16 @@ fn make_display_info(
     }
 }
 
-async fn capture_print_config(view: &ConfigView) -> String {
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_config(view, OutputFormat::Table);
-    })
-    .await;
-    output
+fn capture_write_config(view: &ConfigView) -> String {
+    let mut buf = Vec::new();
+    write_config(view, OutputFormat::Table, &mut buf);
+    String::from_utf8(buf).unwrap()
 }
 
-#[tokio::test]
-async fn print_config_renders_table_for_inline_server() {
-    // Exercises print_config / print_server / print_api_key with the
+#[test]
+fn write_config_renders_table_for_inline_server() {
+    // Exercises write_config / write_server / write_api_key with the
     // inline credential branch.
-    let _lock = crate::ENV_LOCK.lock().await;
     let mut info = make_display_info("https://bugzilla.example", "12345678...", "inline", true);
     info.email = Some("admin@example.com".into());
     info.auth_method = Some(AuthMethod::Header);
@@ -213,7 +210,7 @@ async fn print_config_renders_table_for_inline_server() {
         default_server: Some("prod".into()),
         servers,
     };
-    let output = capture_print_config(&view).await;
+    let output = capture_write_config(&view);
     for needle in [
         "Config file: /tmp/bzr/config.toml",
         "Default server: prod",
@@ -228,10 +225,9 @@ async fn print_config_renders_table_for_inline_server() {
     }
 }
 
-#[tokio::test]
-async fn print_config_renders_env_and_keyring_labels() {
-    // Exercises both non-inline branches of print_api_key in one run.
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_config_renders_env_and_keyring_labels() {
+    // Exercises both non-inline branches of write_api_key in one run.
     let mut servers = std::collections::BTreeMap::new();
     servers.insert(
         "env-srv".into(),
@@ -246,21 +242,20 @@ async fn print_config_renders_env_and_keyring_labels() {
         default_server: None,
         servers,
     };
-    let output = capture_print_config(&view).await;
+    let output = capture_write_config(&view);
     for needle in ["API Key Env", "BZR_API_KEY", "Keyring", "bzr/kr-srv"] {
         assert!(output.contains(needle), "missing {needle:?} in output");
     }
 }
 
-#[tokio::test]
-async fn print_config_renders_empty_servers_message() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_config_renders_empty_servers_message() {
     let view = ConfigView {
         config_file: "/tmp/bzr/config.toml".into(),
         default_server: None,
         servers: std::collections::BTreeMap::new(),
     };
-    let output = capture_print_config(&view).await;
+    let output = capture_write_config(&view);
     assert!(output.contains("No servers configured."));
 }
 

--- a/src/output/field.rs
+++ b/src/output/field.rs
@@ -1,9 +1,9 @@
-use std::io::{self, Write as _};
+use std::io::Write;
 
 use serde::Serialize;
 use tabled::{Table, Tabled};
 
-use super::formatting::{print_formatted, yes_no};
+use super::formatting::{write_formatted, yes_no};
 use crate::types::{FieldValue, OutputFormat};
 
 #[derive(Tabled)]
@@ -16,8 +16,12 @@ struct FieldValueRow {
     can_change_to: String,
 }
 
-pub fn print_field_values(values: &[FieldValue], format: OutputFormat) {
-    print_formatted(values, format, |values| {
+pub fn write_field_values<W: Write + ?Sized>(
+    values: &[FieldValue],
+    format: OutputFormat,
+    out: &mut W,
+) {
+    write_formatted(values, format, out, |values, out| {
         let rows: Vec<FieldValueRow> = values
             .iter()
             .map(|v| {
@@ -38,7 +42,7 @@ pub fn print_field_values(values: &[FieldValue], format: OutputFormat) {
                 }
             })
             .collect();
-        let _ = writeln!(io::stdout(), "{}", Table::new(rows));
+        let _ = writeln!(out, "{}", Table::new(rows));
     });
 }
 
@@ -50,13 +54,17 @@ struct FieldAliasRow {
     api_name: &'static str,
 }
 
-pub fn print_field_aliases(aliases: &[(&'static str, &'static str)], format: OutputFormat) {
+pub fn write_field_aliases<W: Write + ?Sized>(
+    aliases: &[(&'static str, &'static str)],
+    format: OutputFormat,
+    out: &mut W,
+) {
     let rows: Vec<FieldAliasRow> = aliases
         .iter()
         .map(|&(alias, api_name)| FieldAliasRow { alias, api_name })
         .collect();
-    print_formatted(&rows, format, |rows| {
-        let _ = writeln!(io::stdout(), "{}", Table::new(rows));
+    write_formatted(&rows, format, out, |rows, out| {
+        let _ = writeln!(out, "{}", Table::new(rows));
     });
 }
 

--- a/src/output/field_tests.rs
+++ b/src/output/field_tests.rs
@@ -1,17 +1,29 @@
 #![expect(clippy::unwrap_used)]
 
-use super::{print_field_aliases, print_field_values};
+use super::{write_field_aliases, write_field_values};
 use crate::types::{FieldValue, OutputFormat, StatusTransition};
 
+fn capture_values(format: OutputFormat, values: &[FieldValue]) -> String {
+    let mut buf = Vec::new();
+    write_field_values(values, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
+
+fn capture_aliases(format: OutputFormat, aliases: &[(&'static str, &'static str)]) -> String {
+    let mut buf = Vec::new();
+    write_field_aliases(aliases, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
+
 #[test]
-fn print_field_values_json_empty() {
+fn write_field_values_json_empty() {
     let values: Vec<FieldValue> = vec![];
     let json = serde_json::to_string_pretty(&values).unwrap();
     assert_eq!(json, "[]");
 }
 
 #[test]
-fn print_field_values_json_with_transitions() {
+fn write_field_values_json_with_transitions() {
     let values = vec![FieldValue {
         name: "NEW".into(),
         sort_key: 0,
@@ -35,7 +47,7 @@ fn print_field_values_json_with_transitions() {
 }
 
 #[test]
-fn print_field_values_json_active_and_inactive() {
+fn write_field_values_json_active_and_inactive() {
     let values = vec![
         FieldValue {
             name: "NEW".into(),
@@ -62,7 +74,7 @@ fn print_field_values_json_active_and_inactive() {
 }
 
 #[test]
-fn print_field_aliases_json_serialization() {
+fn write_field_aliases_json_serialization() {
     let aliases: &[(&str, &str)] = &[("status", "bug_status"), ("severity", "bug_severity")];
     let rows: Vec<super::FieldAliasRow> = aliases
         .iter()
@@ -78,38 +90,24 @@ fn print_field_aliases_json_serialization() {
     assert_eq!(arr[1]["api_name"], "bug_severity");
 }
 
-// ── capture_stdout-based formatter tests ─────────────────────────
-
-#[cfg(unix)]
-#[tokio::test]
-async fn print_field_values_table_empty_renders_only_headers() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_field_values(&[], OutputFormat::Table);
-    })
-    .await;
+#[test]
+fn write_field_values_table_empty_renders_only_headers() {
+    let output = capture_values(OutputFormat::Table, &[]);
     assert!(output.contains("NAME"));
     assert!(output.contains("ACTIVE"));
     assert!(output.contains("CAN CHANGE TO"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_field_values_json_empty_renders_empty_array() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_field_values(&[], OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
+#[test]
+fn write_field_values_json_empty_renders_empty_array() {
+    let output = capture_values(OutputFormat::Json, &[]);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert!(parsed.is_array());
     assert_eq!(parsed.as_array().unwrap().len(), 0);
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_field_values_table_renders_transitions_and_inactive() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_field_values_table_renders_transitions_and_inactive() {
     let values = vec![
         FieldValue {
             name: "NEW".into(),
@@ -131,10 +129,7 @@ async fn print_field_values_table_renders_transitions_and_inactive() {
             can_change_to: None,
         },
     ];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_field_values(&values, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_values(OutputFormat::Table, &values);
     assert!(output.contains("NEW"));
     assert!(output.contains("CLOSED"));
     assert!(output.contains("Yes"));
@@ -142,10 +137,8 @@ async fn print_field_values_table_renders_transitions_and_inactive() {
     assert!(output.contains("ASSIGNED, RESOLVED"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_field_values_table_handles_unicode_value_name() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_field_values_table_handles_unicode_value_name() {
     let values = vec![FieldValue {
         name: "résolu".into(),
         sort_key: 0,
@@ -154,18 +147,13 @@ async fn print_field_values_table_handles_unicode_value_name() {
             name: "fermé".into(),
         }]),
     }];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_field_values(&values, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_values(OutputFormat::Table, &values);
     assert!(output.contains("résolu"));
     assert!(output.contains("fermé"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_field_values_json_via_print() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_field_values_json_via_write() {
     let values = vec![FieldValue {
         name: "NEW".into(),
         sort_key: 0,
@@ -174,24 +162,17 @@ async fn print_field_values_json_via_print() {
             name: "ASSIGNED".into(),
         }]),
     }];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_field_values(&values, OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
+    let output = capture_values(OutputFormat::Json, &values);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(parsed[0]["name"], "NEW");
     assert_eq!(parsed[0]["is_active"], true);
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_field_aliases_table_renders_rows() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let aliases: &[(&str, &str)] = &[("status", "bug_status"), ("severity", "bug_severity")];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_field_aliases(aliases, OutputFormat::Table);
-    })
-    .await;
+#[test]
+fn write_field_aliases_table_renders_rows() {
+    let aliases: &[(&'static str, &'static str)] =
+        &[("status", "bug_status"), ("severity", "bug_severity")];
+    let output = capture_aliases(OutputFormat::Table, aliases);
     assert!(output.contains("ALIAS"));
     assert!(output.contains("API FIELD NAME"));
     assert!(output.contains("status"));
@@ -200,16 +181,11 @@ async fn print_field_aliases_table_renders_rows() {
     assert!(output.contains("bug_severity"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_field_aliases_json_via_print() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let aliases: &[(&str, &str)] = &[("status", "bug_status")];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_field_aliases(aliases, OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
+#[test]
+fn write_field_aliases_json_via_write() {
+    let aliases: &[(&'static str, &'static str)] = &[("status", "bug_status")];
+    let output = capture_aliases(OutputFormat::Json, aliases);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(parsed[0]["alias"], "status");
     assert_eq!(parsed[0]["api_name"], "bug_status");
 }

--- a/src/output/formatting.rs
+++ b/src/output/formatting.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Write};
+use std::io::Write;
 
 use colored::Colorize;
 use serde::Serialize;
@@ -7,23 +7,26 @@ use crate::types::OutputFormat;
 
 // ── Formatting primitives ───────────────────────────────────────────
 
-pub(super) fn print_json(value: &(impl Serialize + ?Sized)) {
-    writeln!(
-        io::stdout(),
+pub(super) fn write_json<W: Write + ?Sized>(value: &(impl Serialize + ?Sized), out: &mut W) {
+    let _ = writeln!(
+        out,
         "{}",
         serde_json::to_string_pretty(value).expect("serializable to JSON")
-    )
-    .expect("write to output");
+    );
 }
 
-pub(super) fn print_formatted<T: Serialize + ?Sized>(
+pub(super) fn write_formatted<T, W>(
     value: &T,
     format: OutputFormat,
-    table_fn: impl FnOnce(&T),
-) {
+    out: &mut W,
+    table_fn: impl FnOnce(&T, &mut W),
+) where
+    T: Serialize + ?Sized,
+    W: Write + ?Sized,
+{
     match format {
-        OutputFormat::Json => print_json(value),
-        OutputFormat::Table => table_fn(value),
+        OutputFormat::Json => write_json(value, out),
+        OutputFormat::Table => table_fn(value, out),
     }
 }
 
@@ -31,34 +34,26 @@ pub(super) fn print_formatted<T: Serialize + ?Sized>(
 // Shared formatting for bug/resource detail views. All use consistent
 // 12-char label alignment and render absent values as "-".
 
-pub(super) fn write_field(out: &mut impl Write, label: &str, value: &str) {
+pub(super) fn write_field<W: Write + ?Sized>(out: &mut W, label: &str, value: &str) {
     let _ = writeln!(out, "  {label:<12}  {value}");
 }
 
-pub(super) fn write_optional_field(out: &mut impl Write, label: &str, value: Option<&str>) {
+pub(super) fn write_optional_field<W: Write + ?Sized>(
+    out: &mut W,
+    label: &str,
+    value: Option<&str>,
+) {
     let _ = writeln!(out, "  {label:<12}  {}", value.unwrap_or("-"));
 }
 
-pub(super) fn write_list_field(out: &mut impl Write, label: &str, items: &[String]) {
+pub(super) fn write_list_field<W: Write + ?Sized>(out: &mut W, label: &str, items: &[String]) {
     if !items.is_empty() {
         let _ = writeln!(out, "  {label:<12}  {}", items.join(", "));
     }
 }
 
-pub(super) fn print_field(label: &str, value: &str) {
-    write_field(&mut io::stdout(), label, value);
-}
-
-pub(super) fn print_optional_field(label: &str, value: Option<&str>) {
-    write_optional_field(&mut io::stdout(), label, value);
-}
-
-pub(super) fn print_list_field(label: &str, items: &[String]) {
-    write_list_field(&mut io::stdout(), label, items);
-}
-
-pub(super) fn print_bool_field(label: &str, value: bool) {
-    writeln!(io::stdout(), "  {label:<12}  {}", yes_no(value)).expect("write to output");
+pub(super) fn write_bool_field<W: Write + ?Sized>(out: &mut W, label: &str, value: bool) {
+    let _ = writeln!(out, "  {label:<12}  {}", yes_no(value));
 }
 
 // ── Section divider ─────────────────────────────────────────────────
@@ -70,7 +65,7 @@ pub(super) fn print_bool_field(label: &str, value: bool) {
 pub(super) const DIVIDER_WIDTH: usize = 60;
 
 /// Write a horizontal section divider followed by a newline.
-pub(crate) fn write_divider(out: &mut impl Write) {
+pub(crate) fn write_divider<W: Write + ?Sized>(out: &mut W) {
     let _ = writeln!(out, "{}", "─".repeat(DIVIDER_WIDTH));
 }
 

--- a/src/output/group.rs
+++ b/src/output/group.rs
@@ -1,21 +1,21 @@
-use std::io::{self, Write as _};
+use std::io::Write;
 
 use colored::Colorize;
 
-use super::formatting::{print_bool_field, print_field, print_formatted};
+use super::formatting::{write_bool_field, write_field, write_formatted};
 use crate::types::{GroupInfo, OutputFormat};
 
-pub fn print_group_info(group: &GroupInfo, format: OutputFormat) {
-    print_formatted(group, format, |group| {
-        let _ = writeln!(io::stdout(), "{} {}", "Group".bold(), group.name.bold());
-        print_field("Description", &group.description);
-        print_bool_field("Active", group.is_active);
-        print_field("ID", &group.id.to_string());
+pub fn write_group_info<W: Write + ?Sized>(group: &GroupInfo, format: OutputFormat, out: &mut W) {
+    write_formatted(group, format, out, |group, out| {
+        let _ = writeln!(out, "{} {}", "Group".bold(), group.name.bold());
+        write_field(out, "Description", &group.description);
+        write_bool_field(out, "Active", group.is_active);
+        write_field(out, "ID", &group.id.to_string());
         if !group.membership.is_empty() {
-            let _ = writeln!(io::stdout(), "\n{}:", "Members".bold());
+            let _ = writeln!(out, "\n{}:", "Members".bold());
             for m in &group.membership {
                 let real = m.real_name.as_deref().unwrap_or("");
-                let _ = writeln!(io::stdout(), "  {} ({real})", m.name);
+                let _ = writeln!(out, "  {} ({real})", m.name);
             }
         }
     });

--- a/src/output/group_tests.rs
+++ b/src/output/group_tests.rs
@@ -1,7 +1,13 @@
 #![expect(clippy::unwrap_used)]
 
-use super::print_group_info;
+use super::write_group_info;
 use crate::types::{GroupInfo, GroupMember, OutputFormat};
+
+fn capture(format: OutputFormat, group: &GroupInfo) -> String {
+    let mut buf = Vec::new();
+    write_group_info(group, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
 
 fn make_group_info() -> GroupInfo {
     GroupInfo {
@@ -62,17 +68,10 @@ fn print_group_info_json_no_members() {
     assert!(parsed["membership"].as_array().unwrap().is_empty());
 }
 
-// ── capture_stdout-based formatter tests ─────────────────────────
-
-#[cfg(unix)]
-#[tokio::test]
-async fn print_group_info_table_renders_all_fields() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_group_info_table_renders_all_fields() {
     let group = make_group_info();
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_group_info(&group, OutputFormat::Table);
-    })
-    .await;
+    let output = capture(OutputFormat::Table, &group);
     assert!(output.contains("Group"));
     assert!(output.contains("core-team"));
     assert!(output.contains("Description"));
@@ -86,10 +85,8 @@ async fn print_group_info_table_renders_all_fields() {
     assert!(output.contains("Alice Smith"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_group_info_table_no_members_omits_section() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_group_info_table_no_members_omits_section() {
     let group = GroupInfo {
         id: 6,
         name: "empty-group".into(),
@@ -97,20 +94,14 @@ async fn print_group_info_table_no_members_omits_section() {
         is_active: false,
         membership: vec![],
     };
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_group_info(&group, OutputFormat::Table);
-    })
-    .await;
+    let output = capture(OutputFormat::Table, &group);
     assert!(output.contains("empty-group"));
     assert!(output.contains("No"));
-    // No members section should be absent
     assert!(!output.contains("Members"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_group_info_table_member_with_no_real_name_renders_empty_parens() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_group_info_table_member_with_no_real_name_renders_empty_parens() {
     let group = GroupInfo {
         id: 7,
         name: "ünicode-group".into(),
@@ -123,26 +114,18 @@ async fn print_group_info_table_member_with_no_real_name_renders_empty_parens() 
             email: None,
         }],
     };
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_group_info(&group, OutputFormat::Table);
-    })
-    .await;
+    let output = capture(OutputFormat::Table, &group);
     assert!(output.contains("ünicode-group"));
     assert!(output.contains("déscription"));
     assert!(output.contains("héllo"));
     assert!(output.contains("()"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_group_info_json_via_print() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_group_info_json_via_write() {
     let group = make_group_info();
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_group_info(&group, OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
+    let output = capture(OutputFormat::Json, &group);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(parsed["id"], 5);
     assert_eq!(parsed["name"], "core-team");
     assert_eq!(parsed["membership"][0]["name"], "alice");

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,6 +1,6 @@
 //! Output formatting facade — command modules import from `output::*` so they
 //! don't couple to which submodule owns each formatter. This keeps internal
-//! reorganization (e.g. moving `print_classification` to its own file) invisible
+//! reorganization (e.g. moving `write_classification` to its own file) invisible
 //! to callers.
 
 mod attachment;
@@ -22,37 +22,26 @@ mod writers;
 // Re-export shared types and helpers used by commands.
 pub(crate) use formatting::write_divider;
 pub use result_types::{
-    print_result, ActionResult, BatchFailure, BatchResult, BugViewFailure, ConfigResult,
+    write_result, ActionResult, BatchFailure, BatchResult, BugViewFailure, ConfigResult,
     DownloadResult, MembershipResult, MultiBugViewResult, ResourceKind, SearchResult, TagResult,
     UploadResult,
 };
-#[cfg_attr(
-    not(any(test, feature = "test-helpers")),
-    expect(
-        unused_imports,
-        reason = "scaffolding for #192 phase 2 — re-export becomes load-bearing when commands::*::execute() gains a Writers parameter"
-    )
-)]
 pub use writers::Writers;
 
 // Re-export all public items from submodules.
 pub use attachment::{
-    print_attachment_batch, print_attachments, AttachmentBatchResult, AttachmentDownloadResult,
+    write_attachment_batch, write_attachments, AttachmentBatchResult, AttachmentDownloadResult,
     BatchSummary, BugDownloadResult, DownloadedFile, TargetStatus,
 };
-pub use bug::{print_bug_detail, print_bugs, print_history, print_multi_bug_view, MultiBugRow};
-pub use classification::print_classification;
-pub use comment::print_comments;
-#[expect(
-    unused_imports,
-    reason = "re-exported for API completeness — used as ConfigView field type"
-)]
+pub use bug::{write_bug_detail, write_bugs, write_history, write_multi_bug_view, MultiBugRow};
+pub use classification::write_classification;
+pub use comment::write_comments;
 pub use config::ServerDisplayInfo;
-pub use config::{print_config, ConfigView};
-pub use field::{print_field_aliases, print_field_values};
-pub use group::print_group_info;
-pub use product::{print_product_detail, print_products};
-pub use query::{print_query_detail, print_query_list, print_query_saved};
-pub use server::print_server_info;
-pub use template::{print_template_detail, print_template_list, print_template_saved};
-pub use user::{print_users, print_users_detailed, print_whoami};
+pub use config::{write_config, ConfigView};
+pub use field::{write_field_aliases, write_field_values};
+pub use group::write_group_info;
+pub use product::{write_product_detail, write_products};
+pub use query::{write_query_detail, write_query_list, write_query_saved};
+pub use server::write_server_info;
+pub use template::{write_template_detail, write_template_list, write_template_saved};
+pub use user::{write_users, write_users_detailed, write_whoami};

--- a/src/output/product.rs
+++ b/src/output/product.rs
@@ -1,8 +1,9 @@
 use std::fmt::Write as _;
+use std::io::Write;
 
 use tabled::{Table, Tabled};
 
-use super::formatting::{print_formatted, truncate};
+use super::formatting::{truncate, write_formatted};
 use crate::types::{OutputFormat, Product};
 
 fn format_named_list(heading: &str, items: &[(impl AsRef<str>, bool)]) -> String {
@@ -56,11 +57,10 @@ struct ProductRow {
     components: usize,
 }
 
-#[expect(clippy::print_stdout)]
-pub fn print_products(products: &[Product], format: OutputFormat) {
-    print_formatted(products, format, |products| {
+pub fn write_products<W: Write + ?Sized>(products: &[Product], format: OutputFormat, out: &mut W) {
+    write_formatted(products, format, out, |products, out| {
         if products.is_empty() {
-            println!("No products found.");
+            let _ = writeln!(out, "No products found.");
             return;
         }
         let rows: Vec<ProductRow> = products
@@ -75,14 +75,17 @@ pub fn print_products(products: &[Product], format: OutputFormat) {
                 }
             })
             .collect();
-        println!("{}", Table::new(rows));
+        let _ = writeln!(out, "{}", Table::new(rows));
     });
 }
 
-#[expect(clippy::print_stdout)]
-pub fn print_product_detail(product: &Product, format: OutputFormat) {
-    print_formatted(product, format, |product| {
-        print!("{}", format_product_detail(product));
+pub fn write_product_detail<W: Write + ?Sized>(
+    product: &Product,
+    format: OutputFormat,
+    out: &mut W,
+) {
+    write_formatted(product, format, out, |product, out| {
+        let _ = write!(out, "{}", format_product_detail(product));
     });
 }
 

--- a/src/output/product_tests.rs
+++ b/src/output/product_tests.rs
@@ -32,17 +32,17 @@ fn make_product(id: u64, name: &str) -> Product {
     }
 }
 
-// ── print_products ───────────────────────────────────────────────
+// ── write_products ───────────────────────────────────────────────
 
 #[test]
-fn print_products_json_empty() {
+fn write_products_json_empty() {
     let products: Vec<Product> = vec![];
     let json = serde_json::to_string_pretty(&products).unwrap();
     assert_eq!(json, "[]");
 }
 
 #[test]
-fn print_products_json_one_product() {
+fn write_products_json_one_product() {
     let products = vec![make_product(1, "Widget")];
     let json = serde_json::to_string_pretty(&products).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -66,10 +66,10 @@ fn product_row_conversion() {
     assert!(table.contains('1')); // 1 component
 }
 
-// ── print_product_detail ─────────────────────────────────────────
+// ── write_product_detail ─────────────────────────────────────────
 
 #[test]
-fn print_product_detail_json() {
+fn write_product_detail_json() {
     let product = make_product(3, "Acme");
     let json = serde_json::to_string_pretty(&product).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();

--- a/src/output/query.rs
+++ b/src/output/query.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
-use std::io::{self, Write as _};
+use std::io::Write;
 
 use crate::types::{OutputFormat, QueryKind, SavedQuery};
 
 use super::formatting::{
-    print_field, print_formatted, print_json, print_list_field, print_optional_field,
+    write_field, write_formatted, write_json, write_list_field, write_optional_field,
 };
 
 fn kind_label(kind: &QueryKind) -> &'static str {
@@ -45,32 +45,49 @@ fn query_summary_line(name: &str, q: &SavedQuery) -> String {
     format!("{name} ({})", parts.join(", "))
 }
 
-pub fn print_query_saved(name: &str, verb: &str, format: OutputFormat) {
+pub fn write_query_saved<W: Write + ?Sized>(
+    name: &str,
+    verb: &str,
+    format: OutputFormat,
+    out: &mut W,
+) {
     match format {
         OutputFormat::Json => {
-            print_json(&serde_json::json!({"name": name, "action": verb.to_lowercase()}));
+            write_json(
+                &serde_json::json!({"name": name, "action": verb.to_lowercase()}),
+                out,
+            );
         }
         OutputFormat::Table => {
-            let _ = writeln!(io::stdout(), "{}", query_saved_message(name, verb));
+            let _ = writeln!(out, "{}", query_saved_message(name, verb));
         }
     }
 }
 
-pub fn print_query_list(queries: &HashMap<String, SavedQuery>, format: OutputFormat) {
-    print_formatted(queries, format, |queries| {
+pub fn write_query_list<W: Write + ?Sized, S: ::std::hash::BuildHasher>(
+    queries: &HashMap<String, SavedQuery, S>,
+    format: OutputFormat,
+    out: &mut W,
+) {
+    write_formatted(queries, format, out, |queries, out| {
         if queries.is_empty() {
-            let _ = writeln!(io::stdout(), "No saved queries configured.");
+            let _ = writeln!(out, "No saved queries configured.");
             return;
         }
         let mut names: Vec<&str> = queries.keys().map(String::as_str).collect();
         names.sort_unstable();
         for name in names {
-            let _ = writeln!(io::stdout(), "{}", query_summary_line(name, &queries[name]));
+            let _ = writeln!(out, "{}", query_summary_line(name, &queries[name]));
         }
     });
 }
 
-pub fn print_query_detail(name: &str, query: &SavedQuery, format: OutputFormat) {
+pub fn write_query_detail<W: Write + ?Sized>(
+    name: &str,
+    query: &SavedQuery,
+    format: OutputFormat,
+    out: &mut W,
+) {
     #[derive(serde::Serialize)]
     struct QueryView<'a> {
         name: &'a str,
@@ -79,36 +96,36 @@ pub fn print_query_detail(name: &str, query: &SavedQuery, format: OutputFormat) 
     }
 
     let view = QueryView { name, query };
-    print_formatted(&view, format, |view| {
-        print_field("Name", view.name);
-        print_field("Kind", kind_label(&view.query.kind));
-        print_optional_field("Source URL", view.query.source_url.as_deref());
-        print_optional_field("Server", view.query.server.as_deref());
-        print_list_field("Product", &view.query.product);
-        print_list_field("Component", &view.query.component);
-        print_list_field("Status", &view.query.status);
-        print_list_field("Assignee", &view.query.assignee);
-        print_list_field("Creator", &view.query.creator);
-        print_list_field("Priority", &view.query.priority);
-        print_list_field("Severity", &view.query.severity);
-        print_optional_field("Search", view.query.quicksearch.as_deref());
+    write_formatted(&view, format, out, |view, out| {
+        write_field(out, "Name", view.name);
+        write_field(out, "Kind", kind_label(&view.query.kind));
+        write_optional_field(out, "Source URL", view.query.source_url.as_deref());
+        write_optional_field(out, "Server", view.query.server.as_deref());
+        write_list_field(out, "Product", &view.query.product);
+        write_list_field(out, "Component", &view.query.component);
+        write_list_field(out, "Status", &view.query.status);
+        write_list_field(out, "Assignee", &view.query.assignee);
+        write_list_field(out, "Creator", &view.query.creator);
+        write_list_field(out, "Priority", &view.query.priority);
+        write_list_field(out, "Severity", &view.query.severity);
+        write_optional_field(out, "Search", view.query.quicksearch.as_deref());
         if let Some(limit) = view.query.limit {
-            print_field("Limit", &limit.to_string());
+            write_field(out, "Limit", &limit.to_string());
         }
-        print_optional_field("Fields", view.query.fields.as_deref());
-        print_optional_field("Exclude", view.query.exclude_fields.as_deref());
-        print_optional_field("Created since", view.query.creation_time.as_deref());
-        print_optional_field("Changed since", view.query.last_change_time.as_deref());
-        print_list_field("Whiteboard", &view.query.whiteboard);
-        print_list_field("Target Milestone", &view.query.target_milestone);
-        print_list_field("Version", &view.query.version);
-        print_list_field("OS", &view.query.op_sys);
-        print_list_field("Platform", &view.query.platform);
-        print_list_field("Resolution", &view.query.resolution);
-        print_list_field("QA Contact", &view.query.qa_contact);
-        print_list_field("URL", &view.query.url);
+        write_optional_field(out, "Fields", view.query.fields.as_deref());
+        write_optional_field(out, "Exclude", view.query.exclude_fields.as_deref());
+        write_optional_field(out, "Created since", view.query.creation_time.as_deref());
+        write_optional_field(out, "Changed since", view.query.last_change_time.as_deref());
+        write_list_field(out, "Whiteboard", &view.query.whiteboard);
+        write_list_field(out, "Target Milestone", &view.query.target_milestone);
+        write_list_field(out, "Version", &view.query.version);
+        write_list_field(out, "OS", &view.query.op_sys);
+        write_list_field(out, "Platform", &view.query.platform);
+        write_list_field(out, "Resolution", &view.query.resolution);
+        write_list_field(out, "QA Contact", &view.query.qa_contact);
+        write_list_field(out, "URL", &view.query.url);
         if !view.query.raw_params.is_empty() {
-            print_field("Raw params", &view.query.raw_params.len().to_string());
+            write_field(out, "Raw params", &view.query.raw_params.len().to_string());
         }
     });
 }

--- a/src/output/query_tests.rs
+++ b/src/output/query_tests.rs
@@ -5,7 +5,13 @@ use std::collections::HashMap;
 use super::*;
 use crate::types::{OutputFormat, QueryKind, SavedQuery};
 
-/// Shared test helper — mirrors the `QueryView` in `print_query_detail` for JSON assertions.
+fn capture_detail(name: &str, query: &SavedQuery, format: OutputFormat) -> String {
+    let mut buf = Vec::new();
+    write_query_detail(name, query, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
+
+/// Shared test helper — mirrors the `QueryView` in `write_query_detail` for JSON assertions.
 #[derive(serde::Serialize)]
 struct QueryView<'a> {
     name: &'a str,
@@ -111,20 +117,15 @@ fn query_summary_line_renders_search_query() {
     assert!(line.contains("limit=10"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_query_detail_table_renders_fields() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_query_detail_table_renders_fields() {
     let mut query = make_list_query();
     query.component = vec!["General".into()];
     query.assignee = vec!["dev@example.com".into()];
     query.fields = Some("id,summary".into());
     query.exclude_fields = Some("comments".into());
 
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_query_detail("firefox-new", &query, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_detail("firefox-new", &query, OutputFormat::Table);
 
     assert!(output.contains("Name"));
     assert!(output.contains("firefox-new"));
@@ -166,16 +167,10 @@ fn query_summary_line_renders_url_query() {
     assert!(line.contains("2 raw params"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_query_detail_table_renders_url_fields() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_query_detail_table_renders_url_fields() {
     let query = make_url_query();
-
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_query_detail("url-q", &query, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_detail("url-q", &query, OutputFormat::Table);
 
     assert!(output.contains("Source URL"));
     assert!(output.contains("bugzilla.example.com"));
@@ -185,18 +180,13 @@ async fn print_query_detail_table_renders_url_fields() {
     assert!(output.contains('2'));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_query_detail_table_shows_date_filters() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_query_detail_table_shows_date_filters() {
     let mut query = make_list_query();
     query.creation_time = Some("2026-04-01T00:00:00Z".into());
     query.last_change_time = Some("2026-04-15T00:00:00Z".into());
 
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_query_detail("recent", &query, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_detail("recent", &query, OutputFormat::Table);
 
     assert!(output.contains("Created since"), "missing label: {output}");
     assert!(
@@ -239,10 +229,8 @@ fn query_summary_line_renders_date_filters() {
     );
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn query_list_names_sort_before_render() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn query_list_names_sort_before_render() {
     let mut queries: HashMap<String, SavedQuery> = HashMap::new();
     queries.insert("zzz".into(), make_list_query());
     queries.insert("aaa".into(), make_search_query());
@@ -263,10 +251,8 @@ async fn query_list_names_sort_before_render() {
     );
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_query_detail_table_shows_158_field_filters() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_query_detail_table_shows_158_field_filters() {
     let mut query = make_list_query();
     query.whiteboard = vec!["needs-review".into()];
     query.target_milestone = vec!["5.0".into()];
@@ -277,10 +263,7 @@ async fn print_query_detail_table_shows_158_field_filters() {
     query.qa_contact = vec!["qa@example.com".into()];
     query.url = vec!["github.com/foo".into()];
 
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_query_detail("complete", &query, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_detail("complete", &query, OutputFormat::Table);
 
     assert!(output.contains("Whiteboard"), "missing label: {output}");
     assert!(output.contains("needs-review"));

--- a/src/output/result_types.rs
+++ b/src/output/result_types.rs
@@ -1,14 +1,23 @@
+use std::io::Write;
+
 use serde::Serialize;
 
-use super::formatting::print_json;
+use super::formatting::write_json;
 use crate::types::OutputFormat;
 
 // ── Result output ───────────────────────────────────────────────────
 
-pub fn print_result(value: &(impl Serialize + ?Sized), human_message: &str, format: OutputFormat) {
+pub fn write_result<W: Write + ?Sized>(
+    value: &(impl Serialize + ?Sized),
+    human_message: &str,
+    format: OutputFormat,
+    out: &mut W,
+) {
     match format {
-        OutputFormat::Json => print_json(value),
-        OutputFormat::Table => println!("{human_message}"),
+        OutputFormat::Json => write_json(value, out),
+        OutputFormat::Table => {
+            let _ = writeln!(out, "{human_message}");
+        }
     }
 }
 

--- a/src/output/result_types_tests.rs
+++ b/src/output/result_types_tests.rs
@@ -162,10 +162,23 @@ fn action_result_updated_named_without_id_skips_id() {
 }
 
 #[test]
-fn print_result_uses_pretty_json() {
+fn write_result_uses_pretty_json() {
     let result = ActionResult::created(1, ResourceKind::Bug);
-    let json = serde_json::to_string_pretty(&result).unwrap();
-    assert!(json.contains('\n'), "expected pretty-printed JSON");
+    let mut buf = Vec::new();
+    write_result(&result, "human", OutputFormat::Json, &mut buf);
+    let s = String::from_utf8(buf).unwrap();
+    assert!(s.contains('\n'), "expected pretty-printed JSON");
+    assert!(s.contains("\"id\": 1"));
+    assert!(s.contains("\"resource\": \"bug\""));
+}
+
+#[test]
+fn write_result_table_emits_human_message() {
+    let result = ActionResult::created(1, ResourceKind::Bug);
+    let mut buf = Vec::new();
+    write_result(&result, "Created bug #1", OutputFormat::Table, &mut buf);
+    let s = String::from_utf8(buf).unwrap();
+    assert_eq!(s, "Created bug #1\n");
 }
 
 #[test]

--- a/src/output/server.rs
+++ b/src/output/server.rs
@@ -1,7 +1,9 @@
+use std::io::Write;
+
 use colored::Colorize;
 use serde::Serialize;
 
-use super::formatting::print_formatted;
+use super::formatting::write_formatted;
 use crate::types::{OutputFormat, ServerInfoResponse};
 
 /// Combined server information for display.
@@ -21,18 +23,21 @@ impl<'a> From<&'a ServerInfoResponse> for ServerInfo<'a> {
     }
 }
 
-#[expect(clippy::print_stdout)]
-pub fn print_server_info(response: &ServerInfoResponse, format: OutputFormat) {
+pub fn write_server_info<W: Write + ?Sized>(
+    response: &ServerInfoResponse,
+    format: OutputFormat,
+    out: &mut W,
+) {
     let info = ServerInfo::from(response);
-    print_formatted(&info, format, |info| {
-        println!("{} {}", "Bugzilla version:".bold(), info.version);
+    write_formatted(&info, format, out, |info, out| {
+        let _ = writeln!(out, "{} {}", "Bugzilla version:".bold(), info.version);
         if info.extensions.is_empty() {
-            println!("\nNo extensions installed.");
+            let _ = writeln!(out, "\nNo extensions installed.");
         } else {
-            println!("\n{}:", "Extensions".bold());
+            let _ = writeln!(out, "\n{}:", "Extensions".bold());
             for (name, ext) in info.extensions {
                 let ver = ext.version.as_deref().unwrap_or("unknown");
-                println!("  {name} ({ver})");
+                let _ = writeln!(out, "  {name} ({ver})");
             }
         }
     });

--- a/src/output/template.rs
+++ b/src/output/template.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
-use std::io::{self, Write as _};
+use std::io::Write;
 
 use crate::types::{BugTemplate, OutputFormat};
 
-use super::formatting::{print_field, print_formatted, print_json, print_optional_field};
+use super::formatting::{write_field, write_formatted, write_json, write_optional_field};
 
 fn template_saved_message(name: &str, verb: &str) -> String {
     format!("{verb} template '{name}'")
@@ -30,36 +30,49 @@ fn template_summary_line(name: &str, tmpl: &BugTemplate) -> String {
     }
 }
 
-pub fn print_template_saved(name: &str, verb: &str, format: OutputFormat) {
+pub fn write_template_saved<W: Write + ?Sized>(
+    name: &str,
+    verb: &str,
+    format: OutputFormat,
+    out: &mut W,
+) {
     match format {
         OutputFormat::Json => {
-            print_json(&serde_json::json!({"name": name, "action": verb.to_lowercase()}));
+            write_json(
+                &serde_json::json!({"name": name, "action": verb.to_lowercase()}),
+                out,
+            );
         }
         OutputFormat::Table => {
-            let _ = writeln!(io::stdout(), "{}", template_saved_message(name, verb));
+            let _ = writeln!(out, "{}", template_saved_message(name, verb));
         }
     }
 }
 
-pub fn print_template_list(templates: &HashMap<String, BugTemplate>, format: OutputFormat) {
-    print_formatted(templates, format, |templates| {
+pub fn write_template_list<W: Write + ?Sized, S: ::std::hash::BuildHasher>(
+    templates: &HashMap<String, BugTemplate, S>,
+    format: OutputFormat,
+    out: &mut W,
+) {
+    write_formatted(templates, format, out, |templates, out| {
         if templates.is_empty() {
-            let _ = writeln!(io::stdout(), "No templates configured.");
+            let _ = writeln!(out, "No templates configured.");
             return;
         }
         let mut names: Vec<&str> = templates.keys().map(String::as_str).collect();
         names.sort_unstable();
         for name in names {
-            let _ = writeln!(
-                io::stdout(),
-                "{}",
-                template_summary_line(name, &templates[name])
-            );
+            let _ = writeln!(out, "{}", template_summary_line(name, &templates[name]));
         }
     });
 }
 
-pub fn print_template_detail(name: &str, template: &BugTemplate, format: OutputFormat) {
+pub fn write_template_detail<W: Write + ?Sized>(
+    name: &str,
+    template: &BugTemplate,
+    format: OutputFormat,
+    out: &mut W,
+) {
     #[derive(serde::Serialize)]
     struct TemplateView<'a> {
         name: &'a str,
@@ -68,17 +81,17 @@ pub fn print_template_detail(name: &str, template: &BugTemplate, format: OutputF
     }
 
     let view = TemplateView { name, template };
-    print_formatted(&view, format, |view| {
-        print_field("Name", view.name);
-        print_optional_field("Product", view.template.product.as_deref());
-        print_optional_field("Component", view.template.component.as_deref());
-        print_optional_field("Version", view.template.version.as_deref());
-        print_optional_field("Priority", view.template.priority.as_deref());
-        print_optional_field("Severity", view.template.severity.as_deref());
-        print_optional_field("Assignee", view.template.assignee.as_deref());
-        print_optional_field("OS", view.template.op_sys.as_deref());
-        print_optional_field("Platform", view.template.rep_platform.as_deref());
-        print_optional_field("Description", view.template.description.as_deref());
+    write_formatted(&view, format, out, |view, out| {
+        write_field(out, "Name", view.name);
+        write_optional_field(out, "Product", view.template.product.as_deref());
+        write_optional_field(out, "Component", view.template.component.as_deref());
+        write_optional_field(out, "Version", view.template.version.as_deref());
+        write_optional_field(out, "Priority", view.template.priority.as_deref());
+        write_optional_field(out, "Severity", view.template.severity.as_deref());
+        write_optional_field(out, "Assignee", view.template.assignee.as_deref());
+        write_optional_field(out, "OS", view.template.op_sys.as_deref());
+        write_optional_field(out, "Platform", view.template.rep_platform.as_deref());
+        write_optional_field(out, "Description", view.template.description.as_deref());
     });
 }
 

--- a/src/output/template_tests.rs
+++ b/src/output/template_tests.rs
@@ -114,10 +114,20 @@ fn template_summary_line_without_fields_is_name_only() {
     assert_eq!(line, "zzz");
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_template_detail_table_renders_missing_fields_as_dash() {
-    let _lock = crate::ENV_LOCK.lock().await;
+fn capture_detail(name: &str, template: &BugTemplate, format: OutputFormat) -> String {
+    let mut buf = Vec::new();
+    write_template_detail(name, template, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
+
+fn capture_list(templates: &HashMap<String, BugTemplate>, format: OutputFormat) -> String {
+    let mut buf = Vec::new();
+    write_template_list(templates, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
+
+#[test]
+fn write_template_detail_table_renders_missing_fields_as_dash() {
     let template = BugTemplate {
         product: Some("Widget".into()),
         component: None,
@@ -130,10 +140,7 @@ async fn print_template_detail_table_renders_missing_fields_as_dash() {
         description: Some("Default description".into()),
     };
 
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_template_detail("default", &template, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_detail("default", &template, OutputFormat::Table);
 
     assert!(output.contains("Name"));
     assert!(output.contains("default"));
@@ -145,10 +152,8 @@ async fn print_template_detail_table_renders_missing_fields_as_dash() {
     assert!(output.contains("Default description"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_template_list_table_renders_sorted_summaries() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_template_list_table_renders_sorted_summaries() {
     let mut templates: HashMap<String, BugTemplate> = HashMap::new();
     templates.insert("zzz".into(), make_template());
     templates.insert(
@@ -166,10 +171,7 @@ async fn print_template_list_table_renders_sorted_summaries() {
         },
     );
 
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_template_list(&templates, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_list(&templates, OutputFormat::Table);
 
     let aaa_pos = output.find("aaa").expect("aaa should appear in output");
     let zzz_pos = output.find("zzz").expect("zzz should appear in output");
@@ -178,14 +180,9 @@ async fn print_template_list_table_renders_sorted_summaries() {
     assert!(output.contains("product=Widget"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_template_list_table_announces_empty() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_template_list_table_announces_empty() {
     let templates: HashMap<String, BugTemplate> = HashMap::new();
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_template_list(&templates, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_list(&templates, OutputFormat::Table);
     assert!(output.contains("No templates configured."));
 }

--- a/src/output/user.rs
+++ b/src/output/user.rs
@@ -1,9 +1,9 @@
-use std::io::{self, Write as _};
+use std::io::Write;
 
 use colored::Colorize;
 use tabled::{Table, Tabled};
 
-use super::formatting::{opt_yes_no, print_field, print_formatted, print_optional_field};
+use super::formatting::{opt_yes_no, write_field, write_formatted, write_optional_field};
 use crate::types::{BugzillaUser, OutputFormat, WhoamiResponse};
 
 #[derive(Tabled)]
@@ -62,34 +62,38 @@ fn detailed_row(user: &BugzillaUser) -> DetailedUserRow {
     }
 }
 
-pub fn print_users(users: &[BugzillaUser], format: OutputFormat) {
-    print_formatted(users, format, |users| {
+pub fn write_users<W: Write + ?Sized>(users: &[BugzillaUser], format: OutputFormat, out: &mut W) {
+    write_formatted(users, format, out, |users, out| {
         if users.is_empty() {
-            let _ = writeln!(io::stdout(), "No users found.");
+            let _ = writeln!(out, "No users found.");
             return;
         }
         let rows: Vec<UserRow> = users.iter().map(basic_row).collect();
-        let _ = writeln!(io::stdout(), "{}", Table::new(rows));
+        let _ = writeln!(out, "{}", Table::new(rows));
     });
 }
 
-pub fn print_users_detailed(users: &[BugzillaUser], format: OutputFormat) {
-    print_formatted(users, format, |users| {
+pub fn write_users_detailed<W: Write + ?Sized>(
+    users: &[BugzillaUser],
+    format: OutputFormat,
+    out: &mut W,
+) {
+    write_formatted(users, format, out, |users, out| {
         if users.is_empty() {
-            let _ = writeln!(io::stdout(), "No users found.");
+            let _ = writeln!(out, "No users found.");
             return;
         }
         let rows: Vec<DetailedUserRow> = users.iter().map(detailed_row).collect();
-        let _ = writeln!(io::stdout(), "{}", Table::new(rows));
+        let _ = writeln!(out, "{}", Table::new(rows));
     });
 }
 
-pub fn print_whoami(whoami: &WhoamiResponse, format: OutputFormat) {
-    print_formatted(whoami, format, |whoami| {
-        let _ = writeln!(io::stdout(), "{} {}", "User".bold(), whoami.name.bold());
-        print_optional_field("Name", whoami.real_name.as_deref());
-        print_optional_field("Login", whoami.login.as_deref());
-        print_field("ID", &whoami.id.to_string());
+pub fn write_whoami<W: Write + ?Sized>(whoami: &WhoamiResponse, format: OutputFormat, out: &mut W) {
+    write_formatted(whoami, format, out, |whoami, out| {
+        let _ = writeln!(out, "{} {}", "User".bold(), whoami.name.bold());
+        write_optional_field(out, "Name", whoami.real_name.as_deref());
+        write_optional_field(out, "Login", whoami.login.as_deref());
+        write_field(out, "ID", &whoami.id.to_string());
     });
 }
 

--- a/src/output/user_tests.rs
+++ b/src/output/user_tests.rs
@@ -129,41 +129,42 @@ fn print_users_json_includes_all_fields() {
     assert_eq!(parsed[0]["groups"][0]["name"], "admin");
 }
 
-// ── capture_stdout-based formatter tests ─────────────────────────
+fn capture_users(format: OutputFormat, users: &[BugzillaUser]) -> String {
+    let mut buf = Vec::new();
+    write_users(users, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_users_table_empty_says_none_found() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_users(&[], OutputFormat::Table);
-    })
-    .await;
+fn capture_users_detailed(format: OutputFormat, users: &[BugzillaUser]) -> String {
+    let mut buf = Vec::new();
+    write_users_detailed(users, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
+
+fn capture_whoami(format: OutputFormat, whoami: &WhoamiResponse) -> String {
+    let mut buf = Vec::new();
+    write_whoami(whoami, format, &mut buf);
+    String::from_utf8(buf).unwrap()
+}
+
+#[test]
+fn write_users_table_empty_says_none_found() {
+    let output = capture_users(OutputFormat::Table, &[]);
     assert!(output.contains("No users found."));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_users_json_empty_renders_empty_array() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_users(&[], OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
+#[test]
+fn write_users_json_empty_renders_empty_array() {
+    let output = capture_users(OutputFormat::Json, &[]);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert!(parsed.is_array());
     assert_eq!(parsed.as_array().unwrap().len(), 0);
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_users_table_renders_basic_columns() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_users_table_renders_basic_columns() {
     let users = vec![make_user(1, "alice", Some(true), vec!["admin"])];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_users(&users, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_users(OutputFormat::Table, &users);
     assert!(output.contains("ID"));
     assert!(output.contains("NAME"));
     assert!(output.contains("REAL NAME"));
@@ -171,48 +172,34 @@ async fn print_users_table_renders_basic_columns() {
     assert!(output.contains("alice"));
     assert!(output.contains("alice Real"));
     assert!(output.contains("alice@example.com"));
-    // Basic table excludes detail columns
     assert!(!output.contains("CAN LOGIN"));
     assert!(!output.contains("GROUPS"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_users_detailed_table_empty_says_none_found() {
-    let _lock = crate::ENV_LOCK.lock().await;
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_users_detailed(&[], OutputFormat::Table);
-    })
-    .await;
+#[test]
+fn write_users_detailed_table_empty_says_none_found() {
+    let output = capture_users_detailed(OutputFormat::Table, &[]);
     assert!(output.contains("No users found."));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_users_detailed_table_renders_groups_and_login() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_users_detailed_table_renders_groups_and_login() {
     let users = vec![
         make_user(1, "alice", Some(true), vec!["admin", "dev"]),
         make_user(2, "bob", Some(false), vec![]),
         make_user(3, "carol", None, vec!["testers"]),
     ];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_users_detailed(&users, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_users_detailed(OutputFormat::Table, &users);
     assert!(output.contains("CAN LOGIN"));
     assert!(output.contains("GROUPS"));
     assert!(output.contains("Yes"));
     assert!(output.contains("No"));
     assert!(output.contains("admin, dev"));
-    // None can_login renders as "-"
     assert!(output.contains('-'));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_users_detailed_handles_missing_real_name_and_email() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_users_detailed_handles_missing_real_name_and_email() {
     let users = vec![BugzillaUser {
         id: 99,
         name: "minimal".into(),
@@ -221,21 +208,11 @@ async fn print_users_detailed_handles_missing_real_name_and_email() {
         groups: vec![],
         can_login: None,
     }];
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_users_detailed(&users, OutputFormat::Table);
-    })
-    .await;
-    // Locate the data row that contains the user's name. Both
-    // can_login (None → "-") and groups (empty → "-") render as a
-    // dash in that row, anchored to the field semantics rather than
-    // the table border.
+    let output = capture_users_detailed(OutputFormat::Table, &users);
     let data_row = output
         .lines()
         .find(|line| line.contains("minimal"))
         .expect("data row for 'minimal' user");
-    // Two "-" cells (can_login + groups) should appear inside the
-    // row. Border separators are `|`, so count the dashes that fall
-    // between bars.
     let dash_cells = data_row
         .split('|')
         .filter(|cell| cell.trim() == "-")
@@ -246,15 +223,10 @@ async fn print_users_detailed_handles_missing_real_name_and_email() {
     );
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_whoami_table_renders_fields() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_whoami_table_renders_fields() {
     let whoami = make_whoami();
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_whoami(&whoami, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_whoami(OutputFormat::Table, &whoami);
     assert!(output.contains("User"));
     assert!(output.contains("testuser"));
     assert!(output.contains("Test User"));
@@ -262,39 +234,26 @@ async fn print_whoami_table_renders_fields() {
     assert!(output.contains("42"));
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_whoami_json_via_print() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_whoami_json_via_write() {
     let whoami = make_whoami();
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_whoami(&whoami, OutputFormat::Json);
-    })
-    .await;
-    let parsed = crate::test_helpers::extract_json(&output);
+    let output = capture_whoami(OutputFormat::Json, &whoami);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(parsed["id"], 42);
     assert_eq!(parsed["name"], "testuser");
     assert_eq!(parsed["real_name"], "Test User");
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn print_whoami_table_renders_dashes_for_missing_fields() {
-    let _lock = crate::ENV_LOCK.lock().await;
+#[test]
+fn write_whoami_table_renders_dashes_for_missing_fields() {
     let whoami = WhoamiResponse {
         id: 1,
         name: "bot".into(),
         real_name: None,
         login: None,
     };
-    let ((), output) = crate::test_helpers::capture_stdout(async {
-        print_whoami(&whoami, OutputFormat::Table);
-    })
-    .await;
+    let output = capture_whoami(OutputFormat::Table, &whoami);
     assert!(output.contains("bot"));
-    // print_optional_field renders "  {label:<12}  -" for missing
-    // values. Anchor to those exact field renderings so the assertion
-    // fails when rendering changes, not when borders do.
     assert!(
         output.contains("Name          -"),
         "expected dashed Name field, got: {output}"

--- a/src/output/writers.rs
+++ b/src/output/writers.rs
@@ -9,26 +9,12 @@
 
 use std::io::Write;
 
-#[cfg_attr(
-    not(any(test, feature = "test-helpers")),
-    expect(
-        dead_code,
-        reason = "scaffolding for #192 phase 2 — first production caller added when commands::*::execute() gains a Writers parameter"
-    )
-)]
 pub struct Writers<'a> {
     pub out: &'a mut dyn Write,
     pub err: &'a mut dyn Write,
 }
 
 impl<'a> Writers<'a> {
-    #[cfg_attr(
-        not(any(test, feature = "test-helpers")),
-        expect(
-            dead_code,
-            reason = "scaffolding for #192 phase 2 — first production caller added when main constructs Writers from locked stdout/stderr"
-        )
-    )]
     pub fn new(out: &'a mut dyn Write, err: &'a mut dyn Write) -> Self {
         Self { out, err }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,7 +6,7 @@
 
 #![expect(clippy::unwrap_used)]
 
-use bzr::test_helpers::{capture_stdout, extract_json, setup_test_env};
+use bzr::test_helpers::setup_test_env;
 use bzr::ENV_LOCK;
 
 use clap::Parser;
@@ -63,15 +63,18 @@ async fn bug_list_integration() {
         .await;
 
     let action = empty_list_action();
-    let (result, output) = capture_stdout(bzr::commands::bug::execute(
+    let mut __io = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::bug::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io.writers(),
+    )
     .await;
+    let output = __io.out_str().to_string();
     assert!(result.is_ok(), "bug list should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["id"], 1);
     assert_eq!(parsed[0]["summary"], "Test bug");
     assert_eq!(parsed[0]["status"], "NEW");
@@ -104,13 +107,16 @@ async fn bug_list_changed_since_canonicalizes_bare_date_on_wire() {
         *product = vec!["Firefox".into()];
         *changed_since = Some("2026-04-01".into());
     }
-    let (result, _output) = capture_stdout(bzr::commands::bug::execute(
+    let mut __io2 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::bug::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io2.writers(),
+    )
     .await;
+    let _output = __io2.out_str().to_string();
     assert!(
         result.is_ok(),
         "bug list with --changed-since should succeed: {result:?}"
@@ -140,15 +146,18 @@ async fn bug_view_integration() {
         fields: None,
         exclude_fields: None,
     };
-    let (result, output) = capture_stdout(bzr::commands::bug::execute(
+    let mut __io3 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::bug::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io3.writers(),
+    )
     .await;
+    let output = __io3.out_str().to_string();
     assert!(result.is_ok(), "bug view should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 42);
     assert_eq!(parsed["summary"], "Test bug");
 }
@@ -175,15 +184,18 @@ async fn bug_search_integration() {
         fields: None,
         exclude_fields: None,
     };
-    let (result, output) = capture_stdout(bzr::commands::bug::execute(
+    let mut __io4 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::bug::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io4.writers(),
+    )
     .await;
+    let output = __io4.out_str().to_string();
     assert!(result.is_ok(), "bug search should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["id"], 99);
     assert_eq!(parsed[0]["summary"], "Crash on startup");
 }
@@ -215,15 +227,18 @@ async fn bug_create_integration() {
         blocks: vec![],
         depends_on: vec![],
     };
-    let (result, output) = capture_stdout(bzr::commands::bug::execute(
+    let mut __io5 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::bug::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io5.writers(),
+    )
     .await;
+    let output = __io5.out_str().to_string();
     assert!(result.is_ok(), "bug create should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 100);
 }
 
@@ -252,15 +267,18 @@ async fn comment_list_integration() {
         bug_id: 42,
         since: None,
     };
-    let (result, output) = capture_stdout(bzr::commands::comment::execute(
+    let mut __io6 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::comment::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io6.writers(),
+    )
     .await;
+    let output = __io6.out_str().to_string();
     assert!(result.is_ok(), "comment list should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["id"], 1);
     assert_eq!(parsed[0]["text"], "First comment");
 }
@@ -282,15 +300,20 @@ async fn whoami_integration() {
         .mount(&mock)
         .await;
 
-    let (result, output) = capture_stdout(bzr::commands::whoami::execute(
+    let mut __io7 = bzr::test_helpers::CapturedIo::new();
+
+    let result = bzr::commands::whoami::execute(
         &bzr::cli::WhoamiAction::Show,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io7.writers(),
+    )
     .await;
+
+    let output = __io7.out_str().to_string();
     assert!(result.is_ok(), "whoami should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "admin@example.com");
     assert_eq!(parsed["real_name"], "Admin User");
 }
@@ -322,15 +345,18 @@ async fn product_list_integration() {
     let action = bzr::cli::ProductAction::List {
         r#type: bzr::types::ProductListType::Accessible,
     };
-    let (result, output) = capture_stdout(bzr::commands::product::execute(
+    let mut __io8 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::product::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io8.writers(),
+    )
     .await;
+    let output = __io8.out_str().to_string();
     assert!(result.is_ok(), "product list should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["name"], "Firefox");
 }
 
@@ -358,15 +384,18 @@ async fn server_info_integration() {
         .await;
 
     let action = bzr::cli::ServerAction::Info;
-    let (result, output) = capture_stdout(bzr::commands::server::execute(
+    let mut __io9 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::server::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io9.writers(),
+    )
     .await;
+    let output = __io9.out_str().to_string();
     assert!(result.is_ok(), "server info should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["version"], "5.1.2");
 }
 
@@ -393,15 +422,18 @@ async fn field_list_integration() {
     let action = bzr::cli::FieldAction::List {
         name: "status".to_string(),
     };
-    let (result, output) = capture_stdout(bzr::commands::field::execute(
+    let mut __io10 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::field::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io10.writers(),
+    )
     .await;
+    let output = __io10.out_str().to_string();
     assert!(result.is_ok(), "field list should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["name"], "NEW");
 }
 
@@ -429,18 +461,21 @@ async fn classification_view_integration() {
     let action = bzr::cli::ClassificationAction::View {
         name: "Unclassified".to_string(),
     };
-    let (result, output) = capture_stdout(bzr::commands::classification::execute(
+    let mut __io11 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::classification::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io11.writers(),
+    )
     .await;
+    let output = __io11.out_str().to_string();
     assert!(
         result.is_ok(),
         "classification view should succeed: {result:?}"
     );
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "Unclassified");
 }
 
@@ -469,15 +504,18 @@ async fn user_search_integration() {
         query: "alice".to_string(),
         details: false,
     };
-    let (result, output) = capture_stdout(bzr::commands::user::execute(
+    let mut __io12 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::user::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io12.writers(),
+    )
     .await;
+    let output = __io12.out_str().to_string();
     assert!(result.is_ok(), "user search should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["name"], "alice@example.com");
     assert_eq!(parsed[0]["real_name"], "Alice");
 }
@@ -507,15 +545,18 @@ async fn group_view_integration() {
     let action = bzr::cli::GroupAction::View {
         group: "admin".to_string(),
     };
-    let (result, output) = capture_stdout(bzr::commands::group::execute(
+    let mut __io13 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::group::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io13.writers(),
+    )
     .await;
+    let output = __io13.out_str().to_string();
     assert!(result.is_ok(), "group view should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "admin");
     assert_eq!(parsed["description"], "Administrators");
 }
@@ -539,18 +580,21 @@ async fn component_create_integration() {
         description: "Backend component".to_string(),
         default_assignee: "dev@test.com".to_string(),
     };
-    let (result, output) = capture_stdout(bzr::commands::component::execute(
+    let mut __io14 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::component::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io14.writers(),
+    )
     .await;
+    let output = __io14.out_str().to_string();
     assert!(
         result.is_ok(),
         "component create should succeed: {result:?}"
     );
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 10);
 }
 
@@ -579,15 +623,18 @@ async fn attachment_list_integration() {
         .await;
 
     let action = bzr::cli::AttachmentAction::List { bug_id: 42 };
-    let (result, output) = capture_stdout(bzr::commands::attachment::execute(
+    let mut __io15 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::attachment::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io15.writers(),
+    )
     .await;
+    let output = __io15.out_str().to_string();
     assert!(result.is_ok(), "attachment list should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["file_name"], "patch.diff");
 }
 
@@ -595,6 +642,7 @@ async fn attachment_list_integration() {
 
 #[tokio::test]
 async fn config_show_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let _lock = ENV_LOCK.lock().await;
     let tmp = tempfile::TempDir::new().unwrap();
 
@@ -614,8 +662,14 @@ api_key = "key-1234567890"
     unsafe { std::env::set_var("XDG_CONFIG_HOME", tmp.path()) };
 
     let action = bzr::cli::ConfigAction::Show;
-    let result =
-        bzr::commands::config::execute(&action, None, bzr::types::OutputFormat::Json, None).await;
+    let result = bzr::commands::config::execute(
+        &action,
+        None,
+        bzr::types::OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_ok(), "config show should succeed: {result:?}");
 }
 
@@ -623,6 +677,7 @@ api_key = "key-1234567890"
 
 #[tokio::test]
 async fn command_with_unknown_server_returns_error() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = empty_list_action();
@@ -631,6 +686,7 @@ async fn command_with_unknown_server_returns_error() {
         Some("nonexistent"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(result.is_err(), "should fail with unknown server");
@@ -640,6 +696,7 @@ async fn command_with_unknown_server_returns_error() {
 
 #[tokio::test]
 async fn api_error_propagates() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -659,9 +716,14 @@ async fn api_error_propagates() {
         fields: None,
         exclude_fields: None,
     };
-    let result =
-        bzr::commands::bug::execute(&action, Some("test"), bzr::types::OutputFormat::Json, None)
-            .await;
+    let result = bzr::commands::bug::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_err(), "should propagate API error");
 }
 
@@ -695,15 +757,18 @@ async fn bug_history_integration() {
         id: 42,
         since: None,
     };
-    let (result, output) = capture_stdout(bzr::commands::bug::execute(
+    let mut __io16 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::bug::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io16.writers(),
+    )
     .await;
+    let output = __io16.out_str().to_string();
     assert!(result.is_ok(), "bug history should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["who"], "dev@example.com");
     assert_eq!(parsed[0]["changes"][0]["field_name"], "status");
 }
@@ -757,15 +822,18 @@ async fn bug_update_integration() {
         comment_file: None,
         comment_private: false,
     };
-    let (result, output) = capture_stdout(bzr::commands::bug::execute(
+    let mut __io17 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::bug::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io17.writers(),
+    )
     .await;
+    let output = __io17.out_str().to_string();
     assert!(result.is_ok(), "bug update should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 42);
     assert_eq!(parsed["action"], "updated");
 }
@@ -819,13 +887,16 @@ async fn bug_update_with_comment_integration() {
         comment_file: None,
         comment_private: true,
     };
-    let (result, _output) = capture_stdout(bzr::commands::bug::execute(
+    let mut __io18 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::bug::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io18.writers(),
+    )
     .await;
+    let _output = __io18.out_str().to_string();
     assert!(
         result.is_ok(),
         "bug update with comment should succeed: {result:?}"
@@ -850,15 +921,18 @@ async fn comment_add_integration() {
         body: Some("This is a test comment".to_string()),
         private: false,
     };
-    let (result, output) = capture_stdout(bzr::commands::comment::execute(
+    let mut __io19 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::comment::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io19.writers(),
+    )
     .await;
+    let output = __io19.out_str().to_string();
     assert!(result.is_ok(), "comment add should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 999);
 }
 
@@ -866,6 +940,7 @@ async fn comment_add_integration() {
 
 #[tokio::test]
 async fn comment_tag_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("PUT"))
@@ -885,6 +960,7 @@ async fn comment_tag_integration() {
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(result.is_ok(), "comment tag should succeed: {result:?}");
@@ -894,6 +970,7 @@ async fn comment_tag_integration() {
 
 #[tokio::test]
 async fn comment_search_tags_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -911,6 +988,7 @@ async fn comment_search_tags_integration() {
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(
@@ -923,6 +1001,7 @@ async fn comment_search_tags_integration() {
 
 #[tokio::test]
 async fn attachment_download_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -956,6 +1035,7 @@ async fn attachment_download_integration() {
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(
@@ -969,6 +1049,7 @@ async fn attachment_download_integration() {
 
 #[tokio::test]
 async fn attachment_download_bulk_per_bug_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -1019,6 +1100,7 @@ async fn attachment_download_bulk_per_bug_integration() {
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(result.is_ok(), "expected ok: {result:?}");
@@ -1039,6 +1121,7 @@ async fn attachment_download_bulk_per_bug_integration() {
 
 #[tokio::test]
 async fn attachment_upload_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     // Create a temporary file to upload
@@ -1068,6 +1151,7 @@ async fn attachment_upload_integration() {
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(
@@ -1079,6 +1163,7 @@ async fn attachment_upload_integration() {
 #[tokio::test]
 async fn attachment_upload_with_comment_integration() {
     use wiremock::matchers::body_string_contains;
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     let upload_file = tmp.path().join("upload.txt");
@@ -1110,6 +1195,7 @@ async fn attachment_upload_with_comment_integration() {
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(
@@ -1121,6 +1207,7 @@ async fn attachment_upload_with_comment_integration() {
 #[tokio::test]
 async fn attachment_upload_with_is_patch_integration() {
     use wiremock::matchers::body_string_contains;
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     let upload_file = tmp.path().join("fix.patch");
@@ -1151,6 +1238,7 @@ async fn attachment_upload_with_is_patch_integration() {
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(
@@ -1162,6 +1250,7 @@ async fn attachment_upload_with_is_patch_integration() {
 #[tokio::test]
 async fn attachment_upload_with_comment_private_integration() {
     use wiremock::matchers::body_string_contains;
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, tmp) = setup_test_env().await;
 
     let upload_file = tmp.path().join("upload.txt");
@@ -1215,6 +1304,7 @@ async fn attachment_upload_with_comment_private_integration() {
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(
@@ -1249,15 +1339,18 @@ async fn attachment_list_returns_is_patch_field_integration() {
         .await;
 
     let action = bzr::cli::AttachmentAction::List { bug_id: 42 };
-    let (result, output) = capture_stdout(bzr::commands::attachment::execute(
+    let mut __io20 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::attachment::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io20.writers(),
+    )
     .await;
+    let output = __io20.out_str().to_string();
     assert!(result.is_ok(), "list should succeed: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["is_patch"], true);
 }
 
@@ -1265,6 +1358,7 @@ async fn attachment_list_returns_is_patch_field_integration() {
 
 #[tokio::test]
 async fn attachment_update_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("PUT"))
@@ -1291,6 +1385,7 @@ async fn attachment_update_integration() {
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(
@@ -1303,6 +1398,7 @@ async fn attachment_update_integration() {
 
 #[tokio::test]
 async fn component_update_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("PUT"))
@@ -1323,6 +1419,7 @@ async fn component_update_integration() {
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(
@@ -1335,6 +1432,7 @@ async fn component_update_integration() {
 
 #[tokio::test]
 async fn product_view_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -1357,6 +1455,7 @@ async fn product_view_integration() {
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(result.is_ok(), "product view should succeed: {result:?}");
@@ -1366,6 +1465,7 @@ async fn product_view_integration() {
 
 #[tokio::test]
 async fn product_create_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("POST"))
@@ -1386,6 +1486,7 @@ async fn product_create_integration() {
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(result.is_ok(), "product create should succeed: {result:?}");
@@ -1395,6 +1496,7 @@ async fn product_create_integration() {
 
 #[tokio::test]
 async fn product_update_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("PUT"))
@@ -1417,6 +1519,7 @@ async fn product_update_integration() {
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
+        &mut __cap_io.writers(),
     )
     .await;
     assert!(result.is_ok(), "product update should succeed: {result:?}");
@@ -1426,6 +1529,7 @@ async fn product_update_integration() {
 
 #[tokio::test]
 async fn user_create_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("POST"))
@@ -1441,9 +1545,14 @@ async fn user_create_integration() {
         full_name: Some("New User".to_string()),
         password: None,
     };
-    let result =
-        bzr::commands::user::execute(&action, Some("test"), bzr::types::OutputFormat::Json, None)
-            .await;
+    let result = bzr::commands::user::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_ok(), "user create should succeed: {result:?}");
 }
 
@@ -1451,6 +1560,7 @@ async fn user_create_integration() {
 
 #[tokio::test]
 async fn user_update_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("PUT"))
@@ -1469,9 +1579,14 @@ async fn user_update_integration() {
         disable_login: None,
         login_denied_text: None,
     };
-    let result =
-        bzr::commands::user::execute(&action, Some("test"), bzr::types::OutputFormat::Json, None)
-            .await;
+    let result = bzr::commands::user::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_ok(), "user update should succeed: {result:?}");
 }
 
@@ -1479,6 +1594,7 @@ async fn user_update_integration() {
 
 #[tokio::test]
 async fn group_create_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("POST"))
@@ -1493,9 +1609,14 @@ async fn group_create_integration() {
         description: "Tester group".to_string(),
         is_active: true,
     };
-    let result =
-        bzr::commands::group::execute(&action, Some("test"), bzr::types::OutputFormat::Json, None)
-            .await;
+    let result = bzr::commands::group::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_ok(), "group create should succeed: {result:?}");
 }
 
@@ -1503,6 +1624,7 @@ async fn group_create_integration() {
 
 #[tokio::test]
 async fn group_update_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("PUT"))
@@ -1519,9 +1641,14 @@ async fn group_update_integration() {
         description: Some("Updated testers".to_string()),
         is_active: None,
     };
-    let result =
-        bzr::commands::group::execute(&action, Some("test"), bzr::types::OutputFormat::Json, None)
-            .await;
+    let result = bzr::commands::group::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_ok(), "group update should succeed: {result:?}");
 }
 
@@ -1529,6 +1656,7 @@ async fn group_update_integration() {
 
 #[tokio::test]
 async fn group_add_user_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("PUT"))
@@ -1544,9 +1672,14 @@ async fn group_add_user_integration() {
         group: "admin".to_string(),
         user: "alice@example.com".to_string(),
     };
-    let result =
-        bzr::commands::group::execute(&action, Some("test"), bzr::types::OutputFormat::Json, None)
-            .await;
+    let result = bzr::commands::group::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(result.is_ok(), "group add-user should succeed: {result:?}");
 }
 
@@ -1554,6 +1687,7 @@ async fn group_add_user_integration() {
 
 #[tokio::test]
 async fn group_remove_user_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("PUT"))
@@ -1569,9 +1703,14 @@ async fn group_remove_user_integration() {
         group: "admin".to_string(),
         user: "alice@example.com".to_string(),
     };
-    let result =
-        bzr::commands::group::execute(&action, Some("test"), bzr::types::OutputFormat::Json, None)
-            .await;
+    let result = bzr::commands::group::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_ok(),
         "group remove-user should succeed: {result:?}"
@@ -1582,6 +1721,7 @@ async fn group_remove_user_integration() {
 
 #[tokio::test]
 async fn group_list_users_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     Mock::given(method("GET"))
@@ -1603,9 +1743,14 @@ async fn group_list_users_integration() {
         group: "admin".to_string(),
         details: false,
     };
-    let result =
-        bzr::commands::group::execute(&action, Some("test"), bzr::types::OutputFormat::Json, None)
-            .await;
+    let result = bzr::commands::group::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_ok(),
         "group list-users should succeed: {result:?}"
@@ -1616,6 +1761,7 @@ async fn group_list_users_integration() {
 
 #[tokio::test]
 async fn config_set_server_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let _lock = ENV_LOCK.lock().await;
     let tmp = tempfile::TempDir::new().unwrap();
 
@@ -1641,8 +1787,14 @@ async fn config_set_server_integration() {
         tls_pin_now: false,
         tls_pin_clear: false,
     };
-    let result =
-        bzr::commands::config::execute(&action, None, bzr::types::OutputFormat::Json, None).await;
+    let result = bzr::commands::config::execute(
+        &action,
+        None,
+        bzr::types::OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_ok(),
         "config set-server should succeed: {result:?}"
@@ -1651,6 +1803,7 @@ async fn config_set_server_integration() {
 
 #[tokio::test]
 async fn config_set_default_integration() {
+    let mut __cap_io = bzr::test_helpers::CapturedIo::new();
     let _lock = ENV_LOCK.lock().await;
     let tmp = tempfile::TempDir::new().unwrap();
 
@@ -1666,8 +1819,14 @@ async fn config_set_default_integration() {
     let action = bzr::cli::ConfigAction::SetDefault {
         name: "staging".to_string(),
     };
-    let result =
-        bzr::commands::config::execute(&action, None, bzr::types::OutputFormat::Json, None).await;
+    let result = bzr::commands::config::execute(
+        &action,
+        None,
+        bzr::types::OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
     assert!(
         result.is_ok(),
         "config set-default should succeed: {result:?}"
@@ -1677,7 +1836,7 @@ async fn config_set_default_integration() {
 // ── CLI-to-execute end-to-end tests ──────────────────────────────────
 // These test the full path: CLI arg parsing → command dispatch → API call
 
-/// Parse CLI args and dispatch to the correct command `execute()` function,
+/// Parse CLI args and dispatch to the correct command `execute(, &mut __cap_io.writers())` function,
 /// exercising the same path as `main.rs::run()`.
 async fn dispatch_cli(args: &[&str]) -> bzr::error::Result<()> {
     let cli = bzr::cli::Cli::try_parse_from(args)
@@ -1689,7 +1848,30 @@ async fn dispatch_cli(args: &[&str]) -> bzr::error::Result<()> {
         cli.output.unwrap_or(bzr::types::OutputFormat::Json)
     };
 
-    bzr::dispatch(&cli, format).await
+    let mut io = bzr::test_helpers::CapturedIo::new();
+    bzr::dispatch(&cli, format, &mut io.writers()).await
+}
+
+/// Like [`dispatch_cli`] but returns the captured stdout alongside the result,
+/// for tests that inspect the printed output.
+async fn dispatch_cli_with_output(args: &[&str]) -> (bzr::error::Result<()>, String) {
+    let cli = match bzr::cli::Cli::try_parse_from(args) {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                Err(bzr::error::BzrError::InputValidation(e.to_string())),
+                String::new(),
+            );
+        }
+    };
+    let format = if cli.json {
+        bzr::types::OutputFormat::Json
+    } else {
+        cli.output.unwrap_or(bzr::types::OutputFormat::Json)
+    };
+    let mut io = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::dispatch(&cli, format, &mut io.writers()).await;
+    (result, io.out_str().to_string())
 }
 
 #[tokio::test]
@@ -1705,7 +1887,7 @@ async fn e2e_bug_list_via_cli_args() {
         .mount(&mock)
         .await;
 
-    let (result, output) = capture_stdout(dispatch_cli(&[
+    let (result, output) = dispatch_cli_with_output(&[
         "bzr",
         "--server",
         "test",
@@ -1714,10 +1896,10 @@ async fn e2e_bug_list_via_cli_args() {
         "list",
         "--product",
         "Firefox",
-    ]))
+    ])
     .await;
     assert!(result.is_ok(), "e2e bug list: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed[0]["summary"], "CLI test");
 }
 
@@ -1734,12 +1916,10 @@ async fn e2e_bug_view_via_cli_args() {
         .mount(&mock)
         .await;
 
-    let (result, output) = capture_stdout(dispatch_cli(&[
-        "bzr", "--server", "test", "--json", "bug", "view", "42",
-    ]))
-    .await;
+    let (result, output) =
+        dispatch_cli_with_output(&["bzr", "--server", "test", "--json", "bug", "view", "42"]).await;
     assert!(result.is_ok(), "e2e bug view: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 42);
     assert_eq!(parsed["summary"], "CLI view test");
 }
@@ -1759,12 +1939,10 @@ async fn e2e_whoami_via_cli_args() {
         .mount(&mock)
         .await;
 
-    let (result, output) = capture_stdout(dispatch_cli(&[
-        "bzr", "--server", "test", "--json", "whoami",
-    ]))
-    .await;
+    let (result, output) =
+        dispatch_cli_with_output(&["bzr", "--server", "test", "--json", "whoami"]).await;
     assert!(result.is_ok(), "e2e whoami: {result:?}");
-    let parsed = extract_json(&output);
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["name"], "admin@example.com");
 }
 
@@ -2113,13 +2291,16 @@ async fn bug_list_issue_158_mixed_positive_and_negation_reaches_wire() {
         *whiteboard = vec!["!wip".into()];
         *resolution = vec!["!FIXED".into()];
     }
-    let (result, _output) = capture_stdout(bzr::commands::bug::execute(
+    let mut __io24 = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::bug::execute(
         &action,
         Some("test"),
         bzr::types::OutputFormat::Json,
         None,
-    ))
+        &mut __io24.writers(),
+    )
     .await;
+    let _output = __io24.out_str().to_string();
     assert!(result.is_ok(), "bug list should succeed: {result:?}");
     // wiremock's `expect(1)` enforces that exactly one request matched
     // every query-param matcher above; if any operator or value were


### PR DESCRIPTION
## Summary

Phase 2 of the #192 migration. Replaces the global-stdout-with-fd-redirection model with explicit `Writers<'_>` parameters threaded from `main` through `dispatch` to the formatters.

- Renames `print_* → write_*` across `src/output/` (~30 helpers, ~14 modules); leaf helpers take `&mut impl Write`.
- Adds `w: &mut Writers<'_>` to all 14 `commands::*::execute()` functions and the 8 `commands::bug::*::handle()` submodules.
- Updates `dispatch()` and `main.rs` to construct and pass `Writers`.
- Migrates ~22 command-layer test files from `capture_stdout(execute(…))` to `CapturedIo::new(); execute(…, &mut io.writers())`.
- Output unit tests (~14 files) become sync `#[test]`s using `&mut Vec<u8>` directly.
- `tests/integration.rs` migrated; adds `dispatch_cli_with_output()` helper for tests that inspect output.
- `pub(crate) mod output;` becomes `pub mod output;` so `main.rs` and integration tests can name `Writers`.

`capture_stdout`, `extract_json`, and the `dup`/`dup2` machinery still live in `src/test_helpers.rs` after this PR — they have no callers but the deletion lands in Phase 3 for reviewable isolation.

## Test plan

- [x] cargo fmt --check clean
- [x] cargo clippy --all-targets --all-features -- -D warnings clean
- [x] cargo test --all-targets --all-features all green
  - 1150 lib + 21 binary + 64 integration = **1235 tests passing**
- [x] `rg 'output::print_'` returns zero hits in src/
- [x] `rg 'capture_stdout|extract_json'` returns zero call sites outside test_helpers.rs (only doc-comment references in commands/bug/view_tests.rs)
- [x] `rg -U '#\[cfg\(unix\)\]\s*\n#\[tokio::test\]' src/output/` returns zero hits — output-layer tests are now sync

## Follow-ups

Phase 3 (separate small PR) deletes `capture_stdout`, `extract_json`, `try_parse_from`, the `dup`/`dup2`/`close` extern block, and the `#[cfg(unix)]` gate from test_helpers.rs.

Refs: #192