### PR TITLE
test: extract shared attachment fixture helper

### DIFF
--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -5,7 +5,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::AttachmentAction;
-use crate::test_helpers::setup_test_env;
+use crate::test_helpers::{make_attachment, setup_test_env};
 use crate::types::OutputFormat;
 
 #[tokio::test]
@@ -697,21 +697,16 @@ async fn write_one_attachment_writes_inline_data_with_att_id_prefix() {
         .await
         .unwrap();
 
-    let att = crate::types::Attachment {
-        id: 9876,
-        bug_id: 12345,
-        file_name: "patch.diff".into(),
-        summary: "Fix patch".into(),
-        content_type: "text/x-diff".into(),
-        creator: None,
-        creation_time: None,
-        last_change_time: None,
-        size: 11,
-        is_obsolete: false,
-        is_private: false,
-        is_patch: true,
-        data: Some(b64(b"Hello world")),
-    };
+    let mut att = make_attachment(
+        9876,
+        12345,
+        "patch.diff",
+        "Fix patch",
+        Some(b64(b"Hello world")),
+    );
+    att.content_type = "text/x-diff".into();
+    att.size = 11;
+    att.is_patch = true;
     let out_dir = tmp.path().to_string_lossy().into_owned();
 
     let file = super::write_one_attachment(&client, &att, &out_dir)
@@ -752,21 +747,8 @@ async fn write_one_attachment_falls_back_when_data_missing() {
         .await
         .unwrap();
 
-    let att = crate::types::Attachment {
-        id: 9876,
-        bug_id: 12345,
-        file_name: "patch.diff".into(),
-        summary: "Fix patch".into(),
-        content_type: "text/plain".into(),
-        creator: None,
-        creation_time: None,
-        last_change_time: None,
-        size: 11,
-        is_obsolete: false,
-        is_private: false,
-        is_patch: false,
-        data: None,
-    };
+    let mut att = make_attachment(9876, 12345, "patch.diff", "Fix patch", None);
+    att.size = 11;
     let out_dir = tmp.path().to_string_lossy().into_owned();
 
     let file = super::write_one_attachment(&client, &att, &out_dir)
@@ -789,21 +771,8 @@ async fn write_one_attachment_overwrites_existing_file() {
     std::fs::create_dir_all(&dir).unwrap();
     std::fs::write(dir.join("9876.patch.diff"), b"OLD CONTENT").unwrap();
 
-    let att = crate::types::Attachment {
-        id: 9876,
-        bug_id: 12345,
-        file_name: "patch.diff".into(),
-        summary: "v2".into(),
-        content_type: "text/plain".into(),
-        creator: None,
-        creation_time: None,
-        last_change_time: None,
-        size: 11,
-        is_obsolete: false,
-        is_private: false,
-        is_patch: false,
-        data: Some(b64(b"NEW CONTENT")),
-    };
+    let mut att = make_attachment(9876, 12345, "patch.diff", "v2", Some(b64(b"NEW CONTENT")));
+    att.size = 11;
     let out_dir = tmp.path().to_string_lossy().into_owned();
 
     super::write_one_attachment(&client, &att, &out_dir)
@@ -1297,21 +1266,14 @@ async fn write_one_attachment_invalid_base64_returns_data_integrity() {
         .await
         .unwrap();
 
-    let att = crate::types::Attachment {
-        id: 9876,
-        bug_id: 12345,
-        file_name: "patch.diff".into(),
-        summary: "broken".into(),
-        content_type: "text/plain".into(),
-        creator: None,
-        creation_time: None,
-        last_change_time: None,
-        size: 0,
-        is_obsolete: false,
-        is_private: false,
-        is_patch: false,
-        data: Some("not valid base64 !!".into()),
-    };
+    let mut att = make_attachment(
+        9876,
+        12345,
+        "patch.diff",
+        "broken",
+        Some("not valid base64 !!".into()),
+    );
+    att.size = 0;
     let out_dir = tmp.path().to_string_lossy().into_owned();
 
     let result = super::write_one_attachment(&client, &att, &out_dir).await;

--- a/src/output/attachment_tests.rs
+++ b/src/output/attachment_tests.rs
@@ -1,24 +1,11 @@
 #![expect(clippy::unwrap_used)]
 
 use super::*;
+use crate::test_helpers::make_attachment;
 use crate::types::{Attachment, OutputFormat};
 
-fn make_attachment(id: u64, summary: &str) -> Attachment {
-    Attachment {
-        id,
-        bug_id: 42,
-        file_name: format!("file_{id}.patch"),
-        summary: summary.into(),
-        content_type: "text/plain".into(),
-        creator: Some("author@example.com".into()),
-        creation_time: Some("2025-03-01T09:00:00Z".into()),
-        last_change_time: Some("2025-03-02T10:00:00Z".into()),
-        size: 1234,
-        is_obsolete: false,
-        is_private: false,
-        is_patch: false,
-        data: None,
-    }
+fn output_attachment(id: u64, summary: &str) -> Attachment {
+    make_attachment(id, 42, &format!("file_{id}.patch"), summary, None)
 }
 
 fn capture(format: OutputFormat, attachments: &[Attachment]) -> String {
@@ -46,7 +33,7 @@ fn write_attachments_json_empty() {
 
 #[test]
 fn write_attachments_json_one_attachment() {
-    let attachments = vec![make_attachment(10, "Fix patch")];
+    let attachments = vec![output_attachment(10, "Fix patch")];
     let json = serde_json::to_string_pretty(&attachments).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
     assert_eq!(parsed[0]["id"], 10);
@@ -58,7 +45,7 @@ fn write_attachments_json_one_attachment() {
 
 #[test]
 fn attachment_text_format_fields() {
-    let att = make_attachment(10, "Fix patch");
+    let att = output_attachment(10, "Fix patch");
     assert_eq!(att.file_name, "file_10.patch");
     assert_eq!(att.content_type, "text/plain");
     assert_eq!(att.size, 1234);
@@ -69,7 +56,7 @@ fn attachment_text_format_fields() {
 
 #[test]
 fn write_attachments_json_obsolete_and_private() {
-    let mut att = make_attachment(11, "Old patch");
+    let mut att = output_attachment(11, "Old patch");
     att.is_obsolete = true;
     att.is_private = true;
     let json = serde_json::to_string(&att).unwrap();
@@ -94,7 +81,7 @@ fn write_attachments_json_empty_renders_empty_array() {
 
 #[test]
 fn write_attachments_table_renders_all_fields() {
-    let mut att = make_attachment(7, "Helpful patch");
+    let mut att = output_attachment(7, "Helpful patch");
     att.is_obsolete = true;
     att.is_private = true;
     let output = capture(OutputFormat::Table, &[att]);
@@ -146,7 +133,7 @@ fn write_attachments_table_missing_optional_fields_render_dash() {
 
 #[test]
 fn write_attachments_table_renders_patch_tag() {
-    let mut att = make_attachment(12, "Patch attachment");
+    let mut att = output_attachment(12, "Patch attachment");
     att.is_patch = true;
     let output = capture(OutputFormat::Table, &[att]);
     assert!(output.contains("Attachment"));
@@ -159,7 +146,7 @@ fn write_attachments_table_renders_patch_tag() {
 
 #[test]
 fn write_attachments_table_patch_tag_precedes_obsolete_and_private() {
-    let mut att = make_attachment(13, "All flags");
+    let mut att = output_attachment(13, "All flags");
     att.is_patch = true;
     att.is_obsolete = true;
     att.is_private = true;
@@ -177,7 +164,7 @@ fn write_attachments_table_patch_tag_precedes_obsolete_and_private() {
 
 #[test]
 fn write_attachments_json_one_via_write() {
-    let output = capture(OutputFormat::Json, &[make_attachment(99, "Json patch")]);
+    let output = capture(OutputFormat::Json, &[output_attachment(99, "Json patch")]);
     let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(parsed[0]["id"], 99);
     assert_eq!(parsed[0]["summary"], "Json patch");
@@ -186,7 +173,7 @@ fn write_attachments_json_one_via_write() {
 
 #[test]
 fn write_attachments_does_not_emit_ansi_when_writing_to_buffer() {
-    let output = capture(OutputFormat::Table, &[make_attachment(1, "p")]);
+    let output = capture(OutputFormat::Table, &[output_attachment(1, "p")]);
     assert!(
         !output.contains('\x1b'),
         "expected no ANSI escapes when writing to Vec<u8>: {output:?}",

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -57,6 +57,31 @@ api_mode = "rest"
     unsafe { std::env::set_var("XDG_CONFIG_HOME", tmp.path()) };
 }
 
+/// Build a full-shaped attachment fixture with common test defaults.
+pub fn make_attachment(
+    id: u64,
+    bug_id: u64,
+    file_name: &str,
+    summary: &str,
+    data: Option<String>,
+) -> crate::types::Attachment {
+    crate::types::Attachment {
+        id,
+        bug_id,
+        file_name: file_name.into(),
+        summary: summary.into(),
+        content_type: "text/plain".into(),
+        creator: Some("author@example.com".into()),
+        creation_time: Some("2025-03-01T09:00:00Z".into()),
+        last_change_time: Some("2025-03-02T10:00:00Z".into()),
+        size: 1234,
+        is_obsolete: false,
+        is_private: false,
+        is_patch: false,
+        data,
+    }
+}
+
 /// Owned `Vec<u8>` buffers for capturing stdout and stderr in tests, plus
 /// a `Writers` constructor that borrows them.
 pub struct CapturedIo {

--- a/src/test_helpers_tests.rs
+++ b/src/test_helpers_tests.rs
@@ -27,3 +27,32 @@ fn captured_io_writers_route_to_owned_buffers() {
     assert_eq!(io.out_str(), "to stdout\n");
     assert_eq!(io.err_str(), "to stderr\n");
 }
+
+#[test]
+fn make_attachment_sets_common_defaults() {
+    let att = make_attachment(10, 42, "patch.diff", "Fix patch", None);
+
+    assert_eq!(att.id, 10);
+    assert_eq!(att.bug_id, 42);
+    assert_eq!(att.file_name, "patch.diff");
+    assert_eq!(att.summary, "Fix patch");
+    assert_eq!(att.content_type, "text/plain");
+    assert_eq!(att.creator.as_deref(), Some("author@example.com"));
+    assert_eq!(att.creation_time.as_deref(), Some("2025-03-01T09:00:00Z"));
+    assert_eq!(
+        att.last_change_time.as_deref(),
+        Some("2025-03-02T10:00:00Z")
+    );
+    assert_eq!(att.size, 1234);
+    assert!(!att.is_obsolete);
+    assert!(!att.is_private);
+    assert!(!att.is_patch);
+    assert!(att.data.is_none());
+}
+
+#[test]
+fn make_attachment_preserves_inline_data() {
+    let att = make_attachment(10, 42, "patch.diff", "Fix patch", Some("aGVsbG8=".into()));
+
+    assert_eq!(att.data.as_deref(), Some("aGVsbG8="));
+}

--- a/src/test_helpers_tests.rs
+++ b/src/test_helpers_tests.rs
@@ -27,32 +27,3 @@ fn captured_io_writers_route_to_owned_buffers() {
     assert_eq!(io.out_str(), "to stdout\n");
     assert_eq!(io.err_str(), "to stderr\n");
 }
-
-#[test]
-fn make_attachment_sets_common_defaults() {
-    let att = make_attachment(10, 42, "patch.diff", "Fix patch", None);
-
-    assert_eq!(att.id, 10);
-    assert_eq!(att.bug_id, 42);
-    assert_eq!(att.file_name, "patch.diff");
-    assert_eq!(att.summary, "Fix patch");
-    assert_eq!(att.content_type, "text/plain");
-    assert_eq!(att.creator.as_deref(), Some("author@example.com"));
-    assert_eq!(att.creation_time.as_deref(), Some("2025-03-01T09:00:00Z"));
-    assert_eq!(
-        att.last_change_time.as_deref(),
-        Some("2025-03-02T10:00:00Z")
-    );
-    assert_eq!(att.size, 1234);
-    assert!(!att.is_obsolete);
-    assert!(!att.is_private);
-    assert!(!att.is_patch);
-    assert!(att.data.is_none());
-}
-
-#[test]
-fn make_attachment_preserves_inline_data() {
-    let att = make_attachment(10, 42, "patch.diff", "Fix patch", Some("aGVsbG8=".into()));
-
-    assert_eq!(att.data.as_deref(), Some("aGVsbG8="));
-}


### PR DESCRIPTION
## Summary
- Add a shared `make_attachment` test helper for full-shaped attachment fixtures
- Replace repeated command attachment literals with helper calls
- Reuse the helper from output attachment tests while keeping the missing-field literal explicit

Closes #189.

## Test Plan
- [x] `cargo test --lib attachment`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] pre-push hook: `cargo test`