### PR TITLE
Fix functional test failures

### DIFF
--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -645,7 +645,7 @@ run_bzr bug create \
 if assert_success; then
     BUG_ID=$(jq -r '.id' "$BZR_STDOUT")
     # Verify the description that landed is from the file, not stdin
-    run_bzr bug view "$BUG_ID"
+    run_bzr comment list "$BUG_ID"
     if assert_stdout_contains "from file"; then test_pass; fi
 fi
 rm -f "$DESC_FILE"

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -372,21 +372,27 @@ if assert_success && assert_json_exists '.id'; then
 fi
 
 test_begin "34. bug create (bug two)"
-run_bzr bug create --product FuncTestProd --component Backend --summary "Bug two searchable" --op-sys All --rep-platform All
+run_bzr bug create --product FuncTestProd --component Backend \
+    --summary "Bug two searchable" --description "Description of bug two" \
+    --op-sys All --rep-platform All
 if assert_success && assert_json_exists '.id'; then
     BUG2=$(jq -r '.id' "$BZR_STDOUT")
     test_pass
 fi
 
 test_begin "34a. bug create (duplicate target)"
-run_bzr bug create --product FuncTestProd --component Backend --summary "Duplicate target" --op-sys All --rep-platform All
+run_bzr bug create --product FuncTestProd --component Backend \
+    --summary "Duplicate target" --description "Duplicate target description" \
+    --op-sys All --rep-platform All
 if assert_success && assert_json_exists '.id'; then
     BUG_DUP_TARGET=$(jq -r '.id' "$BZR_STDOUT")
     test_pass
 fi
 
 test_begin "34b. bug create (duplicate source)"
-run_bzr bug create --product FuncTestProd --component Backend --summary "Duplicate source" --op-sys All --rep-platform All
+run_bzr bug create --product FuncTestProd --component Backend \
+    --summary "Duplicate source" --description "Duplicate source description" \
+    --op-sys All --rep-platform All
 if assert_success && assert_json_exists '.id'; then
     BUG_DUP_SOURCE=$(jq -r '.id' "$BZR_STDOUT")
     test_pass
@@ -593,7 +599,9 @@ fi
 
 test_begin "48. bug create (bug four — with relationships)"
 if [[ -n "$BUG1" ]] && [[ -n "$BUG2" ]]; then
-    run_bzr bug create --product FuncTestProd --component Backend --summary "Bug with relationships" --blocks "$BUG1" --depends-on "$BUG2" --op-sys All --rep-platform All
+    run_bzr bug create --product FuncTestProd --component Backend \
+        --summary "Bug with relationships" --description "Relationship test description" \
+        --blocks "$BUG1" --depends-on "$BUG2" --op-sys All --rep-platform All
     if assert_success && assert_json_exists '.id'; then
         BUG4=$(jq -r '.id' "$BZR_STDOUT")
         test_pass
@@ -864,7 +872,8 @@ run_bzr template show func-tmpl
 if assert_success && assert_json '.product' "FuncTestProd"; then test_pass; fi
 
 test_begin "68. bug create --template"
-run_bzr bug create --template func-tmpl --summary "Bug from template" --op-sys All --rep-platform All
+run_bzr bug create --template func-tmpl --summary "Bug from template" \
+    --description "Description from template test" --op-sys All --rep-platform All
 if assert_success && assert_json_exists '.id'; then
     TMPL_BUG=$(jq -r '.id' "$BZR_STDOUT")
     test_pass

--- a/tests/functional/versions/bz50/entrypoint.sh
+++ b/tests/functional/versions/bz50/entrypoint.sh
@@ -48,6 +48,13 @@ WHERE login_name = 'admin@test.bzr'
 LIMIT 1;
 SQL
 
+# ── Seed functional-test keywords ───────────────────────────────────
+echo "==> Seeding functional-test keywords..."
+mysql -u root bugs <<'SQL'
+INSERT IGNORE INTO keyworddefs (name, description)
+VALUES ('fix-needed', 'Functional test keyword');
+SQL
+
 # ── Configure insidergroup ──────────────────────────────────────────
 # Bugzilla's default `insidergroup` is empty, which forbids anyone
 # (including admins) from marking comments private. Real deployments

--- a/tests/functional/versions/bz50/entrypoint.sh
+++ b/tests/functional/versions/bz50/entrypoint.sh
@@ -70,6 +70,17 @@ if [[ -f data/params ]]; then
     perl -pi -e "s/'insidergroup' => ''/'insidergroup' => 'admin'/g" data/params 2>/dev/null || true
 fi
 
+# ── Disable outbound mail for functional tests ──────────────────────
+# Comment and attachment mutations trigger bugmail. The functional
+# containers do not run an MTA, so use Bugzilla's built-in no-op mailer.
+echo "==> Disabling outbound mail..."
+if [[ -f data/params.json ]]; then
+    perl -pi -e 's/"mail_delivery_method"\s*:\s*"[^"]*"/"mail_delivery_method":"None"/g' data/params.json 2>/dev/null || true
+fi
+if [[ -f data/params ]]; then
+    perl -pi -e "s/'mail_delivery_method' => '[^']*'/'mail_delivery_method' => 'None'/g" data/params 2>/dev/null || true
+fi
+
 # ── Fix permissions ──────────────────────────────────────────────────
 chown -R apache:apache "$BZ_DIR/data" "$BZ_DIR/lib" 2>/dev/null || true
 

--- a/tests/functional/versions/bz52/entrypoint.sh
+++ b/tests/functional/versions/bz52/entrypoint.sh
@@ -81,6 +81,17 @@ if [[ -f data/params ]]; then
     perl -pi -e "s/'insidergroup' => ''/'insidergroup' => 'admin'/g" data/params 2>/dev/null || true
 fi
 
+# ── Disable outbound mail for functional tests ──────────────────────
+# Comment and attachment mutations trigger bugmail. The functional
+# containers do not run an MTA, so use Bugzilla's built-in no-op mailer.
+echo "==> Disabling outbound mail..."
+if [[ -f data/params.json ]]; then
+    perl -pi -e 's/"mail_delivery_method"\s*:\s*"[^"]*"/"mail_delivery_method":"None"/g' data/params.json 2>/dev/null || true
+fi
+if [[ -f data/params ]]; then
+    perl -pi -e "s/'mail_delivery_method' => '[^']*'/'mail_delivery_method' => 'None'/g" data/params 2>/dev/null || true
+fi
+
 # ── Fix permissions ──────────────────────────────────────────────────
 chown -R apache:apache "$BZ_DIR/data" "$BZ_DIR/lib" 2>/dev/null || true
 

--- a/tests/functional/versions/bz52/entrypoint.sh
+++ b/tests/functional/versions/bz52/entrypoint.sh
@@ -59,6 +59,13 @@ WHERE login_name = 'admin@test.bzr'
 LIMIT 1;
 SQL
 
+# ── Seed functional-test keywords ───────────────────────────────────
+echo "==> Seeding functional-test keywords..."
+mysql -u root bugs <<'SQL'
+INSERT IGNORE INTO keyworddefs (name, description)
+VALUES ('fix-needed', 'Functional test keyword');
+SQL
+
 # ── Configure insidergroup ──────────────────────────────────────────
 # Bugzilla's default `insidergroup` is empty, which forbids anyone
 # (including admins) from marking comments private. Real deployments

--- a/tests/functional/versions/bz53/entrypoint.sh
+++ b/tests/functional/versions/bz53/entrypoint.sh
@@ -97,6 +97,17 @@ if [[ -f data/params ]]; then
     perl -pi -e "s/'insidergroup' => ''/'insidergroup' => 'admin'/g" data/params 2>/dev/null || true
 fi
 
+# ── Disable outbound mail for functional tests ──────────────────────
+# Comment and attachment mutations trigger bugmail. The functional
+# containers do not run an MTA, so use Bugzilla's built-in no-op mailer.
+echo "==> Disabling outbound mail..."
+if [[ -f data/params.json ]]; then
+    perl -pi -e 's/"mail_delivery_method"\s*:\s*"[^"]*"/"mail_delivery_method":"None"/g' data/params.json 2>/dev/null || true
+fi
+if [[ -f data/params ]]; then
+    perl -pi -e "s/'mail_delivery_method' => '[^']*'/'mail_delivery_method' => 'None'/g" data/params 2>/dev/null || true
+fi
+
 # ── Fix permissions ──────────────────────────────────────────────────
 chown -R apache:apache "$BZ_DIR/data" "$BZ_DIR/lib" 2>/dev/null || true
 

--- a/tests/functional/versions/bz53/entrypoint.sh
+++ b/tests/functional/versions/bz53/entrypoint.sh
@@ -75,6 +75,13 @@ WHERE login_name = 'admin@test.bzr'
 LIMIT 1;
 SQL
 
+# ── Seed functional-test keywords ───────────────────────────────────
+echo "==> Seeding functional-test keywords..."
+mysql -u root bugs <<'SQL'
+INSERT IGNORE INTO keyworddefs (name, description)
+VALUES ('fix-needed', 'Functional test keyword');
+SQL
+
 # ── Configure insidergroup ──────────────────────────────────────────
 # Bugzilla's default `insidergroup` is empty, which forbids anyone
 # (including admins) from marking comments private. Real deployments


### PR DESCRIPTION
## Summary
- Add explicit descriptions to noninteractive functional bug creation setup calls so they do not open $EDITOR.
- Verify description-file precedence through comment listing, where Bugzilla exposes the initial description.
- Seed the functional keyword fixture and disable outbound mail in all Bugzilla functional containers.

## Test Plan
- make functional-test-all
  - bz50: PASSED
  - bz52: PASSED
  - bz53: PASSED
- git push pre-push hook: cargo test passed
  - lib tests: 1172 passed
  - main tests: 21 passed
  - integration tests: 65 passed
  - doctests: 0 passed, 0 failed
