### PR TITLE
release: prep v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-09
+
 ### Added
 
 - `bzr bug update --dupe-of <ID>` marks a bug as a duplicate by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzr"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "apple-native-keyring-store",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 
 [package]
 name = "bzr"
-version = "0.4.0-dev"
+version = "0.4.0"
 edition = "2021"
 description = "A CLI for Bugzilla, inspired by gh"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Set Cargo package version to 0.4.0.
- Date the v0.4.0 changelog entry.
- Prepare release notes for GitHub release extraction.

## Test Plan
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- make check-test-layout
- cargo build --release --locked
- target/release/bzr --version
- make man
- cargo publish --dry-run --locked
- make functional-test-all