### PR TITLE
chore: bump version to 0.4.1-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzr"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "apple-native-keyring-store",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 
 [package]
 name = "bzr"
-version = "0.4.0"
+version = "0.4.1-dev"
 edition = "2021"
 description = "A CLI for Bugzilla, inspired by gh"
 license = "MIT"


### PR DESCRIPTION
Automated post-release version bump after `v0.4.0` shipped.

This restores the development version suffix on `main` for the next patch cycle. The release workflow pushed the branch, but GitHub blocked `GITHUB_TOKEN` from opening the PR, so this PR was opened manually.