### PR TITLE
fix(bug): --fields/--exclude-fields shape table and --json output (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   for every bug subcommand (`bug list`, `bug my`, `bug search`, `query run`),
   so the exit code is deterministic and independent of server reachability.
   Partial-unknown selections still warn and show the valid columns. (#206)
+- Under `--json`, `id` is always fetched, so `--exclude-fields id` does not
+  drop it and it is never null; every other unselected field still comes back
+  null/empty. The stderr advisory now discloses this `id` exception and prints
+  only when stderr is a terminal, so piped and CI runs aren't spammed. (#206)
 
 ## [0.4.0] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   selects which columns appear in table output (in the order given) and
   `--exclude-fields` removes columns, instead of always rendering a fixed
   five-column table. `bug view` honors an explicit field set for its detail
-  rows. `--json` output is unchanged. (#206)
+  rows. `--json` always emits the full bug object. (#206)
+- An id-less `--fields` (e.g. `--fields summary,status`) no longer fails to
+  deserialize: `id` is always requested from the server so every bug parses,
+  regardless of the field selection. (#206)
+- A `--fields` value with no displayable columns (e.g. only custom `cf_*`
+  fields) or an `--exclude-fields` that removes every column now exits 7 with
+  a clear message, instead of silently falling back to the default columns or
+  rendering a blank table. Partial-unknown selections still warn and show the
+  valid columns. (#206)
 
 ## [0.4.0] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,28 +13,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   selects which columns appear in table output (in the order given) and
   `--exclude-fields` removes columns, instead of always rendering a fixed
   five-column table. `bug view` honors an explicit field set for its detail
-  rows. Under `--json`, all keys are still emitted, but `--fields` /
-  `--exclude-fields` only control which fields are *fetched*: unselected
-  fields come back null/empty rather than their real values, and a stderr
-  warning now says so. (#206)
+  rows. (#206)
+- Under `--json`, `--fields` / `--exclude-fields` now trim the output object
+  to the selected fields, gh-style: `bzr bug list --fields summary --json`
+  returns `[{"summary": ...}]` rather than the full object with every other
+  field nulled. The selection is honored literally — `id` appears only when
+  requested, and `--exclude-fields id` drops it — while the client still
+  fetches `id` internally so every bug deserializes. With no field selection
+  the full object is returned, unchanged. Trimming happens client-side after
+  the fetch, so it applies on REST and XML-RPC alike. Single-ID `bug view`
+  emits a trimmed bare object; multi-ID `bug view` trims each entry in `bugs`
+  while leaving the `{"bugs": [...], "failed": [...]}` wrapper and the per-bug
+  failure metadata intact. (#206)
 - An id-less `--fields` (e.g. `--fields summary,status`) no longer fails to
   deserialize: `id` is always requested from the server so every bug parses,
   regardless of the field selection. (#206)
-- A `--fields` value with no displayable columns (e.g. only custom `cf_*`
-  fields) or an `--exclude-fields` that removes every column now exits 7 with
-  a clear message, instead of silently falling back to the default columns or
-  rendering a blank table. This validation now runs before any network I/O
-  for every bug subcommand (`bug list`, `bug my`, `bug search`, `query run`),
-  so the exit code is deterministic and independent of server reachability.
-  Partial-unknown selections still warn and show the valid columns. (#206)
-- Under `--json`, `id` is always fetched, so `--exclude-fields id` does not
-  drop it and it is never null; every other unselected field still comes back
-  null/empty. The stderr advisory discloses this `id` exception and now fires
-  only when the selection genuinely restricts which fields are fetched, so
-  `--exclude-fields id` (which the client transparently re-adds) stays silent.
-  It prints only when stderr is a terminal, so redirected-stderr and CI/cron
-  runs aren't spammed — an interactive `… --json | jq` still warns, since that
-  user is watching stderr. (#206)
+- A field selection that leaves nothing to emit now exits 7 with a clear
+  message, before any network I/O, for every bug subcommand (`bug list`,
+  `bug my`, `bug search`, `query run`) — an all-unknown `--fields` value, or
+  an `--exclude-fields` that removes every field. In table mode emptiness is
+  measured against the five default columns; under `--json` against the full
+  field set, so `--exclude-fields` of the five table defaults still succeeds
+  and keeps the other fields. `bug view` is exempt in both modes, since a
+  sparse or empty single-bug object is a coherent result. Unknown `--fields`
+  tokens (typos, custom `cf_*` fields) are reported once on stderr. (#206)
 
 ## [0.4.0] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `bzr bug list`, `bug search`, `bug my`, and `query run`: `--fields` now
+  selects which columns appear in table output (in the order given) and
+  `--exclude-fields` removes columns, instead of always rendering a fixed
+  five-column table. `bug view` honors an explicit field set for its detail
+  rows. `--json` output is unchanged. (#206)
+
 ## [0.4.0] - 2026-05-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   selects which columns appear in table output (in the order given) and
   `--exclude-fields` removes columns, instead of always rendering a fixed
   five-column table. `bug view` honors an explicit field set for its detail
-  rows. `--json` always emits the full bug object. (#206)
+  rows. Under `--json`, all keys are still emitted, but `--fields` /
+  `--exclude-fields` only control which fields are *fetched*: unselected
+  fields come back null/empty rather than their real values, and a stderr
+  warning now says so. (#206)
 - An id-less `--fields` (e.g. `--fields summary,status`) no longer fails to
   deserialize: `id` is always requested from the server so every bug parses,
   regardless of the field selection. (#206)
 - A `--fields` value with no displayable columns (e.g. only custom `cf_*`
   fields) or an `--exclude-fields` that removes every column now exits 7 with
   a clear message, instead of silently falling back to the default columns or
-  rendering a blank table. Partial-unknown selections still warn and show the
-  valid columns. (#206)
+  rendering a blank table. This validation now runs before any network I/O
+  for every bug subcommand (`bug list`, `bug my`, `bug search`, `query run`),
+  so the exit code is deterministic and independent of server reachability.
+  Partial-unknown selections still warn and show the valid columns. (#206)
 
 ## [0.4.0] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Partial-unknown selections still warn and show the valid columns. (#206)
 - Under `--json`, `id` is always fetched, so `--exclude-fields id` does not
   drop it and it is never null; every other unselected field still comes back
-  null/empty. The stderr advisory now discloses this `id` exception and prints
-  only when stderr is a terminal, so piped and CI runs aren't spammed. (#206)
+  null/empty. The stderr advisory discloses this `id` exception and now fires
+  only when the selection genuinely restricts which fields are fetched, so
+  `--exclude-fields id` (which the client transparently re-adds) stays silent.
+  It prints only when stderr is a terminal, so redirected-stderr and CI/cron
+  runs aren't spammed — an interactive `… --json | jq` still warns, since that
+  user is watching stderr. (#206)
 
 ## [0.4.0] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   and keeps the other fields. `bug view` is exempt in both modes, since a
   sparse or empty single-bug object is a coherent result. Unknown `--fields`
   tokens (typos, custom `cf_*` fields) are reported once on stderr. (#206)
+- `bzr bug view --json` stays lenient where the list-style commands now exit
+  7: a selection that resolves to no known fields (an unknown/mistyped
+  `--fields`, or an `--exclude-fields` covering everything) emits an empty
+  `{}` object and exits 0 with a one-line stderr warning, rather than failing.
+  A `{}` plus a zero exit can therefore signal a misspelled field name —
+  consistent with `bug view` being exempt from the zero-field error in table
+  mode too. (#206)
+
+### Changed
+
+- Enabling `serde_json`'s `preserve_order` feature (needed for #206 bug-field
+  trimming) is crate-wide: JSON values built via the `json!` macro now
+  serialize keys in insertion order rather than alphabetically. The
+  user-visible effect is cosmetic key ordering — the error envelope
+  (`{"error":{"type",…,"message",…,"exit_code"}}`) and the `query`/`template`
+  `--json` result objects emit their keys in a different order. JSON key order
+  is not a contract for spec-compliant consumers; typed result structs (e.g.
+  `ActionResult`) are unaffected, since they already serialize in declaration
+  order. (#206)
 
 ## [0.4.0] - 2026-05-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,6 +1750,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ rustls-native-certs = "0.8"
 sha2 = "0.10"
 webpki-roots = "1.0"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
 toml = "0.8"
 dirs = "6"

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -212,8 +212,8 @@ Filter flags (`--product`, `--component`, `--status`, `--assignee`, `--creator`,
 | `--alias <A>` | No | | Filter by bug alias |
 | `--summary <S>` | No | | Substring match on the Summary field (matches all bug states) |
 | `--limit <N>` | No | 50 | Max results |
-| `--fields <F>` | No | | Table: columns to show (in order). JSON: fields to return (comma-separated). |
-| `--exclude-fields <F>` | No | | Table: columns to drop. JSON: fields to exclude (comma-separated). |
+| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). `--json` always emits the full bug object. |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. `--json` always emits the full bug object. |
 | `--created-since <DATE>` | No | | Filter to bugs whose `creation_time` is `>= DATE`. See [Date format](#date-format) below. |
 | `--changed-since <DATE>` | No | | Filter to bugs whose `last_change_time` is `>= DATE`. See [Date format](#date-format) below. |
 
@@ -268,8 +268,8 @@ bzr bug view my-alias --fields id,summary,assigned_to
 |--------|----------|-------------|
 | `<IDS>...` | Yes | One or more bug IDs or aliases. Aliases and numeric IDs may be mixed. |
 | `--permissive` | No | Multi-ID only. Continue past per-bug failures, surfacing them as `Bug #N — UNAVAILABLE` placeholder rows (table) or entries in `failed` (JSON). Exit 0 even if some bugs fail. Has no effect on session-wide failures (transport, auth, security) — those still bail. Setting `--permissive` with a single ID returns input-validation error (exit 7). |
-| `--fields <F>` | No | Table: detail rows to show. JSON: fields to return (comma-separated). |
-| `--exclude-fields <F>` | No | Table: detail rows to drop. JSON: fields to exclude (comma-separated). |
+| `--fields <F>` | No | Comma-separated fields requested from the server; in table output, selects which detail rows to show. `--json` always emits the full bug object. |
+| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those detail rows. `--json` always emits the full bug object. |
 
 **Output shapes:**
 
@@ -302,8 +302,8 @@ bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?known_name=m
 | `--from-url <URL>` | No* | | Execute a search from a Bugzilla buglist.cgi URL. Recognized parameters (product, component, status, etc.) are mapped to structured fields; unrecognized parameters (boolean charts, field-change filters) are passed through to the REST API verbatim. |
 | `--save-as [NAME]` | No | | Save this URL query for future reuse. If `NAME` is omitted, uses the URL's `known_name` parameter as the query name. Requires `--from-url`. |
 | `--limit <N>` | No | 50 | Max results. When `--from-url` is used, the URL's own limit parameter takes precedence unless overridden here. |
-| `--fields <F>` | No | | Table: columns to show (in order). JSON: fields to return (comma-separated). |
-| `--exclude-fields <F>` | No | | Table: columns to drop. JSON: fields to exclude (comma-separated). |
+| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). `--json` always emits the full bug object. |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. `--json` always emits the full bug object. |
 
 *One of `<QUERY>` or `--from-url` must be provided.
 
@@ -344,8 +344,8 @@ bzr bug my --status NEW --status '!RESOLVED'  # mixed positive and negated
 | `--all` | No | | Show all bugs related to me (assigned + created + CC'd) |
 | `--status <S>` | No | | Filter by status (repeatable; `!` prefix to exclude) |
 | `--limit <N>` | No | 50 | Max results per category. With `--all`, each of the three categories (assigned, created, CC'd) is queried separately up to this limit; duplicates across categories are removed. |
-| `--fields <F>` | No | | Table: columns to show (in order). JSON: fields to return (comma-separated). |
-| `--exclude-fields <F>` | No | | Table: columns to drop. JSON: fields to exclude (comma-separated). |
+| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). `--json` always emits the full bug object. |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. `--json` always emits the full bug object. |
 
 ### `bzr bug create`
 
@@ -1271,8 +1271,8 @@ bzr query save recent-firefox --product Firefox --changed-since 2026-04-01
 | `--severity <S>` | No* | Filter by severity (repeatable; prefix with `!` to exclude) |
 | `--search <Q>` | No* | Free-text search query |
 | `--limit <N>` | No | Max results |
-| `--fields <F>` | No | Stored with the query; at run time selects table columns and trims JSON output (comma-separated). |
-| `--exclude-fields <F>` | No | Stored with the query; at run time drops table columns and trims JSON output (comma-separated). |
+| `--fields <F>` | No | Stored with the query (comma-separated); at run time sets the fields requested from the server and selects table columns. `--json` always emits the full bug object. |
+| `--exclude-fields <F>` | No | Stored with the query (comma-separated); at run time drops those fields from the server request and removes table columns. `--json` always emits the full bug object. |
 | `--created-since <DATE>` | No | Save a `creation_time >= DATE` filter into the query. Same accepted forms as [`bzr bug list --created-since`](#date-format). |
 | `--changed-since <DATE>` | No | Save a `last_change_time >= DATE` filter into the query. Same accepted forms as [`bzr bug list --changed-since`](#date-format). |
 
@@ -1341,8 +1341,8 @@ bzr query run recent-firefox --changed-since 2026-05-01
 |--------|----------|-------------|
 | `<NAME>` | Yes | Query name |
 | `--limit <N>` | No | Override the saved limit |
-| `--fields <F>` | No | Table: columns to show (in order). JSON: fields to return (comma-separated). |
-| `--exclude-fields <F>` | No | Table: columns to drop. JSON: fields to exclude (comma-separated). |
+| `--fields <F>` | No | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). `--json` always emits the full bug object. |
+| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those columns. `--json` always emits the full bug object. |
 | `--server <NAME>` | No | Override the server to run the query against. Takes precedence over the server stored in the saved query. The global `--server` flag takes precedence over this flag. |
 | `--created-since <DATE>` | No | Override the saved `creation_time` filter for this run. Same accepted forms as [`bzr bug list --created-since`](#date-format). |
 | `--changed-since <DATE>` | No | Override the saved `last_change_time` filter for this run. Same accepted forms as [`bzr bug list --changed-since`](#date-format). |

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -185,6 +185,8 @@ List bugs matching filter criteria.
 bzr bug list --product Fedora --status ASSIGNED --limit 20
 bzr bug list --assignee user@example.com
 bzr bug list --product Fedora --fields id,summary,status
+# Select table columns
+bzr bug list --product Fedora --fields id,priority,severity,status,summary
 bzr bug list --id 100 --id 200 --id 300
 bzr bug list --status NEW --status ASSIGNED          # OR: match either status
 bzr bug list --status '!CLOSED'                      # NOT: exclude CLOSED
@@ -210,8 +212,8 @@ Filter flags (`--product`, `--component`, `--status`, `--assignee`, `--creator`,
 | `--alias <A>` | No | | Filter by bug alias |
 | `--summary <S>` | No | | Substring match on the Summary field (matches all bug states) |
 | `--limit <N>` | No | 50 | Max results |
-| `--fields <F>` | No | | Only return these fields (comma-separated) |
-| `--exclude-fields <F>` | No | | Exclude these fields (comma-separated) |
+| `--fields <F>` | No | | Table: columns to show (in order). JSON: fields to return (comma-separated). |
+| `--exclude-fields <F>` | No | | Table: columns to drop. JSON: fields to exclude (comma-separated). |
 | `--created-since <DATE>` | No | | Filter to bugs whose `creation_time` is `>= DATE`. See [Date format](#date-format) below. |
 | `--changed-since <DATE>` | No | | Filter to bugs whose `last_change_time` is `>= DATE`. See [Date format](#date-format) below. |
 
@@ -266,8 +268,8 @@ bzr bug view my-alias --fields id,summary,assigned_to
 |--------|----------|-------------|
 | `<IDS>...` | Yes | One or more bug IDs or aliases. Aliases and numeric IDs may be mixed. |
 | `--permissive` | No | Multi-ID only. Continue past per-bug failures, surfacing them as `Bug #N — UNAVAILABLE` placeholder rows (table) or entries in `failed` (JSON). Exit 0 even if some bugs fail. Has no effect on session-wide failures (transport, auth, security) — those still bail. Setting `--permissive` with a single ID returns input-validation error (exit 7). |
-| `--fields <F>` | No | Only return these fields (comma-separated) |
-| `--exclude-fields <F>` | No | Exclude these fields (comma-separated) |
+| `--fields <F>` | No | Table: detail rows to show. JSON: fields to return (comma-separated). |
+| `--exclude-fields <F>` | No | Table: detail rows to drop. JSON: fields to exclude (comma-separated). |
 
 **Output shapes:**
 
@@ -300,8 +302,8 @@ bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?known_name=m
 | `--from-url <URL>` | No* | | Execute a search from a Bugzilla buglist.cgi URL. Recognized parameters (product, component, status, etc.) are mapped to structured fields; unrecognized parameters (boolean charts, field-change filters) are passed through to the REST API verbatim. |
 | `--save-as [NAME]` | No | | Save this URL query for future reuse. If `NAME` is omitted, uses the URL's `known_name` parameter as the query name. Requires `--from-url`. |
 | `--limit <N>` | No | 50 | Max results. When `--from-url` is used, the URL's own limit parameter takes precedence unless overridden here. |
-| `--fields <F>` | No | | Only return these fields (comma-separated) |
-| `--exclude-fields <F>` | No | | Exclude these fields (comma-separated) |
+| `--fields <F>` | No | | Table: columns to show (in order). JSON: fields to return (comma-separated). |
+| `--exclude-fields <F>` | No | | Table: columns to drop. JSON: fields to exclude (comma-separated). |
 
 *One of `<QUERY>` or `--from-url` must be provided.
 
@@ -342,8 +344,8 @@ bzr bug my --status NEW --status '!RESOLVED'  # mixed positive and negated
 | `--all` | No | | Show all bugs related to me (assigned + created + CC'd) |
 | `--status <S>` | No | | Filter by status (repeatable; `!` prefix to exclude) |
 | `--limit <N>` | No | 50 | Max results per category. With `--all`, each of the three categories (assigned, created, CC'd) is queried separately up to this limit; duplicates across categories are removed. |
-| `--fields <F>` | No | | Only return these fields (comma-separated) |
-| `--exclude-fields <F>` | No | | Exclude these fields (comma-separated) |
+| `--fields <F>` | No | | Table: columns to show (in order). JSON: fields to return (comma-separated). |
+| `--exclude-fields <F>` | No | | Table: columns to drop. JSON: fields to exclude (comma-separated). |
 
 ### `bzr bug create`
 
@@ -1269,8 +1271,8 @@ bzr query save recent-firefox --product Firefox --changed-since 2026-04-01
 | `--severity <S>` | No* | Filter by severity (repeatable; prefix with `!` to exclude) |
 | `--search <Q>` | No* | Free-text search query |
 | `--limit <N>` | No | Max results |
-| `--fields <F>` | No | Only return these fields when the query runs (comma-separated) |
-| `--exclude-fields <F>` | No | Exclude these fields when the query runs (comma-separated) |
+| `--fields <F>` | No | Stored with the query; at run time selects table columns and trims JSON output (comma-separated). |
+| `--exclude-fields <F>` | No | Stored with the query; at run time drops table columns and trims JSON output (comma-separated). |
 | `--created-since <DATE>` | No | Save a `creation_time >= DATE` filter into the query. Same accepted forms as [`bzr bug list --created-since`](#date-format). |
 | `--changed-since <DATE>` | No | Save a `last_change_time >= DATE` filter into the query. Same accepted forms as [`bzr bug list --changed-since`](#date-format). |
 
@@ -1339,8 +1341,8 @@ bzr query run recent-firefox --changed-since 2026-05-01
 |--------|----------|-------------|
 | `<NAME>` | Yes | Query name |
 | `--limit <N>` | No | Override the saved limit |
-| `--fields <F>` | No | Only return these fields (comma-separated) |
-| `--exclude-fields <F>` | No | Exclude these fields (comma-separated) |
+| `--fields <F>` | No | Table: columns to show (in order). JSON: fields to return (comma-separated). |
+| `--exclude-fields <F>` | No | Table: columns to drop. JSON: fields to exclude (comma-separated). |
 | `--server <NAME>` | No | Override the server to run the query against. Takes precedence over the server stored in the saved query. The global `--server` flag takes precedence over this flag. |
 | `--created-since <DATE>` | No | Override the saved `creation_time` filter for this run. Same accepted forms as [`bzr bug list --created-since`](#date-format). |
 | `--changed-since <DATE>` | No | Override the saved `last_change_time` filter for this run. Same accepted forms as [`bzr bug list --changed-since`](#date-format). |

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -212,8 +212,8 @@ Filter flags (`--product`, `--component`, `--status`, `--assignee`, `--creator`,
 | `--alias <A>` | No | | Filter by bug alias |
 | `--summary <S>` | No | | Substring match on the Summary field (matches all bug states) |
 | `--limit <N>` | No | 50 | Max results |
-| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). `--json` always emits the full bug object. |
-| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. `--json` always emits the full bug object. |
+| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
 | `--created-since <DATE>` | No | | Filter to bugs whose `creation_time` is `>= DATE`. See [Date format](#date-format) below. |
 | `--changed-since <DATE>` | No | | Filter to bugs whose `last_change_time` is `>= DATE`. See [Date format](#date-format) below. |
 
@@ -268,8 +268,8 @@ bzr bug view my-alias --fields id,summary,assigned_to
 |--------|----------|-------------|
 | `<IDS>...` | Yes | One or more bug IDs or aliases. Aliases and numeric IDs may be mixed. |
 | `--permissive` | No | Multi-ID only. Continue past per-bug failures, surfacing them as `Bug #N — UNAVAILABLE` placeholder rows (table) or entries in `failed` (JSON). Exit 0 even if some bugs fail. Has no effect on session-wide failures (transport, auth, security) — those still bail. Setting `--permissive` with a single ID returns input-validation error (exit 7). |
-| `--fields <F>` | No | Comma-separated fields requested from the server; in table output, selects which detail rows to show. `--json` always emits the full bug object. |
-| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those detail rows. `--json` always emits the full bug object. |
+| `--fields <F>` | No | Comma-separated fields requested from the server; in table output, selects which detail rows to show. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
+| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those detail rows. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
 
 **Output shapes:**
 
@@ -302,8 +302,8 @@ bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?known_name=m
 | `--from-url <URL>` | No* | | Execute a search from a Bugzilla buglist.cgi URL. Recognized parameters (product, component, status, etc.) are mapped to structured fields; unrecognized parameters (boolean charts, field-change filters) are passed through to the REST API verbatim. |
 | `--save-as [NAME]` | No | | Save this URL query for future reuse. If `NAME` is omitted, uses the URL's `known_name` parameter as the query name. Requires `--from-url`. |
 | `--limit <N>` | No | 50 | Max results. When `--from-url` is used, the URL's own limit parameter takes precedence unless overridden here. |
-| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). `--json` always emits the full bug object. |
-| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. `--json` always emits the full bug object. |
+| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
 
 *One of `<QUERY>` or `--from-url` must be provided.
 
@@ -344,8 +344,8 @@ bzr bug my --status NEW --status '!RESOLVED'  # mixed positive and negated
 | `--all` | No | | Show all bugs related to me (assigned + created + CC'd) |
 | `--status <S>` | No | | Filter by status (repeatable; `!` prefix to exclude) |
 | `--limit <N>` | No | 50 | Max results per category. With `--all`, each of the three categories (assigned, created, CC'd) is queried separately up to this limit; duplicates across categories are removed. |
-| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). `--json` always emits the full bug object. |
-| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. `--json` always emits the full bug object. |
+| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
 
 ### `bzr bug create`
 
@@ -1271,8 +1271,8 @@ bzr query save recent-firefox --product Firefox --changed-since 2026-04-01
 | `--severity <S>` | No* | Filter by severity (repeatable; prefix with `!` to exclude) |
 | `--search <Q>` | No* | Free-text search query |
 | `--limit <N>` | No | Max results |
-| `--fields <F>` | No | Stored with the query (comma-separated); at run time sets the fields requested from the server and selects table columns. `--json` always emits the full bug object. |
-| `--exclude-fields <F>` | No | Stored with the query (comma-separated); at run time drops those fields from the server request and removes table columns. `--json` always emits the full bug object. |
+| `--fields <F>` | No | Stored with the query (comma-separated); at run time sets the fields requested from the server and selects table columns. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
+| `--exclude-fields <F>` | No | Stored with the query (comma-separated); at run time drops those fields from the server request and removes table columns. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
 | `--created-since <DATE>` | No | Save a `creation_time >= DATE` filter into the query. Same accepted forms as [`bzr bug list --created-since`](#date-format). |
 | `--changed-since <DATE>` | No | Save a `last_change_time >= DATE` filter into the query. Same accepted forms as [`bzr bug list --changed-since`](#date-format). |
 
@@ -1341,8 +1341,8 @@ bzr query run recent-firefox --changed-since 2026-05-01
 |--------|----------|-------------|
 | `<NAME>` | Yes | Query name |
 | `--limit <N>` | No | Override the saved limit |
-| `--fields <F>` | No | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). `--json` always emits the full bug object. |
-| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those columns. `--json` always emits the full bug object. |
+| `--fields <F>` | No | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
+| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
 | `--server <NAME>` | No | Override the server to run the query against. Takes precedence over the server stored in the saved query. The global `--server` flag takes precedence over this flag. |
 | `--created-since <DATE>` | No | Override the saved `creation_time` filter for this run. Same accepted forms as [`bzr bug list --created-since`](#date-format). |
 | `--changed-since <DATE>` | No | Override the saved `last_change_time` filter for this run. Same accepted forms as [`bzr bug list --changed-since`](#date-format). |

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -255,6 +255,12 @@ upstream Bugzilla and `bzl-search`.
 
 Display detailed information about one or more bugs.
 
+On XML-RPC servers, single-bug `bzr bug view` fetches the full bug
+regardless of `--fields`/`--exclude-fields`; the selection still
+controls which detail rows render, and under `--json` the returned
+object is complete (the field-restriction note below applies to REST
+servers and to `bug list`/`bug my`/`bug search`/`query run`).
+
 ```bash
 bzr bug view 12345
 bzr bug view 12345 12346 12347

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -212,8 +212,8 @@ Filter flags (`--product`, `--component`, `--status`, `--assignee`, `--creator`,
 | `--alias <A>` | No | | Filter by bug alias |
 | `--summary <S>` | No | | Substring match on the Summary field (matches all bug states) |
 | `--limit <N>` | No | 50 | Max results |
-| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
-| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
+| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). |
 | `--created-since <DATE>` | No | | Filter to bugs whose `creation_time` is `>= DATE`. See [Date format](#date-format) below. |
 | `--changed-since <DATE>` | No | | Filter to bugs whose `last_change_time` is `>= DATE`. See [Date format](#date-format) below. |
 
@@ -255,11 +255,12 @@ upstream Bugzilla and `bzl-search`.
 
 Display detailed information about one or more bugs.
 
-On XML-RPC servers, single-bug `bzr bug view` fetches the full bug
-regardless of `--fields`/`--exclude-fields`; the selection still
-controls which detail rows render, and under `--json` the returned
-object is complete (the field-restriction note below applies to REST
-servers and to `bug list`/`bug my`/`bug search`/`query run`).
+Under `--json` the returned object is trimmed to the selected fields
+(gh-style) on every transport, since trimming happens client-side after
+the fetch. On XML-RPC servers, single-bug `bzr bug view` fetches the full
+bug regardless of `--fields`/`--exclude-fields`, so there the selection
+only controls which detail rows (table) or object keys (JSON) appear, not
+what is sent over the wire.
 
 ```bash
 bzr bug view 12345
@@ -274,13 +275,13 @@ bzr bug view my-alias --fields id,summary,assigned_to
 |--------|----------|-------------|
 | `<IDS>...` | Yes | One or more bug IDs or aliases. Aliases and numeric IDs may be mixed. |
 | `--permissive` | No | Multi-ID only. Continue past per-bug failures, surfacing them as `Bug #N — UNAVAILABLE` placeholder rows (table) or entries in `failed` (JSON). Exit 0 even if some bugs fail. Has no effect on session-wide failures (transport, auth, security) — those still bail. Setting `--permissive` with a single ID returns input-validation error (exit 7). |
-| `--fields <F>` | No | Comma-separated fields requested from the server; in table output, selects which detail rows to show. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
-| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those detail rows. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
+| `--fields <F>` | No | Comma-separated fields requested from the server; in table output, selects which detail rows to show. Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
+| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those detail rows. Under `--json`, the object omits the dropped fields (including `id`, when excluded). |
 
 **Output shapes:**
 
 - **Single-ID, table:** detail block (status, priority, assignee, etc.).
-- **Single-ID, `--json`:** bare `Bug` object — *unchanged from prior versions*.
+- **Single-ID, `--json`:** bare `Bug` object, trimmed to `--fields`/`--exclude-fields` when given (the full object otherwise). The wrapper shape is unchanged from prior versions.
 - **Multi-ID, table:** one detail block per bug in argument order, separated by a `─` divider line. Inaccessible bugs (under `--permissive`) appear as `Bug #N — UNAVAILABLE` blocks.
 - **Multi-ID, `--json`:** wrapped object `{"bugs": [...], "failed": [...]}`. The `failed` array is always present (empty when there are no failures) so `jq` consumers can rely on `.bugs[]` regardless of whether `--permissive` was passed.
 
@@ -308,8 +309,8 @@ bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?known_name=m
 | `--from-url <URL>` | No* | | Execute a search from a Bugzilla buglist.cgi URL. Recognized parameters (product, component, status, etc.) are mapped to structured fields; unrecognized parameters (boolean charts, field-change filters) are passed through to the REST API verbatim. |
 | `--save-as [NAME]` | No | | Save this URL query for future reuse. If `NAME` is omitted, uses the URL's `known_name` parameter as the query name. Requires `--from-url`. |
 | `--limit <N>` | No | 50 | Max results. When `--from-url` is used, the URL's own limit parameter takes precedence unless overridden here. |
-| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
-| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
+| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). |
 
 *One of `<QUERY>` or `--from-url` must be provided.
 
@@ -350,8 +351,8 @@ bzr bug my --status NEW --status '!RESOLVED'  # mixed positive and negated
 | `--all` | No | | Show all bugs related to me (assigned + created + CC'd) |
 | `--status <S>` | No | | Filter by status (repeatable; `!` prefix to exclude) |
 | `--limit <N>` | No | 50 | Max results per category. With `--all`, each of the three categories (assigned, created, CC'd) is queried separately up to this limit; duplicates across categories are removed. |
-| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
-| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
+| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). |
 
 ### `bzr bug create`
 
@@ -1277,8 +1278,8 @@ bzr query save recent-firefox --product Firefox --changed-since 2026-04-01
 | `--severity <S>` | No* | Filter by severity (repeatable; prefix with `!` to exclude) |
 | `--search <Q>` | No* | Free-text search query |
 | `--limit <N>` | No | Max results |
-| `--fields <F>` | No | Stored with the query (comma-separated); at run time sets the fields requested from the server and selects table columns. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
-| `--exclude-fields <F>` | No | Stored with the query (comma-separated); at run time drops those fields from the server request and removes table columns. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
+| `--fields <F>` | No | Stored with the query (comma-separated); at run time sets the fields requested from the server and selects table columns. Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
+| `--exclude-fields <F>` | No | Stored with the query (comma-separated); at run time drops those fields from the server request and removes table columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). |
 | `--created-since <DATE>` | No | Save a `creation_time >= DATE` filter into the query. Same accepted forms as [`bzr bug list --created-since`](#date-format). |
 | `--changed-since <DATE>` | No | Save a `last_change_time >= DATE` filter into the query. Same accepted forms as [`bzr bug list --changed-since`](#date-format). |
 
@@ -1347,8 +1348,8 @@ bzr query run recent-firefox --changed-since 2026-05-01
 |--------|----------|-------------|
 | `<NAME>` | Yes | Query name |
 | `--limit <N>` | No | Override the saved limit |
-| `--fields <F>` | No | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
-| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, all keys are emitted, but unselected fields come back null/empty, not their real values. |
+| `--fields <F>` | No | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
+| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). |
 | `--server <NAME>` | No | Override the server to run the query against. Takes precedence over the server stored in the saved query. The global `--server` flag takes precedence over this flag. |
 | `--created-since <DATE>` | No | Override the saved `creation_time` filter for this run. Same accepted forms as [`bzr bug list --created-since`](#date-format). |
 | `--changed-since <DATE>` | No | Override the saved `last_change_time` filter for this run. Same accepted forms as [`bzr bug list --changed-since`](#date-format). |

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -285,6 +285,14 @@ bzr bug view my-alias --fields id,summary,assigned_to
 - **Multi-ID, table:** one detail block per bug in argument order, separated by a `─` divider line. Inaccessible bugs (under `--permissive`) appear as `Bug #N — UNAVAILABLE` blocks.
 - **Multi-ID, `--json`:** wrapped object `{"bugs": [...], "failed": [...]}`. The `failed` array is always present (empty when there are no failures) so `jq` consumers can rely on `.bugs[]` regardless of whether `--permissive` was passed.
 
+> **Note:** Under `--json`, `bzr bug view` stays lenient when the field
+> selection resolves to nothing known — an unknown/mistyped `--fields`, or an
+> `--exclude-fields` covering every field — emitting an empty `{}` object and
+> exiting 0 with a one-line stderr warning. The list-style commands
+> (`bzr bug list`, `bzr bug my`, `bzr bug search`, `query run`) instead exit 7
+> for the same mistake. A `{}` result with a zero exit can therefore mean a
+> field name was misspelled; check stderr.
+
 ### `bzr bug search`
 
 Search bugs using Bugzilla's quicksearch syntax, or execute a search from a Bugzilla buglist.cgi URL.

--- a/docs/superpowers/specs/2026-05-27-json-field-trimming-design.md
+++ b/docs/superpowers/specs/2026-05-27-json-field-trimming-design.md
@@ -1,0 +1,204 @@
+# `--json` field selection trims the output object
+
+**Date:** 2026-05-27
+**Issue:** follow-up on [#206](https://github.com/randomparity/bzr/issues/206) (`fix/issue-206`)
+**Supersedes:** the `--json` field advisory shipped earlier on this branch
+(commits `518e29f`..`8831cdc`)
+
+## Goal
+
+Make `--fields` / `--exclude-fields` actually trim the JSON output object
+to the selected fields, the way `gh ... --json <fields>` does. Today the
+`Bug` struct is serialized whole, so a field selection only controls which
+values are *fetched* — unselected keys are still emitted with `null`/empty
+values. That is a footgun for scripted and agent consumers and wastes
+tokens: an agent that asks for two fields should get two fields.
+
+After this change, `bzr bug list --fields summary --json` returns
+`[{"summary": "..."}]`, not the full object with everything-but-summary
+nulled.
+
+## Decisions (locked during brainstorming)
+
+1. **`id` contract: honor the selection literally (gh-style).** Output
+   exactly the requested keys. `--fields summary` omits `id` unless asked;
+   `--exclude-fields id` drops `id` from output. This reverses the
+   "`id` is always present" guarantee the earlier #206 work established —
+   that guarantee was only meaningful because output wasn't trimmed.
+   The client still *fetches* `id` internally for deserialization (see
+   Non-goals); output trimming is independent.
+2. **Unknown/unmodeled field tokens mirror table mode.** All-unknown
+   include → exit 7 with the existing message; partial-unknown → warn once
+   on stderr and project the known fields; an `--exclude-fields` that drops
+   every key → exit 7. The column registry is 1:1 with the `Bug` struct's
+   serde keys, so "unknown for a table column" and "unknown for a JSON key"
+   are the same set — JSON reuses table mode's validation verbatim.
+3. **`bug view` is exempt from the zero-field error in JSON, as it already
+   is in table mode.** A sparse or empty single-bug object (`{}`) is a
+   coherent result, matching the existing detail-view exemption.
+4. **`preserve_order` for `serde_json`.** Enable the feature so projected
+   objects keep struct-declaration order rather than going alphabetical,
+   keeping trimmed output consistent with the existing full-object output.
+
+## Non-goals
+
+- No change to bare `--json` (no field selection) — it still returns the
+  full object.
+- No change to table / detail rendering — `field_selected` already controls
+  which rows and columns appear.
+- No change to `force_id_fields` in the client: `id` is still always added
+  to the wire request so every bug deserializes. That is about the request,
+  not the output, and is orthogonal to trimming.
+- No support for custom `cf_*` fields in JSON output. `Bug` is a fixed
+  struct with no `#[serde(flatten)]`, so unmodeled fields are already
+  dropped at deserialization and can never appear — trimming does not change
+  this. Capturing custom fields is possible future work, out of scope here.
+- No new `BzrError` variants. The zero-field cases reuse the existing
+  `InputValidation` (exit 7).
+
+## Architecture
+
+### Projection helpers (`src/output/resources/bug.rs`)
+
+```rust
+/// Project a bug into a JSON object honoring `spec`:
+/// - include: keep exactly the canonical keys named (intersection)
+/// - exclude: drop the canonical keys named
+/// - neither: full object, unchanged
+fn bug_to_json(bug: &Bug, spec: ColumnSpec<'_>) -> serde_json::Value;
+
+/// `bug_to_json` over a slice, for the array output paths.
+fn bugs_to_json(bugs: &[Bug], spec: ColumnSpec<'_>) -> Vec<serde_json::Value>;
+```
+
+Implementation:
+1. `serde_json::to_value(bug)` → a `Value::Object`. With `preserve_order`
+   the map keeps struct order.
+2. Resolve `spec` to a canonical key set via the existing
+   `canonical_field_list` (include) and a `partition_include`-based split
+   for the known/unknown distinction — the same primitives table mode uses,
+   so alias resolution (`assignee`→`assigned_to`, `platform`→`rep_platform`)
+   can't drift between modes.
+3. Include: `retain` keys in the canonical set. Exclude: `remove` the
+   canonical keys. Neither: return the object untouched.
+
+Projection operates only on keys already present in the serialized object,
+so unknown tokens are inert at this layer; the warn/error behavior for them
+is handled by validation (below), not here.
+
+### Validation becomes mode-agnostic
+
+`validate_table_columns` is renamed `validate_field_selection` and its doc
+updated (it is no longer table-only — the known set is identical for both
+output modes). Its error messages are genericized off "table column" so they
+read correctly in JSON mode too: all-unknown include → "none of the requested
+fields are valid bug fields: …"; exclude-everything → "--exclude-fields
+removed every field; nothing left to display". The pre-network gate in
+`src/commands/bug/mod.rs` and `src/commands/query.rs` collapses to one path:
+
+```rust
+if let Some(spec) = bug_column_spec(action) {
+    if !matches!(action, BugAction::View { .. }) {
+        validate_field_selection(spec)?;   // exit 7 on zero fields, both modes
+    }
+}
+```
+
+The `format == Json` branch that called `warn_json_field_selection` is
+removed. `query run` mirrors this (no `match format` split for validation).
+
+### Partial-unknown warning for JSON
+
+Table mode warns about ignored unknown tokens at render time inside
+`resolve_columns`. For JSON, the projection path computes the unknown tokens
+once (via `partition_include`) and emits the warning on `err` a single time
+before projecting — not once per bug. The warning text is genericized to
+`"warning: ignoring unknown field(s): …"` (dropping the table-specific
+"no table column" phrasing) so it reads correctly in both modes; the existing
+table-mode tests that assert the old wording are updated accordingly. None of
+the new phrasings collide with the forbidden phrases checked by
+`cli_and_docs_avoid_misleading_trim_phrasing`.
+
+### JSON sinks
+
+Three call sites serialize bugs; each switches to projected values:
+
+| Path | Commands | Change |
+|------|----------|--------|
+| `write_bugs` JSON branch | `bug list`, `bug my`, `bug search`, `query run` | serialize `bugs_to_json(bugs, spec)` |
+| `write_bug_detail` JSON branch | single `bug view` | serialize `bug_to_json(bug, spec)` |
+| multi `bug view` | `bug view <many>` | emit `{"bugs": [bug_to_json…], "failed": […]}`; wrapper keys and `BugViewFailure {id, error}` are metadata, untrimmed |
+
+`write_formatted`/`write_json` stay generic; the bug writers project before
+handing a `Value`/`Vec<Value>` to the JSON path. The multi-bug wrapper is
+built explicitly (e.g. `serde_json::json!({...})` or a small struct holding
+`Vec<Value>`) since `MultiBugViewResult`'s typed `Vec<Bug>` would serialize
+whole.
+
+## Data flow
+
+```
+CLI args ──> ColumnSpec ──> validate_field_selection (pre-network, exit 7 on zero fields; view exempt)
+                                  │
+                          network fetch (client always includes id on the wire)
+                                  │
+                       bug_to_json / bugs_to_json
+                         · resolve aliases -> canonical keys (shared with table mode)
+                         · warn once on partial-unknown
+                         · include: retain named keys | exclude: drop named keys | none: full
+                                  │
+                          serde_json -> stdout
+```
+
+## Removals (replace, don't deprecate)
+
+- `warn_json_field_selection` and the `json_selection_restricts` helper in
+  `src/output/resources/bug.rs`.
+- Their unit tests in `src/output/resources/bug_tests.rs`
+  (`warn_json_field_selection_*`).
+- The #206 CHANGELOG bullet's "null/empty" / advisory language → rewritten
+  to describe trimming and the gh-style `id` contract.
+- The `--fields` / `--exclude-fields` per-arg help and the `bug view`
+  long-doc in `src/cli/bug.rs`, and the matching prose in
+  `docs/bzr-cli.md`: replace "unselected fields come back null/empty" with
+  "the JSON object contains only the selected fields." The XML-RPC `bug
+  view` no-op note narrows to table/detail output, since JSON is now trimmed
+  client-side regardless of transport (this closes Finding 3).
+
+## Testing (TDD)
+
+**Unit — `src/output/resources/bug_tests.rs`:**
+- `bug_to_json` include keeps exactly the named keys (e.g. `summary,status`
+  → object with those two keys only).
+- include with alias (`assignee`) yields canonical key (`assigned_to`).
+- `--exclude-fields id` drops `id`; `--exclude-fields cc,keywords` drops
+  those, keeps the rest.
+- no selection (`None`/`""`/`,,`) → full object, all keys present.
+- partial-unknown (`summary,cf_x`) → object has `summary`, stderr has the
+  one ignore-warning, no `cf_x` key.
+- key order matches struct order (locks the `preserve_order` decision).
+- `bugs_to_json` projects every element.
+
+**Command/integration:**
+- all-unknown include under `--json` → exit 7 (mirrors table); reuse/extend
+  the existing zero-column tests now that validation is mode-agnostic.
+- multi `bug view --json --fields summary` → each entry in `bugs` trimmed,
+  `failed` untouched.
+- `cli_and_docs_avoid_misleading_trim_phrasing` stays green after the prose
+  rewrites (no forbidden phrase reintroduced).
+
+**Dependency/build:** add `serde_json` `preserve_order`; confirm full-object
+output ordering is unchanged and `cargo test`/`clippy`/`fmt` clean.
+
+## Blast radius
+
+- **Output shape changes** for any existing `--json` + field-selection
+  invocation: previously a full object with nulls, now a trimmed object.
+  This is the intended fix. `jq` on a now-absent key still returns `null`,
+  so well-behaved consumers are unaffected; consumers that distinguished
+  "key present and null" from "key absent" would see a difference (rare,
+  and the prior shape was the bug).
+- **`--exclude-fields id --json`** now omits `id` (was: present). Documented
+  as part of the gh-style contract.
+- **Auto-JSON on a pipe** is unchanged: JSON is still selected when stdout
+  is not a TTY. Trimming applies there too, which is the point.

--- a/docs/superpowers/specs/2026-05-27-json-field-trimming-design.md
+++ b/docs/superpowers/specs/2026-05-27-json-field-trimming-design.md
@@ -28,14 +28,20 @@ nulled.
    The client still *fetches* `id` internally for deserialization (see
    Non-goals); output trimming is independent.
 2. **Unknown/unmodeled field tokens mirror table mode.** All-unknown
-   include → exit 7 with the existing message; partial-unknown → warn once
-   on stderr and project the known fields; an `--exclude-fields` that drops
-   every key → exit 7. The column registry is 1:1 with the `Bug` struct's
-   serde keys, so "unknown for a table column" and "unknown for a JSON key"
-   are the same set — JSON reuses table mode's validation verbatim.
+   include → exit 7; partial-unknown → warn once on stderr and project the
+   known fields; an `--exclude-fields` that drops every key → exit 7. The
+   column registry is 1:1 with the `Bug` struct's serde keys (23 each), so
+   "unknown for a table column" and "unknown for a JSON key" are the same
+   set. **Validation is *not* reused verbatim**, however: table mode measures
+   emptiness against its five-column `default_columns()` base, while JSON must
+   measure against the full 23-key universe (otherwise `--exclude-fields` of
+   the five table defaults would falsely exit 7 even though 18 keys remain).
+   A separate `validate_json_field_selection` does this — see Validation.
 3. **`bug view` is exempt from the zero-field error in JSON, as it already
    is in table mode.** A sparse or empty single-bug object (`{}`) is a
-   coherent result, matching the existing detail-view exemption.
+   coherent result, matching the existing detail-view exemption. To keep a
+   typo from silently yielding `{}`, `bug view --json` still **warns** about
+   unknown `--fields` tokens (it just doesn't exit 7).
 4. **`preserve_order` for `serde_json`.** Enable the feature so projected
    objects keep struct-declaration order rather than going alphabetical,
    keeping trimmed output consistent with the existing full-object output.
@@ -86,37 +92,48 @@ Projection operates only on keys already present in the serialized object,
 so unknown tokens are inert at this layer; the warn/error behavior for them
 is handled by validation (below), not here.
 
-### Validation becomes mode-agnostic
+### Validation is mode-specific
 
-`validate_table_columns` is renamed `validate_field_selection` and its doc
-updated (it is no longer table-only — the known set is identical for both
-output modes). Its error messages are genericized off "table column" so they
-read correctly in JSON mode too: all-unknown include → "none of the requested
-fields are valid bug fields: …"; exclude-everything → "--exclude-fields
-removed every field; nothing left to display". The pre-network gate in
-`src/commands/bug/mod.rs` and `src/commands/query.rs` collapses to one path:
+`validate_table_columns` is left **unchanged** — its five-column base is
+correct for table semantics. A new `validate_json_field_selection(spec)`
+validates against the full 23-key universe: it computes the effective
+projected key set (start from the include-knowns when a non-blank include is
+present, else all `COLUMNS` canonical names; subtract the exclude-knowns) and
+returns `InputValidation` (exit 7) iff that set is empty. This naturally
+covers both *all-unknown include* and *exclude-every-key*, while **passing**
+`--exclude-fields` of the five table defaults (18 keys remain). A blank
+include (`""` / `,,`) is treated as no selection.
+
+The pre-network gate in `src/commands/bug/mod.rs` and `src/commands/query.rs`
+branches on format, validating against the right base and warning in the same
+place (it has `w.err`, so the warning is implementable without threading an
+`err` sink through the pure projection helpers):
 
 ```rust
 if let Some(spec) = bug_column_spec(action) {
-    if !matches!(action, BugAction::View { .. }) {
-        validate_field_selection(spec)?;   // exit 7 on zero fields, both modes
+    let is_view = matches!(action, BugAction::View { .. });
+    match format {
+        OutputFormat::Table => { if !is_view { validate_table_columns(spec)?; } }
+        OutputFormat::Json => {
+            if !is_view { validate_json_field_selection(spec)?; } // view stays lenient
+            warn_unknown_fields(spec, w.err);                     // all actions incl. view
+        }
     }
 }
 ```
 
-The `format == Json` branch that called `warn_json_field_selection` is
-removed. `query run` mirrors this (no `match format` split for validation).
+`warn_json_field_selection` and `json_selection_restricts` are removed.
+`query run` mirrors the gate (it has no `view` case, so it always validates).
 
-### Partial-unknown warning for JSON
+### Partial-unknown warning lives in the gate
 
 Table mode warns about ignored unknown tokens at render time inside
-`resolve_columns`. For JSON, the projection path computes the unknown tokens
-once (via `partition_include`) and emits the warning on `err` a single time
-before projecting — not once per bug. The warning text is genericized to
-`"warning: ignoring unknown field(s): …"` (dropping the table-specific
-"no table column" phrasing) so it reads correctly in both modes; the existing
-table-mode tests that assert the old wording are updated accordingly. None of
-the new phrasings collide with the forbidden phrases checked by
+`resolve_columns` (unchanged). For JSON the gate calls `warn_unknown_fields`
+once — covering `list`/`my`/`search`/`query run` **and** `view` — before any
+network I/O, so the projection helpers (`bug_to_json` / `bugs_to_json`) stay
+pure and take no `err` sink. The warning text is genericized to
+`"warning: ignoring unknown field(s): …"` so it reads correctly in both
+modes; it does not collide with the forbidden phrases checked by
 `cli_and_docs_avoid_misleading_trim_phrasing`.
 
 ### JSON sinks
@@ -138,13 +155,14 @@ whole.
 ## Data flow
 
 ```
-CLI args ──> ColumnSpec ──> validate_field_selection (pre-network, exit 7 on zero fields; view exempt)
+CLI args ──> ColumnSpec ──> pre-network gate
+                              · validate_json_field_selection (exit 7 on zero fields; view exempt)
+                              · warn_unknown_fields on err (all actions incl. view)
                                   │
                           network fetch (client always includes id on the wire)
                                   │
-                       bug_to_json / bugs_to_json
+                       bug_to_json / bugs_to_json   (pure; no err sink)
                          · resolve aliases -> canonical keys (shared with table mode)
-                         · warn once on partial-unknown
                          · include: retain named keys | exclude: drop named keys | none: full
                                   │
                           serde_json -> stdout
@@ -174,21 +192,39 @@ CLI args ──> ColumnSpec ──> validate_field_selection (pre-network, exit 
 - `--exclude-fields id` drops `id`; `--exclude-fields cc,keywords` drops
   those, keeps the rest.
 - no selection (`None`/`""`/`,,`) → full object, all keys present.
-- partial-unknown (`summary,cf_x`) → object has `summary`, stderr has the
-  one ignore-warning, no `cf_x` key.
-- key order matches struct order (locks the `preserve_order` decision).
+- partial-unknown (`summary,cf_x`) → object has `summary`, no `cf_x` key.
 - `bugs_to_json` projects every element.
 
+**Finding 4 — real ordering lock (replaces the vacuous full-object test):**
+- projected object key order equals struct-declaration order, *even when the
+  include list is given out of order* (`status,id,summary` → `id, summary,
+  status`). The full-object struct path can't exercise `preserve_order`; a
+  projected object built from a `Value::Object` can, so this is the test that
+  actually fails if `preserve_order` is dropped.
+
+**Finding 3 — registry drift guard:**
+- serialize a `Bug`, assert its serde key set equals the `COLUMNS`
+  canonical-name set (both directions) and that `COLUMNS` has no duplicate
+  canonical names, so future field drift fails loudly.
+
+**Finding 1 — JSON validator regression:**
+- `validate_json_field_selection`: all-unknown include → `Err` (exit 7);
+  exclude all 23 keys → `Err`; **`--exclude-fields` of the five default
+  columns → `Ok`** (must not exit 7); blank / no selection → `Ok`.
+
 **Command/integration:**
-- all-unknown include under `--json` → exit 7 (mirrors table); reuse/extend
-  the existing zero-column tests now that validation is mode-agnostic.
+- `bug list --json` all-unknown → exit 7; partial-unknown → warning on
+  stderr + projected array.
+- `bug view --json` all-unknown → exit 0 + `{}` + stderr warning (lenient);
+  partial → warning + projected.
 - multi `bug view --json --fields summary` → each entry in `bugs` trimmed,
   `failed` untouched.
 - `cli_and_docs_avoid_misleading_trim_phrasing` stays green after the prose
   rewrites (no forbidden phrase reintroduced).
 
-**Dependency/build:** add `serde_json` `preserve_order`; confirm full-object
-output ordering is unchanged and `cargo test`/`clippy`/`fmt` clean.
+**Dependency/build:** add `serde_json` `preserve_order` (no new crate —
+`indexmap` is already in the tree via reqwest/h2); `cargo deny check` clean
+and `cargo test`/`clippy`/`fmt` clean.
 
 ## Blast radius
 

--- a/docs/superpowers/specs/2026-05-27-json-field-trimming-design.md
+++ b/docs/superpowers/specs/2026-05-27-json-field-trimming-design.md
@@ -41,7 +41,13 @@ nulled.
    is in table mode.** A sparse or empty single-bug object (`{}`) is a
    coherent result, matching the existing detail-view exemption. To keep a
    typo from silently yielding `{}`, `bug view --json` still **warns** about
-   unknown `--fields` tokens (it just doesn't exit 7).
+   unknown `--fields` tokens (it just doesn't exit 7). Accepted trade-off:
+   this makes the exit code for an identical typo diverge by command —
+   `bug view --json --fields <typo>` exits 0 with `{}` while
+   `bug list`/`my`/`search`/`query run` exit 7. The asymmetry is the
+   deliberate price of `view` staying exempt; it is documented in the
+   `bug view` help and `docs/bzr-cli.md` so a `{}`-plus-exit-0 result is
+   discoverable as a possible misspelling.
 4. **`preserve_order` for `serde_json`.** Enable the feature so projected
    objects keep struct-declaration order rather than going alphabetical,
    keeping trimmed output consistent with the existing full-object output.

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -158,7 +158,11 @@ pub enum BugAction {
     /// Session-wide failures (transport, auth, security) still bail.
     ///
     /// Use `--fields` to fetch only specific fields (faster on large
-    /// bugs); `--exclude-fields` is the inverse.
+    /// bugs); `--exclude-fields` is the inverse. On XML-RPC servers,
+    /// single-bug `bug view` fetches the full bug regardless of the
+    /// field list (the selection still controls which detail rows or
+    /// table columns render, and under `--json` the returned object is
+    /// complete).
     ///
     /// Examples:
     ///

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -21,8 +21,11 @@ pub enum BugAction {
     ///
     /// `--limit` defaults to 50; raise it for broader scans, but very
     /// large values may exceed the server's max-results setting and
-    /// return a truncated list. Use `--fields` / `--exclude-fields` to
-    /// trim the response payload.
+    /// return a truncated list. In table output, `--fields` selects which
+    /// columns are shown (in the given order) and `--exclude-fields`
+    /// removes columns; in `--json` output both trim the response payload.
+    /// Fields with no table column (e.g. custom `cf_*` fields) are skipped
+    /// with a warning in table mode — use `--json` to see them.
     ///
     /// `--created-since` / `--changed-since` filter by Bugzilla's
     /// `creation_time` / `last_change_time` fields. Both accept ISO
@@ -84,10 +87,11 @@ pub enum BugAction {
         /// Max number of results
         #[arg(long, default_value = "50")]
         limit: u32,
-        /// Only return these fields (comma-separated)
+        /// Fields to show as columns / return (comma-separated). In table
+        /// output, selects columns; with --json, trims the payload.
         #[arg(long)]
         fields: Option<String>,
-        /// Exclude these fields (comma-separated)
+        /// Fields to drop from columns / response (comma-separated).
         #[arg(long)]
         exclude_fields: Option<String>,
         /// Filter to bugs created at or after this date.
@@ -175,10 +179,11 @@ pub enum BugAction {
         /// security) — those always bail.
         #[arg(long)]
         permissive: bool,
-        /// Only return these fields (comma-separated)
+        /// Fields to show as detail rows / return (comma-separated). In table
+        /// output, selects which rows display; with --json, trims the payload.
         #[arg(long)]
         fields: Option<String>,
-        /// Exclude these fields (comma-separated)
+        /// Fields to drop from detail rows / response (comma-separated).
         #[arg(long)]
         exclude_fields: Option<String>,
     },
@@ -248,10 +253,11 @@ pub enum BugAction {
         /// Max number of results (default: 50)
         #[arg(long)]
         limit: Option<u32>,
-        /// Only return these fields (comma-separated)
+        /// Fields to show as columns / return (comma-separated). In table
+        /// output, selects columns; with --json, trims the payload.
         #[arg(long)]
         fields: Option<String>,
-        /// Exclude these fields (comma-separated)
+        /// Fields to drop from columns / response (comma-separated).
         #[arg(long)]
         exclude_fields: Option<String>,
     },
@@ -442,10 +448,11 @@ pub enum BugAction {
         /// the limit applies to the single active category.
         #[arg(long, default_value = "50")]
         limit: u32,
-        /// Only return these fields (comma-separated)
+        /// Fields to show as columns / return (comma-separated). In table
+        /// output, selects columns; with --json, trims the payload.
         #[arg(long)]
         fields: Option<String>,
-        /// Exclude these fields (comma-separated)
+        /// Fields to drop from columns / response (comma-separated).
         #[arg(long)]
         exclude_fields: Option<String>,
     },

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -165,6 +165,14 @@ pub enum BugAction {
     /// list, so there the selection only controls which detail rows (table)
     /// or object keys (JSON) appear, not what is sent over the wire.
     ///
+    /// Under `--json`, `bug view` stays lenient when the selection resolves
+    /// to nothing known: an unknown or mistyped `--fields`, or an
+    /// `--exclude-fields` covering every field, yields an empty `{}` object
+    /// and exits 0, with a one-line warning on stderr. `bug list`, `my`,
+    /// `search`, and `query run` instead exit 7 in that case. So a `{}`
+    /// object plus a zero exit can mean a field name was misspelled — check
+    /// stderr.
+    ///
     /// Examples:
     ///
     ///   bzr bug view 12345

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -21,11 +21,12 @@ pub enum BugAction {
     ///
     /// `--limit` defaults to 50; raise it for broader scans, but very
     /// large values may exceed the server's max-results setting and
-    /// return a truncated list. In table output, `--fields` selects which
-    /// columns are shown (in the given order) and `--exclude-fields`
-    /// removes columns; in `--json` output both trim the response payload.
-    /// Fields with no table column (e.g. custom `cf_*` fields) are skipped
-    /// with a warning in table mode — use `--json` to see them.
+    /// return a truncated list. `--fields` and `--exclude-fields` control
+    /// which fields are requested from the server; in table output they
+    /// select and remove columns (in the given order), while `--json`
+    /// always emits the full bug object. Fields with no table column
+    /// (e.g. custom `cf_*` fields) are skipped with a warning in table
+    /// mode and are not shown in any output mode.
     ///
     /// `--created-since` / `--changed-since` filter by Bugzilla's
     /// `creation_time` / `last_change_time` fields. Both accept ISO
@@ -87,11 +88,13 @@ pub enum BugAction {
         /// Max number of results
         #[arg(long, default_value = "50")]
         limit: u32,
-        /// Fields to show as columns / return (comma-separated). In table
-        /// output, selects columns; with --json, trims the payload.
+        /// Fields to request from the server (comma-separated). In table
+        /// output, selects which columns to show; --json always emits the
+        /// full bug object.
         #[arg(long)]
         fields: Option<String>,
-        /// Fields to drop from columns / response (comma-separated).
+        /// Fields to drop from the server request (comma-separated). In
+        /// table output, removes those columns.
         #[arg(long)]
         exclude_fields: Option<String>,
         /// Filter to bugs created at or after this date.
@@ -179,11 +182,13 @@ pub enum BugAction {
         /// security) — those always bail.
         #[arg(long)]
         permissive: bool,
-        /// Fields to show as detail rows / return (comma-separated). In table
-        /// output, selects which rows display; with --json, trims the payload.
+        /// Fields to request from the server (comma-separated). In table
+        /// output, selects which detail rows to show; --json always emits
+        /// the full bug object.
         #[arg(long)]
         fields: Option<String>,
-        /// Fields to drop from detail rows / response (comma-separated).
+        /// Fields to drop from the server request (comma-separated). In
+        /// table output, removes those detail rows.
         #[arg(long)]
         exclude_fields: Option<String>,
     },
@@ -253,11 +258,13 @@ pub enum BugAction {
         /// Max number of results (default: 50)
         #[arg(long)]
         limit: Option<u32>,
-        /// Fields to show as columns / return (comma-separated). In table
-        /// output, selects columns; with --json, trims the payload.
+        /// Fields to request from the server (comma-separated). In table
+        /// output, selects which columns to show; --json always emits the
+        /// full bug object.
         #[arg(long)]
         fields: Option<String>,
-        /// Fields to drop from columns / response (comma-separated).
+        /// Fields to drop from the server request (comma-separated). In
+        /// table output, removes those columns.
         #[arg(long)]
         exclude_fields: Option<String>,
     },
@@ -448,11 +455,13 @@ pub enum BugAction {
         /// the limit applies to the single active category.
         #[arg(long, default_value = "50")]
         limit: u32,
-        /// Fields to show as columns / return (comma-separated). In table
-        /// output, selects columns; with --json, trims the payload.
+        /// Fields to request from the server (comma-separated). In table
+        /// output, selects which columns to show; --json always emits the
+        /// full bug object.
         #[arg(long)]
         fields: Option<String>,
-        /// Fields to drop from columns / response (comma-separated).
+        /// Fields to drop from the server request (comma-separated). In
+        /// table output, removes those columns.
         #[arg(long)]
         exclude_fields: Option<String>,
     },

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -23,12 +23,12 @@ pub enum BugAction {
     /// large values may exceed the server's max-results setting and
     /// return a truncated list. `--fields` and `--exclude-fields` control
     /// which fields are requested from the server; in table output they
-    /// select and remove columns (in the given order). Under `--json` all
-    /// keys are still emitted, but only selected fields carry real values:
-    /// `id` is always populated and every other unselected field comes back
-    /// null/empty (an advisory prints when stderr is a terminal). Fields with
-    /// no table column (e.g. custom `cf_*` fields) are skipped with a warning
-    /// in table mode.
+    /// select and remove columns (in the given order). Under `--json` the
+    /// output object is trimmed to the selected fields (gh-style):
+    /// `--fields summary` returns `{"summary": ...}` with no `id` unless you
+    /// ask for it, and `--exclude-fields id` drops `id`. With no selection the
+    /// full object is returned. Unknown fields (typos, custom `cf_*` fields
+    /// that have no table column) are skipped with a warning.
     ///
     /// `--created-since` / `--changed-since` filter by Bugzilla's
     /// `creation_time` / `last_change_time` fields. Both accept ISO
@@ -91,13 +91,13 @@ pub enum BugAction {
         #[arg(long, default_value = "50")]
         limit: u32,
         /// Fields to request from the server (comma-separated). Table:
-        /// selects which columns to show. --json: all keys are emitted, but
-        /// unselected fields come back null/empty, not their real values.
+        /// selects which columns to show (in order). --json: the JSON object
+        /// contains only the selected fields (id is included only if requested).
         #[arg(long)]
         fields: Option<String>,
         /// Fields to drop from the server request (comma-separated). Table:
-        /// removes those columns. --json: all keys are still emitted, but
-        /// dropped fields come back null/empty, not their real values.
+        /// removes those columns. --json: the JSON object omits the dropped
+        /// fields (including id, if excluded).
         #[arg(long)]
         exclude_fields: Option<String>,
         /// Filter to bugs created at or after this date.
@@ -158,11 +158,12 @@ pub enum BugAction {
     /// Session-wide failures (transport, auth, security) still bail.
     ///
     /// Use `--fields` to fetch only specific fields (faster on large
-    /// bugs); `--exclude-fields` is the inverse. On XML-RPC servers,
-    /// single-bug `bug view` fetches the full bug regardless of the
-    /// field list (the selection still controls which detail rows or
-    /// table columns render, and under `--json` the returned object is
-    /// complete).
+    /// bugs over REST); `--exclude-fields` is the inverse. Under `--json`
+    /// the returned object is trimmed to the selected fields (gh-style) on
+    /// every transport, since trimming happens client-side after the fetch.
+    /// On XML-RPC servers the full bug is fetched regardless of the field
+    /// list, so there the selection only controls which detail rows (table)
+    /// or object keys (JSON) appear, not what is sent over the wire.
     ///
     /// Examples:
     ///
@@ -190,13 +191,13 @@ pub enum BugAction {
         #[arg(long)]
         permissive: bool,
         /// Fields to request from the server (comma-separated). Table:
-        /// selects which detail rows to show. --json: all keys are emitted,
-        /// but unselected fields come back null/empty, not their real values.
+        /// selects which detail rows to show. --json: the JSON object contains
+        /// only the selected fields (id is included only if requested).
         #[arg(long)]
         fields: Option<String>,
         /// Fields to drop from the server request (comma-separated). Table:
-        /// removes those detail rows. --json: all keys are still emitted, but
-        /// dropped fields come back null/empty, not their real values.
+        /// removes those detail rows. --json: the JSON object omits the
+        /// dropped fields (including id, if excluded).
         #[arg(long)]
         exclude_fields: Option<String>,
     },
@@ -267,13 +268,13 @@ pub enum BugAction {
         #[arg(long)]
         limit: Option<u32>,
         /// Fields to request from the server (comma-separated). Table:
-        /// selects which columns to show. --json: all keys are emitted, but
-        /// unselected fields come back null/empty, not their real values.
+        /// selects which columns to show (in order). --json: the JSON object
+        /// contains only the selected fields (id is included only if requested).
         #[arg(long)]
         fields: Option<String>,
         /// Fields to drop from the server request (comma-separated). Table:
-        /// removes those columns. --json: all keys are still emitted, but
-        /// dropped fields come back null/empty, not their real values.
+        /// removes those columns. --json: the JSON object omits the dropped
+        /// fields (including id, if excluded).
         #[arg(long)]
         exclude_fields: Option<String>,
     },
@@ -465,13 +466,13 @@ pub enum BugAction {
         #[arg(long, default_value = "50")]
         limit: u32,
         /// Fields to request from the server (comma-separated). Table:
-        /// selects which columns to show. --json: all keys are emitted, but
-        /// unselected fields come back null/empty, not their real values.
+        /// selects which columns to show (in order). --json: the JSON object
+        /// contains only the selected fields (id is included only if requested).
         #[arg(long)]
         fields: Option<String>,
         /// Fields to drop from the server request (comma-separated). Table:
-        /// removes those columns. --json: all keys are still emitted, but
-        /// dropped fields come back null/empty, not their real values.
+        /// removes those columns. --json: the JSON object omits the dropped
+        /// fields (including id, if excluded).
         #[arg(long)]
         exclude_fields: Option<String>,
     },

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -24,10 +24,11 @@ pub enum BugAction {
     /// return a truncated list. `--fields` and `--exclude-fields` control
     /// which fields are requested from the server; in table output they
     /// select and remove columns (in the given order). Under `--json` all
-    /// keys are still emitted, but unselected fields come back null/empty,
-    /// not their real values (a warning is printed). Fields with no table
-    /// column (e.g. custom `cf_*` fields) are skipped with a warning in
-    /// table mode.
+    /// keys are still emitted, but only selected fields carry real values:
+    /// `id` is always populated and every other unselected field comes back
+    /// null/empty (an advisory prints when stderr is a terminal). Fields with
+    /// no table column (e.g. custom `cf_*` fields) are skipped with a warning
+    /// in table mode.
     ///
     /// `--created-since` / `--changed-since` filter by Bugzilla's
     /// `creation_time` / `last_change_time` fields. Both accept ISO

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -23,10 +23,11 @@ pub enum BugAction {
     /// large values may exceed the server's max-results setting and
     /// return a truncated list. `--fields` and `--exclude-fields` control
     /// which fields are requested from the server; in table output they
-    /// select and remove columns (in the given order), while `--json`
-    /// always emits the full bug object. Fields with no table column
-    /// (e.g. custom `cf_*` fields) are skipped with a warning in table
-    /// mode and are not shown in any output mode.
+    /// select and remove columns (in the given order). Under `--json` all
+    /// keys are still emitted, but unselected fields come back null/empty,
+    /// not their real values (a warning is printed). Fields with no table
+    /// column (e.g. custom `cf_*` fields) are skipped with a warning in
+    /// table mode.
     ///
     /// `--created-since` / `--changed-since` filter by Bugzilla's
     /// `creation_time` / `last_change_time` fields. Both accept ISO
@@ -88,13 +89,14 @@ pub enum BugAction {
         /// Max number of results
         #[arg(long, default_value = "50")]
         limit: u32,
-        /// Fields to request from the server (comma-separated). In table
-        /// output, selects which columns to show; --json always emits the
-        /// full bug object.
+        /// Fields to request from the server (comma-separated). Table:
+        /// selects which columns to show. --json: all keys are emitted, but
+        /// unselected fields come back null/empty, not their real values.
         #[arg(long)]
         fields: Option<String>,
-        /// Fields to drop from the server request (comma-separated). In
-        /// table output, removes those columns.
+        /// Fields to drop from the server request (comma-separated). Table:
+        /// removes those columns. --json: all keys are still emitted, but
+        /// dropped fields come back null/empty, not their real values.
         #[arg(long)]
         exclude_fields: Option<String>,
         /// Filter to bugs created at or after this date.
@@ -182,13 +184,14 @@ pub enum BugAction {
         /// security) — those always bail.
         #[arg(long)]
         permissive: bool,
-        /// Fields to request from the server (comma-separated). In table
-        /// output, selects which detail rows to show; --json always emits
-        /// the full bug object.
+        /// Fields to request from the server (comma-separated). Table:
+        /// selects which detail rows to show. --json: all keys are emitted,
+        /// but unselected fields come back null/empty, not their real values.
         #[arg(long)]
         fields: Option<String>,
-        /// Fields to drop from the server request (comma-separated). In
-        /// table output, removes those detail rows.
+        /// Fields to drop from the server request (comma-separated). Table:
+        /// removes those detail rows. --json: all keys are still emitted, but
+        /// dropped fields come back null/empty, not their real values.
         #[arg(long)]
         exclude_fields: Option<String>,
     },
@@ -258,13 +261,14 @@ pub enum BugAction {
         /// Max number of results (default: 50)
         #[arg(long)]
         limit: Option<u32>,
-        /// Fields to request from the server (comma-separated). In table
-        /// output, selects which columns to show; --json always emits the
-        /// full bug object.
+        /// Fields to request from the server (comma-separated). Table:
+        /// selects which columns to show. --json: all keys are emitted, but
+        /// unselected fields come back null/empty, not their real values.
         #[arg(long)]
         fields: Option<String>,
-        /// Fields to drop from the server request (comma-separated). In
-        /// table output, removes those columns.
+        /// Fields to drop from the server request (comma-separated). Table:
+        /// removes those columns. --json: all keys are still emitted, but
+        /// dropped fields come back null/empty, not their real values.
         #[arg(long)]
         exclude_fields: Option<String>,
     },
@@ -455,13 +459,14 @@ pub enum BugAction {
         /// the limit applies to the single active category.
         #[arg(long, default_value = "50")]
         limit: u32,
-        /// Fields to request from the server (comma-separated). In table
-        /// output, selects which columns to show; --json always emits the
-        /// full bug object.
+        /// Fields to request from the server (comma-separated). Table:
+        /// selects which columns to show. --json: all keys are emitted, but
+        /// unselected fields come back null/empty, not their real values.
         #[arg(long)]
         fields: Option<String>,
-        /// Fields to drop from the server request (comma-separated). In
-        /// table output, removes those columns.
+        /// Fields to drop from the server request (comma-separated). Table:
+        /// removes those columns. --json: all keys are still emitted, but
+        /// dropped fields come back null/empty, not their real values.
         #[arg(long)]
         exclude_fields: Option<String>,
     },

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -219,10 +219,11 @@ pub enum QueryAction {
         /// Override the saved limit
         #[arg(long)]
         limit: Option<u32>,
-        /// Override the saved fields selection
+        /// Fields to show as columns / return (comma-separated). In table
+        /// output, selects columns; with --json, trims the payload.
         #[arg(long)]
         fields: Option<String>,
-        /// Override the saved exclude-fields selection
+        /// Fields to drop from columns / response (comma-separated).
         #[arg(long)]
         exclude_fields: Option<String>,
         /// Override the server to run against

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -220,13 +220,13 @@ pub enum QueryAction {
         #[arg(long)]
         limit: Option<u32>,
         /// Fields to request from the server (comma-separated). Table:
-        /// selects which columns to show. --json: all keys are emitted, but
-        /// unselected fields come back null/empty, not their real values.
+        /// selects which columns to show (in order). --json: the JSON object
+        /// contains only the selected fields (id is included only if requested).
         #[arg(long)]
         fields: Option<String>,
         /// Fields to drop from the server request (comma-separated). Table:
-        /// removes those columns. --json: all keys are still emitted, but
-        /// dropped fields come back null/empty, not their real values.
+        /// removes those columns. --json: the JSON object omits the dropped
+        /// fields (including id, if excluded).
         #[arg(long)]
         exclude_fields: Option<String>,
         /// Override the server to run against

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -219,13 +219,14 @@ pub enum QueryAction {
         /// Override the saved limit
         #[arg(long)]
         limit: Option<u32>,
-        /// Fields to request from the server (comma-separated). In table
-        /// output, selects which columns to show; --json always emits the
-        /// full bug object.
+        /// Fields to request from the server (comma-separated). Table:
+        /// selects which columns to show. --json: all keys are emitted, but
+        /// unselected fields come back null/empty, not their real values.
         #[arg(long)]
         fields: Option<String>,
-        /// Fields to drop from the server request (comma-separated). In
-        /// table output, removes those columns.
+        /// Fields to drop from the server request (comma-separated). Table:
+        /// removes those columns. --json: all keys are still emitted, but
+        /// dropped fields come back null/empty, not their real values.
         #[arg(long)]
         exclude_fields: Option<String>,
         /// Override the server to run against

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -219,11 +219,13 @@ pub enum QueryAction {
         /// Override the saved limit
         #[arg(long)]
         limit: Option<u32>,
-        /// Fields to show as columns / return (comma-separated). In table
-        /// output, selects columns; with --json, trims the payload.
+        /// Fields to request from the server (comma-separated). In table
+        /// output, selects which columns to show; --json always emits the
+        /// full bug object.
         #[arg(long)]
         fields: Option<String>,
-        /// Fields to drop from columns / response (comma-separated).
+        /// Fields to drop from the server request (comma-separated). In
+        /// table output, removes those columns.
         #[arg(long)]
         exclude_fields: Option<String>,
         /// Override the server to run against

--- a/src/client/bug.rs
+++ b/src/client/bug.rs
@@ -17,6 +17,43 @@ const BUG_DEFAULT_FIELDS: &str = "id,summary,status,resolution,dupe_of,product,c
     assigned_to,priority,severity,creation_time,last_change_time,creator,\
     url,whiteboard,keywords,blocks,depends_on,cc,op_sys,rep_platform,deadline";
 
+/// Ensure `id` is present in an include list and absent from an exclude list,
+/// so the non-defaulted `Bug.id` always deserializes. `None` include is left
+/// as-is (the REST sink injects `BUG_DEFAULT_FIELDS`, which leads with `id`;
+/// XML-RPC returns `id` by server default). Returns owned strings only when a
+/// change is needed.
+fn force_id_fields(
+    include: Option<&str>,
+    exclude: Option<&str>,
+) -> (Option<String>, Option<String>) {
+    let has_id = |list: &str| list.split(',').any(|t| t.trim().eq_ignore_ascii_case("id"));
+
+    let include = include.map(|list| {
+        if has_id(list) {
+            list.to_string()
+        } else {
+            format!("id,{list}")
+        }
+    });
+
+    let exclude = exclude.and_then(|list| {
+        if !has_id(list) {
+            return Some(list.to_string());
+        }
+        let kept: Vec<&str> = list
+            .split(',')
+            .filter(|t| !t.trim().eq_ignore_ascii_case("id"))
+            .collect();
+        if kept.is_empty() {
+            None
+        } else {
+            Some(kept.join(","))
+        }
+    });
+
+    (include, exclude)
+}
+
 #[derive(Deserialize)]
 struct BugListResponse {
     bugs: Vec<Bug>,
@@ -160,6 +197,21 @@ impl BugzillaClient {
 
     pub async fn search_bugs(&self, params: &SearchParams) -> Result<Vec<Bug>> {
         tracing::debug!(?params, %self.api_mode, "search parameters");
+        // Guarantee `id` is fetched so the non-defaulted `Bug.id` deserializes,
+        // even when the caller passed an id-less `--fields`. Only clone when
+        // normalization actually changed something, keeping the common
+        // no-`--fields` path allocation-free.
+        let (inc, exc) = force_id_fields(
+            params.include_fields.as_deref(),
+            params.exclude_fields.as_deref(),
+        );
+        let normalized =
+            (inc != params.include_fields || exc != params.exclude_fields).then(|| SearchParams {
+                include_fields: inc,
+                exclude_fields: exc,
+                ..params.clone()
+            });
+        let params = normalized.as_ref().unwrap_or(params);
         // Raw params (boolean charts from URLs) only work with REST.
         if !params.raw_params.is_empty() && self.api_mode != ApiMode::Rest {
             tracing::warn!(
@@ -265,6 +317,10 @@ impl BugzillaClient {
         include_fields: Option<&str>,
         exclude_fields: Option<&str>,
     ) -> Result<Bug> {
+        // Guarantee `id` is fetched so the non-defaulted `Bug.id` deserializes.
+        // XML-RPC ignores field lists, so this is a no-op there.
+        let (inc, exc) = force_id_fields(include_fields, exclude_fields);
+        let (include_fields, exclude_fields) = (inc.as_deref(), exc.as_deref());
         match self.api_mode {
             ApiMode::XmlRpc => self.xmlrpc_client()?.get_bug(id).await,
             ApiMode::Hybrid => {

--- a/src/client/bug_tests.rs
+++ b/src/client/bug_tests.rs
@@ -1075,3 +1075,177 @@ async fn search_bugs_negation_url_uses_notsubstring() {
     };
     client.search_bugs(&params).await.unwrap();
 }
+
+// ── force_id_fields (F1) ─────────────────────────────────────────
+
+#[test]
+fn force_id_fields_prepends_id_to_idless_include() {
+    let (inc, exc) = force_id_fields(Some("summary,status"), None);
+    assert_eq!(inc.as_deref(), Some("id,summary,status"));
+    assert_eq!(exc, None);
+}
+
+#[test]
+fn force_id_fields_leaves_include_with_id_unchanged() {
+    let (inc, _) = force_id_fields(Some("summary,id,status"), None);
+    assert_eq!(inc.as_deref(), Some("summary,id,status"));
+}
+
+#[test]
+fn force_id_fields_matches_id_case_insensitively() {
+    let (inc, _) = force_id_fields(Some("summary,ID"), None);
+    assert_eq!(inc.as_deref(), Some("summary,ID"));
+}
+
+#[test]
+fn force_id_fields_trims_tokens_when_detecting_id() {
+    let (inc, _) = force_id_fields(Some(" id , summary "), None);
+    assert_eq!(inc.as_deref(), Some(" id , summary "));
+}
+
+#[test]
+fn force_id_fields_include_none_stays_none() {
+    let (inc, _) = force_id_fields(None, None);
+    assert_eq!(inc, None);
+}
+
+#[test]
+fn force_id_fields_strips_id_from_exclude() {
+    let (_, exc) = force_id_fields(None, Some("id,status"));
+    assert_eq!(exc.as_deref(), Some("status"));
+}
+
+#[test]
+fn force_id_fields_exclude_only_id_becomes_none() {
+    let (_, exc) = force_id_fields(None, Some("id"));
+    assert_eq!(exc, None);
+}
+
+#[test]
+fn force_id_fields_exclude_without_id_unchanged() {
+    let (_, exc) = force_id_fields(None, Some("status,priority"));
+    assert_eq!(exc.as_deref(), Some("status,priority"));
+}
+
+// ── F1: id is always fetched at the client entry points ──────────
+
+#[tokio::test]
+async fn search_bugs_prepends_id_to_idless_include_fields() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("include_fields", "id,summary,status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 7, "summary": "s", "status": "NEW"}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let params = SearchParams {
+        include_fields: Some("summary,status".into()),
+        ..Default::default()
+    };
+    let bugs = client.search_bugs(&params).await.unwrap();
+    assert_eq!(bugs.len(), 1);
+}
+
+#[tokio::test]
+async fn search_bugs_strips_id_from_exclude_fields() {
+    use wiremock::matchers::query_param_is_missing;
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param_is_missing("exclude_fields"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let params = SearchParams {
+        exclude_fields: Some("id".into()),
+        ..Default::default()
+    };
+    client.search_bugs(&params).await.unwrap();
+}
+
+#[tokio::test]
+async fn get_bug_prepends_id_to_idless_include_fields() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .and(query_param("include_fields", "id,summary,status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            serde_json::json!({"bugs": [{"id": 1, "summary": "test", "status": "NEW"}]}),
+        ))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let bug = client
+        .get_bug("1", Some("summary,status"), None)
+        .await
+        .unwrap();
+    assert_eq!(bug.id, 1);
+}
+
+#[tokio::test]
+async fn get_bug_via_search_fallback_carries_id() {
+    let mock = MockServer::start().await;
+    // Direct endpoint crashes with 100500, forcing the search fallback.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "error": true,
+            "code": BUGZILLA_INTERNAL_ERROR,
+            "message": "Extension crash"
+        })))
+        .mount(&mock)
+        .await;
+    // The search fallback must request id even though the caller omitted it.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "1"))
+        .and(query_param("include_fields", "id,summary,status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            serde_json::json!({"bugs": [{"id": 1, "summary": "test", "status": "NEW"}]}),
+        ))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let bug = client
+        .get_bug("1", Some("summary,status"), None)
+        .await
+        .unwrap();
+    assert_eq!(bug.id, 1);
+}
+
+#[tokio::test]
+async fn xmlrpc_search_idless_include_fields_carries_id() {
+    use crate::client::test_helpers::test_client_xmlrpc;
+    use wiremock::matchers::body_string_contains;
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/xmlrpc.cgi"))
+        .and(body_string_contains("<name>include_fields</name>"))
+        .and(body_string_contains("<string>id</string>"))
+        .and(body_string_contains("<string>summary</string>"))
+        .and(body_string_contains("<string>status</string>"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(xmlrpc_bug_response(5, "x")))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client_xmlrpc(&mock.uri());
+    let params = SearchParams {
+        include_fields: Some("summary,status".into()),
+        ..Default::default()
+    };
+    let bugs = client.search_bugs(&params).await.unwrap();
+    assert_eq!(bugs.len(), 1);
+}

--- a/src/commands/bug/list.rs
+++ b/src/commands/bug/list.rs
@@ -1,7 +1,7 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output::resources::bug::write_bugs;
+use crate::output::resources::bug::{write_bugs, ColumnSpec};
 use crate::output::writers::Writers;
 use crate::types::{OutputFormat, SearchParams};
 use crate::validation::parse_optional_date;
@@ -71,7 +71,11 @@ pub(super) async fn handle(
         ..Default::default()
     };
     let bugs = client.search_bugs(&params).await?;
-    write_bugs(&bugs, format, w.out);
+    let spec = ColumnSpec {
+        include: fields.as_deref(),
+        exclude: exclude_fields.as_deref(),
+    };
+    write_bugs(&bugs, spec, format, w.out, w.err);
     Ok(())
 }
 

--- a/src/commands/bug/list.rs
+++ b/src/commands/bug/list.rs
@@ -1,7 +1,7 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output::resources::bug::{write_bugs, ColumnSpec};
+use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
 use crate::output::writers::Writers;
 use crate::types::{OutputFormat, SearchParams};
 use crate::validation::parse_optional_date;
@@ -56,8 +56,8 @@ pub(super) async fn handle(
         alias: alias.clone(),
         summary: summary.clone(),
         limit: Some(*limit),
-        include_fields: fields.clone(),
-        exclude_fields: exclude_fields.clone(),
+        include_fields: canonical_field_list(fields.as_deref()),
+        exclude_fields: canonical_field_list(exclude_fields.as_deref()),
         creation_time,
         last_change_time,
         whiteboard: whiteboard.clone(),

--- a/src/commands/bug/list.rs
+++ b/src/commands/bug/list.rs
@@ -1,7 +1,9 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
+use crate::output::resources::bug::{
+    canonical_field_list, validate_table_columns, write_bugs, ColumnSpec,
+};
 use crate::output::writers::Writers;
 use crate::types::{OutputFormat, SearchParams};
 use crate::validation::parse_optional_date;
@@ -70,11 +72,14 @@ pub(super) async fn handle(
         url: url.clone(),
         ..Default::default()
     };
-    let bugs = client.search_bugs(&params).await?;
     let spec = ColumnSpec {
         include: fields.as_deref(),
         exclude: exclude_fields.as_deref(),
     };
+    if format == OutputFormat::Table {
+        validate_table_columns(spec)?;
+    }
+    let bugs = client.search_bugs(&params).await?;
     write_bugs(&bugs, spec, format, w.out, w.err);
     Ok(())
 }

--- a/src/commands/bug/list.rs
+++ b/src/commands/bug/list.rs
@@ -1,9 +1,7 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output::resources::bug::{
-    canonical_field_list, validate_table_columns, write_bugs, ColumnSpec,
-};
+use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
 use crate::output::writers::Writers;
 use crate::types::{OutputFormat, SearchParams};
 use crate::validation::parse_optional_date;
@@ -76,9 +74,6 @@ pub(super) async fn handle(
         include: fields.as_deref(),
         exclude: exclude_fields.as_deref(),
     };
-    if format == OutputFormat::Table {
-        validate_table_columns(spec)?;
-    }
     let bugs = client.search_bugs(&params).await?;
     write_bugs(&bugs, spec, format, w.out, w.err);
     Ok(())

--- a/src/commands/bug/list_tests.rs
+++ b/src/commands/bug/list_tests.rs
@@ -364,3 +364,56 @@ async fn bug_list_mixed_positive_notequals_notsubstring() {
     .await;
     assert!(result.is_ok(), "bug list failed: {result:?}");
 }
+
+#[tokio::test]
+async fn bug_list_table_all_unknown_fields_exits_7_before_network() {
+    // No /rest/bug mock is mounted: the field selection must be rejected
+    // (exit 7) before any search request is issued (F2).
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let mut action = empty_list_action();
+    let BugAction::List { fields, .. } = &mut action else {
+        unreachable!()
+    };
+    *fields = Some("cf_custom".into());
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+        &mut __io.writers(),
+    )
+    .await;
+    let err = result.unwrap_err();
+    assert_eq!(err.exit_code(), 7, "all-unknown --fields exits 7: {err}");
+}
+
+#[tokio::test]
+async fn bug_list_json_unknown_fields_is_not_validated() {
+    // Validation is table-only: --json with unknown fields proceeds and
+    // emits the full bug object (F2 gate is Table-only, F4 reality).
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1, "summary": "Test bug", "status": "NEW"}]
+        })))
+        .mount(&mock)
+        .await;
+
+    let mut action = empty_list_action();
+    let BugAction::List { fields, .. } = &mut action else {
+        unreachable!()
+    };
+    *fields = Some("cf_custom".into());
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    assert!(result.is_ok(), "json path is not validated: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    assert_eq!(parsed[0]["summary"], "Test bug");
+}

--- a/src/commands/bug/list_tests.rs
+++ b/src/commands/bug/list_tests.rs
@@ -397,12 +397,10 @@ async fn bug_list_table_all_unknown_fields_exits_7_before_network() {
 }
 
 #[tokio::test]
-async fn bug_list_json_fields_does_not_block() {
-    // --json with a field selection still emits the full bug object — warn,
-    // don't block. The stderr advisory is TTY-gated (fd 2 is non-TTY under
-    // `cargo test`), so the content is locked by the unit test in
-    // bug_tests.rs; here we only assert the path succeeds and the full
-    // struct is emitted regardless of whether fd 2 is a terminal in CI.
+async fn bug_list_json_fields_trims_output() {
+    // --json with a field selection trims the output object to the selected
+    // fields (gh-style): `--fields summary` yields `{"summary": ...}` only,
+    // with id and every other unselected key dropped.
     let (_lock, mock, _tmp) = setup_test_env().await;
     Mock::given(method("GET"))
         .and(path("/rest/bug"))
@@ -422,18 +420,24 @@ async fn bug_list_json_fields_does_not_block() {
     let result =
         crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
             .await;
-    assert!(result.is_ok(), "json path is not blocked: {result:?}");
+    assert!(result.is_ok(), "json path succeeds: {result:?}");
     let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    let obj = parsed[0].as_object().unwrap();
     assert!(
-        parsed[0].get("status").is_some(),
-        "full struct keys still emitted:\n{}",
+        obj.contains_key("summary"),
+        "summary present:\n{}",
+        __io.out_str()
+    );
+    assert!(
+        !obj.contains_key("status") && !obj.contains_key("id"),
+        "unselected keys trimmed:\n{}",
         __io.out_str()
     );
 }
 
 #[tokio::test]
 async fn bug_list_json_without_fields_does_not_warn() {
-    // --json with no field selection: no value-blanking warning (F1).
+    // --json with no field selection: full object, no unknown-field warning.
     let (_lock, mock, _tmp) = setup_test_env().await;
     Mock::given(method("GET"))
         .and(path("/rest/bug"))
@@ -457,17 +461,11 @@ async fn bug_list_json_without_fields_does_not_warn() {
 }
 
 #[tokio::test]
-async fn bug_list_json_unknown_fields_is_not_validated() {
-    // Validation is table-only: --json with unknown fields proceeds and
-    // emits the full bug object (F2 gate is Table-only, F4 reality).
+async fn bug_list_json_all_unknown_fields_exits_7() {
+    // --json validation measures emptiness against the full field universe: an
+    // all-unknown --fields value exits 7 before any network I/O, mirroring
+    // table mode. (`bug view` stays exempt — covered in the integration suite.)
     let (_lock, mock, _tmp) = setup_test_env().await;
-    Mock::given(method("GET"))
-        .and(path("/rest/bug"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "bugs": [{"id": 1, "summary": "Test bug", "status": "NEW"}]
-        })))
-        .mount(&mock)
-        .await;
 
     let mut action = empty_list_action();
     let BugAction::List { fields, .. } = &mut action else {
@@ -479,7 +477,14 @@ async fn bug_list_json_unknown_fields_is_not_validated() {
     let result =
         crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
             .await;
-    assert!(result.is_ok(), "json path is not validated: {result:?}");
-    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
-    assert_eq!(parsed[0]["summary"], "Test bug");
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.exit_code(),
+        7,
+        "all-unknown --fields under --json exits 7: {err}"
+    );
+    assert!(
+        mock.received_requests().await.unwrap().is_empty(),
+        "validation must run before any network I/O"
+    );
 }

--- a/src/commands/bug/list_tests.rs
+++ b/src/commands/bug/list_tests.rs
@@ -397,9 +397,12 @@ async fn bug_list_table_all_unknown_fields_exits_7_before_network() {
 }
 
 #[tokio::test]
-async fn bug_list_json_fields_warns_about_value_blanking() {
-    // --json with a field selection warns that unselected fields come back
-    // null/empty (F1), but still emits the full bug object — warn, don't block.
+async fn bug_list_json_fields_does_not_block() {
+    // --json with a field selection still emits the full bug object — warn,
+    // don't block. The stderr advisory is TTY-gated (fd 2 is non-TTY under
+    // `cargo test`), so the content is locked by the unit test in
+    // bug_tests.rs; here we only assert the path succeeds and the full
+    // struct is emitted regardless of whether fd 2 is a terminal in CI.
     let (_lock, mock, _tmp) = setup_test_env().await;
     Mock::given(method("GET"))
         .and(path("/rest/bug"))
@@ -420,11 +423,6 @@ async fn bug_list_json_fields_warns_about_value_blanking() {
         crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
             .await;
     assert!(result.is_ok(), "json path is not blocked: {result:?}");
-    assert!(
-        __io.err_str().contains("null/empty"),
-        "warns about value-blanking: {:?}",
-        __io.err_str()
-    );
     let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
     assert!(
         parsed[0].get("status").is_some(),

--- a/src/commands/bug/list_tests.rs
+++ b/src/commands/bug/list_tests.rs
@@ -368,8 +368,10 @@ async fn bug_list_mixed_positive_notequals_notsubstring() {
 #[tokio::test]
 async fn bug_list_table_all_unknown_fields_exits_7_before_network() {
     // No /rest/bug mock is mounted: the field selection must be rejected
-    // (exit 7) before any search request is issued (F2).
-    let (_lock, _mock, _tmp) = setup_test_env().await;
+    // (exit 7) before any network I/O at all (F2). The validation is
+    // hoisted ahead of `connect_and_configure`, so not even the auth/TLS
+    // probe round-trip fires — the mock sees zero requests.
+    let (_lock, mock, _tmp) = setup_test_env().await;
 
     let mut action = empty_list_action();
     let BugAction::List { fields, .. } = &mut action else {
@@ -388,6 +390,72 @@ async fn bug_list_table_all_unknown_fields_exits_7_before_network() {
     .await;
     let err = result.unwrap_err();
     assert_eq!(err.exit_code(), 7, "all-unknown --fields exits 7: {err}");
+    assert!(
+        mock.received_requests().await.unwrap().is_empty(),
+        "validation must run before any network I/O"
+    );
+}
+
+#[tokio::test]
+async fn bug_list_json_fields_warns_about_value_blanking() {
+    // --json with a field selection warns that unselected fields come back
+    // null/empty (F1), but still emits the full bug object — warn, don't block.
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1, "summary": "Test bug", "status": "NEW"}]
+        })))
+        .mount(&mock)
+        .await;
+
+    let mut action = empty_list_action();
+    let BugAction::List { fields, .. } = &mut action else {
+        unreachable!()
+    };
+    *fields = Some("summary".into());
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    assert!(result.is_ok(), "json path is not blocked: {result:?}");
+    assert!(
+        __io.err_str().contains("null/empty"),
+        "warns about value-blanking: {:?}",
+        __io.err_str()
+    );
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    assert!(
+        parsed[0].get("status").is_some(),
+        "full struct keys still emitted:\n{}",
+        __io.out_str()
+    );
+}
+
+#[tokio::test]
+async fn bug_list_json_without_fields_does_not_warn() {
+    // --json with no field selection: no value-blanking warning (F1).
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1, "summary": "Test bug", "status": "NEW"}]
+        })))
+        .mount(&mock)
+        .await;
+
+    let action = empty_list_action();
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    assert!(result.is_ok(), "json list succeeds: {result:?}");
+    assert!(
+        __io.err_str().is_empty(),
+        "no warning without a field selection: {:?}",
+        __io.err_str()
+    );
 }
 
 #[tokio::test]

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -2,6 +2,9 @@
 
 use crate::cli::BugAction;
 use crate::error::Result;
+use crate::output::resources::bug::{
+    validate_table_columns, warn_json_field_selection, ColumnSpec,
+};
 use crate::output::writers::Writers;
 use crate::types::{ApiMode, OutputFormat};
 
@@ -14,6 +17,37 @@ mod search;
 mod update;
 mod view;
 
+/// The `--fields` / `--exclude-fields` column spec for the four field-bearing
+/// bug actions, or `None` for actions that take no field selection.
+fn bug_column_spec(action: &BugAction) -> Option<ColumnSpec<'_>> {
+    match action {
+        BugAction::List {
+            fields,
+            exclude_fields,
+            ..
+        }
+        | BugAction::My {
+            fields,
+            exclude_fields,
+            ..
+        }
+        | BugAction::Search {
+            fields,
+            exclude_fields,
+            ..
+        }
+        | BugAction::View {
+            fields,
+            exclude_fields,
+            ..
+        } => Some(ColumnSpec {
+            include: fields.as_deref(),
+            exclude: exclude_fields.as_deref(),
+        }),
+        _ => None,
+    }
+}
+
 /// Dispatch bug actions to their respective handlers.
 pub async fn execute(
     action: &BugAction,
@@ -23,6 +57,20 @@ pub async fn execute(
     w: &mut Writers<'_>,
 ) -> Result<()> {
     update::validate_action(action)?;
+
+    // Resolve the field selection before any network I/O. In JSON mode, warn
+    // that `--fields`/`--exclude-fields` restricts what is *fetched*, not what
+    // is shown (unselected fields come back null/empty). In table mode, a
+    // zero-column selection exits 7 deterministically, regardless of subcommand
+    // or server reachability. `bug view` is exempt from table validation: a
+    // header-only detail block is a coherent sparse result, not an error.
+    if let Some(spec) = bug_column_spec(action) {
+        if format == OutputFormat::Json {
+            warn_json_field_selection(spec, w.err);
+        } else if !matches!(action, BugAction::View { .. }) {
+            validate_table_columns(spec)?;
+        }
+    }
 
     // Search builds its own client because --from-url may resolve a different
     // server from the URL hostname. Skip the shared connect to avoid double

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -1,5 +1,7 @@
 //! Bug subcommand handlers, split per-action.
 
+use std::io::IsTerminal;
+
 use crate::cli::BugAction;
 use crate::error::Result;
 use crate::output::resources::bug::{
@@ -66,7 +68,7 @@ pub async fn execute(
     // header-only detail block is a coherent sparse result, not an error.
     if let Some(spec) = bug_column_spec(action) {
         if format == OutputFormat::Json {
-            warn_json_field_selection(spec, w.err);
+            warn_json_field_selection(spec, std::io::stderr().is_terminal(), w.err);
         } else if !matches!(action, BugAction::View { .. }) {
             validate_table_columns(spec)?;
         }

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -1,11 +1,9 @@
 //! Bug subcommand handlers, split per-action.
 
-use std::io::IsTerminal;
-
 use crate::cli::BugAction;
 use crate::error::Result;
 use crate::output::resources::bug::{
-    validate_table_columns, warn_json_field_selection, ColumnSpec,
+    validate_json_field_selection, validate_table_columns, warn_unknown_fields, ColumnSpec,
 };
 use crate::output::writers::Writers;
 use crate::types::{ApiMode, OutputFormat};
@@ -60,17 +58,30 @@ pub async fn execute(
 ) -> Result<()> {
     update::validate_action(action)?;
 
-    // Resolve the field selection before any network I/O. In JSON mode, warn
-    // that `--fields`/`--exclude-fields` restricts what is *fetched*, not what
-    // is shown (unselected fields come back null/empty). In table mode, a
-    // zero-column selection exits 7 deterministically, regardless of subcommand
-    // or server reachability. `bug view` is exempt from table validation: a
-    // header-only detail block is a coherent sparse result, not an error.
+    // Resolve the field selection before any network I/O. A selection that
+    // leaves nothing to show exits 7 deterministically — measured against the
+    // five-column default in table mode, against the full field universe in
+    // JSON mode (where output is trimmed gh-style to the selected keys). Either
+    // way the exit code is independent of subcommand or server reachability.
+    // `bug view` is exempt from this zero-field error in both modes: a sparse
+    // (or empty `{}`) single-bug result is coherent, not an error. Unknown
+    // `--fields` tokens (typos, custom `cf_*` fields) warn once on stderr;
+    // under JSON the warning fires for every action including `view`, since a
+    // typo would otherwise silently yield `{}`.
     if let Some(spec) = bug_column_spec(action) {
-        if format == OutputFormat::Json {
-            warn_json_field_selection(spec, std::io::stderr().is_terminal(), w.err);
-        } else if !matches!(action, BugAction::View { .. }) {
-            validate_table_columns(spec)?;
+        let is_view = matches!(action, BugAction::View { .. });
+        match format {
+            OutputFormat::Table => {
+                if !is_view {
+                    validate_table_columns(spec)?;
+                }
+            }
+            OutputFormat::Json => {
+                if !is_view {
+                    validate_json_field_selection(spec)?;
+                }
+                warn_unknown_fields(spec, w.err);
+            }
         }
     }
 

--- a/src/commands/bug/my.rs
+++ b/src/commands/bug/my.rs
@@ -1,7 +1,7 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output::resources::bug::write_bugs;
+use crate::output::resources::bug::{write_bugs, ColumnSpec};
 use crate::output::writers::Writers;
 use crate::types::{OutputFormat, SearchParams};
 
@@ -62,7 +62,11 @@ pub(super) async fn handle(
         }
     }
 
-    write_bugs(&all_bugs, format, w.out);
+    let spec = ColumnSpec {
+        include: fields.as_deref(),
+        exclude: exclude_fields.as_deref(),
+    };
+    write_bugs(&all_bugs, spec, format, w.out, w.err);
     Ok(())
 }
 

--- a/src/commands/bug/my.rs
+++ b/src/commands/bug/my.rs
@@ -1,9 +1,7 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output::resources::bug::{
-    canonical_field_list, validate_table_columns, write_bugs, ColumnSpec,
-};
+use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
 use crate::output::writers::Writers;
 use crate::types::{OutputFormat, SearchParams};
 
@@ -30,9 +28,6 @@ pub(super) async fn handle(
         include: fields.as_deref(),
         exclude: exclude_fields.as_deref(),
     };
-    if format == OutputFormat::Table {
-        validate_table_columns(spec)?;
-    }
 
     let whoami = client.whoami().await?;
     let email = whoami.name;

--- a/src/commands/bug/my.rs
+++ b/src/commands/bug/my.rs
@@ -1,7 +1,7 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output::resources::bug::{write_bugs, ColumnSpec};
+use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
 use crate::output::writers::Writers;
 use crate::types::{OutputFormat, SearchParams};
 
@@ -33,8 +33,8 @@ pub(super) async fn handle(
     let base = SearchParams {
         status: status.clone(),
         limit: Some(*limit),
-        include_fields: fields.clone(),
-        exclude_fields: exclude_fields.clone(),
+        include_fields: canonical_field_list(fields.as_deref()),
+        exclude_fields: canonical_field_list(exclude_fields.as_deref()),
         ..Default::default()
     };
     let mut searches = Vec::new();

--- a/src/commands/bug/my.rs
+++ b/src/commands/bug/my.rs
@@ -1,7 +1,9 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
+use crate::output::resources::bug::{
+    canonical_field_list, validate_table_columns, write_bugs, ColumnSpec,
+};
 use crate::output::writers::Writers;
 use crate::types::{OutputFormat, SearchParams};
 
@@ -23,6 +25,14 @@ pub(super) async fn handle(
     else {
         unreachable!()
     };
+
+    let spec = ColumnSpec {
+        include: fields.as_deref(),
+        exclude: exclude_fields.as_deref(),
+    };
+    if format == OutputFormat::Table {
+        validate_table_columns(spec)?;
+    }
 
     let whoami = client.whoami().await?;
     let email = whoami.name;
@@ -62,10 +72,6 @@ pub(super) async fn handle(
         }
     }
 
-    let spec = ColumnSpec {
-        include: fields.as_deref(),
-        exclude: exclude_fields.as_deref(),
-    };
     write_bugs(&all_bugs, spec, format, w.out, w.err);
     Ok(())
 }

--- a/src/commands/bug/search.rs
+++ b/src/commands/bug/search.rs
@@ -1,6 +1,8 @@
 use crate::cli::BugAction;
 use crate::error::Result;
-use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
+use crate::output::resources::bug::{
+    canonical_field_list, validate_table_columns, write_bugs, ColumnSpec,
+};
 use crate::output::resources::query::write_query_saved;
 use crate::output::writers::Writers;
 use crate::types::{ApiMode, OutputFormat, Overrides, SavedQuery, SearchParams};
@@ -72,6 +74,14 @@ pub(super) async fn handle(
         unreachable!()
     };
 
+    let spec = ColumnSpec {
+        include: fields.as_deref(),
+        exclude: exclude_fields.as_deref(),
+    };
+    if format == OutputFormat::Table {
+        validate_table_columns(spec)?;
+    }
+
     let (client, params, save_info) = if let Some(url_str) = from_url {
         let config = crate::config::Config::load()?;
         let parsed = crate::url_parser::parse_bugzilla_url(url_str, &config)?;
@@ -105,10 +115,6 @@ pub(super) async fn handle(
     };
 
     let bugs = client.search_bugs(&params).await?;
-    let spec = ColumnSpec {
-        include: fields.as_deref(),
-        exclude: exclude_fields.as_deref(),
-    };
     write_bugs(&bugs, spec, format, w.out, w.err);
 
     if let Some((name, query)) = save_info {

--- a/src/commands/bug/search.rs
+++ b/src/commands/bug/search.rs
@@ -1,6 +1,6 @@
 use crate::cli::BugAction;
 use crate::error::Result;
-use crate::output::resources::bug::write_bugs;
+use crate::output::resources::bug::{write_bugs, ColumnSpec};
 use crate::output::resources::query::write_query_saved;
 use crate::output::writers::Writers;
 use crate::types::{ApiMode, OutputFormat, Overrides, SavedQuery, SearchParams};
@@ -103,7 +103,11 @@ pub(super) async fn handle(
     };
 
     let bugs = client.search_bugs(&params).await?;
-    write_bugs(&bugs, format, w.out);
+    let spec = ColumnSpec {
+        include: fields.as_deref(),
+        exclude: exclude_fields.as_deref(),
+    };
+    write_bugs(&bugs, spec, format, w.out, w.err);
 
     if let Some((name, query)) = save_info {
         let mut config = crate::config::Config::load()?;

--- a/src/commands/bug/search.rs
+++ b/src/commands/bug/search.rs
@@ -1,6 +1,6 @@
 use crate::cli::BugAction;
 use crate::error::Result;
-use crate::output::resources::bug::{write_bugs, ColumnSpec};
+use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
 use crate::output::resources::query::write_query_saved;
 use crate::output::writers::Writers;
 use crate::types::{ApiMode, OutputFormat, Overrides, SavedQuery, SearchParams};
@@ -78,11 +78,13 @@ pub(super) async fn handle(
         let effective_server = server.or(parsed.query.server.as_deref());
         let client = crate::commands::shared::connect_and_configure(effective_server, api).await?;
         let save_info = resolve_save_info(save_as.as_ref(), parsed.suggested_name, &parsed.query)?;
+        let canonical_fields = canonical_field_list(fields.as_deref());
+        let canonical_exclude = canonical_field_list(exclude_fields.as_deref());
         let params = build_params_from_url(
             parsed.query,
             *limit,
-            fields.as_deref(),
-            exclude_fields.as_deref(),
+            canonical_fields.as_deref(),
+            canonical_exclude.as_deref(),
         );
         (client, params, save_info)
     } else {
@@ -95,8 +97,8 @@ pub(super) async fn handle(
         let params = SearchParams {
             quicksearch: Some(query_str.to_string()),
             limit: Some(limit.unwrap_or(50)),
-            include_fields: fields.clone(),
-            exclude_fields: exclude_fields.clone(),
+            include_fields: canonical_field_list(fields.as_deref()),
+            exclude_fields: canonical_field_list(exclude_fields.as_deref()),
             ..Default::default()
         };
         (client, params, None)

--- a/src/commands/bug/search.rs
+++ b/src/commands/bug/search.rs
@@ -1,8 +1,6 @@
 use crate::cli::BugAction;
 use crate::error::Result;
-use crate::output::resources::bug::{
-    canonical_field_list, validate_table_columns, write_bugs, ColumnSpec,
-};
+use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
 use crate::output::resources::query::write_query_saved;
 use crate::output::writers::Writers;
 use crate::types::{ApiMode, OutputFormat, Overrides, SavedQuery, SearchParams};
@@ -78,9 +76,6 @@ pub(super) async fn handle(
         include: fields.as_deref(),
         exclude: exclude_fields.as_deref(),
     };
-    if format == OutputFormat::Table {
-        validate_table_columns(spec)?;
-    }
 
     let (client, params, save_info) = if let Some(url_str) = from_url {
         let config = crate::config::Config::load()?;

--- a/src/commands/bug/view.rs
+++ b/src/commands/bug/view.rs
@@ -1,7 +1,9 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::{BzrError, Result};
-use crate::output::resources::bug::{write_bug_detail, write_multi_bug_view, MultiBugRow};
+use crate::output::resources::bug::{
+    write_bug_detail, write_multi_bug_view, ColumnSpec, MultiBugRow,
+};
 use crate::output::result_types::{write_result, BugViewFailure, MultiBugViewResult};
 use crate::output::writers::Writers;
 use crate::types::{Bug, OutputFormat};
@@ -83,7 +85,11 @@ pub(super) async fn handle(
         BugViewMode::Strict
     };
     let batch = fetch_batch(client, ids, inc, exc, mode).await?;
-    write_batch(batch, format, w);
+    let spec = ColumnSpec {
+        include: inc,
+        exclude: exc,
+    };
+    write_batch(batch, spec, format, w);
     Ok(())
 }
 
@@ -96,7 +102,11 @@ async fn view_single(
     w: &mut Writers<'_>,
 ) -> Result<()> {
     let bug = client.get_bug(id, include_fields, exclude_fields).await?;
-    write_bug_detail(&bug, format, w.out);
+    let spec = ColumnSpec {
+        include: include_fields,
+        exclude: exclude_fields,
+    };
+    write_bug_detail(&bug, spec, format, w.out);
     Ok(())
 }
 
@@ -123,11 +133,16 @@ async fn fetch_batch(
     Ok(BugViewBatch { rows })
 }
 
-fn write_batch(batch: BugViewBatch, format: OutputFormat, w: &mut Writers<'_>) {
+fn write_batch(
+    batch: BugViewBatch,
+    spec: ColumnSpec<'_>,
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) {
     match format {
         OutputFormat::Table => {
             let rows = batch.into_table_rows();
-            write_multi_bug_view(&rows, w.out);
+            write_multi_bug_view(&rows, spec, w.out);
         }
         OutputFormat::Json => {
             let result = batch.into_json_result();

--- a/src/commands/bug/view.rs
+++ b/src/commands/bug/view.rs
@@ -2,7 +2,7 @@ use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::{BzrError, Result};
 use crate::output::resources::bug::{
-    write_bug_detail, write_multi_bug_view, ColumnSpec, MultiBugRow,
+    canonical_field_list, write_bug_detail, write_multi_bug_view, ColumnSpec, MultiBugRow,
 };
 use crate::output::result_types::{write_result, BugViewFailure, MultiBugViewResult};
 use crate::output::writers::Writers;
@@ -72,11 +72,23 @@ pub(super) async fn handle(
         ));
     }
 
+    // Raw values drive column / detail-row selection (aliases resolve fine);
+    // canonical values go to the server so aliased fields are populated.
     let inc = fields.as_deref();
     let exc = exclude_fields.as_deref();
+    let inc_canonical = canonical_field_list(inc);
+    let exc_canonical = canonical_field_list(exc);
 
     if ids.len() == 1 {
-        return view_single(client, &ids[0], inc, exc, format, w).await;
+        return view_single(
+            client,
+            &ids[0],
+            inc_canonical.as_deref(),
+            exc_canonical.as_deref(),
+            format,
+            w,
+        )
+        .await;
     }
 
     let mode = if *permissive {
@@ -84,7 +96,14 @@ pub(super) async fn handle(
     } else {
         BugViewMode::Strict
     };
-    let batch = fetch_batch(client, ids, inc, exc, mode).await?;
+    let batch = fetch_batch(
+        client,
+        ids,
+        inc_canonical.as_deref(),
+        exc_canonical.as_deref(),
+        mode,
+    )
+    .await?;
     let spec = ColumnSpec {
         include: inc,
         exclude: exc,

--- a/src/commands/bug/view.rs
+++ b/src/commands/bug/view.rs
@@ -2,7 +2,8 @@ use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::{BzrError, Result};
 use crate::output::resources::bug::{
-    canonical_field_list, write_bug_detail, write_multi_bug_view, ColumnSpec, MultiBugRow,
+    bug_to_json, canonical_field_list, write_bug_detail, write_multi_bug_view, ColumnSpec,
+    MultiBugRow,
 };
 use crate::output::result_types::{write_result, BugViewFailure, MultiBugViewResult};
 use crate::output::writers::Writers;
@@ -164,8 +165,14 @@ fn write_batch(
             write_multi_bug_view(&rows, spec, w.out);
         }
         OutputFormat::Json => {
+            // Project each bug to the selected fields; the wrapper keys and the
+            // per-failure metadata (`id`, `error`) stay untrimmed so `jq`
+            // consumers can always rely on `.bugs[]` / `.failed[]`.
             let result = batch.into_json_result();
-            write_result(&result, "", format, w.out);
+            let bugs: Vec<serde_json::Value> =
+                result.bugs.iter().map(|b| bug_to_json(b, spec)).collect();
+            let value = serde_json::json!({ "bugs": bugs, "failed": result.failed });
+            write_result(&value, "", format, w.out);
         }
     }
 }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -6,7 +6,9 @@
 use crate::cli::QueryAction;
 use crate::config::Config;
 use crate::error::{BzrError, Result};
-use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
+use crate::output::resources::bug::{
+    canonical_field_list, validate_table_columns, write_bugs, ColumnSpec,
+};
 use crate::output::resources::query::{write_query_detail, write_query_list, write_query_saved};
 use crate::output::writers::Writers;
 use crate::types::{OutputFormat, QueryKind, SavedQuery};
@@ -241,14 +243,18 @@ async fn handle_run(
     params.include_fields = canonical_field_list(params.include_fields.as_deref());
     params.exclude_fields = canonical_field_list(params.exclude_fields.as_deref());
 
-    let client = super::shared::connect_and_configure(effective_server, api).await?;
-    let bugs = client.search_bugs(&params).await?;
     // Source columns from the resolved params (saved-query fields + CLI
     // overrides), not the raw flags, so a stored field selection is honored.
     let spec = ColumnSpec {
         include: params.include_fields.as_deref(),
         exclude: params.exclude_fields.as_deref(),
     };
+    if format == OutputFormat::Table {
+        validate_table_columns(spec)?;
+    }
+
+    let client = super::shared::connect_and_configure(effective_server, api).await?;
+    let bugs = client.search_bugs(&params).await?;
     write_bugs(&bugs, spec, format, w.out, w.err);
     Ok(())
 }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -241,6 +241,8 @@ async fn handle_run(
 
     let client = super::shared::connect_and_configure(effective_server, api).await?;
     let bugs = client.search_bugs(&params).await?;
+    // Source columns from the resolved params (saved-query fields + CLI
+    // overrides), not the raw flags, so a stored field selection is honored.
     let spec = ColumnSpec {
         include: params.include_fields.as_deref(),
         exclude: params.exclude_fields.as_deref(),

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -6,7 +6,7 @@
 use crate::cli::QueryAction;
 use crate::config::Config;
 use crate::error::{BzrError, Result};
-use crate::output::resources::bug::{write_bugs, ColumnSpec};
+use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
 use crate::output::resources::query::{write_query_detail, write_query_list, write_query_saved};
 use crate::output::writers::Writers;
 use crate::types::{OutputFormat, QueryKind, SavedQuery};
@@ -238,6 +238,8 @@ async fn handle_run(
         qa_contact: slice_override(qa_contact),
         url: slice_override(url),
     });
+    params.include_fields = canonical_field_list(params.include_fields.as_deref());
+    params.exclude_fields = canonical_field_list(params.exclude_fields.as_deref());
 
     let client = super::shared::connect_and_configure(effective_server, api).await?;
     let bugs = client.search_bugs(&params).await?;

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -3,6 +3,8 @@
 //! Query operations (save/list/show/delete) are pure local file I/O.
 //! Only `run` requires a network client.
 
+use std::io::IsTerminal;
+
 use crate::cli::QueryAction;
 use crate::config::Config;
 use crate::error::{BzrError, Result};
@@ -251,7 +253,9 @@ async fn handle_run(
     };
     match format {
         OutputFormat::Table => validate_table_columns(spec)?,
-        OutputFormat::Json => warn_json_field_selection(spec, w.err),
+        OutputFormat::Json => {
+            warn_json_field_selection(spec, std::io::stderr().is_terminal(), w.err);
+        }
     }
 
     let client = super::shared::connect_and_configure(effective_server, api).await?;

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -6,7 +6,7 @@
 use crate::cli::QueryAction;
 use crate::config::Config;
 use crate::error::{BzrError, Result};
-use crate::output::resources::bug::write_bugs;
+use crate::output::resources::bug::{write_bugs, ColumnSpec};
 use crate::output::resources::query::{write_query_detail, write_query_list, write_query_saved};
 use crate::output::writers::Writers;
 use crate::types::{OutputFormat, QueryKind, SavedQuery};
@@ -241,7 +241,11 @@ async fn handle_run(
 
     let client = super::shared::connect_and_configure(effective_server, api).await?;
     let bugs = client.search_bugs(&params).await?;
-    write_bugs(&bugs, format, w.out);
+    let spec = ColumnSpec {
+        include: params.include_fields.as_deref(),
+        exclude: params.exclude_fields.as_deref(),
+    };
+    write_bugs(&bugs, spec, format, w.out, w.err);
     Ok(())
 }
 

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -7,7 +7,7 @@ use crate::cli::QueryAction;
 use crate::config::Config;
 use crate::error::{BzrError, Result};
 use crate::output::resources::bug::{
-    canonical_field_list, validate_table_columns, write_bugs, ColumnSpec,
+    canonical_field_list, validate_table_columns, warn_json_field_selection, write_bugs, ColumnSpec,
 };
 use crate::output::resources::query::{write_query_detail, write_query_list, write_query_saved};
 use crate::output::writers::Writers;
@@ -249,8 +249,9 @@ async fn handle_run(
         include: params.include_fields.as_deref(),
         exclude: params.exclude_fields.as_deref(),
     };
-    if format == OutputFormat::Table {
-        validate_table_columns(spec)?;
+    match format {
+        OutputFormat::Table => validate_table_columns(spec)?,
+        OutputFormat::Json => warn_json_field_selection(spec, w.err),
     }
 
     let client = super::shared::connect_and_configure(effective_server, api).await?;

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -3,13 +3,12 @@
 //! Query operations (save/list/show/delete) are pure local file I/O.
 //! Only `run` requires a network client.
 
-use std::io::IsTerminal;
-
 use crate::cli::QueryAction;
 use crate::config::Config;
 use crate::error::{BzrError, Result};
 use crate::output::resources::bug::{
-    canonical_field_list, validate_table_columns, warn_json_field_selection, write_bugs, ColumnSpec,
+    canonical_field_list, validate_json_field_selection, validate_table_columns,
+    warn_unknown_fields, write_bugs, ColumnSpec,
 };
 use crate::output::resources::query::{write_query_detail, write_query_list, write_query_saved};
 use crate::output::writers::Writers;
@@ -254,7 +253,8 @@ async fn handle_run(
     match format {
         OutputFormat::Table => validate_table_columns(spec)?,
         OutputFormat::Json => {
-            warn_json_field_selection(spec, std::io::stderr().is_terminal(), w.err);
+            validate_json_field_selection(spec)?;
+            warn_unknown_fields(spec, w.err);
         }
     }
 

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -5,7 +5,7 @@ use tabled::builder::Builder;
 
 use crate::output::formatting::{
     colorize_status, shorten_email, truncate, write_divider, write_field, write_formatted,
-    write_list_field, write_optional_field,
+    write_json, write_list_field, write_optional_field,
 };
 use crate::types::{Bug, HistoryEntry, OutputFormat};
 
@@ -303,42 +303,96 @@ pub fn validate_table_columns(spec: ColumnSpec<'_>) -> crate::error::Result<()> 
     Ok(())
 }
 
-/// Whether a `--json` field selection actually restricts which fields carry real values,
-/// mirroring `force_id_fields` in the client: an include narrows the fetched set, and an exclude
-/// matters only if it drops a field other than `id` (the client always re-adds `id`). Blank-only
-/// input (`""`, `,,`, `id`) restricts nothing.
-fn json_selection_restricts(spec: ColumnSpec<'_>) -> bool {
-    if canonical_field_list(spec.include).is_some() {
-        return true;
+/// The canonical exclude key set: each `--exclude-fields` token resolved to its
+/// canonical Bugzilla field name. Unknown tokens (e.g. custom `cf_*` fields)
+/// name no key in the serialized object and are dropped here, matching table
+/// mode's [`apply_exclude`].
+fn canonical_excludes(exclude: Option<&str>) -> Vec<&'static str> {
+    match exclude {
+        None => Vec::new(),
+        Some(list) => list
+            .split(',')
+            .filter_map(resolve_bug_column)
+            .map(BugColumn::canonical)
+            .collect(),
     }
-    spec.exclude.is_some_and(|list| {
-        list.split(',').any(|t| {
-            let t = t.trim();
-            !t.is_empty() && !t.eq_ignore_ascii_case("id")
-        })
-    })
 }
 
-/// Warn that under `--json` a `--fields`/`--exclude-fields` selection controls
-/// which fields are *fetched*, not which are shown: `id` is always present, but
-/// every other unselected field deserializes to null/empty rather than its real
-/// value. No-op unless `interactive` (stderr is a terminal) and a non-blank
-/// selection is active — matching `validate_table_columns`'s notion of "no
-/// selection" for all-blank input like `""` / `,,`.
-pub fn warn_json_field_selection<E: Write + ?Sized>(
-    spec: ColumnSpec<'_>,
-    interactive: bool,
-    err: &mut E,
-) {
-    if !interactive {
-        return;
+/// Project a serialized bug object to honor `spec` (gh-style trimming):
+/// a non-blank `include` retains exactly the named canonical keys; `exclude`
+/// drops the named canonical keys; neither (or a blank include) leaves the
+/// object untouched. Aliases resolve to canonical keys via the same primitives
+/// table mode uses. Unknown tokens are inert — they name no key in the object,
+/// so they neither add nor remove anything; the pre-network gate warns about
+/// them via [`warn_unknown_fields`].
+pub fn bug_to_json(bug: &Bug, spec: ColumnSpec<'_>) -> serde_json::Value {
+    let mut value = serde_json::to_value(bug).expect("Bug serializes to JSON");
+    if let serde_json::Value::Object(map) = &mut value {
+        if let Some(include) = canonical_field_list(spec.include) {
+            let keep: std::collections::HashSet<&str> = include.split(',').collect();
+            map.retain(|k, _| keep.contains(k.as_str()));
+        }
+        for canonical in canonical_excludes(spec.exclude) {
+            map.remove(canonical);
+        }
     }
-    if json_selection_restricts(spec) {
+    value
+}
+
+/// [`bug_to_json`] over a slice, for the array output paths.
+pub fn bugs_to_json(bugs: &[Bug], spec: ColumnSpec<'_>) -> Vec<serde_json::Value> {
+    bugs.iter().map(|bug| bug_to_json(bug, spec)).collect()
+}
+
+/// Validate that `spec` leaves at least one JSON key to emit, measured against
+/// the full bug-field universe (every [`COLUMNS`] canonical key), not table
+/// mode's five-column default. Call ONLY when output is JSON, before the
+/// network request. Errors (exit 7) when the effective projected key set is
+/// empty — i.e. an all-unknown `--fields` value, or an `--exclude-fields` that
+/// drops every key. A `--fields` that drops the table defaults but keeps other
+/// fields still passes. Partial-unknown (some valid, some not) is allowed and
+/// handled as a warning via [`warn_unknown_fields`].
+pub fn validate_json_field_selection(spec: ColumnSpec<'_>) -> crate::error::Result<()> {
+    let mut keys: std::collections::HashSet<&'static str> = match spec.include {
+        Some(list) => {
+            let (knowns, _unknowns) = partition_include(list);
+            if knowns.is_empty() && list.split(',').all(|t| t.trim().is_empty()) {
+                // Blank include like "" / ",," — treat as no selection.
+                COLUMNS.iter().map(BugColumn::canonical).collect()
+            } else {
+                knowns.iter().map(|c| c.canonical()).collect()
+            }
+        }
+        None => COLUMNS.iter().map(BugColumn::canonical).collect(),
+    };
+    for canonical in canonical_excludes(spec.exclude) {
+        keys.remove(canonical);
+    }
+    if keys.is_empty() {
+        return Err(crate::error::BzrError::InputValidation(
+            "the field selection leaves no fields to emit; \
+             adjust --fields / --exclude-fields"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Warn once on stderr about `--fields` tokens that name no known bug field
+/// (e.g. a typo or a custom `cf_*` field). Genericized off "table column" so it
+/// reads correctly under both table and JSON output. Only inspects the include
+/// list — unknown `--exclude-fields` tokens are inert and silently ignored,
+/// matching table mode's [`apply_exclude`].
+pub fn warn_unknown_fields<E: Write + ?Sized>(spec: ColumnSpec<'_>, err: &mut E) {
+    let Some(list) = spec.include else {
+        return;
+    };
+    let (_knowns, unknowns) = partition_include(list);
+    if !unknowns.is_empty() {
         let _ = writeln!(
             err,
-            "warning: under --json, --fields/--exclude-fields controls which fields are fetched, \
-             not which are shown; id is always present, any other unselected field is returned \
-             as null/empty, not its real value"
+            "warning: ignoring unknown field(s): {}",
+            unknowns.join(", ")
         );
     }
 }
@@ -368,19 +422,22 @@ pub fn write_bugs<W: Write + ?Sized, E: Write + ?Sized>(
     out: &mut W,
     err: &mut E,
 ) {
-    write_formatted(bugs, format, out, |bugs, out| {
-        if bugs.is_empty() {
-            let _ = writeln!(out, "No bugs found.");
-            return;
+    match format {
+        OutputFormat::Json => write_json(&bugs_to_json(bugs, spec), out),
+        OutputFormat::Table => {
+            if bugs.is_empty() {
+                let _ = writeln!(out, "No bugs found.");
+                return;
+            }
+            let columns = resolve_columns(spec, err);
+            let mut builder = Builder::default();
+            builder.push_record(columns.iter().map(|c| c.header.to_string()));
+            for bug in bugs {
+                builder.push_record(columns.iter().map(|c| (c.render)(bug)));
+            }
+            let _ = writeln!(out, "{}", builder.build());
         }
-        let columns = resolve_columns(spec, err);
-        let mut builder = Builder::default();
-        builder.push_record(columns.iter().map(|c| c.header.to_string()));
-        for bug in bugs {
-            builder.push_record(columns.iter().map(|c| (c.render)(bug)));
-        }
-        let _ = writeln!(out, "{}", builder.build());
-    });
+    }
 }
 
 pub fn write_bug_detail<W: Write + ?Sized>(
@@ -389,9 +446,10 @@ pub fn write_bug_detail<W: Write + ?Sized>(
     format: OutputFormat,
     out: &mut W,
 ) {
-    write_formatted(bug, format, out, |bug, out| {
-        write_bug_detail_table(bug, spec, out);
-    });
+    match format {
+        OutputFormat::Json => write_json(&bug_to_json(bug, spec), out),
+        OutputFormat::Table => write_bug_detail_table(bug, spec, out),
+    }
 }
 
 fn write_bug_detail_table(bug: &Bug, spec: ColumnSpec<'_>, out: &mut (impl Write + ?Sized)) {
@@ -508,11 +566,12 @@ pub enum MultiBugRow {
 
 /// Render a multi-ID `bzr bug view` result.
 ///
-/// JSON mode is **not** handled here — the caller emits a
-/// `MultiBugViewResult` via `output::write_result`. This function only
-/// covers table mode: argument-order detail blocks for `Ok`, visually
-/// distinct `UNAVAILABLE` placeholder blocks for `Failed`, with a
-/// `─`-divider line between every pair of blocks (no trailing divider).
+/// JSON mode is **not** handled here — the caller builds the
+/// `{"bugs": [...], "failed": [...]}` wrapper itself (projecting each bug via
+/// [`bug_to_json`]). This function only covers table mode: argument-order
+/// detail blocks for `Ok`, visually distinct `UNAVAILABLE` placeholder blocks
+/// for `Failed`, with a `─`-divider line between every pair of blocks (no
+/// trailing divider).
 pub fn write_multi_bug_view<W: Write + ?Sized>(
     rows: &[MultiBugRow],
     spec: ColumnSpec<'_>,

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -217,6 +217,24 @@ fn resolve_columns<E: Write + ?Sized>(
     columns
 }
 
+/// Whether a detail-view field should render given `spec`. With no include
+/// list, every field shows (minus excludes). Tokens are matched against the
+/// column registry so `assignee`/`assigned_to` etc. are equivalent. Fields
+/// with no registry entry always show by default.
+fn field_selected(spec: ColumnSpec<'_>, field: &str) -> bool {
+    let Some(target) = resolve_bug_column(field) else {
+        return true;
+    };
+    let matches = |list: &str| {
+        list.split(',')
+            .filter_map(resolve_bug_column)
+            .any(|c| c.header == target.header)
+    };
+    let included = spec.include.is_none_or(matches);
+    let excluded = spec.exclude.is_some_and(matches);
+    included && !excluded
+}
+
 pub fn write_bugs<W: Write + ?Sized, E: Write + ?Sized>(
     bugs: &[Bug],
     spec: ColumnSpec<'_>,
@@ -239,36 +257,73 @@ pub fn write_bugs<W: Write + ?Sized, E: Write + ?Sized>(
     });
 }
 
-pub fn write_bug_detail<W: Write + ?Sized>(bug: &Bug, format: OutputFormat, out: &mut W) {
+pub fn write_bug_detail<W: Write + ?Sized>(
+    bug: &Bug,
+    spec: ColumnSpec<'_>,
+    format: OutputFormat,
+    out: &mut W,
+) {
     write_formatted(bug, format, out, |bug, out| {
-        write_bug_detail_table(bug, out);
+        write_bug_detail_table(bug, spec, out);
     });
 }
 
-fn write_bug_detail_table(bug: &Bug, out: &mut (impl Write + ?Sized)) {
-    let _ = writeln!(
-        out,
-        "{} #{}\n{}\n",
-        "Bug".bold(),
-        bug.id.to_string().bold(),
-        bug.summary.bold()
-    );
-    write_field(out, "Status", &colorize_status(&bug.status));
-    write_optional_field(out, "Resolution", bug.resolution.as_deref());
-    if let Some(dupe_of) = bug.dupe_of {
-        let _ = writeln!(out, "  {:<12}  {dupe_of}", "Duplicate of");
+fn write_bug_detail_table(bug: &Bug, spec: ColumnSpec<'_>, out: &mut (impl Write + ?Sized)) {
+    if field_selected(spec, "summary") {
+        let _ = writeln!(
+            out,
+            "{} #{}\n{}\n",
+            "Bug".bold(),
+            bug.id.to_string().bold(),
+            bug.summary.bold()
+        );
+    } else {
+        let _ = writeln!(out, "{} #{}\n", "Bug".bold(), bug.id.to_string().bold());
     }
-    write_optional_field(out, "Product", bug.product.as_deref());
-    write_optional_field(out, "Component", bug.component.as_deref());
-    write_optional_field(out, "Assignee", bug.assigned_to.as_deref());
-    write_optional_field(out, "Priority", bug.priority.as_deref());
-    write_optional_field(out, "Severity", bug.severity.as_deref());
-    write_optional_field(out, "Creator", bug.creator.as_deref());
-    write_optional_field(out, "Created", bug.creation_time.as_deref());
-    write_optional_field(out, "Updated", bug.last_change_time.as_deref());
-    write_list_field(out, "Keywords", &bug.keywords);
-    write_id_list_field(out, "Blocks", &bug.blocks);
-    write_id_list_field(out, "Depends on", &bug.depends_on);
+    if field_selected(spec, "status") {
+        write_field(out, "Status", &colorize_status(&bug.status));
+    }
+    if field_selected(spec, "resolution") {
+        write_optional_field(out, "Resolution", bug.resolution.as_deref());
+    }
+    if field_selected(spec, "dupe_of") {
+        if let Some(dupe_of) = bug.dupe_of {
+            let _ = writeln!(out, "  {:<12}  {dupe_of}", "Duplicate of");
+        }
+    }
+    if field_selected(spec, "product") {
+        write_optional_field(out, "Product", bug.product.as_deref());
+    }
+    if field_selected(spec, "component") {
+        write_optional_field(out, "Component", bug.component.as_deref());
+    }
+    if field_selected(spec, "assigned_to") {
+        write_optional_field(out, "Assignee", bug.assigned_to.as_deref());
+    }
+    if field_selected(spec, "priority") {
+        write_optional_field(out, "Priority", bug.priority.as_deref());
+    }
+    if field_selected(spec, "severity") {
+        write_optional_field(out, "Severity", bug.severity.as_deref());
+    }
+    if field_selected(spec, "creator") {
+        write_optional_field(out, "Creator", bug.creator.as_deref());
+    }
+    if field_selected(spec, "creation_time") {
+        write_optional_field(out, "Created", bug.creation_time.as_deref());
+    }
+    if field_selected(spec, "last_change_time") {
+        write_optional_field(out, "Updated", bug.last_change_time.as_deref());
+    }
+    if field_selected(spec, "keywords") {
+        write_list_field(out, "Keywords", &bug.keywords);
+    }
+    if field_selected(spec, "blocks") {
+        write_id_list_field(out, "Blocks", &bug.blocks);
+    }
+    if field_selected(spec, "depends_on") {
+        write_id_list_field(out, "Depends on", &bug.depends_on);
+    }
 }
 
 fn write_id_list_field(out: &mut (impl Write + ?Sized), label: &str, ids: &[u64]) {
@@ -332,13 +387,17 @@ pub enum MultiBugRow {
 /// covers table mode: argument-order detail blocks for `Ok`, visually
 /// distinct `UNAVAILABLE` placeholder blocks for `Failed`, with a
 /// `─`-divider line between every pair of blocks (no trailing divider).
-pub fn write_multi_bug_view<W: Write + ?Sized>(rows: &[MultiBugRow], out: &mut W) {
+pub fn write_multi_bug_view<W: Write + ?Sized>(
+    rows: &[MultiBugRow],
+    spec: ColumnSpec<'_>,
+    out: &mut W,
+) {
     for (i, row) in rows.iter().enumerate() {
         if i > 0 {
             write_divider(out);
         }
         match row {
-            MultiBugRow::Ok(bug) => write_bug_detail_table(bug, out),
+            MultiBugRow::Ok(bug) => write_bug_detail_table(bug, spec, out),
             MultiBugRow::Failed { id, error } => write_unavailable_block(id, error, out),
         }
     }

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use colored::Colorize;
-use tabled::{Table, Tabled};
+use tabled::builder::Builder;
 
 use crate::output::formatting::{
     colorize_status, shorten_email, truncate, write_divider, write_field, write_formatted,
@@ -9,42 +9,233 @@ use crate::output::formatting::{
 };
 use crate::types::{Bug, HistoryEntry, OutputFormat};
 
-#[derive(Tabled)]
-struct BugRow {
-    #[tabled(rename = "ID")]
-    id: u64,
-    #[tabled(rename = "STATUS")]
-    status: String,
-    #[tabled(rename = "PRIORITY")]
-    priority: String,
-    #[tabled(rename = "ASSIGNEE")]
-    assignee: String,
-    #[tabled(rename = "SUMMARY")]
-    summary: String,
+/// Which fields the caller asked to include / exclude, as the raw
+/// comma-separated `--fields` / `--exclude-fields` values. `Default`
+/// (both `None`) means "use the default column set".
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ColumnSpec<'a> {
+    pub include: Option<&'a str>,
+    pub exclude: Option<&'a str>,
 }
 
-impl From<&Bug> for BugRow {
-    fn from(b: &Bug) -> Self {
-        let summary = truncate(&b.summary, 72);
-        BugRow {
-            id: b.id,
-            status: b.status.clone(),
-            priority: b.priority.clone().unwrap_or_default(),
-            assignee: shorten_email(b.assigned_to.as_deref().unwrap_or("")),
-            summary,
+/// A selectable column in bug table output: the tokens that map to it,
+/// its header, and how to render one bug's cell.
+struct BugColumn {
+    /// Accepted field tokens (lowercase) that resolve to this column.
+    aliases: &'static [&'static str],
+    header: &'static str,
+    render: fn(&Bug) -> String,
+}
+
+/// Columns shown when `--fields` is not supplied. Order and headers match
+/// the historical fixed table.
+const DEFAULT_COLUMNS: &[&str] = &["id", "status", "priority", "assignee", "summary"];
+
+/// The full set of fields renderable as table columns. Tokens are matched
+/// case-insensitively against `aliases`. Fields absent here (e.g. custom
+/// `cf_*` fields) have no table representation.
+const COLUMNS: &[BugColumn] = &[
+    BugColumn {
+        aliases: &["id"],
+        header: "ID",
+        render: |b| b.id.to_string(),
+    },
+    BugColumn {
+        aliases: &["status"],
+        header: "STATUS",
+        render: |b| b.status.clone(),
+    },
+    BugColumn {
+        aliases: &["priority"],
+        header: "PRIORITY",
+        render: |b| b.priority.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["assignee", "assigned_to"],
+        header: "ASSIGNEE",
+        render: |b| shorten_email(b.assigned_to.as_deref().unwrap_or("")),
+    },
+    BugColumn {
+        aliases: &["summary"],
+        header: "SUMMARY",
+        render: |b| truncate(&b.summary, 72),
+    },
+    BugColumn {
+        aliases: &["severity"],
+        header: "SEVERITY",
+        render: |b| b.severity.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["product"],
+        header: "PRODUCT",
+        render: |b| b.product.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["component"],
+        header: "COMPONENT",
+        render: |b| b.component.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["resolution"],
+        header: "RESOLUTION",
+        render: |b| b.resolution.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["version"],
+        header: "VERSION",
+        render: |b| b.version.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["creator", "reporter"],
+        header: "CREATOR",
+        render: |b| b.creator.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["creation_time", "created"],
+        header: "CREATED",
+        render: |b| b.creation_time.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["last_change_time", "updated"],
+        header: "UPDATED",
+        render: |b| b.last_change_time.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["url"],
+        header: "URL",
+        render: |b| b.url.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["whiteboard"],
+        header: "WHITEBOARD",
+        render: |b| b.whiteboard.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["op_sys"],
+        header: "OP_SYS",
+        render: |b| b.op_sys.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["platform", "rep_platform"],
+        header: "PLATFORM",
+        render: |b| b.rep_platform.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["deadline"],
+        header: "DEADLINE",
+        render: |b| b.deadline.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["keywords"],
+        header: "KEYWORDS",
+        render: |b| b.keywords.join(", "),
+    },
+    BugColumn {
+        aliases: &["blocks"],
+        header: "BLOCKS",
+        render: |b| join_ids(&b.blocks),
+    },
+    BugColumn {
+        aliases: &["depends_on"],
+        header: "DEPENDS_ON",
+        render: |b| join_ids(&b.depends_on),
+    },
+    BugColumn {
+        aliases: &["cc"],
+        header: "CC",
+        render: |b| b.cc.join(", "),
+    },
+    BugColumn {
+        aliases: &["dupe_of"],
+        header: "DUPE_OF",
+        render: |b| b.dupe_of.map(|id| id.to_string()).unwrap_or_default(),
+    },
+];
+
+fn join_ids(ids: &[u64]) -> String {
+    ids.iter()
+        .map(std::string::ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Resolve a single field token to its column, case-insensitively.
+fn resolve_bug_column(token: &str) -> Option<&'static BugColumn> {
+    let token = token.trim().to_ascii_lowercase();
+    COLUMNS.iter().find(|c| c.aliases.contains(&token.as_str()))
+}
+
+fn default_columns() -> Vec<&'static BugColumn> {
+    DEFAULT_COLUMNS
+        .iter()
+        .filter_map(|name| resolve_bug_column(name))
+        .collect()
+}
+
+/// Resolve `spec` into the ordered list of columns to render. Unknown
+/// include tokens are collected and reported on `err`. If every requested
+/// token is unknown, falls back to the default column set so output stays
+/// useful.
+fn resolve_columns<E: Write + ?Sized>(
+    spec: ColumnSpec<'_>,
+    err: &mut E,
+) -> Vec<&'static BugColumn> {
+    let mut columns = match spec.include {
+        None => default_columns(),
+        Some(list) => {
+            let mut cols = Vec::new();
+            let mut unknown = Vec::new();
+            for token in list.split(',') {
+                let token = token.trim();
+                if token.is_empty() {
+                    continue;
+                }
+                match resolve_bug_column(token) {
+                    Some(col) => cols.push(col),
+                    None => unknown.push(token),
+                }
+            }
+            if !unknown.is_empty() {
+                let _ = writeln!(
+                    err,
+                    "warning: field(s) not displayable in table output: {}; use --json to see them",
+                    unknown.join(", ")
+                );
+            }
+            if cols.is_empty() {
+                default_columns()
+            } else {
+                cols
+            }
         }
+    };
+    if let Some(list) = spec.exclude {
+        let excluded: Vec<&'static BugColumn> =
+            list.split(',').filter_map(resolve_bug_column).collect();
+        columns.retain(|c| !excluded.iter().any(|e| e.header == c.header));
     }
+    columns
 }
 
-pub fn write_bugs<W: Write + ?Sized>(bugs: &[Bug], format: OutputFormat, out: &mut W) {
+pub fn write_bugs<W: Write + ?Sized, E: Write + ?Sized>(
+    bugs: &[Bug],
+    spec: ColumnSpec<'_>,
+    format: OutputFormat,
+    out: &mut W,
+    err: &mut E,
+) {
     write_formatted(bugs, format, out, |bugs, out| {
         if bugs.is_empty() {
             let _ = writeln!(out, "No bugs found.");
             return;
         }
-        let rows: Vec<BugRow> = bugs.iter().map(BugRow::from).collect();
-        let table = Table::new(rows).to_string();
-        let _ = writeln!(out, "{table}");
+        let columns = resolve_columns(spec, err);
+        let mut builder = Builder::default();
+        builder.push_record(columns.iter().map(|c| c.header.to_string()));
+        for bug in bugs {
+            builder.push_record(columns.iter().map(|c| (c.render)(bug)));
+        }
+        let _ = writeln!(out, "{}", builder.build());
     });
 }
 

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -303,6 +303,21 @@ pub fn validate_table_columns(spec: ColumnSpec<'_>) -> crate::error::Result<()> 
     Ok(())
 }
 
+/// Warn that in JSON output `--fields`/`--exclude-fields` restricts which
+/// fields are *fetched*, not which are emitted: every key is still present,
+/// but unselected fields serialize as null/empty, not their real values.
+/// No-op when no field selection is active.
+pub fn warn_json_field_selection<E: Write + ?Sized>(spec: ColumnSpec<'_>, err: &mut E) {
+    if spec.include.is_some() || spec.exclude.is_some() {
+        let _ = writeln!(
+            err,
+            "warning: in --json output, --fields/--exclude-fields selects which fields are \
+             fetched, not which are shown; unselected fields are returned as null/empty, \
+             not their real values"
+        );
+    }
+}
+
 /// Whether a detail-view field should render given `spec`. With no include
 /// list, every field shows (minus excludes). Tokens are matched against the
 /// column registry so `assignee`/`assigned_to` etc. are equivalent. Fields

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -208,10 +208,40 @@ fn default_columns() -> Vec<&'static BugColumn> {
         .collect()
 }
 
+/// Split a comma list into (resolved columns, unknown tokens), trimming and
+/// skipping blanks. Shared by `resolve_columns` and `validate_table_columns`
+/// so the renderer and the pre-flight validator can't drift.
+fn partition_include(list: &str) -> (Vec<&'static BugColumn>, Vec<&str>) {
+    let mut knowns = Vec::new();
+    let mut unknowns = Vec::new();
+    for token in list.split(',') {
+        let token = token.trim();
+        if token.is_empty() {
+            continue;
+        }
+        match resolve_bug_column(token) {
+            Some(col) => knowns.push(col),
+            None => unknowns.push(token),
+        }
+    }
+    (knowns, unknowns)
+}
+
+/// Apply `spec.exclude` to `columns` in place, dropping any column whose
+/// header matches an excluded token.
+fn apply_exclude(columns: &mut Vec<&'static BugColumn>, exclude: Option<&str>) {
+    if let Some(list) = exclude {
+        let excluded: Vec<&'static BugColumn> =
+            list.split(',').filter_map(resolve_bug_column).collect();
+        columns.retain(|c| !excluded.iter().any(|e| e.header == c.header));
+    }
+}
+
 /// Resolve `spec` into the ordered list of columns to render. Unknown
-/// include tokens are collected and reported on `err`. If every requested
+/// include tokens are reported as a warning on `err`. If every requested
 /// token is unknown, falls back to the default column set so output stays
-/// useful.
+/// useful. Infallible by design — the fully-degenerate cases (zero columns)
+/// are rejected up front by [`validate_table_columns`].
 fn resolve_columns<E: Write + ?Sized>(
     spec: ColumnSpec<'_>,
     err: &mut E,
@@ -219,38 +249,58 @@ fn resolve_columns<E: Write + ?Sized>(
     let mut columns = match spec.include {
         None => default_columns(),
         Some(list) => {
-            let mut cols = Vec::new();
-            let mut unknown = Vec::new();
-            for token in list.split(',') {
-                let token = token.trim();
-                if token.is_empty() {
-                    continue;
-                }
-                match resolve_bug_column(token) {
-                    Some(col) => cols.push(col),
-                    None => unknown.push(token),
-                }
-            }
-            if !unknown.is_empty() {
+            let (knowns, unknowns) = partition_include(list);
+            if !unknowns.is_empty() {
                 let _ = writeln!(
                     err,
-                    "warning: field(s) not displayable in table output: {}; use --json to see them",
-                    unknown.join(", ")
+                    "warning: ignoring field(s) with no table column: {}",
+                    unknowns.join(", ")
                 );
             }
-            if cols.is_empty() {
+            if knowns.is_empty() {
                 default_columns()
             } else {
-                cols
+                knowns
             }
         }
     };
-    if let Some(list) = spec.exclude {
-        let excluded: Vec<&'static BugColumn> =
-            list.split(',').filter_map(resolve_bug_column).collect();
-        columns.retain(|c| !excluded.iter().any(|e| e.header == c.header));
-    }
+    apply_exclude(&mut columns, spec.exclude);
     columns
+}
+
+/// Validate that `spec` yields at least one renderable table column. Call
+/// ONLY when output is a table, before the network request. Errors (exit 7)
+/// when a `--fields` value resolves to zero columns (all tokens unknown), or
+/// when `--exclude-fields` removes every column. Partial-unknown (some valid,
+/// some not) is allowed and handled as a warning at render time.
+pub fn validate_table_columns(spec: ColumnSpec<'_>) -> crate::error::Result<()> {
+    let mut columns = match spec.include {
+        None => default_columns(),
+        Some(list) => {
+            let (knowns, unknowns) = partition_include(list);
+            if knowns.is_empty() {
+                if unknowns.is_empty() {
+                    // All-blank like ",," — treat as no selection, not an error.
+                    default_columns()
+                } else {
+                    return Err(crate::error::BzrError::InputValidation(format!(
+                        "none of the requested fields can be shown as table columns: {}; \
+                         these fields have no table representation",
+                        unknowns.join(", ")
+                    )));
+                }
+            } else {
+                knowns
+            }
+        }
+    };
+    apply_exclude(&mut columns, spec.exclude);
+    if columns.is_empty() {
+        return Err(crate::error::BzrError::InputValidation(
+            "--exclude-fields removed every table column; nothing left to display".into(),
+        ));
+    }
+    Ok(())
 }
 
 /// Whether a detail-view field should render given `spec`. With no include

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -303,17 +303,28 @@ pub fn validate_table_columns(spec: ColumnSpec<'_>) -> crate::error::Result<()> 
     Ok(())
 }
 
-/// Warn that in JSON output `--fields`/`--exclude-fields` restricts which
-/// fields are *fetched*, not which are emitted: every key is still present,
-/// but unselected fields serialize as null/empty, not their real values.
-/// No-op when no field selection is active.
-pub fn warn_json_field_selection<E: Write + ?Sized>(spec: ColumnSpec<'_>, err: &mut E) {
-    if spec.include.is_some() || spec.exclude.is_some() {
+/// Warn that under `--json` a `--fields`/`--exclude-fields` selection controls
+/// which fields are *fetched*, not which are shown: `id` is always present, but
+/// every other unselected field deserializes to null/empty rather than its real
+/// value. No-op unless `interactive` (stderr is a terminal) and a non-blank
+/// selection is active — matching `validate_table_columns`'s notion of "no
+/// selection" for all-blank input like `""` / `,,`.
+pub fn warn_json_field_selection<E: Write + ?Sized>(
+    spec: ColumnSpec<'_>,
+    interactive: bool,
+    err: &mut E,
+) {
+    if !interactive {
+        return;
+    }
+    let active = canonical_field_list(spec.include).is_some()
+        || canonical_field_list(spec.exclude).is_some();
+    if active {
         let _ = writeln!(
             err,
-            "warning: in --json output, --fields/--exclude-fields selects which fields are \
-             fetched, not which are shown; unselected fields are returned as null/empty, \
-             not their real values"
+            "warning: under --json, --fields/--exclude-fields controls which fields are fetched, \
+             not which are shown; id is always present, any other unselected field is returned \
+             as null/empty, not its real value"
         );
     }
 }

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -303,6 +303,22 @@ pub fn validate_table_columns(spec: ColumnSpec<'_>) -> crate::error::Result<()> 
     Ok(())
 }
 
+/// Whether a `--json` field selection actually restricts which fields carry real values,
+/// mirroring `force_id_fields` in the client: an include narrows the fetched set, and an exclude
+/// matters only if it drops a field other than `id` (the client always re-adds `id`). Blank-only
+/// input (`""`, `,,`, `id`) restricts nothing.
+fn json_selection_restricts(spec: ColumnSpec<'_>) -> bool {
+    if canonical_field_list(spec.include).is_some() {
+        return true;
+    }
+    spec.exclude.is_some_and(|list| {
+        list.split(',').any(|t| {
+            let t = t.trim();
+            !t.is_empty() && !t.eq_ignore_ascii_case("id")
+        })
+    })
+}
+
 /// Warn that under `--json` a `--fields`/`--exclude-fields` selection controls
 /// which fields are *fetched*, not which are shown: `id` is always present, but
 /// every other unselected field deserializes to null/empty rather than its real
@@ -317,9 +333,7 @@ pub fn warn_json_field_selection<E: Write + ?Sized>(
     if !interactive {
         return;
     }
-    let active = canonical_field_list(spec.include).is_some()
-        || canonical_field_list(spec.exclude).is_some();
-    if active {
+    if json_selection_restricts(spec) {
         let _ = writeln!(
             err,
             "warning: under --json, --fields/--exclude-fields controls which fields are fetched, \

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -21,10 +21,21 @@ pub struct ColumnSpec<'a> {
 /// A selectable column in bug table output: the tokens that map to it,
 /// its header, and how to render one bug's cell.
 struct BugColumn {
-    /// Accepted field tokens (lowercase) that resolve to this column.
+    /// Accepted field tokens (lowercase) that resolve to this column. By
+    /// convention `aliases[0]` is the canonical Bugzilla field name used for
+    /// the server's `include_fields`/`exclude_fields` payload; the remaining
+    /// entries are accepted synonyms for column selection only.
     aliases: &'static [&'static str],
     header: &'static str,
     render: fn(&Bug) -> String,
+}
+
+impl BugColumn {
+    /// The canonical Bugzilla field name (first alias), used when building
+    /// the server's `include_fields`/`exclude_fields` payload.
+    fn canonical(&self) -> &'static str {
+        self.aliases[0]
+    }
 }
 
 /// Columns shown when `--fields` is not supplied. Order and headers match
@@ -51,7 +62,7 @@ const COLUMNS: &[BugColumn] = &[
         render: |b| b.priority.clone().unwrap_or_default(),
     },
     BugColumn {
-        aliases: &["assignee", "assigned_to"],
+        aliases: &["assigned_to", "assignee"],
         header: "ASSIGNEE",
         render: |b| shorten_email(b.assigned_to.as_deref().unwrap_or("")),
     },
@@ -116,7 +127,7 @@ const COLUMNS: &[BugColumn] = &[
         render: |b| b.op_sys.clone().unwrap_or_default(),
     },
     BugColumn {
-        aliases: &["platform", "rep_platform"],
+        aliases: &["rep_platform", "platform"],
         header: "PLATFORM",
         render: |b| b.rep_platform.clone().unwrap_or_default(),
     },
@@ -163,6 +174,31 @@ fn join_ids(ids: &[u64]) -> String {
 fn resolve_bug_column(token: &str) -> Option<&'static BugColumn> {
     let token = token.trim().to_ascii_lowercase();
     COLUMNS.iter().find(|c| c.aliases.contains(&token.as_str()))
+}
+
+/// Translate a comma-separated field list (which may use column aliases such
+/// as `assignee` or `updated`) into canonical Bugzilla field names for the
+/// server's `include_fields` / `exclude_fields` parameters. Unknown tokens
+/// (e.g. custom `cf_*` fields) pass through unchanged. Empty input or an
+/// all-empty list yields `None`.
+pub fn canonical_field_list(fields: Option<&str>) -> Option<String> {
+    let fields = fields?;
+    let mut out: Vec<&str> = Vec::new();
+    for token in fields.split(',') {
+        let token = token.trim();
+        if token.is_empty() {
+            continue;
+        }
+        match resolve_bug_column(token) {
+            Some(col) => out.push(col.canonical()),
+            None => out.push(token),
+        }
+    }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out.join(","))
+    }
 }
 
 fn default_columns() -> Vec<&'static BugColumn> {

--- a/src/output/resources/bug_tests.rs
+++ b/src/output/resources/bug_tests.rs
@@ -233,6 +233,42 @@ fn write_bugs_json_ignores_columns() {
     );
 }
 
+#[test]
+fn write_bugs_assignee_alias_still_selects_column() {
+    let bugs = vec![make_bug(1, "s", "NEW")];
+    let spec = ColumnSpec {
+        include: Some("id,assignee"),
+        exclude: None,
+    };
+    let (out, err) = capture_bugs_spec(OutputFormat::Table, &bugs, spec);
+    assert!(out.contains("ASSIGNEE"), "alias resolves column:\n{out}");
+    assert!(err.is_empty(), "no warning: {err:?}");
+}
+
+// ── canonical_field_list ─────────────────────────────────────────
+
+#[test]
+fn canonical_field_list_translates_aliases() {
+    let got = canonical_field_list(Some("assignee,updated,created,reporter,platform"));
+    assert_eq!(
+        got.as_deref(),
+        Some("assigned_to,last_change_time,creation_time,creator,rep_platform")
+    );
+}
+
+#[test]
+fn canonical_field_list_passes_through_unknown_and_canonical() {
+    let got = canonical_field_list(Some("id,cf_custom,summary"));
+    assert_eq!(got.as_deref(), Some("id,cf_custom,summary"));
+}
+
+#[test]
+fn canonical_field_list_handles_empty_and_blanks() {
+    assert_eq!(canonical_field_list(None), None);
+    assert_eq!(canonical_field_list(Some("")), None);
+    assert_eq!(canonical_field_list(Some(",, ,")), None);
+}
+
 // ── write_bug_detail ─────────────────────────────────────────────
 
 #[test]

--- a/src/output/resources/bug_tests.rs
+++ b/src/output/resources/bug_tests.rs
@@ -69,8 +69,14 @@ fn capture_bugs_spec(format: OutputFormat, bugs: &[Bug], spec: ColumnSpec<'_>) -
 
 fn capture_bug_detail(format: OutputFormat, bug: &Bug) -> String {
     let mut buf = Vec::new();
-    write_bug_detail(bug, format, &mut buf);
+    write_bug_detail(bug, ColumnSpec::default(), format, &mut buf);
     String::from_utf8(buf).unwrap()
+}
+
+fn capture_detail_spec(bug: &Bug, spec: ColumnSpec<'_>) -> String {
+    let mut out = Vec::new();
+    write_bug_detail(bug, spec, OutputFormat::Table, &mut out);
+    String::from_utf8(out).unwrap()
 }
 
 fn capture_history(format: OutputFormat, history: &[HistoryEntry]) -> String {
@@ -317,7 +323,12 @@ fn write_bug_detail_table_shows_dupe_of() {
     };
     let mut out = Vec::new();
 
-    super::write_bug_detail(&bug, crate::types::OutputFormat::Table, &mut out);
+    super::write_bug_detail(
+        &bug,
+        ColumnSpec::default(),
+        crate::types::OutputFormat::Table,
+        &mut out,
+    );
 
     let output = String::from_utf8(out).unwrap();
     assert!(output.contains("Duplicate of"));
@@ -366,6 +377,43 @@ fn write_bug_detail_json_via_write() {
     let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(parsed["id"], 7);
     assert_eq!(parsed["summary"], "Json bug");
+}
+
+#[test]
+fn detail_default_shows_all_present_fields() {
+    let bug = make_bug(7, "boom", "ASSIGNED");
+    let out = capture_detail_spec(&bug, ColumnSpec::default());
+    assert!(out.contains("Status"), "status row present:\n{out}");
+    assert!(out.contains("Priority"), "priority row present:\n{out}");
+    assert!(out.contains("Product"), "product row present:\n{out}");
+}
+
+#[test]
+fn detail_include_limits_rows() {
+    let bug = make_bug(7, "boom", "ASSIGNED");
+    let spec = ColumnSpec {
+        include: Some("id,priority"),
+        exclude: None,
+    };
+    let out = capture_detail_spec(&bug, spec);
+    assert!(out.contains("Priority"), "priority row present:\n{out}");
+    assert!(
+        !out.contains("Status"),
+        "status row hidden when not requested:\n{out}"
+    );
+    assert!(!out.contains("Product"), "product row hidden:\n{out}");
+}
+
+#[test]
+fn detail_exclude_drops_row() {
+    let bug = make_bug(7, "boom", "ASSIGNED");
+    let spec = ColumnSpec {
+        include: None,
+        exclude: Some("priority"),
+    };
+    let out = capture_detail_spec(&bug, spec);
+    assert!(out.contains("Status"), "status retained:\n{out}");
+    assert!(!out.contains("Priority"), "priority excluded:\n{out}");
 }
 
 // ── write_json (pretty) ──────────────────────────────────────────
@@ -487,7 +535,7 @@ fn multi_bug_view_renders_success_blocks_with_dividers() {
         MultiBugRow::Ok(Box::new(sample_bug(3, "third"))),
     ];
     let mut buf = Vec::new();
-    write_multi_bug_view(&rows, &mut buf);
+    write_multi_bug_view(&rows, ColumnSpec::default(), &mut buf);
     let out = String::from_utf8(buf).unwrap();
     assert!(out.contains("Bug #1"));
     assert!(out.contains("Bug #2"));
@@ -504,7 +552,7 @@ fn multi_bug_view_renders_failure_block_with_unavailable_marker() {
         error: "bug not found: 999".into(),
     }];
     let mut buf = Vec::new();
-    write_multi_bug_view(&rows, &mut buf);
+    write_multi_bug_view(&rows, ColumnSpec::default(), &mut buf);
     let out = String::from_utf8(buf).unwrap();
     assert!(out.contains("Bug #999"));
     assert!(out.contains("UNAVAILABLE"));
@@ -516,7 +564,7 @@ fn multi_bug_view_single_row_emits_no_divider() {
     no_color();
     let rows = vec![MultiBugRow::Ok(Box::new(sample_bug(7, "only")))];
     let mut buf = Vec::new();
-    write_multi_bug_view(&rows, &mut buf);
+    write_multi_bug_view(&rows, ColumnSpec::default(), &mut buf);
     let out = String::from_utf8(buf).unwrap();
     let divider = "─".repeat(60);
     assert_eq!(out.matches(&divider).count(), 0);
@@ -534,7 +582,7 @@ fn multi_bug_view_interleaves_success_and_failure_in_order() {
         MultiBugRow::Ok(Box::new(sample_bug(12, "gamma"))),
     ];
     let mut buf = Vec::new();
-    write_multi_bug_view(&rows, &mut buf);
+    write_multi_bug_view(&rows, ColumnSpec::default(), &mut buf);
     let out = String::from_utf8(buf).unwrap();
     let pos_alpha = out.find("Bug #10").unwrap();
     let pos_unavail = out.find("Bug #11").unwrap();

--- a/src/output/resources/bug_tests.rs
+++ b/src/output/resources/bug_tests.rs
@@ -219,18 +219,21 @@ fn write_bugs_unknown_field_warns_and_falls_back() {
 }
 
 #[test]
-fn write_bugs_json_ignores_columns() {
+fn write_bugs_json_trims_to_selected_fields() {
     let bugs = vec![make_bug(42, "x", "NEW")];
     let spec = ColumnSpec {
         include: Some("id"),
         exclude: None,
     };
     let (out, _err) = capture_bugs_spec(OutputFormat::Json, &bugs, spec);
-    // JSON path is unchanged: full serialized struct, not column-filtered.
-    assert!(
-        out.contains("\"summary\""),
-        "JSON still serializes summary:\n{out}"
-    );
+    let parsed: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    let keys: Vec<&str> = parsed[0]
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(keys, vec!["id"], "JSON array element trimmed to id:\n{out}");
 }
 
 #[test]
@@ -685,107 +688,288 @@ fn validate_table_columns_ok_for_all_blank_include() {
     assert!(validate_table_columns(spec).is_ok());
 }
 
-// ── warn_json_field_selection (F1) ───────────────────────────────
+// ── bug_to_json / bugs_to_json projection (#206) ─────────────────
 
-fn capture_json_warning(spec: ColumnSpec<'_>) -> String {
+/// The serde key sequence of `Bug`, in struct-declaration order. Locks the
+/// `preserve_order` decision (Finding 4) and is the reference for the registry
+/// drift guard (Finding 3).
+const BUG_STRUCT_KEY_ORDER: [&str; 23] = [
+    "id",
+    "summary",
+    "status",
+    "resolution",
+    "dupe_of",
+    "deadline",
+    "product",
+    "component",
+    "version",
+    "assigned_to",
+    "priority",
+    "severity",
+    "creation_time",
+    "last_change_time",
+    "creator",
+    "url",
+    "whiteboard",
+    "keywords",
+    "blocks",
+    "depends_on",
+    "cc",
+    "op_sys",
+    "rep_platform",
+];
+
+fn keys_of(value: &serde_json::Value) -> Vec<String> {
+    value.as_object().unwrap().keys().cloned().collect()
+}
+
+#[test]
+fn bug_to_json_include_keeps_only_named_keys() {
+    let bug = make_bug(1, "s", "NEW");
+    let spec = ColumnSpec {
+        include: Some("summary,status"),
+        exclude: None,
+    };
+    assert_eq!(keys_of(&bug_to_json(&bug, spec)), vec!["summary", "status"]);
+}
+
+#[test]
+fn bug_to_json_include_alias_resolves_to_canonical_key() {
+    let bug = make_bug(1, "s", "NEW");
+    let spec = ColumnSpec {
+        include: Some("assignee"),
+        exclude: None,
+    };
+    let v = bug_to_json(&bug, spec);
+    assert_eq!(keys_of(&v), vec!["assigned_to"]);
+    assert_eq!(v["assigned_to"], "dev@example.com");
+}
+
+#[test]
+fn bug_to_json_exclude_id_drops_id() {
+    let bug = make_bug(1, "s", "NEW");
+    let spec = ColumnSpec {
+        include: None,
+        exclude: Some("id"),
+    };
+    let v = bug_to_json(&bug, spec);
+    let map = v.as_object().unwrap();
+    assert!(!map.contains_key("id"), "id dropped");
+    assert!(map.contains_key("summary"), "other keys retained");
+    assert_eq!(map.len(), BUG_STRUCT_KEY_ORDER.len() - 1);
+}
+
+#[test]
+fn bug_to_json_exclude_subset_drops_only_those() {
+    let bug = make_bug(1, "s", "NEW");
+    let spec = ColumnSpec {
+        include: None,
+        exclude: Some("cc,keywords"),
+    };
+    let v = bug_to_json(&bug, spec);
+    let map = v.as_object().unwrap();
+    assert!(!map.contains_key("cc"));
+    assert!(!map.contains_key("keywords"));
+    assert!(map.contains_key("id"));
+    assert_eq!(map.len(), BUG_STRUCT_KEY_ORDER.len() - 2);
+}
+
+#[test]
+fn bug_to_json_no_selection_is_full_object() {
+    let bug = make_bug(1, "s", "NEW");
+    for spec in [
+        ColumnSpec::default(),
+        ColumnSpec {
+            include: Some(""),
+            exclude: None,
+        },
+        ColumnSpec {
+            include: Some(",,"),
+            exclude: None,
+        },
+    ] {
+        let v = bug_to_json(&bug, spec);
+        assert_eq!(
+            v.as_object().unwrap().len(),
+            BUG_STRUCT_KEY_ORDER.len(),
+            "full object for {spec:?}"
+        );
+    }
+}
+
+#[test]
+fn bug_to_json_partial_unknown_keeps_known_only() {
+    let bug = make_bug(1, "s", "NEW");
+    let spec = ColumnSpec {
+        include: Some("summary,cf_x"),
+        exclude: None,
+    };
+    let v = bug_to_json(&bug, spec);
+    let map = v.as_object().unwrap();
+    assert!(map.contains_key("summary"));
+    assert!(!map.contains_key("cf_x"));
+    assert_eq!(map.len(), 1);
+}
+
+#[test]
+fn bug_to_json_full_object_preserves_struct_field_order() {
+    let bug = make_bug(1, "s", "NEW");
+    let v = bug_to_json(&bug, ColumnSpec::default());
+    assert_eq!(keys_of(&v), BUG_STRUCT_KEY_ORDER.to_vec());
+}
+
+#[test]
+fn bug_to_json_projection_preserves_struct_order_not_request_order() {
+    // Include given out of struct order; the projected object must still be in
+    // struct-declaration order (Finding 4: real ordering lock, not vacuous).
+    let bug = make_bug(1, "s", "NEW");
+    let spec = ColumnSpec {
+        include: Some("status,id,summary"),
+        exclude: None,
+    };
+    assert_eq!(
+        keys_of(&bug_to_json(&bug, spec)),
+        vec!["id", "summary", "status"]
+    );
+}
+
+#[test]
+fn bugs_to_json_projects_every_element() {
+    let bugs = vec![make_bug(1, "a", "NEW"), make_bug(2, "b", "RESOLVED")];
+    let spec = ColumnSpec {
+        include: Some("id"),
+        exclude: None,
+    };
+    let arr = bugs_to_json(&bugs, spec);
+    assert_eq!(arr.len(), 2);
+    for v in &arr {
+        assert_eq!(keys_of(v), vec!["id"]);
+    }
+    assert_eq!(arr[0]["id"], 1);
+    assert_eq!(arr[1]["id"], 2);
+}
+
+// ── Registry drift guard (Finding 3) ─────────────────────────────
+
+#[test]
+fn columns_registry_is_one_to_one_with_bug_serde_keys() {
+    let bug = make_bug(1, "s", "NEW");
+    let value = serde_json::to_value(&bug).unwrap();
+    let serde_keys: std::collections::HashSet<String> =
+        value.as_object().unwrap().keys().cloned().collect();
+    let registry_keys: std::collections::HashSet<String> =
+        COLUMNS.iter().map(|c| c.canonical().to_string()).collect();
+    assert_eq!(
+        serde_keys, registry_keys,
+        "COLUMNS canonical names must be 1:1 with Bug's serde keys"
+    );
+    assert_eq!(
+        registry_keys.len(),
+        COLUMNS.len(),
+        "no duplicate canonical names in COLUMNS"
+    );
+}
+
+// ── validate_json_field_selection (Finding 1) ────────────────────
+
+#[test]
+fn validate_json_default_spec_ok() {
+    assert!(validate_json_field_selection(ColumnSpec::default()).is_ok());
+}
+
+#[test]
+fn validate_json_all_unknown_include_errs() {
+    let spec = ColumnSpec {
+        include: Some("cf_x,cf_y"),
+        exclude: None,
+    };
+    let err = validate_json_field_selection(spec).unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+}
+
+#[test]
+fn validate_json_exclude_every_key_errs() {
+    let all = COLUMNS
+        .iter()
+        .map(BugColumn::canonical)
+        .collect::<Vec<_>>()
+        .join(",");
+    let spec = ColumnSpec {
+        include: None,
+        exclude: Some(all.as_str()),
+    };
+    let err = validate_json_field_selection(spec).unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+}
+
+#[test]
+fn validate_json_exclude_table_defaults_ok() {
+    // Excluding the five default *table* columns must NOT exit 7 under --json:
+    // 18 other fields remain. This is the regression the table validator would
+    // get wrong if reused verbatim (Finding 1).
+    let spec = ColumnSpec {
+        include: None,
+        exclude: Some("id,status,priority,assignee,summary"),
+    };
+    assert!(validate_json_field_selection(spec).is_ok());
+}
+
+#[test]
+fn validate_json_partial_unknown_include_ok() {
+    let spec = ColumnSpec {
+        include: Some("summary,cf_x"),
+        exclude: None,
+    };
+    assert!(validate_json_field_selection(spec).is_ok());
+}
+
+#[test]
+fn validate_json_blank_include_ok() {
+    for blank in ["", ",,"] {
+        let spec = ColumnSpec {
+            include: Some(blank),
+            exclude: None,
+        };
+        assert!(
+            validate_json_field_selection(spec).is_ok(),
+            "blank include {blank:?} is no selection"
+        );
+    }
+}
+
+// ── warn_unknown_fields ──────────────────────────────────────────
+
+fn capture_unknown_warning(spec: ColumnSpec<'_>) -> String {
     let mut err = Vec::new();
-    warn_json_field_selection(spec, true, &mut err);
+    warn_unknown_fields(spec, &mut err);
     String::from_utf8(err).unwrap()
 }
 
 #[test]
-fn warn_json_field_selection_warns_for_include() {
-    let warning = capture_json_warning(ColumnSpec {
-        include: Some("summary"),
+fn warn_unknown_fields_warns_for_unknown_include_token() {
+    let w = capture_unknown_warning(ColumnSpec {
+        include: Some("summary,cf_x"),
         exclude: None,
     });
-    assert!(
-        warning.contains("null/empty"),
-        "warns about value-blanking: {warning:?}"
-    );
-    assert!(
-        warning.contains("id is always present"),
-        "discloses the id exception: {warning:?}"
-    );
+    assert!(w.contains("ignoring unknown field(s): cf_x"), "{w:?}");
 }
 
 #[test]
-fn warn_json_field_selection_silent_when_not_interactive() {
-    let mut err = Vec::new();
-    warn_json_field_selection(
-        ColumnSpec {
-            include: Some("summary"),
-            exclude: None,
-        },
-        false,
-        &mut err,
-    );
-    let warning = String::from_utf8(err).unwrap();
-    assert!(
-        warning.is_empty(),
-        "no warning when stderr is not a terminal: {warning:?}"
-    );
-}
-
-#[test]
-fn warn_json_field_selection_silent_for_blank_selection() {
-    for blank in ["", ",,"] {
-        let warning = capture_json_warning(ColumnSpec {
-            include: Some(blank),
-            exclude: None,
-        });
-        assert!(
-            warning.is_empty(),
-            "blank include {blank:?} is no selection: {warning:?}"
-        );
-    }
-}
-
-#[test]
-fn warn_json_field_selection_warns_for_exclude() {
-    let warning = capture_json_warning(ColumnSpec {
-        include: None,
-        exclude: Some("status"),
+fn warn_unknown_fields_silent_for_all_known() {
+    let w = capture_unknown_warning(ColumnSpec {
+        include: Some("summary,status"),
+        exclude: None,
     });
-    assert!(
-        warning.contains("null/empty"),
-        "warns about value-blanking: {warning:?}"
-    );
+    assert!(w.is_empty(), "no warning when all known: {w:?}");
 }
 
 #[test]
-fn warn_json_field_selection_silent_without_selection() {
-    let warning = capture_json_warning(ColumnSpec::default());
-    assert!(
-        warning.is_empty(),
-        "no warning when no field selection is active: {warning:?}"
-    );
-}
-
-#[test]
-fn warn_json_field_selection_silent_for_exclude_id_only() {
-    for excl in ["id", "ID", "id,"] {
-        let warning = capture_json_warning(ColumnSpec {
-            include: None,
-            exclude: Some(excl),
-        });
-        assert!(
-            warning.is_empty(),
-            "excluding only id restricts nothing (client re-adds id): {excl:?} -> {warning:?}"
-        );
-    }
-}
-
-#[test]
-fn warn_json_field_selection_warns_for_exclude_non_id() {
-    let warning = capture_json_warning(ColumnSpec {
+fn warn_unknown_fields_silent_without_include() {
+    let w = capture_unknown_warning(ColumnSpec {
         include: None,
-        exclude: Some("id,cc"),
+        exclude: Some("cf_x"),
     });
-    assert!(
-        warning.contains("null/empty"),
-        "a non-id field is genuinely dropped, so warn: {warning:?}"
-    );
+    assert!(w.is_empty(), "exclude-only never warns: {w:?}");
 }
 
 #[test]

--- a/src/output/resources/bug_tests.rs
+++ b/src/output/resources/bug_tests.rs
@@ -685,6 +685,47 @@ fn validate_table_columns_ok_for_all_blank_include() {
     assert!(validate_table_columns(spec).is_ok());
 }
 
+// ── warn_json_field_selection (F1) ───────────────────────────────
+
+fn capture_json_warning(spec: ColumnSpec<'_>) -> String {
+    let mut err = Vec::new();
+    warn_json_field_selection(spec, &mut err);
+    String::from_utf8(err).unwrap()
+}
+
+#[test]
+fn warn_json_field_selection_warns_for_include() {
+    let warning = capture_json_warning(ColumnSpec {
+        include: Some("summary"),
+        exclude: None,
+    });
+    assert!(
+        warning.contains("null/empty"),
+        "warns about value-blanking: {warning:?}"
+    );
+}
+
+#[test]
+fn warn_json_field_selection_warns_for_exclude() {
+    let warning = capture_json_warning(ColumnSpec {
+        include: None,
+        exclude: Some("status"),
+    });
+    assert!(
+        warning.contains("null/empty"),
+        "warns about value-blanking: {warning:?}"
+    );
+}
+
+#[test]
+fn warn_json_field_selection_silent_without_selection() {
+    let warning = capture_json_warning(ColumnSpec::default());
+    assert!(
+        warning.is_empty(),
+        "no warning when no field selection is active: {warning:?}"
+    );
+}
+
 #[test]
 fn write_bugs_partial_unknown_warns_with_new_wording_and_shows_known() {
     let bugs = vec![make_bug(1, "summary text", "NEW")];

--- a/src/output/resources/bug_tests.rs
+++ b/src/output/resources/bug_tests.rs
@@ -2,7 +2,6 @@
 
 use super::*;
 use crate::types::{Bug, FieldChange, HistoryEntry};
-use tabled::Table;
 
 fn make_bug(id: u64, summary: &str, status: &str) -> Bug {
     Bug {
@@ -54,9 +53,18 @@ fn make_history_entry() -> HistoryEntry {
 }
 
 fn capture_bugs(format: OutputFormat, bugs: &[Bug]) -> String {
-    let mut buf = Vec::new();
-    write_bugs(bugs, format, &mut buf);
-    String::from_utf8(buf).unwrap()
+    capture_bugs_spec(format, bugs, ColumnSpec::default()).0
+}
+
+/// Returns (stdout, stderr) so column-selection tests can assert warnings.
+fn capture_bugs_spec(format: OutputFormat, bugs: &[Bug], spec: ColumnSpec<'_>) -> (String, String) {
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    write_bugs(bugs, spec, format, &mut out, &mut err);
+    (
+        String::from_utf8(out).unwrap(),
+        String::from_utf8(err).unwrap(),
+    )
 }
 
 fn capture_bug_detail(format: OutputFormat, bug: &Bug) -> String {
@@ -69,59 +77,6 @@ fn capture_history(format: OutputFormat, history: &[HistoryEntry]) -> String {
     let mut buf = Vec::new();
     write_history(history, format, &mut buf);
     String::from_utf8(buf).unwrap()
-}
-
-// ── BugRow conversion ────────────────────────────────────────────
-
-#[test]
-fn bug_row_from_bug_truncates_summary() {
-    let mut bug = make_bug(1, &"x".repeat(100), "NEW");
-    let row = BugRow::from(&bug);
-    assert_eq!(row.summary.chars().count(), 72);
-    assert!(row.summary.ends_with("..."));
-
-    bug.summary = "short".into();
-    let row = BugRow::from(&bug);
-    assert_eq!(row.summary, "short");
-}
-
-#[test]
-fn bug_row_from_bug_shortens_assignee() {
-    let bug = make_bug(1, "test", "NEW");
-    let row = BugRow::from(&bug);
-    assert_eq!(row.assignee, "dev");
-}
-
-#[test]
-fn bug_row_from_bug_missing_fields() {
-    let bug = Bug {
-        id: 1,
-        summary: "minimal".into(),
-        status: "NEW".into(),
-        resolution: None,
-        dupe_of: None,
-        deadline: None,
-        product: None,
-        component: None,
-        version: None,
-        assigned_to: None,
-        priority: None,
-        severity: None,
-        creation_time: None,
-        last_change_time: None,
-        creator: None,
-        url: None,
-        whiteboard: None,
-        keywords: vec![],
-        blocks: vec![],
-        depends_on: vec![],
-        cc: vec![],
-        op_sys: None,
-        rep_platform: None,
-    };
-    let row = BugRow::from(&bug);
-    assert_eq!(row.priority, "");
-    assert_eq!(row.assignee, "");
 }
 
 // ── write_bugs ───────────────────────────────────────────────────
@@ -140,19 +95,6 @@ fn write_bugs_json_one_bug() {
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
     assert_eq!(parsed[0]["id"], 42);
     assert_eq!(parsed[0]["summary"], "Login broken");
-}
-
-#[test]
-fn write_bugs_table_renders_rows() {
-    let bugs = [make_bug(42, "Login broken", "NEW")];
-    let rows: Vec<BugRow> = bugs.iter().map(BugRow::from).collect();
-    let table = Table::new(rows).to_string();
-    assert!(table.contains("42"));
-    assert!(table.contains("NEW"));
-    assert!(table.contains("Login broken"));
-    assert!(table.contains("ID"));
-    assert!(table.contains("STATUS"));
-    assert!(table.contains("SUMMARY"));
 }
 
 #[test]
@@ -193,6 +135,96 @@ fn write_bugs_json_via_write() {
     assert_eq!(parsed[0]["id"], 99);
     assert_eq!(parsed[0]["summary"], "Crash on startup");
     assert_eq!(parsed[0]["status"], "ASSIGNED");
+}
+
+#[test]
+fn write_bugs_fields_selects_only_requested_columns() {
+    let bugs = vec![make_bug(217559, "kernel panic on boot", "ASSIGNED")];
+    let spec = ColumnSpec {
+        include: Some("id,priority"),
+        exclude: None,
+    };
+    let (out, err) = capture_bugs_spec(OutputFormat::Table, &bugs, spec);
+    assert!(out.contains("ID"), "ID column present:\n{out}");
+    assert!(out.contains("PRIORITY"), "PRIORITY column present:\n{out}");
+    assert!(!out.contains("STATUS"), "STATUS must be absent:\n{out}");
+    assert!(!out.contains("ASSIGNEE"), "ASSIGNEE must be absent:\n{out}");
+    assert!(!out.contains("SUMMARY"), "SUMMARY must be absent:\n{out}");
+    assert!(err.is_empty(), "no warning for known fields: {err:?}");
+}
+
+#[test]
+fn write_bugs_fields_adds_non_default_columns_populated() {
+    let bugs = vec![make_bug(218034, "LPM crash", "WORKING")];
+    let spec = ColumnSpec {
+        include: Some("id,priority,severity,status,product,summary"),
+        exclude: None,
+    };
+    let (out, _err) = capture_bugs_spec(OutputFormat::Table, &bugs, spec);
+    for header in ["ID", "PRIORITY", "SEVERITY", "STATUS", "PRODUCT", "SUMMARY"] {
+        assert!(out.contains(header), "{header} column present:\n{out}");
+    }
+    // make_bug populates severity=major and product=TestProduct.
+    assert!(out.contains("major"), "severity value rendered:\n{out}");
+    assert!(
+        out.contains("TestProduct"),
+        "product value rendered:\n{out}"
+    );
+}
+
+#[test]
+fn write_bugs_no_fields_keeps_default_columns() {
+    let bugs = vec![make_bug(1, "summary text", "NEW")];
+    let out = capture_bugs(OutputFormat::Table, &bugs);
+    for header in ["ID", "STATUS", "PRIORITY", "ASSIGNEE", "SUMMARY"] {
+        assert!(out.contains(header), "default header {header}:\n{out}");
+    }
+}
+
+#[test]
+fn write_bugs_exclude_fields_drops_default_column() {
+    let bugs = vec![make_bug(1, "summary text", "NEW")];
+    let spec = ColumnSpec {
+        include: None,
+        exclude: Some("summary"),
+    };
+    let (out, _err) = capture_bugs_spec(OutputFormat::Table, &bugs, spec);
+    assert!(out.contains("ID"), "ID retained:\n{out}");
+    assert!(!out.contains("SUMMARY"), "SUMMARY excluded:\n{out}");
+}
+
+#[test]
+fn write_bugs_unknown_field_warns_and_falls_back() {
+    let bugs = vec![make_bug(1, "summary text", "NEW")];
+    let spec = ColumnSpec {
+        include: Some("cf_custom_thing"),
+        exclude: None,
+    };
+    let (out, err) = capture_bugs_spec(OutputFormat::Table, &bugs, spec);
+    assert!(
+        err.contains("cf_custom_thing"),
+        "warns about unknown field: {err:?}"
+    );
+    // All requested columns were unknown -> fall back to the default set.
+    assert!(
+        out.contains("ID") && out.contains("SUMMARY"),
+        "fallback default columns:\n{out}"
+    );
+}
+
+#[test]
+fn write_bugs_json_ignores_columns() {
+    let bugs = vec![make_bug(42, "x", "NEW")];
+    let spec = ColumnSpec {
+        include: Some("id"),
+        exclude: None,
+    };
+    let (out, _err) = capture_bugs_spec(OutputFormat::Json, &bugs, spec);
+    // JSON path is unchanged: full serialized struct, not column-filtered.
+    assert!(
+        out.contains("\"summary\""),
+        "JSON still serializes summary:\n{out}"
+    );
 }
 
 // ── write_bug_detail ─────────────────────────────────────────────

--- a/src/output/resources/bug_tests.rs
+++ b/src/output/resources/bug_tests.rs
@@ -689,7 +689,7 @@ fn validate_table_columns_ok_for_all_blank_include() {
 
 fn capture_json_warning(spec: ColumnSpec<'_>) -> String {
     let mut err = Vec::new();
-    warn_json_field_selection(spec, &mut err);
+    warn_json_field_selection(spec, true, &mut err);
     String::from_utf8(err).unwrap()
 }
 
@@ -703,6 +703,42 @@ fn warn_json_field_selection_warns_for_include() {
         warning.contains("null/empty"),
         "warns about value-blanking: {warning:?}"
     );
+    assert!(
+        warning.contains("id is always present"),
+        "discloses the id exception: {warning:?}"
+    );
+}
+
+#[test]
+fn warn_json_field_selection_silent_when_not_interactive() {
+    let mut err = Vec::new();
+    warn_json_field_selection(
+        ColumnSpec {
+            include: Some("summary"),
+            exclude: None,
+        },
+        false,
+        &mut err,
+    );
+    let warning = String::from_utf8(err).unwrap();
+    assert!(
+        warning.is_empty(),
+        "no warning when stderr is not a terminal: {warning:?}"
+    );
+}
+
+#[test]
+fn warn_json_field_selection_silent_for_blank_selection() {
+    for blank in ["", ",,"] {
+        let warning = capture_json_warning(ColumnSpec {
+            include: Some(blank),
+            exclude: None,
+        });
+        assert!(
+            warning.is_empty(),
+            "blank include {blank:?} is no selection: {warning:?}"
+        );
+    }
 }
 
 #[test]

--- a/src/output/resources/bug_tests.rs
+++ b/src/output/resources/bug_tests.rs
@@ -625,3 +625,77 @@ fn multi_bug_view_interleaves_success_and_failure_in_order() {
     let pos_gamma = out.find("Bug #12").unwrap();
     assert!(pos_alpha < pos_unavail && pos_unavail < pos_gamma);
 }
+
+// ── validate_table_columns (F2/F3) ───────────────────────────────
+
+#[test]
+fn validate_table_columns_ok_for_default_spec() {
+    assert!(validate_table_columns(ColumnSpec::default()).is_ok());
+}
+
+#[test]
+fn validate_table_columns_ok_for_partial_unknown_include() {
+    let spec = ColumnSpec {
+        include: Some("id,cf_custom"),
+        exclude: None,
+    };
+    assert!(validate_table_columns(spec).is_ok());
+}
+
+#[test]
+fn validate_table_columns_errors_for_all_unknown_include() {
+    let spec = ColumnSpec {
+        include: Some("cf_custom"),
+        exclude: None,
+    };
+    let err = validate_table_columns(spec).unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+    assert!(
+        err.to_string().contains("cf_custom"),
+        "names the offending field: {err}"
+    );
+}
+
+#[test]
+fn validate_table_columns_errors_when_exclude_removes_all_defaults() {
+    let spec = ColumnSpec {
+        include: None,
+        exclude: Some("id,status,priority,assignee,summary"),
+    };
+    let err = validate_table_columns(spec).unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+}
+
+#[test]
+fn validate_table_columns_errors_when_exclude_removes_sole_include() {
+    let spec = ColumnSpec {
+        include: Some("id"),
+        exclude: Some("id"),
+    };
+    let err = validate_table_columns(spec).unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+}
+
+#[test]
+fn validate_table_columns_ok_for_all_blank_include() {
+    let spec = ColumnSpec {
+        include: Some(",,"),
+        exclude: None,
+    };
+    assert!(validate_table_columns(spec).is_ok());
+}
+
+#[test]
+fn write_bugs_partial_unknown_warns_with_new_wording_and_shows_known() {
+    let bugs = vec![make_bug(1, "summary text", "NEW")];
+    let spec = ColumnSpec {
+        include: Some("id,cf_x"),
+        exclude: None,
+    };
+    let (out, err) = capture_bugs_spec(OutputFormat::Table, &bugs, spec);
+    assert!(
+        err.contains("ignoring field(s) with no table column: cf_x"),
+        "new warning wording: {err:?}"
+    );
+    assert!(out.contains("ID"), "known column shown:\n{out}");
+}

--- a/src/output/resources/bug_tests.rs
+++ b/src/output/resources/bug_tests.rs
@@ -763,6 +763,32 @@ fn warn_json_field_selection_silent_without_selection() {
 }
 
 #[test]
+fn warn_json_field_selection_silent_for_exclude_id_only() {
+    for excl in ["id", "ID", "id,"] {
+        let warning = capture_json_warning(ColumnSpec {
+            include: None,
+            exclude: Some(excl),
+        });
+        assert!(
+            warning.is_empty(),
+            "excluding only id restricts nothing (client re-adds id): {excl:?} -> {warning:?}"
+        );
+    }
+}
+
+#[test]
+fn warn_json_field_selection_warns_for_exclude_non_id() {
+    let warning = capture_json_warning(ColumnSpec {
+        include: None,
+        exclude: Some("id,cc"),
+    });
+    assert!(
+        warning.contains("null/empty"),
+        "a non-id field is genuinely dropped, so warn: {warning:?}"
+    );
+}
+
+#[test]
 fn write_bugs_partial_unknown_warns_with_new_wording_and_shows_known() {
     let bugs = vec![make_bug(1, "summary text", "NEW")];
     let spec = ColumnSpec {

--- a/src/output/resources/bug_tests.rs
+++ b/src/output/resources/bug_tests.rs
@@ -145,7 +145,7 @@ fn write_bugs_json_via_write() {
 
 #[test]
 fn write_bugs_fields_selects_only_requested_columns() {
-    let bugs = vec![make_bug(217559, "kernel panic on boot", "ASSIGNED")];
+    let bugs = vec![make_bug(217_559, "kernel panic on boot", "ASSIGNED")];
     let spec = ColumnSpec {
         include: Some("id,priority"),
         exclude: None,
@@ -161,7 +161,7 @@ fn write_bugs_fields_selects_only_requested_columns() {
 
 #[test]
 fn write_bugs_fields_adds_non_default_columns_populated() {
-    let bugs = vec![make_bug(218034, "LPM crash", "WORKING")];
+    let bugs = vec![make_bug(218_034, "LPM crash", "WORKING")];
     let spec = ColumnSpec {
         include: Some("id,priority,severity,status,product,summary"),
         exclude: None,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1962,6 +1962,29 @@ async fn dispatch_cli_with_output(args: &[&str]) -> (bzr::error::Result<()>, Str
     (result, io.out_str().to_string())
 }
 
+/// Like [`dispatch_cli_with_output`] but also returns captured stderr, for
+/// tests that assert on warnings emitted to stderr.
+async fn dispatch_cli_with_io(args: &[&str]) -> (bzr::error::Result<()>, String, String) {
+    let cli = match bzr::cli::Cli::try_parse_from(args) {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                Err(bzr::error::BzrError::InputValidation(e.to_string())),
+                String::new(),
+                String::new(),
+            );
+        }
+    };
+    let format = if cli.json {
+        bzr::types::OutputFormat::Json
+    } else {
+        cli.output.unwrap_or(bzr::types::OutputFormat::Json)
+    };
+    let mut io = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::dispatch(&cli, format, &mut io.writers()).await;
+    (result, io.out_str().to_string(), io.err_str().to_string())
+}
+
 #[tokio::test]
 async fn e2e_bug_list_via_cli_args() {
     let (_lock, mock, _tmp) = setup_test_env().await;
@@ -2396,11 +2419,12 @@ async fn bug_list_issue_158_mixed_positive_and_negation_reaches_wire() {
     // causing `result` to be `Err`.
 }
 
-/// Guards against the misleading "trims output" messaging (issue #206, F4):
-/// `--fields`/`--exclude-fields` control which fields are *requested from
-/// the server*; `--json` always emits the full bug object. None of these
-/// phrases — which imply `--json` output is trimmed, or that custom fields
-/// can be seen via `--json` — may reappear in the CLI help or the manual.
+/// Guards the #206 `--json` prose against misleading phrasings. `--json` now
+/// trims output to the selected fields, but a few specific phrases stay
+/// forbidden: the older marketing-style "trims the payload" wordings, and any
+/// claim that custom `cf_*` fields become visible via `--json` ("to see them")
+/// — they can't, since `Bug` is a fixed struct with no `#[serde(flatten)]`.
+/// None of these may reappear in the CLI help or the manual.
 #[test]
 fn cli_and_docs_avoid_misleading_trim_phrasing() {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -2431,4 +2455,185 @@ fn cli_and_docs_avoid_misleading_trim_phrasing() {
             );
         }
     }
+}
+
+// ── #206 --json field trimming ───────────────────────────────────────
+
+fn json_keys(value: &serde_json::Value) -> Vec<&str> {
+    value
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect()
+}
+
+/// An all-unknown `--fields` value under `--json` exits 7 before any network
+/// I/O — measured against the full field universe, not the table defaults.
+#[tokio::test]
+async fn e2e_bug_list_json_all_unknown_fields_exits_7() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let (result, _out, _err) = dispatch_cli_with_io(&[
+        "bzr",
+        "--server",
+        "test",
+        "--json",
+        "bug",
+        "list",
+        "--product",
+        "Firefox",
+        "--fields",
+        "cf_nope,cf_alsonope",
+    ])
+    .await;
+
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.exit_code(),
+        7,
+        "all-unknown --fields under --json exits 7"
+    );
+}
+
+/// A partial-unknown selection warns once on stderr and projects the array to
+/// the known fields.
+#[tokio::test]
+async fn e2e_bug_list_json_partial_unknown_warns_and_projects() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 7, "summary": "boom", "status": "NEW"}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let (result, out, err) = dispatch_cli_with_io(&[
+        "bzr",
+        "--server",
+        "test",
+        "--json",
+        "bug",
+        "list",
+        "--product",
+        "Firefox",
+        "--fields",
+        "summary,cf_x",
+    ])
+    .await;
+
+    assert!(result.is_ok(), "partial-unknown should succeed: {result:?}");
+    assert!(
+        err.contains("ignoring unknown field(s): cf_x"),
+        "stderr warning: {err:?}"
+    );
+    let parsed = serde_json::from_str::<serde_json::Value>(out.trim()).unwrap();
+    assert_eq!(
+        json_keys(&parsed[0]),
+        vec!["summary"],
+        "projected to summary only:\n{out}"
+    );
+}
+
+/// `bug view --json` with an all-unknown field stays lenient: exit 0, an empty
+/// `{}` object, and a stderr warning so the typo isn't silent.
+#[tokio::test]
+async fn e2e_bug_view_json_all_unknown_is_lenient_with_warning() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 42, "summary": "view", "status": "NEW"}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let (result, out, err) = dispatch_cli_with_io(&[
+        "bzr", "--server", "test", "--json", "bug", "view", "42", "--fields", "sumary",
+    ])
+    .await;
+
+    assert!(result.is_ok(), "view stays lenient: {result:?}");
+    assert!(
+        err.contains("ignoring unknown field(s): sumary"),
+        "stderr warning: {err:?}"
+    );
+    let parsed = serde_json::from_str::<serde_json::Value>(out.trim()).unwrap();
+    assert!(
+        parsed.as_object().unwrap().is_empty(),
+        "empty object for all-unknown view:\n{out}"
+    );
+}
+
+/// Single-ID `bug view --json --fields` trims the bare object to the selected
+/// fields.
+#[tokio::test]
+async fn e2e_bug_view_json_single_trims_object() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 42, "summary": "view", "status": "NEW"}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let (result, out, _err) = dispatch_cli_with_io(&[
+        "bzr", "--server", "test", "--json", "bug", "view", "42", "--fields", "summary",
+    ])
+    .await;
+
+    assert!(result.is_ok(), "single view: {result:?}");
+    let parsed = serde_json::from_str::<serde_json::Value>(out.trim()).unwrap();
+    assert_eq!(
+        json_keys(&parsed),
+        vec!["summary"],
+        "trimmed object:\n{out}"
+    );
+}
+
+/// Multi-ID `bug view --json --fields summary` trims each entry in `bugs`
+/// while the `{"bugs": [...], "failed": [...]}` wrapper stays intact.
+#[tokio::test]
+async fn e2e_multi_bug_view_json_trims_bugs_keeps_wrapper() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1, "summary": "alpha", "status": "NEW"}]
+        })))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 2, "summary": "beta", "status": "NEW"}]
+        })))
+        .mount(&mock)
+        .await;
+
+    let (result, out, _err) = dispatch_cli_with_io(&[
+        "bzr", "--server", "test", "--json", "bug", "view", "1", "2", "--fields", "summary",
+    ])
+    .await;
+
+    assert!(result.is_ok(), "multi view: {result:?}");
+    let parsed = serde_json::from_str::<serde_json::Value>(out.trim()).unwrap();
+    let bugs = parsed["bugs"].as_array().unwrap();
+    assert_eq!(bugs.len(), 2);
+    for b in bugs {
+        assert_eq!(json_keys(b), vec!["summary"], "each bug trimmed to summary");
+    }
+    assert!(
+        parsed["failed"].as_array().unwrap().is_empty(),
+        "failed wrapper key present and empty"
+    );
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2637,3 +2637,48 @@ async fn e2e_multi_bug_view_json_trims_bugs_keeps_wrapper() {
         "failed wrapper key present and empty"
     );
 }
+
+/// End-to-end `--exclude-fields id --json` contract: the CLI drops `id` from
+/// the output object, yet the bug still deserializes because `force_id_fields`
+/// keeps `id` on the wire (the lone `id` exclude collapses to `None`, so no
+/// `exclude_fields` query param is sent). The mock is gated on
+/// `query_param_is_missing("exclude_fields")`, so a regression that forwarded
+/// `exclude_fields=id` would miss the matcher → 404 → this test fails.
+#[tokio::test]
+async fn e2e_bug_list_json_exclude_id_drops_key_but_parses() {
+    use wiremock::matchers::query_param_is_missing;
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param_is_missing("exclude_fields"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1, "summary": "keep me", "status": "NEW"}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let (result, out, _err) = dispatch_cli_with_io(&[
+        "bzr",
+        "--server",
+        "test",
+        "--json",
+        "bug",
+        "list",
+        "--product",
+        "Firefox",
+        "--exclude-fields",
+        "id",
+    ])
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "exclude id should parse and succeed: {result:?}"
+    );
+    let parsed = serde_json::from_str::<serde_json::Value>(out.trim()).unwrap();
+    let keys = json_keys(&parsed[0]);
+    assert!(!keys.contains(&"id"), "id dropped from output:\n{out}");
+    assert_eq!(parsed[0]["summary"], "keep me", "summary retained:\n{out}");
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2395,3 +2395,40 @@ async fn bug_list_issue_158_mixed_positive_and_negation_reaches_wire() {
     // wrong, the matcher would miss and the response would be a 404,
     // causing `result` to be `Err`.
 }
+
+/// Guards against the misleading "trims output" messaging (issue #206, F4):
+/// `--fields`/`--exclude-fields` control which fields are *requested from
+/// the server*; `--json` always emits the full bug object. None of these
+/// phrases — which imply `--json` output is trimmed, or that custom fields
+/// can be seen via `--json` — may reappear in the CLI help or the manual.
+#[test]
+fn cli_and_docs_avoid_misleading_trim_phrasing() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let forbidden = [
+        "trims the payload",
+        "trim the response payload",
+        "trims JSON output",
+        "to see them",
+        "JSON: fields to return",
+        "JSON: fields to exclude",
+    ];
+
+    let mut files = vec![root.join("docs/bzr-cli.md")];
+    for entry in std::fs::read_dir(root.join("src/cli")).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().is_some_and(|e| e == "rs") {
+            files.push(path);
+        }
+    }
+
+    for file in &files {
+        let content = std::fs::read_to_string(file).unwrap();
+        for phrase in forbidden {
+            assert!(
+                !content.contains(phrase),
+                "{}: remove misleading phrase {phrase:?}",
+                file.display()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #206. `--fields` / `--exclude-fields` now actually shape `bzr bug`
output instead of always rendering a fixed five-column table (or a full JSON
object with unrequested fields nulled). `--fields` selects which columns/keys
appear, in order; `--exclude-fields` removes them. Under `--json` the output
object is trimmed to the selection, gh-style.

## Changes

- **Table output** — `bug list`, `my`, `search`, and `query run` honor
  `--fields` (column selection, in the given order) and `--exclude-fields`
  (column removal), replacing the hardcoded five-column table. `bug view`
  detail rows honor an explicit field set.
- **JSON output** — `--fields` / `--exclude-fields` trim the output object to
  the selection. `id` appears only when requested, and `--exclude-fields id`
  drops it — while the client still fetches `id` on the wire
  (`force_id_fields`) so every bug deserializes regardless of the selection.
  Trimming happens client-side after the fetch, so it applies on REST and
  XML-RPC alike. Multi-ID `bug view` trims each entry in `bugs` while leaving
  the `{"bugs": [...], "failed": [...]}` wrapper intact.
- **Pre-network validation** — a selection that leaves nothing to emit exits 7
  with a clear message before any network I/O, for every list-style bug
  subcommand. Table emptiness is measured against the five default columns;
  JSON against the full field set. `bug view` is exempt in both modes (a sparse
  or empty single-bug object is a coherent result) and warns rather than
  failing — documented so a `{}` + exit-0 result is discoverable as a possible
  field-name typo.
- **serde_json `preserve_order`** — enabled for trimming; crate-wide, so
  `json!` values now serialize keys in insertion order. Cosmetic effect on the
  error envelope and `query`/`template` results; noted in the changelog.

## Testing

- Unit tests for the projection helpers (`canonical_field_list`,
  `force_id_fields`, `bug_to_json`/`bugs_to_json`, `validate_*_field_selection`)
  and the client entry points that prepend/strip `id`.
- Integration tests covering `bug list`/`view` `--json` trimming, all-unknown
  vs. partial-unknown selections, the list/view exit-code asymmetry, and an
  end-to-end `--exclude-fields id --json` contract gated on
  `query_param_is_missing("exclude_fields")` so a `force_id_fields` regression
  fails the test.
- A guard test (`cli_and_docs_avoid_misleading_trim_phrasing`) keeps stale
  marketing-style phrasings out of the CLI help and manual.

Full suite: 1224 lib + 21 + 72 integration tests pass.

## Notes

- One pre-existing clippy lint remains at `src/xmlrpc/client_tests.rs:792`
  (`map_unwrap_or`), tracked separately as #216 — not introduced by this branch.
- Design spec: `docs/superpowers/specs/2026-05-27-json-field-trimming-design.md`.
