### PR TITLE
chore(deps): ignore sha2 0.11.x dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      # `dbus-secret-service` (keyring default feature) pins sha2 0.10.x as a
+      # transitive dep, so bumping the direct dep to 0.11.x cannot collapse to
+      # a single version — it only adds a duplicate crypto stack
+      # (sha2/digest/crypto-common/block-buffer/cpufeatures all doubled).
+      # Revisit when the keyring chain moves to digest 0.11.  See #207, #184.
+      - dependency-name: "sha2"
+        versions: ["0.11.x"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

Add a Dependabot `ignore` rule for `sha2` 0.11.x. Stops the weekly bump PR (#184 then #207) from being re-proposed.

## Why

`dbus-secret-service` — pulled in by the `keyring` default feature — pins `sha2 0.10.x` as a transitive dependency. Bumping the direct `sha2` dep to 0.11.x cannot collapse the tree to one version, it only adds a duplicate crypto stack: `sha2`, `digest`, `crypto-common`, `block-buffer`, and `cpufeatures` each end up with two versions, plus new `const-oid` and `hybrid-array` crates.

bzr's only `sha2` use is one SHA-256 digest in `src/tls/verifier.rs` for cert pinning; `sha2 0.10` handles that fine.

## History

- #184 (commit `8bcf064`, 2026-05-08) merged the 0.11 bump.
- Commit `0aecee7` "Improve code quality with desloppify" (same day, ~7h later) reverted it — its *only* `Cargo.toml` change was `sha2 = "0.11"` → `"0.10"`.
- #207 reproposed the same bump and was closed today for the same reason.

## Revisit when

The keyring chain moves to `digest 0.11` (i.e. `dbus-secret-service` or whichever transitive consumer drops the 0.10 pin). At that point the ignore can be removed and the bump merged cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
