### PR TITLE
fix(xmlrpc): use is_ok_and over map/unwrap_or in NotBodyContains

### DIFF
--- a/src/xmlrpc/client_tests.rs
+++ b/src/xmlrpc/client_tests.rs
@@ -789,9 +789,7 @@ struct NotBodyContains(&'static str);
 
 impl wiremock::Match for NotBodyContains {
     fn matches(&self, request: &wiremock::Request) -> bool {
-        !std::str::from_utf8(&request.body)
-            .map(|s| s.contains(self.0))
-            .unwrap_or(false)
+        !std::str::from_utf8(&request.body).is_ok_and(|s| s.contains(self.0))
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces the `.map(<f>).unwrap_or(false)` pattern in the test-only
`NotBodyContains::matches` matcher with `.is_ok_and(<f>)`. Closes #216.

| Issue | Title | Type | Files Changed |
|-------|-------|------|---------------|
| #216 | clippy: `map(...).unwrap_or(false)` in xmlrpc client_tests trips `clippy --all-targets` | fix | `src/xmlrpc/client_tests.rs` |

## Why

`cargo clippy --all-targets -- -D warnings` (clippy 1.95+) fails on
`!std::str::from_utf8(&request.body).map(|s| s.contains(self.0)).unwrap_or(false)`
with `clippy::map_unwrap_or`. CI runs `cargo clippy --locked -- -D warnings`
without `--all-targets`, so test-only siblings aren't compiled and the lint
doesn't trip CI today. Local `--all-targets` runs still hit it.

The rewrite to `is_ok_and` is the clippy-suggested fix and is semantically
identical for both `Ok(bool)` (returns the inner bool) and `Err(_)` (returns
`false`) branches.

## Test coverage

No new tests — this is a 1:1 semantic rewrite of an existing test helper used
by the surrounding `wiremock` matchers in `src/xmlrpc/client_tests.rs`.

## Validation

- `cargo test --lib` — 1224 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
