### PR TITLE
refactor: bundle 6-arg helper params; enforce too-many-args = 5

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 5

--- a/docs/superpowers/specs/2026-05-27-issue-215-too-many-args-design.md
+++ b/docs/superpowers/specs/2026-05-27-issue-215-too-many-args-design.md
@@ -1,0 +1,92 @@
+# Enforce `too-many-arguments-threshold = 5` (issue #215)
+
+## Problem
+
+The project guideline is ≤5 positional parameters per function, but clippy's
+default `too-many-arguments-threshold` (8) does not enforce it. Three command-
+layer helpers currently sit at 6 positional params, all sharing the same
+`(…, format: OutputFormat, w: &mut Writers<'_>)` tail:
+
+- `download_batch` — `src/commands/attachment.rs`
+- `migrate_to_keyring` — `src/commands/config.rs`
+- `view_single` — `src/commands/bug/view.rs`
+
+After lowering the threshold all three trip
+`clippy::too-many-arguments`; running `cargo clippy --all-targets -- -D warnings`
+with the new `clippy.toml` confirms exactly these three sites and nothing else.
+
+## Design
+
+### 1. `clippy.toml`
+
+Create a new top-level `clippy.toml` containing the single setting:
+
+```toml
+too-many-arguments-threshold = 5
+```
+
+This is the only Clippy configuration in the file — `Cargo.toml`'s
+`[lints.clippy]` block already sets per-lint levels; `clippy.toml` is the
+correct location for behavior-tuning knobs like this threshold.
+
+### 2. Per-function param bundling
+
+Rather than introduce a generic `OutputContext` and use it in only 3 of ~40
+helpers that share the `format, w` tail (mixed-pattern code drift), each
+function gets a small bundle struct for its **command-specific** parameters.
+The `format, w` tail is left intact so it remains consistent with the rest of
+the command layer. The end state for each is exactly 5 positional params (the
+threshold) or fewer.
+
+| Function | New bundling | Final arity |
+|---|---|---|
+| `view_single` | Reuse existing `ColumnSpec<'_>` (it already wraps `include` / `exclude`) | 5 |
+| `download_batch` | New `BatchTargets<'a> { ids, bug_ids, out_dir }` (private to `commands/attachment.rs`) | 4 |
+| `migrate_to_keyring` | New `MigrateSpec<'a> { name, service, account }` (private to `commands/config.rs`) | 4 |
+
+Rationale for not introducing an `OutputContext`:
+
+- It would only be used in 3 of the ~40 helpers that pair `format` with
+  `Writers`; the other 37 are already at or under threshold 5 and have no
+  pressure to adopt it. Mixed adoption is worse than no adoption.
+- Folding `format` into `Writers` would be uniformly clean but touches 261
+  `.writers()` call sites in tests plus every command-layer helper —
+  disproportionate scope for a 3-function lint fix.
+- Per-function bundles are local, single-purpose, and document the natural
+  grouping (a `view` operates on a `ColumnSpec`; a `download_batch` operates
+  on `BatchTargets`). They impose no convention on future helpers; future
+  helpers can stay under threshold without adopting any pattern.
+
+### 3. Call-site updates
+
+Only the three direct callers change — none of them are exported:
+
+- `view::execute_view` (the multi-vs-single dispatcher) constructs a
+  `ColumnSpec` from the already-computed `inc_canonical` / `exc_canonical` and
+  passes it.
+- `attachment::execute`'s `Download` arm constructs a `BatchTargets`.
+- `config::execute`'s `MigrateToKeyring` arm constructs a `MigrateSpec`.
+
+### 4. CHANGELOG
+
+No entry. This is an internal refactor + lint-threshold change with no
+user-visible behavior.
+
+## Testing
+
+- `cargo clippy --all-targets -- -D warnings` — passes (verifies threshold
+  enforcement and absence of new lints)
+- `cargo test --lib` — 1224 passing tests must still pass (no behavior change)
+- `cargo fmt --check` — clean
+
+## Risks
+
+- **Drift on `view_single`'s `ColumnSpec` semantics.** The current
+  `view_single` builds a `ColumnSpec` from canonical field names; the multi-ID
+  path uses raw field names for its `ColumnSpec`. That pre-existing
+  asymmetry is preserved exactly — the refactor only relocates the
+  `ColumnSpec` construction one frame up the call stack with the same field
+  values. Not in scope to fix here.
+- **Future helpers exceeding threshold.** The `clippy.toml` setting is now
+  enforced; future helpers will either need to stay ≤5 params or introduce
+  their own bundling. That is the intent of the issue.

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -43,7 +43,12 @@ pub async fn execute(
             if bug_ids.is_empty() && ids.len() == 1 {
                 download_single(&client, ids[0], out.as_deref(), format, w).await?;
             } else {
-                download_batch(&client, ids, bug_ids, out_dir, format, w).await?;
+                let targets = BatchTargets {
+                    ids,
+                    bug_ids,
+                    out_dir,
+                };
+                download_batch(&client, targets, format, w).await?;
             }
         }
         AttachmentAction::Upload {
@@ -306,6 +311,18 @@ async fn write_one_attachment(
     })
 }
 
+/// Targets for the multi-source `Download` batch path. `ids` are
+/// individual attachment IDs; `bug_ids` resolve to every attachment on
+/// the named bugs. Both lists may be non-empty (the two streams merge
+/// into one `AttachmentBatchResult`). `out_dir` is the shared
+/// destination directory.
+#[derive(Clone, Copy)]
+struct BatchTargets<'a> {
+    ids: &'a [u64],
+    bug_ids: &'a [u64],
+    out_dir: &'a str,
+}
+
 /// Bulk attachment download: walks every `--bug <ID>` then every
 /// positional attachment ID, recording successes and per-target
 /// failures. On any failure, returns `BatchPartialFailure` (exit 11).
@@ -315,28 +332,26 @@ async fn write_one_attachment(
 /// loop — better than burying the same error in N per-attachment rows.
 async fn download_batch(
     client: &BugzillaClient,
-    ids: &[u64],
-    bug_ids: &[u64],
-    out_dir: &str,
+    targets: BatchTargets<'_>,
     format: OutputFormat,
     w: &mut Writers<'_>,
 ) -> Result<()> {
-    std::fs::create_dir_all(out_dir)?;
+    std::fs::create_dir_all(targets.out_dir)?;
 
     let mut bug_results: Vec<BugDownloadResult> = Vec::new();
     let mut attachment_results: Vec<AttachmentDownloadResult> = Vec::new();
 
-    for &bug_id in bug_ids {
-        bug_results.push(download_bug_target(client, bug_id, out_dir).await);
+    for &bug_id in targets.bug_ids {
+        bug_results.push(download_bug_target(client, bug_id, targets.out_dir).await);
     }
 
-    for &att_id in ids {
-        attachment_results.push(download_attachment_target(client, att_id, out_dir).await);
+    for &att_id in targets.ids {
+        attachment_results.push(download_attachment_target(client, att_id, targets.out_dir).await);
     }
 
     let summary = BatchSummary::from_results(&bug_results, &attachment_results);
     let result = AttachmentBatchResult {
-        out_dir: out_dir.to_string(),
+        out_dir: targets.out_dir.to_string(),
         bug_results,
         attachment_results,
         summary,

--- a/src/commands/bug/view.rs
+++ b/src/commands/bug/view.rs
@@ -81,15 +81,11 @@ pub(super) async fn handle(
     let exc_canonical = canonical_field_list(exc);
 
     if ids.len() == 1 {
-        return view_single(
-            client,
-            &ids[0],
-            inc_canonical.as_deref(),
-            exc_canonical.as_deref(),
-            format,
-            w,
-        )
-        .await;
+        let spec = ColumnSpec {
+            include: inc_canonical.as_deref(),
+            exclude: exc_canonical.as_deref(),
+        };
+        return view_single(client, &ids[0], spec, format, w).await;
     }
 
     let mode = if *permissive {
@@ -116,16 +112,11 @@ pub(super) async fn handle(
 async fn view_single(
     client: &BugzillaClient,
     id: &str,
-    include_fields: Option<&str>,
-    exclude_fields: Option<&str>,
+    spec: ColumnSpec<'_>,
     format: OutputFormat,
     w: &mut Writers<'_>,
 ) -> Result<()> {
-    let bug = client.get_bug(id, include_fields, exclude_fields).await?;
-    let spec = ColumnSpec {
-        include: include_fields,
-        exclude: exclude_fields,
-    };
+    let bug = client.get_bug(id, spec.include, spec.exclude).await?;
     write_bug_detail(&bug, spec, format, w.out);
     Ok(())
 }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -95,14 +95,14 @@ pub async fn execute(
             service,
             account,
             yes,
-        } => migrate_to_keyring(
-            name.as_str(),
-            service.as_deref(),
-            account.as_deref(),
-            *yes,
-            format,
-            w,
-        ),
+        } => {
+            let spec = MigrateSpec {
+                name: name.as_str(),
+                service: service.as_deref(),
+                account: account.as_deref(),
+            };
+            migrate_to_keyring(spec, *yes, format, w)
+        }
     }
 }
 
@@ -311,10 +311,20 @@ fn unset_keyring(name: &str, format: OutputFormat, w: &mut Writers<'_>) -> Resul
     Ok(())
 }
 
+/// `migrate-to-keyring` operands: which server to migrate and the
+/// optional `--service` / `--account` overrides for where the credential
+/// gets stored. Bundles together so `migrate_to_keyring` stays under
+/// the 5-positional-arg threshold; `Option<&str>` defaults
+/// (service="bzr", account=name) are resolved inside the function.
+#[derive(Clone, Copy)]
+struct MigrateSpec<'a> {
+    name: &'a str,
+    service: Option<&'a str>,
+    account: Option<&'a str>,
+}
+
 fn migrate_to_keyring(
-    name: &str,
-    service: Option<&str>,
-    account: Option<&str>,
+    spec: MigrateSpec<'_>,
     yes: bool,
     format: OutputFormat,
     w: &mut Writers<'_>,
@@ -324,6 +334,12 @@ fn migrate_to_keyring(
             "migrate-to-keyring requires --yes to confirm non-interactive migration".into(),
         ));
     }
+
+    let MigrateSpec {
+        name,
+        service,
+        account,
+    } = spec;
 
     let mut config = Config::load()?;
     let server = config


### PR DESCRIPTION
## Summary

Enforces the project guideline of ≤5 positional parameters per function
project-wide and brings the three command-layer helpers that sat at 6
parameters under the limit. Closes #215.

| Issue | Title | Type | Files Changed |
|-------|-------|------|---------------|
| #215 | Enforce `too-many-arguments-threshold = 5` and refactor the 3 functions over the limit | refactor | `clippy.toml`, `src/commands/attachment.rs`, `src/commands/bug/view.rs`, `src/commands/config.rs`, plus design spec |

## Approach

`clippy.toml` (new) sets `too-many-arguments-threshold = 5`. The three
helpers that trip the lint each get a small private bundle struct for their
command-specific operands:

| Function | Bundling | Arity after |
|---|---|---|
| `view_single` (bug/view.rs) | reuse existing `ColumnSpec<'_>` (caller constructs it one frame up) | 5 |
| `download_batch` (attachment.rs) | new `BatchTargets<'a> { ids, bug_ids, out_dir }` | 4 |
| `migrate_to_keyring` (config.rs) | new `MigrateSpec<'a> { name, service, account }`, destructured after `--yes` guard | 4 |

### Why not a generic `OutputContext`

The issue floated bundling the shared `format` + `w: &mut Writers<'_>` tail
into an output-context struct "threaded through the command layer". Going
deeper on that direction:

- **Used in only 3 of ~40 helpers:** the other 37 helpers in `commands/` that
  pair `format` with `Writers` are already at or under threshold 5 and have
  no pressure to adopt it. Mixed adoption (some take `ctx`, most take
  `format, w`) is worse than no adoption.
- **Wholesale fold (e.g., adding `format` as a field of `Writers`) would
  touch 261 `.writers()` test-call sites** plus every command-layer helper —
  disproportionate scope for a 3-function lint fix.

Per-function bundling produces local, single-purpose types that document the
natural grouping (a `view` operates on a `ColumnSpec`; a `download_batch`
operates on `BatchTargets`) without imposing a convention on future helpers.

## Pre-existing behavior preserved

`view_single` previously built its `ColumnSpec` from **canonical** field names,
while the multi-ID path of `view::handle` builds its `ColumnSpec` from **raw**
field names — that asymmetry is pre-existing and explicitly out of scope. The
refactor only moves the `ColumnSpec` construction one frame up the call stack
with the same field values.

## Test coverage

No new tests. All three helpers are reached via the same public entry points
(`AttachmentAction::Download`, `ConfigAction::MigrateToKeyring`,
`BugAction::View`) which the existing test suite already exercises through
`execute()`.

## Validation

- `cargo clippy --locked -- -D warnings` — clean
- `cargo clippy --all-targets -- -D warnings` — clean once #216 lands
  (this branch is otherwise free of new lints; verified with
  `-A clippy::map_unwrap_or`)
- `cargo test --lib` — 1224 passed, 0 failed
- `cargo doc --no-deps` — both `BatchTargets` and `download_batch` render
  with correct doc comments (the first-draft bisection caught in /challenge
  is fixed)
- `cargo fmt --check` — clean

## Design doc

`docs/superpowers/specs/2026-05-27-issue-215-too-many-args-design.md` records
the design choice and rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
