### PR TITLE
chore: prep v0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.4.1] - 2026-05-27
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzr"
-version = "0.4.1-dev"
+version = "0.4.1"
 dependencies = [
  "apple-native-keyring-store",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 
 [package]
 name = "bzr"
-version = "0.4.1-dev"
+version = "0.4.1"
 edition = "2021"
 description = "A CLI for Bugzilla, inspired by gh"
 license = "MIT"


### PR DESCRIPTION
## Summary

Prep release of `bzr v0.4.1`. Patch release covering the #206 series of
`--fields` / `--exclude-fields` fixes plus the cosmetic JSON key-order
change from enabling `serde_json`'s `preserve_order` feature.

## Changes

- `Cargo.toml`: `version = "0.4.1-dev"` → `"0.4.1"`
- `Cargo.lock`: regenerated (single hunk, `bzr` package only)
- `CHANGELOG.md`: rename `[Unreleased]` heading to `[0.4.1] - 2026-05-27`

No code changes; this PR is purely the version/changelog snapshot.

## Testing

Locally on `release/v0.4.1-prep`:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --locked` — 72 integration + all unit tests pass
- `cargo build --release` — clean
- `cargo publish --dry-run --locked` — `Packaging bzr v0.4.1`, dry-run aborted upload as expected
- `./target/release/bzr --version` — reports `bzr 0.4.1 (<sha>)`
- CHANGELOG awk extraction for `0.4.1` returns the full `### Fixed` /
  `### Changed` body (51 lines), matching what `release.yml` will pull
  for the GitHub Release body

## Notes

- Per `RELEASING.md`, after merge: tag `v0.4.1` from `main`, which fires
  `release.yml` (multi-arch artifacts, GitHub Release, installer smoke,
  Homebrew tap bump) and `publish-crates.yml` (crates.io publish, since
  the tag has no `-` suffix).
- Post-release, bump `Cargo.toml` on `main` to `0.4.2-dev` per the
  project's `-dev` suffix convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
