### PR TITLE
refactor: replace magic numbers with named constants (TD-011/018/021/022/026)

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -375,7 +375,7 @@ impl BugzillaClient {
     fn parse_body_to_value(body: &str, safe_url: &str) -> Result<serde_json::Value> {
         tracing::trace!(
             url = safe_url,
-            body = &body[..body.len().min(2048)],
+            body = &body[..body.len().min(BODY_TRACE_MAX_BYTES)],
             "response body"
         );
 
@@ -383,7 +383,7 @@ impl BugzillaClient {
             tracing::debug!(
                 url = safe_url,
                 error = %e,
-                body_preview = &body[..body.len().min(512)],
+                body_preview = &body[..body.len().min(BODY_PREVIEW_MAX_BYTES)],
                 "JSON deserialization failed"
             );
             BzrError::Deserialize(format!(
@@ -553,6 +553,11 @@ impl BugzillaClient {
 /// 512 bytes is enough to capture the top-level keys of any realistic
 /// Bugzilla envelope while keeping the error message human-scaled.
 const BODY_PREVIEW_MAX_BYTES: usize = 512;
+
+/// Maximum length of the response body logged at `trace` level. Larger than
+/// [`BODY_PREVIEW_MAX_BYTES`] because trace logs are opt-in diagnostics where
+/// seeing more of the payload outweighs message compactness.
+const BODY_TRACE_MAX_BYTES: usize = 2048;
 
 /// Format a response body for inclusion in a `BzrError::Deserialize` message.
 ///

--- a/src/commands/bug/search.rs
+++ b/src/commands/bug/search.rs
@@ -5,6 +5,11 @@ use crate::output::resources::query::write_query_saved;
 use crate::output::writers::Writers;
 use crate::types::{ApiMode, OutputFormat, Overrides, SavedQuery, SearchParams};
 
+/// Default cap on bugs returned by a search when neither the URL nor `--limit`
+/// specifies one. Keeps unbounded `bug search` invocations from pulling an
+/// entire installation's bug list.
+const DEFAULT_SEARCH_LIMIT: u32 = 50;
+
 /// Determine the `save_as` name + query to persist after a successful URL-based
 /// search. Returns None when --save-as wasn't passed; errors when --save-as=""
 /// is passed but the URL has no `known_name`/`query_based_on` to fall back on.
@@ -40,7 +45,7 @@ fn build_params_from_url(
 ) -> SearchParams {
     let mut params = parsed_query.into_search_params();
     if params.limit.is_none() && limit.is_none() {
-        params.limit = Some(50);
+        params.limit = Some(DEFAULT_SEARCH_LIMIT);
     }
     params.apply_overrides(Overrides {
         limit,
@@ -101,7 +106,7 @@ pub(super) async fn handle(
         let client = crate::commands::shared::connect_and_configure(server, api).await?;
         let params = SearchParams {
             quicksearch: Some(query_str.to_string()),
-            limit: Some(limit.unwrap_or(50)),
+            limit: Some(limit.unwrap_or(DEFAULT_SEARCH_LIMIT)),
             include_fields: canonical_field_list(fields.as_deref()),
             exclude_fields: canonical_field_list(exclude_fields.as_deref()),
             ..Default::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,9 +70,9 @@ async fn main() -> ExitCode {
     ExitCode::SUCCESS
 }
 
-/// Convert a `BzrError` exit code (1-12) to a `std::process::ExitCode`.
+/// Convert a `BzrError` exit code (1-13) to a `std::process::ExitCode`.
 fn exit_code(e: &BzrError) -> ExitCode {
-    // All BzrError exit codes are in the range 1..=12.
+    // All BzrError exit codes are in the range 1..=13.
     ExitCode::from(u8::try_from(e.exit_code()).unwrap_or(1))
 }
 

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -192,6 +192,25 @@ fn exit_code_maps_other_variant() {
 }
 
 #[test]
+fn exit_code_maps_highest_tls_code() {
+    // Guards the upper bound documented on `exit_code`: the TLS variants
+    // return 13, the largest code, and must survive the `u8::try_from`
+    // conversion without collapsing to the `unwrap_or(1)` fallback.
+    let err = BzrError::PinMismatch {
+        server: "example.com".into(),
+        expected: "sha256//old".into(),
+        actual: "sha256//new".into(),
+    };
+    assert_eq!(err.exit_code(), 13);
+    let code = exit_code(&err);
+    let rendered = format!("{code:?}");
+    assert!(
+        rendered.contains("13"),
+        "expected ExitCode debug to include 13, got {rendered}"
+    );
+}
+
+#[test]
 fn format_dispatch_error_renders_json() {
     let err = BzrError::Config("bad config".into());
     let out = format_dispatch_error(&err, OutputFormat::Json);

--- a/src/output/formatting.rs
+++ b/src/output/formatting.rs
@@ -88,6 +88,14 @@ pub(super) fn opt_yes_no(value: Option<bool>) -> &'static str {
 
 // ── Text helpers ────────────────────────────────────────────────────
 
+/// Column width for bug summaries in table output. Wider than
+/// [`DESCRIPTION_TRUNCATE_WIDTH`] because summaries are the primary
+/// identifying text in `bug list`/`bug search` rows.
+pub(super) const SUMMARY_TRUNCATE_WIDTH: usize = 72;
+
+/// Column width for product/classification descriptions in table output.
+pub(super) const DESCRIPTION_TRUNCATE_WIDTH: usize = 60;
+
 pub(super) fn truncate(s: &str, max_chars: usize) -> String {
     if s.chars().count() > max_chars {
         let truncated: String = s.chars().take(max_chars.saturating_sub(3)).collect();

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -5,7 +5,7 @@ use tabled::builder::Builder;
 
 use crate::output::formatting::{
     colorize_status, shorten_email, truncate, write_divider, write_field, write_formatted,
-    write_json, write_list_field, write_optional_field,
+    write_json, write_list_field, write_optional_field, SUMMARY_TRUNCATE_WIDTH,
 };
 use crate::types::{Bug, HistoryEntry, OutputFormat};
 
@@ -69,7 +69,7 @@ const COLUMNS: &[BugColumn] = &[
     BugColumn {
         aliases: &["summary"],
         header: "SUMMARY",
-        render: |b| truncate(&b.summary, 72),
+        render: |b| truncate(&b.summary, SUMMARY_TRUNCATE_WIDTH),
     },
     BugColumn {
         aliases: &["severity"],

--- a/src/output/resources/classification.rs
+++ b/src/output/resources/classification.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use colored::Colorize;
 
-use crate::output::formatting::{truncate, write_formatted};
+use crate::output::formatting::{truncate, write_formatted, DESCRIPTION_TRUNCATE_WIDTH};
 use crate::types::{Classification, OutputFormat};
 
 pub fn write_classification<W: Write + ?Sized>(
@@ -21,7 +21,12 @@ pub fn write_classification<W: Write + ?Sized>(
         if !classification.products.is_empty() {
             let _ = writeln!(out, "{}:", "Products".bold());
             for p in &classification.products {
-                let _ = writeln!(out, "  {} - {}", p.name, truncate(&p.description, 60));
+                let _ = writeln!(
+                    out,
+                    "  {} - {}",
+                    p.name,
+                    truncate(&p.description, DESCRIPTION_TRUNCATE_WIDTH)
+                );
             }
         }
     });

--- a/src/output/resources/comment.rs
+++ b/src/output/resources/comment.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use colored::Colorize;
 
-use crate::output::formatting::write_formatted;
+use crate::output::formatting::{write_divider, write_formatted};
 use crate::types::{Comment, OutputFormat};
 
 pub fn write_comments<W: Write + ?Sized>(comments: &[Comment], format: OutputFormat, out: &mut W) {
@@ -28,7 +28,7 @@ pub fn write_comments<W: Write + ?Sized>(comments: &[Comment], format: OutputFor
                 let _ = writeln!(out, "  {line}");
             }
             let _ = writeln!(out);
-            let _ = writeln!(out, "{}", "─".repeat(60));
+            write_divider(out);
         }
     });
 }

--- a/src/output/resources/product.rs
+++ b/src/output/resources/product.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use tabled::{Table, Tabled};
 
-use crate::output::formatting::{truncate, write_formatted};
+use crate::output::formatting::{truncate, write_formatted, DESCRIPTION_TRUNCATE_WIDTH};
 use crate::types::{OutputFormat, Product};
 
 fn format_named_list(heading: &str, items: &[(impl AsRef<str>, bool)]) -> String {
@@ -66,7 +66,7 @@ pub fn write_products<W: Write + ?Sized>(products: &[Product], format: OutputFor
         let rows: Vec<ProductRow> = products
             .iter()
             .map(|p| {
-                let description = truncate(&p.description, 60);
+                let description = truncate(&p.description, DESCRIPTION_TRUNCATE_WIDTH);
                 ProductRow {
                     id: p.id,
                     name: p.name.clone(),


### PR DESCRIPTION
## Summary

Replaces inline magic-number literals with named constants and reuses an
existing helper, per the 2026-05-29 technical-debt audit. Pure refactor —
no behavior change; output bytes are identical at every site.

| Issue | TD | Change |
|-------|----|--------|
| #237 | TD-011 | `comment.rs` calls `write_divider` instead of `"─".repeat(60)` |
| #244 | TD-018 | `BODY_TRACE_MAX_BYTES` (2048); debug preview reuses `BODY_PREVIEW_MAX_BYTES` (512) |
| #247 | TD-021 | `DEFAULT_SEARCH_LIMIT` (50) replaces both literal `50` sites |
| #248 | TD-022 | `SUMMARY_TRUNCATE_WIDTH` (72) / `DESCRIPTION_TRUNCATE_WIDTH` (60) |
| #252 | TD-026 | stale `1..=12` exit-code comment → `1..=13`; main-path test for TLS exit 13 |

## Notes

- TD-026's suggested exit-13 unit tests already existed in `error_tests.rs`
  (`exit_code_pin_mismatch`, `exit_code_issuer_changed`). This PR adds the
  missing coverage on the `main.rs::exit_code()` conversion path itself, which
  is where the stale range comment lived.
- `DIVIDER_WIDTH` (60) already matched the hardcoded `repeat(60)`, so the
  divider output is unchanged.

## Validation

- `cargo build` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test`: 1241 unit + 22 + 72 integration pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
