### PR TITLE
refactor: extract duplicated helpers (TD-004/009/010/012/013/020)

### DIFF
--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -150,30 +150,38 @@ fn validate_action(action: &AttachmentAction) -> Result<()> {
     }
 }
 
+/// Maps file extensions (compared case-insensitively) to their MIME type.
+const CONTENT_TYPES: &[(&[&str], &str)] = &[
+    (
+        &[
+            "txt", "log", "c", "h", "cpp", "rs", "py", "sh", "pl", "rb", "js", "ts",
+        ],
+        "text/plain",
+    ),
+    (&["html", "htm"], "text/html"),
+    (&["json"], "application/json"),
+    (&["xml"], "application/xml"),
+    (&["pdf"], "application/pdf"),
+    (&["png"], "image/png"),
+    (&["jpg", "jpeg"], "image/jpeg"),
+    (&["gif"], "image/gif"),
+    (&["svg"], "image/svg+xml"),
+    (&["gz", "tgz"], "application/gzip"),
+    (&["zip"], "application/zip"),
+    (&["tar"], "application/x-tar"),
+    (&["patch", "diff"], "text/x-diff"),
+];
+
 fn guess_content_type(filename: &str) -> &'static str {
-    match filename
-        .rsplit('.')
-        .next()
-        .map(str::to_lowercase)
-        .as_deref()
-    {
-        Some(
-            "txt" | "log" | "c" | "h" | "cpp" | "rs" | "py" | "sh" | "pl" | "rb" | "js" | "ts",
-        ) => "text/plain",
-        Some("html" | "htm") => "text/html",
-        Some("json") => "application/json",
-        Some("xml") => "application/xml",
-        Some("pdf") => "application/pdf",
-        Some("png") => "image/png",
-        Some("jpg" | "jpeg") => "image/jpeg",
-        Some("gif") => "image/gif",
-        Some("svg") => "image/svg+xml",
-        Some("gz" | "tgz") => "application/gzip",
-        Some("zip") => "application/zip",
-        Some("tar") => "application/x-tar",
-        Some("patch" | "diff") => "text/x-diff",
-        _ => "application/octet-stream",
+    let Some(ext) = filename.rsplit('.').next() else {
+        return "application/octet-stream";
+    };
+    for (extensions, content_type) in CONTENT_TYPES {
+        if extensions.iter().any(|e| e.eq_ignore_ascii_case(ext)) {
+            return content_type;
+        }
     }
+    "application/octet-stream"
 }
 
 /// Flip the privacy of the comment that `Bug.add_attachment` just

--- a/src/commands/bug/create.rs
+++ b/src/commands/bug/create.rs
@@ -8,15 +8,6 @@ use crate::output::result_types::{write_result, ActionResult, ResourceKind};
 use crate::output::writers::Writers;
 use crate::types::{CreateBugParams, OutputFormat};
 
-fn read_description_file(path: &std::path::Path) -> Result<String> {
-    std::fs::read_to_string(path).map_err(|e| {
-        crate::error::BzrError::InputValidation(format!(
-            "--description-file could not be read ({}): {e}",
-            path.display()
-        ))
-    })
-}
-
 const SENTINEL: &str = "# ------------------------ >8 ------------------------";
 
 /// CLI-over-template field merge, computed once and shared between
@@ -137,7 +128,10 @@ fn resolve_description(
         return Ok(Some(d.to_owned()));
     }
     if let Some(p) = description_file {
-        return Ok(Some(read_description_file(p)?));
+        return Ok(Some(crate::commands::shared::read_file_with_context(
+            p,
+            "--description-file",
+        )?));
     }
     if !std::io::stdin().is_terminal() {
         let mut buf = String::new();

--- a/src/commands/bug/list.rs
+++ b/src/commands/bug/list.rs
@@ -70,10 +70,7 @@ pub(super) async fn handle(
         url: url.clone(),
         ..Default::default()
     };
-    let spec = ColumnSpec {
-        include: fields.as_deref(),
-        exclude: exclude_fields.as_deref(),
-    };
+    let spec = ColumnSpec::new(fields.as_deref(), exclude_fields.as_deref());
     let bugs = client.search_bugs(&params).await?;
     write_bugs(&bugs, spec, format, w.out, w.err);
     Ok(())

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -40,10 +40,10 @@ fn bug_column_spec(action: &BugAction) -> Option<ColumnSpec<'_>> {
             fields,
             exclude_fields,
             ..
-        } => Some(ColumnSpec {
-            include: fields.as_deref(),
-            exclude: exclude_fields.as_deref(),
-        }),
+        } => Some(ColumnSpec::new(
+            fields.as_deref(),
+            exclude_fields.as_deref(),
+        )),
         _ => None,
     }
 }

--- a/src/commands/bug/my.rs
+++ b/src/commands/bug/my.rs
@@ -24,10 +24,7 @@ pub(super) async fn handle(
         unreachable!()
     };
 
-    let spec = ColumnSpec {
-        include: fields.as_deref(),
-        exclude: exclude_fields.as_deref(),
-    };
+    let spec = ColumnSpec::new(fields.as_deref(), exclude_fields.as_deref());
 
     let whoami = client.whoami().await?;
     let email = whoami.name;

--- a/src/commands/bug/search.rs
+++ b/src/commands/bug/search.rs
@@ -77,10 +77,7 @@ pub(super) async fn handle(
         unreachable!()
     };
 
-    let spec = ColumnSpec {
-        include: fields.as_deref(),
-        exclude: exclude_fields.as_deref(),
-    };
+    let spec = ColumnSpec::new(fields.as_deref(), exclude_fields.as_deref());
 
     let (client, params, save_info) = if let Some(url_str) = from_url {
         let config = crate::config::Config::load()?;

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -40,15 +40,6 @@ fn clean_string_list(field: &str, values: &[String]) -> Result<Vec<String>> {
     Ok(out)
 }
 
-fn read_comment_file(path: &std::path::Path) -> Result<String> {
-    std::fs::read_to_string(path).map_err(|e| {
-        crate::error::BzrError::InputValidation(format!(
-            "cannot read --comment-file {}: {e}",
-            path.display()
-        ))
-    })
-}
-
 fn resolve_comment(
     comment: Option<&str>,
     comment_file: Option<&std::path::Path>,
@@ -61,7 +52,10 @@ fn resolve_comment(
             ));
         }
         (Some(s), None) => Some(s.to_string()),
-        (None, Some(path)) => Some(read_comment_file(path)?),
+        (None, Some(path)) => Some(crate::commands::shared::read_file_with_context(
+            path,
+            "--comment-file",
+        )?),
         (None, None) => None,
     };
     if body.is_none() && comment_private {

--- a/src/commands/bug/view.rs
+++ b/src/commands/bug/view.rs
@@ -81,10 +81,7 @@ pub(super) async fn handle(
     let exc_canonical = canonical_field_list(exc);
 
     if ids.len() == 1 {
-        let spec = ColumnSpec {
-            include: inc_canonical.as_deref(),
-            exclude: exc_canonical.as_deref(),
-        };
+        let spec = ColumnSpec::new(inc_canonical.as_deref(), exc_canonical.as_deref());
         return view_single(client, &ids[0], spec, format, w).await;
     }
 
@@ -101,10 +98,7 @@ pub(super) async fn handle(
         mode,
     )
     .await?;
-    let spec = ColumnSpec {
-        include: inc,
-        exclude: exc,
-    };
+    let spec = ColumnSpec::new(inc, exc);
     write_batch(batch, spec, format, w);
     Ok(())
 }

--- a/src/commands/shared.rs
+++ b/src/commands/shared.rs
@@ -395,6 +395,18 @@ pub async fn connect_and_configure(
     Ok(client)
 }
 
+/// Read a UTF-8 file, mapping any I/O error to an `InputValidation` error that
+/// names the originating CLI flag and the path. `flag` is the user-facing
+/// option name (e.g. `--description-file`) used to prefix the message.
+pub(crate) fn read_file_with_context(path: &std::path::Path, flag: &str) -> Result<String> {
+    std::fs::read_to_string(path).map_err(|e| {
+        BzrError::InputValidation(format!(
+            "{flag} could not be read ({}): {e}",
+            path.display()
+        ))
+    })
+}
+
 #[cfg(test)]
 #[path = "shared_tests.rs"]
 mod tests;

--- a/src/output/formatting.rs
+++ b/src/output/formatting.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 
 use colored::Colorize;
 use serde::Serialize;
+use tabled::{Table, Tabled};
 
 use crate::types::OutputFormat;
 
@@ -28,6 +29,30 @@ pub(super) fn write_formatted<T, W>(
         OutputFormat::Json => write_json(value, out),
         OutputFormat::Table => table_fn(value, out),
     }
+}
+
+/// Render a slice as JSON or a `tabled` table, printing `empty_msg` instead of
+/// an empty table when there are no items. `to_row` maps each item to a
+/// `Tabled` row type.
+pub(super) fn write_table_or_empty<T, R, W>(
+    items: &[T],
+    format: OutputFormat,
+    out: &mut W,
+    empty_msg: &str,
+    to_row: impl Fn(&T) -> R,
+) where
+    T: Serialize,
+    R: Tabled,
+    W: Write + ?Sized,
+{
+    write_formatted(items, format, out, |items, out| {
+        if items.is_empty() {
+            let _ = writeln!(out, "{empty_msg}");
+            return;
+        }
+        let rows: Vec<R> = items.iter().map(to_row).collect();
+        let _ = writeln!(out, "{}", Table::new(rows));
+    });
 }
 
 // ── Detail-field helpers ────────────────────────────────────────────

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -18,6 +18,15 @@ pub struct ColumnSpec<'a> {
     pub exclude: Option<&'a str>,
 }
 
+impl<'a> ColumnSpec<'a> {
+    /// Build a spec from the `--fields` / `--exclude-fields` values. Single
+    /// construction point so the struct can gain fields without updating every
+    /// call site.
+    pub fn new(include: Option<&'a str>, exclude: Option<&'a str>) -> Self {
+        ColumnSpec { include, exclude }
+    }
+}
+
 /// A selectable column in bug table output: the tokens that map to it,
 /// its header, and how to render one bug's cell.
 struct BugColumn {

--- a/src/output/resources/product.rs
+++ b/src/output/resources/product.rs
@@ -1,9 +1,11 @@
 use std::fmt::Write as _;
 use std::io::Write;
 
-use tabled::{Table, Tabled};
+use tabled::Tabled;
 
-use crate::output::formatting::{truncate, write_formatted, DESCRIPTION_TRUNCATE_WIDTH};
+use crate::output::formatting::{
+    truncate, write_formatted, write_table_or_empty, DESCRIPTION_TRUNCATE_WIDTH,
+};
 use crate::types::{OutputFormat, Product};
 
 fn format_named_list(heading: &str, items: &[(impl AsRef<str>, bool)]) -> String {
@@ -57,26 +59,17 @@ struct ProductRow {
     components: usize,
 }
 
+fn product_row(p: &Product) -> ProductRow {
+    ProductRow {
+        id: p.id,
+        name: p.name.clone(),
+        description: truncate(&p.description, DESCRIPTION_TRUNCATE_WIDTH),
+        components: p.components.len(),
+    }
+}
+
 pub fn write_products<W: Write + ?Sized>(products: &[Product], format: OutputFormat, out: &mut W) {
-    write_formatted(products, format, out, |products, out| {
-        if products.is_empty() {
-            let _ = writeln!(out, "No products found.");
-            return;
-        }
-        let rows: Vec<ProductRow> = products
-            .iter()
-            .map(|p| {
-                let description = truncate(&p.description, DESCRIPTION_TRUNCATE_WIDTH);
-                ProductRow {
-                    id: p.id,
-                    name: p.name.clone(),
-                    description,
-                    components: p.components.len(),
-                }
-            })
-            .collect();
-        let _ = writeln!(out, "{}", Table::new(rows));
-    });
+    write_table_or_empty(products, format, out, "No products found.", product_row);
 }
 
 pub fn write_product_detail<W: Write + ?Sized>(

--- a/src/output/resources/user.rs
+++ b/src/output/resources/user.rs
@@ -1,9 +1,11 @@
 use std::io::Write;
 
 use colored::Colorize;
-use tabled::{Table, Tabled};
+use tabled::Tabled;
 
-use crate::output::formatting::{opt_yes_no, write_field, write_formatted, write_optional_field};
+use crate::output::formatting::{
+    opt_yes_no, write_field, write_formatted, write_optional_field, write_table_or_empty,
+};
 use crate::types::{BugzillaUser, OutputFormat, WhoamiResponse};
 
 #[derive(Tabled)]
@@ -63,14 +65,7 @@ fn detailed_row(user: &BugzillaUser) -> DetailedUserRow {
 }
 
 pub fn write_users<W: Write + ?Sized>(users: &[BugzillaUser], format: OutputFormat, out: &mut W) {
-    write_formatted(users, format, out, |users, out| {
-        if users.is_empty() {
-            let _ = writeln!(out, "No users found.");
-            return;
-        }
-        let rows: Vec<UserRow> = users.iter().map(basic_row).collect();
-        let _ = writeln!(out, "{}", Table::new(rows));
-    });
+    write_table_or_empty(users, format, out, "No users found.", basic_row);
 }
 
 pub fn write_users_detailed<W: Write + ?Sized>(
@@ -78,14 +73,7 @@ pub fn write_users_detailed<W: Write + ?Sized>(
     format: OutputFormat,
     out: &mut W,
 ) {
-    write_formatted(users, format, out, |users, out| {
-        if users.is_empty() {
-            let _ = writeln!(out, "No users found.");
-            return;
-        }
-        let rows: Vec<DetailedUserRow> = users.iter().map(detailed_row).collect();
-        let _ = writeln!(out, "{}", Table::new(rows));
-    });
+    write_table_or_empty(users, format, out, "No users found.", detailed_row);
 }
 
 pub fn write_whoami<W: Write + ?Sized>(whoami: &WhoamiResponse, format: OutputFormat, out: &mut W) {

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -178,6 +178,34 @@ pub struct Overrides<'a> {
     pub url: Option<&'a [String]>,
 }
 
+/// Map a [`FilterField`] to the matching multi-value `Vec<String>` on `$self`.
+///
+/// Shared by `SearchParams` and `SavedQuery`, which carry identical filter
+/// fields except for the assignee column (`assigned_to` vs `assignee`) — the
+/// caller passes its own field name as `$assignee`. Pass a trailing `mut` for
+/// a mutable borrow.
+macro_rules! filter_field_arm {
+    ($self:ident, $field:ident, $assignee:ident $(, $mutability:tt)?) => {
+        match $field {
+            FilterField::Product => & $($mutability)? $self.product,
+            FilterField::Component => & $($mutability)? $self.component,
+            FilterField::Status => & $($mutability)? $self.status,
+            FilterField::AssignedTo => & $($mutability)? $self.$assignee,
+            FilterField::Creator => & $($mutability)? $self.creator,
+            FilterField::Priority => & $($mutability)? $self.priority,
+            FilterField::Severity => & $($mutability)? $self.severity,
+            FilterField::Whiteboard => & $($mutability)? $self.whiteboard,
+            FilterField::TargetMilestone => & $($mutability)? $self.target_milestone,
+            FilterField::Version => & $($mutability)? $self.version,
+            FilterField::OpSys => & $($mutability)? $self.op_sys,
+            FilterField::Platform => & $($mutability)? $self.platform,
+            FilterField::Resolution => & $($mutability)? $self.resolution,
+            FilterField::QaContact => & $($mutability)? $self.qa_contact,
+            FilterField::Url => & $($mutability)? $self.url,
+        }
+    };
+}
+
 impl SearchParams {
     /// Apply optional per-invocation overrides. `Some(_)` replaces;
     /// `None` keeps the saved value.
@@ -235,44 +263,12 @@ impl SearchParams {
     }
 
     fn get_filter_field(&self, field: FilterField) -> &[String] {
-        match field {
-            FilterField::Product => &self.product,
-            FilterField::Component => &self.component,
-            FilterField::Status => &self.status,
-            FilterField::AssignedTo => &self.assigned_to,
-            FilterField::Creator => &self.creator,
-            FilterField::Priority => &self.priority,
-            FilterField::Severity => &self.severity,
-            FilterField::Whiteboard => &self.whiteboard,
-            FilterField::TargetMilestone => &self.target_milestone,
-            FilterField::Version => &self.version,
-            FilterField::OpSys => &self.op_sys,
-            FilterField::Platform => &self.platform,
-            FilterField::Resolution => &self.resolution,
-            FilterField::QaContact => &self.qa_contact,
-            FilterField::Url => &self.url,
-        }
+        filter_field_arm!(self, field, assigned_to)
     }
 
     #[cfg(test)]
     fn get_filter_field_mut(&mut self, field: FilterField) -> &mut Vec<String> {
-        match field {
-            FilterField::Product => &mut self.product,
-            FilterField::Component => &mut self.component,
-            FilterField::Status => &mut self.status,
-            FilterField::AssignedTo => &mut self.assigned_to,
-            FilterField::Creator => &mut self.creator,
-            FilterField::Priority => &mut self.priority,
-            FilterField::Severity => &mut self.severity,
-            FilterField::Whiteboard => &mut self.whiteboard,
-            FilterField::TargetMilestone => &mut self.target_milestone,
-            FilterField::Version => &mut self.version,
-            FilterField::OpSys => &mut self.op_sys,
-            FilterField::Platform => &mut self.platform,
-            FilterField::Resolution => &mut self.resolution,
-            FilterField::QaContact => &mut self.qa_contact,
-            FilterField::Url => &mut self.url,
-        }
+        filter_field_arm!(self, field, assigned_to, mut)
     }
 
     fn has_mapped_filters(&self) -> bool {
@@ -788,43 +784,11 @@ impl SavedQuery {
     }
 
     fn get_filter_field(&self, field: FilterField) -> &[String] {
-        match field {
-            FilterField::Product => &self.product,
-            FilterField::Component => &self.component,
-            FilterField::Status => &self.status,
-            FilterField::AssignedTo => &self.assignee,
-            FilterField::Creator => &self.creator,
-            FilterField::Priority => &self.priority,
-            FilterField::Severity => &self.severity,
-            FilterField::Whiteboard => &self.whiteboard,
-            FilterField::TargetMilestone => &self.target_milestone,
-            FilterField::Version => &self.version,
-            FilterField::OpSys => &self.op_sys,
-            FilterField::Platform => &self.platform,
-            FilterField::Resolution => &self.resolution,
-            FilterField::QaContact => &self.qa_contact,
-            FilterField::Url => &self.url,
-        }
+        filter_field_arm!(self, field, assignee)
     }
 
     fn get_filter_field_mut(&mut self, field: FilterField) -> &mut Vec<String> {
-        match field {
-            FilterField::Product => &mut self.product,
-            FilterField::Component => &mut self.component,
-            FilterField::Status => &mut self.status,
-            FilterField::AssignedTo => &mut self.assignee,
-            FilterField::Creator => &mut self.creator,
-            FilterField::Priority => &mut self.priority,
-            FilterField::Severity => &mut self.severity,
-            FilterField::Whiteboard => &mut self.whiteboard,
-            FilterField::TargetMilestone => &mut self.target_milestone,
-            FilterField::Version => &mut self.version,
-            FilterField::OpSys => &mut self.op_sys,
-            FilterField::Platform => &mut self.platform,
-            FilterField::Resolution => &mut self.resolution,
-            FilterField::QaContact => &mut self.qa_contact,
-            FilterField::Url => &mut self.url,
-        }
+        filter_field_arm!(self, field, assignee, mut)
     }
 
     fn has_mapped_filters(&self) -> bool {

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -9,6 +9,10 @@ use crate::xmlrpc::call::build_request;
 use crate::xmlrpc::parsing::parse_response;
 use crate::xmlrpc::value::Value;
 
+/// Error message used whenever an XML-RPC method expects a top-level struct
+/// in the response but receives a different value type.
+const EXPECTED_STRUCT_RESPONSE: &str = "expected struct response";
+
 const ATTACHMENT_LIST_FIELDS: &[&str] = &[
     "id",
     "bug_id",
@@ -171,7 +175,7 @@ impl XmlRpcClient {
         let result = self.call("Group.get", rpc_params).await?;
         let top = result
             .as_struct()
-            .ok_or_else(|| BzrError::XmlRpc("expected struct response".into()))?;
+            .ok_or_else(|| BzrError::XmlRpc(EXPECTED_STRUCT_RESPONSE.into()))?;
         let groups = top
             .get("groups")
             .and_then(Value::as_array)
@@ -233,7 +237,7 @@ impl XmlRpcClient {
 fn extract_id(response: &Value) -> Result<u64> {
     let m = response
         .as_struct()
-        .ok_or_else(|| BzrError::XmlRpc("expected struct response".into()))?;
+        .ok_or_else(|| BzrError::XmlRpc(EXPECTED_STRUCT_RESPONSE.into()))?;
 
     let id = m
         .get("id")
@@ -281,7 +285,7 @@ fn add_field_lists(rpc_params: &mut BTreeMap<String, Value>, params: &SearchPara
 fn extract_bugs(response: &Value) -> Result<Vec<Bug>> {
     let top = response
         .as_struct()
-        .ok_or_else(|| BzrError::XmlRpc("expected struct response".into()))?;
+        .ok_or_else(|| BzrError::XmlRpc(EXPECTED_STRUCT_RESPONSE.into()))?;
 
     let Some(bugs_val) = top.get("bugs") else {
         return Ok(Vec::new());
@@ -344,7 +348,7 @@ fn value_to_bug(val: &Value) -> Result<Bug> {
 fn lookup_bug_entry(response: &Value, bug_id: u64) -> Result<Option<&Value>> {
     let top = response
         .as_struct()
-        .ok_or_else(|| BzrError::XmlRpc("expected struct response".into()))?;
+        .ok_or_else(|| BzrError::XmlRpc(EXPECTED_STRUCT_RESPONSE.into()))?;
 
     let Some(bugs_val) = top.get("bugs") else {
         return Ok(None);
@@ -438,7 +442,7 @@ fn extract_attachment_by_id(
 ) -> Result<crate::types::Attachment> {
     let top = response
         .as_struct()
-        .ok_or_else(|| BzrError::XmlRpc("expected struct response".into()))?;
+        .ok_or_else(|| BzrError::XmlRpc(EXPECTED_STRUCT_RESPONSE.into()))?;
 
     let attachments_struct = top
         .get("attachments")


### PR DESCRIPTION
## Summary

Deduplicates near-identical code flagged by the 2026-05-29 technical-debt
audit. Behavior-preserving (one intentional error-message wording fix); net
−28 LOC.

| Issue | TD | Change |
|-------|----|--------|
| #230 | TD-004 | `filter_field_arm!` macro for the `FilterField`→`Vec` match shared by `SearchParams`/`SavedQuery` (covers shared + `mut` accessors) |
| #235 | TD-009 | `read_file_with_context` replaces `read_description_file`/`read_comment_file` |
| #236 | TD-010 | `ColumnSpec::new` single construction point across bug query handlers |
| #238 | TD-012 | `write_table_or_empty` used in `write_users`/`write_users_detailed`/`write_products` |
| #239 | TD-013 | `EXPECTED_STRUCT_RESPONSE` const replaces 5 duplicated XML-RPC literals |
| #246 | TD-020 | `guess_content_type` matches a `CONTENT_TYPES` table via `eq_ignore_ascii_case`, dropping the per-call `to_lowercase` allocation |

## Review notes

- **TD-009** unifies the `--comment-file` read-error wording to match
  `--description-file` (`{flag} could not be read ({path}): {e}`). No test or
  doc asserted the old text.
- **TD-004** macro expands to byte-identical match arms; `FilterField`
  resolves unqualified since both call sites share the module.
- **TD-020** preserves case-insensitive matching; the `let…else` guard is a
  defensive default (`rsplit` always yields `Some`).

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test`: 1241 unit + 22 + 72 integration pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
