### PR TITLE
fix: close input-validation gaps (TD-005/024/025)

### DIFF
--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -132,12 +132,13 @@ fn build_update_params(action: &BugAction) -> Result<(Vec<u64>, UpdateBugParams)
     };
 
     let flags = crate::commands::flags::parse_flags(flag)?;
+    let deadline = crate::validation::parse_optional_date_only(deadline.as_deref(), "--deadline")?;
     let params = UpdateBugParams {
         status: status.clone(),
         resolution: resolution.clone(),
         dupe_of: *dupe_of,
         alias: alias.clone(),
-        deadline: deadline.clone(),
+        deadline,
         estimated_time: *estimated_time,
         remaining_time: *remaining_time,
         work_time: *work_time,

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -125,6 +125,13 @@ fn update_ids_mut(action: &mut BugAction) -> Option<&mut Vec<u64>> {
     Some(ids)
 }
 
+fn update_deadline_mut(action: &mut BugAction) -> Option<&mut Option<String>> {
+    let BugAction::Update { deadline, .. } = action else {
+        return None;
+    };
+    Some(deadline)
+}
+
 #[derive(Default)]
 struct UpdateLists<'a> {
     keywords_add: Vec<&'a str>,
@@ -355,6 +362,29 @@ fn build_update_params_populates_scalar_parity_fields() {
     assert_eq!(params.work_time, Some(0.5));
     assert!(params.reset_assigned_to);
     assert!(params.reset_qa_contact);
+}
+
+#[test]
+fn build_update_params_accepts_valid_deadline_verbatim() {
+    let mut action = make_update_action(vec![42]);
+    *update_deadline_mut(&mut action).expect("update action") = Some("2026-12-31".into());
+
+    let (_ids, params) = super::build_update_params(&action).unwrap();
+    // Date-only deadlines must reach the server unchanged (no datetime expansion).
+    assert_eq!(params.deadline.as_deref(), Some("2026-12-31"));
+}
+
+#[test]
+fn build_update_params_rejects_invalid_deadline() {
+    let mut action = make_update_action(vec![42]);
+    *update_deadline_mut(&mut action).expect("update action") = Some("garbage".into());
+
+    let err = super::build_update_params(&action).unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+    assert!(
+        matches!(err, crate::error::BzrError::InputValidation(ref msg) if msg.contains("--deadline")),
+        "expected --deadline validation error, got {err:?}"
+    );
 }
 
 #[test]

--- a/src/url_parser.rs
+++ b/src/url_parser.rs
@@ -160,7 +160,20 @@ pub fn parse_bugzilla_url(url_str: &str, config: &Config) -> Result<ParsedUrl> {
                 }
             }
             ParamKind::Limit => {
-                if let Ok(n) = value.parse::<u32>() {
+                let trimmed = value.trim();
+                // An empty `limit=` carries no value; treat it as absent
+                // (consistent with the other trimmed params above).
+                if !trimmed.is_empty() {
+                    // `limit=0` is accepted verbatim: Bugzilla interprets 0 as
+                    // "no limit" (return all matches). Non-numeric or
+                    // out-of-range values (e.g. `abc`, `99999999999`) are
+                    // rejected here rather than silently dropped.
+                    let n = trimmed.parse::<u32>().map_err(|_| {
+                        BzrError::InputValidation(format!(
+                            "URL limit '{trimmed}' is not a valid integer in 0..={}",
+                            u32::MAX
+                        ))
+                    })?;
                     query.limit = Some(n);
                 }
             }

--- a/src/url_parser_tests.rs
+++ b/src/url_parser_tests.rs
@@ -94,6 +94,45 @@ fn parse_simple_url_with_recognized_params() {
 }
 
 #[test]
+fn limit_zero_accepted_as_no_limit() {
+    // Bugzilla treats limit=0 as "no limit"; we pass it through verbatim.
+    let parsed = parse_test_url("product=Firefox&limit=0");
+    assert_eq!(parsed.query.limit, Some(0));
+}
+
+#[test]
+fn empty_limit_treated_as_absent() {
+    let parsed = parse_test_url("product=Firefox&limit=");
+    assert_eq!(parsed.query.limit, None);
+}
+
+#[test]
+fn non_numeric_limit_rejected() {
+    let config = make_config("https://bugzilla.example.com");
+    let err = parse_bugzilla_url(
+        "https://bugzilla.example.com/buglist.cgi?limit=abc",
+        &config,
+    )
+    .unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+    assert!(
+        matches!(err, BzrError::InputValidation(ref m) if m.contains("limit")),
+        "expected limit validation error, got {err:?}"
+    );
+}
+
+#[test]
+fn overflow_limit_rejected() {
+    let config = make_config("https://bugzilla.example.com");
+    let err = parse_bugzilla_url(
+        "https://bugzilla.example.com/buglist.cgi?limit=99999999999",
+        &config,
+    )
+    .unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+}
+
+#[test]
 fn parse_complex_boolean_chart_url() {
     let parsed = parse_test_url(
         "known_name=My+Query\

--- a/src/validation/datetime.rs
+++ b/src/validation/datetime.rs
@@ -31,6 +31,22 @@ pub fn parse_iso8601_or_date(s: &str, flag: &str) -> Result<String> {
     }
 }
 
+/// Validate a bare `YYYY-MM-DD` date, returning it unchanged on success.
+///
+/// Unlike [`parse_iso8601_or_date`], this does **not** expand the value to a
+/// datetime — it is for date-only fields such as the bug deadline, which
+/// Bugzilla stores and echoes back as `YYYY-MM-DD`. `flag` is the CLI flag
+/// name included in the error message.
+pub fn parse_date_only(s: &str, flag: &str) -> Result<String> {
+    if s.is_ascii() && s.len() == 10 && parse_date(s).is_some() {
+        Ok(s.to_string())
+    } else {
+        Err(BzrError::InputValidation(format!(
+            "{flag}: '{s}' is not a valid date. Expected: YYYY-MM-DD"
+        )))
+    }
+}
+
 fn try_canonicalize(s: &str) -> Option<String> {
     // Length-check first; this also gates the byte-indexing below
     // (each branch knows the input is exactly that many bytes long).

--- a/src/validation/datetime_tests.rs
+++ b/src/validation/datetime_tests.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::unwrap_used)]
 
-use super::parse_iso8601_or_date;
+use super::{parse_date_only, parse_iso8601_or_date};
 
 const FLAG: &str = "--created-since";
 
@@ -128,6 +128,29 @@ fn accepts_february_twenty_ninth_on_leap_year() {
 }
 
 #[test]
+fn rejects_february_twenty_ninth_on_century_non_leap_year() {
+    // 1900 is divisible by 100 but not 400, so it is NOT a leap year.
+    assert!(parse_iso8601_or_date("1900-02-29", FLAG).is_err());
+}
+
+#[test]
+fn accepts_february_twenty_ninth_on_quadricentennial_leap_year() {
+    // 2000 is divisible by 400, so it IS a leap year.
+    let canon = parse_iso8601_or_date("2000-02-29", FLAG).unwrap();
+    assert_eq!(canon, "2000-02-29T00:00:00Z");
+}
+
+#[test]
+fn accepts_year_zero() {
+    // Year 0000 is divisible by 400 (leap). The validator is purely
+    // structural — it does not impose a lower year bound — so 0000-01-01
+    // is accepted and canonicalized. Bugzilla itself rejects such dates;
+    // we fail fast only on malformed shapes, not implausible-but-valid ones.
+    let canon = parse_iso8601_or_date("0000-01-01", FLAG).unwrap();
+    assert_eq!(canon, "0000-01-01T00:00:00Z");
+}
+
+#[test]
 fn rejects_hour_above_twenty_three() {
     assert!(parse_iso8601_or_date("2026-04-01T25:00:00Z", FLAG).is_err());
 }
@@ -181,4 +204,30 @@ fn error_message_includes_expected_forms() {
     assert!(msg.contains("YYYY-MM-DDTHH:MM:SS"));
     assert!(msg.contains("YYYY-MM-DDTHH:MM:SSZ"));
     assert!(msg.contains("YYYY-MM-DDTHH:MM:SS±HH:MM"));
+}
+
+#[test]
+fn date_only_accepts_bare_date_verbatim() {
+    // Unlike parse_iso8601_or_date, no datetime expansion.
+    assert_eq!(
+        parse_date_only("2026-12-31", "--deadline").unwrap(),
+        "2026-12-31"
+    );
+}
+
+#[test]
+fn date_only_rejects_datetime() {
+    assert!(parse_date_only("2026-12-31T00:00:00Z", "--deadline").is_err());
+}
+
+#[test]
+fn date_only_rejects_garbage_and_names_flag() {
+    let err = parse_date_only("garbage", "--deadline").unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+    assert!(err.to_string().contains("--deadline"));
+}
+
+#[test]
+fn date_only_rejects_century_non_leap_feb_29() {
+    assert!(parse_date_only("1900-02-29", "--deadline").is_err());
 }

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -7,7 +7,7 @@
 
 pub mod datetime;
 
-pub use datetime::parse_iso8601_or_date;
+pub use datetime::{parse_date_only, parse_iso8601_or_date};
 
 use crate::error::Result;
 
@@ -19,4 +19,12 @@ use crate::error::Result;
 /// idiom used at every CLI date-flag site.
 pub fn parse_optional_date(opt: Option<&str>, flag: &str) -> Result<Option<String>> {
     opt.map(|s| parse_iso8601_or_date(s, flag)).transpose()
+}
+
+/// Validate an optional bare `YYYY-MM-DD` date for a date-only field.
+///
+/// `None` is passed through unchanged; `Some(s)` is validated via
+/// [`parse_date_only`] and returned verbatim (no datetime expansion).
+pub fn parse_optional_date_only(opt: Option<&str>, flag: &str) -> Result<Option<String>> {
+    opt.map(|s| parse_date_only(s, flag)).transpose()
 }


### PR DESCRIPTION
## Summary

Closes three input-validation gaps from the 2026-05-29 technical-debt audit.
Each makes a previously-deferred or silently-dropped bad input fail fast at
exit 7.

| Issue | TD | Change |
|-------|----|--------|
| #231 | TD-005 | `bug update --deadline` validated via new `parse_date_only` (exit 7 on malformed) |
| #250 | TD-024 | century leap-year tests (1900/2000) + year-0000 behavior locked |
| #251 | TD-025 | URL `limit=` rejects non-numeric/overflow; `limit=0` and empty `limit=` documented |

## Design note (TD-005)

The audit suggested `parse_optional_date`, but that **canonicalizes**
`YYYY-MM-DD` → `YYYY-MM-DDT00:00:00Z`. Bugzilla's `deadline` is a date-only
field and existing tests (`update_tests.rs:352`, functional test) assert the
value reaches the server verbatim as `2026-12-31`. So this PR adds a sibling
`parse_date_only` validator that checks structure but returns the value
**unchanged** — no wire-format change for valid deadlines, only malformed ones
now fail client-side (exit 7) instead of server-side (exit 4).

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test`: 1254 unit (+13) + 22 + 72 integration pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
