### PR TITLE
test: cover BatchPartialFailure; document empty JSON projection (TD-007/027)

### DIFF
--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -212,8 +212,8 @@ Filter flags (`--product`, `--component`, `--status`, `--assignee`, `--creator`,
 | `--alias <A>` | No | | Filter by bug alias |
 | `--summary <S>` | No | | Substring match on the Summary field (matches all bug states) |
 | `--limit <N>` | No | 50 | Max results |
-| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
-| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). |
+| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
 | `--created-since <DATE>` | No | | Filter to bugs whose `creation_time` is `>= DATE`. See [Date format](#date-format) below. |
 | `--changed-since <DATE>` | No | | Filter to bugs whose `last_change_time` is `>= DATE`. See [Date format](#date-format) below. |
 
@@ -317,8 +317,8 @@ bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?known_name=m
 | `--from-url <URL>` | No* | | Execute a search from a Bugzilla buglist.cgi URL. Recognized parameters (product, component, status, etc.) are mapped to structured fields; unrecognized parameters (boolean charts, field-change filters) are passed through to the REST API verbatim. |
 | `--save-as [NAME]` | No | | Save this URL query for future reuse. If `NAME` is omitted, uses the URL's `known_name` parameter as the query name. Requires `--from-url`. |
 | `--limit <N>` | No | 50 | Max results. When `--from-url` is used, the URL's own limit parameter takes precedence unless overridden here. |
-| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
-| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). |
+| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
 
 *One of `<QUERY>` or `--from-url` must be provided.
 
@@ -359,8 +359,8 @@ bzr bug my --status NEW --status '!RESOLVED'  # mixed positive and negated
 | `--all` | No | | Show all bugs related to me (assigned + created + CC'd) |
 | `--status <S>` | No | | Filter by status (repeatable; `!` prefix to exclude) |
 | `--limit <N>` | No | 50 | Max results per category. With `--all`, each of the three categories (assigned, created, CC'd) is queried separately up to this limit; duplicates across categories are removed. |
-| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
-| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). |
+| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
 
 ### `bzr bug create`
 

--- a/src/error_tests.rs
+++ b/src/error_tests.rs
@@ -127,6 +127,17 @@ fn exit_code_data_integrity() {
 }
 
 #[test]
+fn exit_code_batch_partial_failure() {
+    let err = BzrError::BatchPartialFailure {
+        succeeded: 3,
+        failed: 2,
+    };
+    assert_eq!(err.exit_code(), 11);
+    assert_eq!(err.error_type(), "batch_partial_failure");
+    assert_eq!(err.to_string(), "batch update: 3 succeeded, 2 failed");
+}
+
+#[test]
 fn exit_code_keyring() {
     let err = BzrError::Keyring("keychain locked".into());
     assert_eq!(err.exit_code(), 12);


### PR DESCRIPTION
## Summary

| Issue | TD | Change |
|-------|----|--------|
| #233 | TD-007 | Add the missing `BatchPartialFailure` exit-code (11) / `error_type` (`batch_partial_failure`) unit test |
| #253 | TD-027 | Document that `--fields`/`--exclude-fields` under `--json` reject an empty projection with exit 7 (not `{}`) |

## Notes on TD-027

Spot-checking the audit's claims against the code showed both halves were
already covered:

- The **field-negation regression test** the audit asked for already exists
  (`search_bugs_negation_whiteboard_uses_notsubstring` — `--whiteboard '!wip'`
  → `o1=notsubstring`), alongside `..._resolution_uses_notequals`.
- The audit's premise that `--exclude-fields` under `--json` "returns `{}`" is
  **stale**: `validate_json_field_selection` (wired at `bug/mod.rs:81` and
  `query.rs:256`, tested at `bug_tests.rs:886,901`) rejects an all-keys-dropped
  projection with exit 7. This PR documents that actual behavior in
  `docs/bzr-cli.md`.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test`: 1255 unit (+1) + 22 + 72 integration pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
