### PR TITLE
fix: detect TLS cert errors during valid_login auth probe (TD-002)

### DIFF
--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -59,6 +59,21 @@ pub async fn detect_server_settings(
     })
 }
 
+/// Log a probe's `send()` error, surfacing TLS-certificate problems at `warn`
+/// with a [`crate::http::tls_hint`] and routing all other transport errors to
+/// `debug`. Shared by the `whoami` and `valid_login` probes so their
+/// network-error handling cannot drift apart (the cause of TD-002).
+fn log_probe_send_error(probe: &str, method: AuthMethod, e: &reqwest::Error) {
+    if crate::http::is_tls_cert_error(e) {
+        tracing::warn!(
+            "{}",
+            crate::http::tls_hint(&format!("{probe} {method} request failed: {e:#}"), e)
+        );
+    } else {
+        tracing::debug!("{probe} {method} request failed: {e:#}");
+    }
+}
+
 async fn detect_auth_method(
     http: &reqwest::Client,
     base_url: &str,

--- a/src/client/auth/valid_login.rs
+++ b/src/client/auth/valid_login.rs
@@ -86,7 +86,7 @@ async fn probe_valid_login(
     let resp = match req.send().await {
         Ok(r) => r,
         Err(e) => {
-            tracing::warn!(error = %e, "valid_login probe network error");
+            super::log_probe_send_error("valid_login", method, &e);
             return ValidLoginOutcome::NetworkError;
         }
     };

--- a/src/client/auth/whoami.rs
+++ b/src/client/auth/whoami.rs
@@ -46,14 +46,7 @@ async fn probe_whoami(request: reqwest::RequestBuilder, method: AuthMethod) -> W
     let resp = match request.send().await {
         Ok(r) => r,
         Err(e) => {
-            if crate::http::is_tls_cert_error(&e) {
-                tracing::warn!(
-                    "{}",
-                    crate::http::tls_hint(&format!("whoami {method} request failed: {e:#}"), &e,)
-                );
-            } else {
-                tracing::debug!("whoami {method} request failed: {e:#}");
-            }
+            super::log_probe_send_error("whoami", method, &e);
             return WhoamiOutcome::NetworkError;
         }
     };


### PR DESCRIPTION
## Summary

`probe_valid_login` logged every `send()` failure generically
(`"valid_login probe network error"`, always at `warn`) and skipped the
TLS-certificate detection (`is_tls_cert_error` + `tls_hint`) that the
`whoami` probe performs. Users authenticating against a server with an
untrusted/expired cert got an opaque error instead of the actionable TLS
hint (TD-002, #228).

## Change

- Extract the shared send-error logging into `auth::log_probe_send_error`
  (TLS → `warn` with hint; other transport errors → `debug`).
- Call it from **both** `whoami` and `valid_login` probes, so their
  network-error handling cannot drift apart again — which was the root cause
  of this finding.

`whoami` behavior is unchanged (identical log output). `valid_login`
non-TLS errors move from `warn` to `debug`, matching `whoami`; the
orchestrator already emits a user-facing `warn` on `NetworkError`, so no
signal is lost.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --lib auth`: 45 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
