### PR TITLE
fix: report new bug ID when clone's follow-up comment fails (TD-006)

### DIFF
--- a/src/commands/bug/clone.rs
+++ b/src/commands/bug/clone.rs
@@ -86,10 +86,23 @@ pub(super) async fn handle(
 
     let new_id = client.create_bug(&params).await?;
 
+    // The bug was created successfully — that is the clone operation. The
+    // "Cloned from" back-reference comment is supplementary, so a failure
+    // posting it must not hide the new bug ID (otherwise the user can't tell
+    // the clone succeeded and may re-clone, creating a duplicate). Warn and
+    // continue rather than propagating.
     if !*no_comment {
-        client
+        if let Err(e) = client
             .add_comment(new_id, &format!("Cloned from bug #{}", source.id), false)
-            .await?;
+            .await
+        {
+            let _ = writeln!(
+                w.err,
+                "warning: created bug #{new_id} but failed to add the \
+                 \"Cloned from bug #{}\" comment: {e}",
+                source.id
+            );
+        }
     }
 
     write_result(

--- a/src/commands/bug/clone_tests.rs
+++ b/src/commands/bug/clone_tests.rs
@@ -112,6 +112,95 @@ async fn bug_clone_copies_fields() {
 }
 
 #[tokio::test]
+async fn bug_clone_reports_id_when_comment_post_fails() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{
+                "id": 100,
+                "summary": "Original bug",
+                "status": "NEW",
+                "product": "TestProduct",
+                "component": "General",
+                "version": "1.0",
+                "cc": [],
+                "keywords": []
+            }]
+        })))
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/100/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": { "100": { "comments": [{
+                "id": 1, "count": 0, "text": "Description",
+                "creator": "dev@test.com", "creation_time": "2025-01-01T00:00:00Z"
+            }] } }
+        })))
+        .mount(&mock)
+        .await;
+
+    // Bug creation succeeds.
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 202})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    // ...but the "Cloned from" comment POST fails with a 500.
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/202/comment"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = BugAction::Clone {
+        id: "100".to_string(),
+        summary: None,
+        product: None,
+        component: None,
+        version: None,
+        description: None,
+        priority: None,
+        severity: None,
+        assignee: None,
+        op_sys: None,
+        rep_platform: None,
+        no_comment: false,
+        add_depends_on: false,
+        add_blocks: false,
+        no_cc: false,
+        no_keywords: false,
+    };
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+
+    // The clone (bug creation) succeeded, so the command must succeed and the
+    // new bug ID must be reported — otherwise the user can't tell a bug was
+    // created and may re-clone, producing a duplicate.
+    assert!(
+        result.is_ok(),
+        "clone should succeed despite comment failure: {result:?}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    assert_eq!(parsed["id"], 202);
+    assert_eq!(parsed["action"], "created");
+    // The comment failure is surfaced as a stderr warning naming the new ID.
+    let err = __io.err_str();
+    assert!(
+        err.contains("202") && err.contains("warning"),
+        "expected warning naming bug #202, got: {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn bug_clone_no_comment_skips_comment() {
     let (_lock, mock, _tmp) = setup_test_env().await;
 


### PR DESCRIPTION
## Summary

`bug clone` created the new bug, then posted a `"Cloned from #N"` comment with
`?`. If that comment POST failed, the error propagated **before** the new bug
ID was printed — so the user couldn't tell the clone had succeeded and might
re-clone, creating a duplicate (TD-006, #232).

## Change

The bug creation *is* the clone operation; the back-reference comment is
supplementary. On comment failure, warn to **stderr** (naming the new bug ID)
and still emit the normal success result, so:

- stdout JSON stays parseable and carries the created ID,
- the user is told a bug was created (no duplicate re-clone),
- the comment failure is visible as a warning.

Adds a regression test mocking a 500 on the comment POST after create succeeds,
asserting the command succeeds, the ID is reported on stdout, and a warning
naming the ID appears on stderr.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --lib clone`: 4 pass (incl. new regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
