### PR TITLE
refactor: drop legacy issuer string-comparison TLS pin shim (TD-015)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- TLS issuer pinning: removed the legacy issuer-DN string-comparison fallback in
+  certificate-change detection. Issuer-change detection (`ISSUER_CHANGED`) now
+  relies solely on tamper-proof raw-DER comparison. Pins created before raw-DER
+  storage existed keep full certificate-fingerprint pinning but no longer emit
+  the secondary `ISSUER_CHANGED` signal (they fall back to `PIN_MISMATCH`) until
+  re-pinned. The human-readable issuer is still stored and shown by
+  `bzr config show`.
+
 ### Security
 
 - `bzr attachment download`: the server-supplied attachment file name is now
@@ -17,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `bzr bug update --deadline`: the deadline is now validated client-side and a
+  malformed value fails fast with exit 7, instead of being forwarded to the
+  server. Valid `YYYY-MM-DD` deadlines are unchanged.
+- `bzr bug search --from-url`: a non-numeric or out-of-range `limit=` in the URL
+  is now rejected with exit 7 instead of being silently dropped; `limit=0`
+  (Bugzilla "no limit") and an empty `limit=` are documented.
+- `bzr bug clone`: if the "Cloned from #N" comment fails to post after the bug
+  is created, the new bug ID is now reported with a warning instead of being
+  lost, so the clone is not accidentally repeated.
 - `bzr query save`: `--search` is now rejected when combined with a structured
   filter flag (`--product`, `--component`, `--whiteboard`, etc.), matching the
   documented mutual exclusivity. Previously only `--search` + `--from-url` was

--- a/src/commands/shared.rs
+++ b/src/commands/shared.rs
@@ -142,7 +142,6 @@ async fn handle_tofu(ctx: &ConnectContext, config: &mut Config) -> Result<Bugzil
             }
             TlsConfig {
                 pin_sha256: Some(fingerprint),
-                pin_issuer: Some(issuer),
                 pin_issuer_der: issuer_der,
                 server_name: Some(ctx.server_name.clone()),
                 ..Default::default()
@@ -152,7 +151,6 @@ async fn handle_tofu(ctx: &ConnectContext, config: &mut Config) -> Result<Bugzil
             // "y" — trust this specific cert for this session only (no config change)
             TlsConfig {
                 pin_sha256: Some(fingerprint),
-                pin_issuer: Some(issuer),
                 pin_issuer_der: issuer_der,
                 server_name: Some(ctx.server_name.clone()),
                 ..Default::default()
@@ -216,7 +214,6 @@ async fn handle_pin_rotation(
 
     let tls_config = TlsConfig {
         pin_sha256: Some(new_fingerprint.to_owned()),
-        pin_issuer: Some(new_issuer.to_owned()),
         pin_issuer_der: existing_issuer_der,
         server_name: Some(ctx.server_name.clone()),
         ..Default::default()

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,7 +117,6 @@ impl ServerConfig {
             insecure: self.tls_insecure,
             ca_cert_path: self.tls_ca_cert.clone(),
             pin_sha256: self.tls_pin_sha256.clone(),
-            pin_issuer: self.tls_pin_issuer.clone(),
             pin_issuer_der: self.tls_pin_issuer_der.clone(),
             server_name: Some(server_name.to_string()),
         }

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -33,7 +33,6 @@ pub struct TlsConfig {
     pub insecure: bool,
     pub ca_cert_path: Option<PathBuf>,
     pub pin_sha256: Option<String>,
-    pub pin_issuer: Option<String>,
     /// Base64-encoded raw DER bytes of the pinned issuer SEQUENCE.
     pub pin_issuer_der: Option<String>,
     pub server_name: Option<String>,
@@ -58,7 +57,6 @@ fn apply_tls_verification(
     } else if let Some(pin) = &config.pin_sha256 {
         let tls_config = verifier::build_pinned_config(
             pin,
-            config.pin_issuer.clone(),
             config.pin_issuer_der.as_deref(),
             config.server_name.as_deref().unwrap_or("unknown"),
         )?;

--- a/src/tls/verifier.rs
+++ b/src/tls/verifier.rs
@@ -21,11 +21,8 @@ pub(crate) struct PinnedCertVerifier {
     pin_hash: [u8; 32],
     /// The full `sha256//<base64>` pin string, kept for error messages.
     pin_str: String,
-    /// Optional expected issuer DN string for change detection
-    /// (legacy fallback for pins created before DER comparison).
-    pin_issuer: Option<String>,
     /// Raw DER bytes of the expected issuer SEQUENCE for tamper-proof
-    /// comparison. Takes precedence over `pin_issuer` string.
+    /// issuer-change detection.
     pin_issuer_der: Option<Vec<u8>>,
     /// The server name this verifier was created for (for errors).
     server_name: String,
@@ -38,11 +35,10 @@ impl PinnedCertVerifier {
     ///
     /// `pin_sha256` must be in `sha256//<base64>` format.
     /// `pin_issuer_der_b64` is the base64-encoded raw DER of the issuer
-    /// SEQUENCE, used for tamper-proof issuer comparison. Falls back to
-    /// `pin_issuer` string comparison when `None` (backward compat).
+    /// SEQUENCE, used for tamper-proof issuer-change detection. When `None`,
+    /// no issuer-change check is performed (only the cert fingerprint pin).
     pub(crate) fn new(
         pin_sha256: &str,
-        pin_issuer: Option<String>,
         pin_issuer_der_b64: Option<&str>,
         server_name: &str,
     ) -> Result<Self> {
@@ -72,52 +68,32 @@ impl PinnedCertVerifier {
         Ok(Self {
             pin_hash,
             pin_str: pin_sha256.to_owned(),
-            pin_issuer,
             pin_issuer_der,
             server_name: server_name.to_owned(),
             sig_verifier,
         })
     }
 
-    /// Check whether the leaf certificate's issuer matches the pinned issuer.
-    /// Returns `Err(TlsError::General(..))` with an `ISSUER_CHANGED` message
-    /// when the issuer differs; `Ok(Some(actual_issuer))` when the legacy
-    /// string-pin branch ran (so the caller can reuse the computed string in
-    /// a `PIN_MISMATCH` error message); `Ok(None)` when no issuer pin is
-    /// configured or the DER-preferred branch ran.
-    ///
-    /// Prefers raw DER comparison (tamper-proof). Falls back to string
-    /// comparison for legacy pins created before DER storage was added.
-    fn check_issuer_change(
-        &self,
-        leaf_der: &[u8],
-    ) -> std::result::Result<Option<String>, TlsError> {
-        if let Some(expected_der) = &self.pin_issuer_der {
-            if let Some(actual_der) = extract_issuer_der(leaf_der) {
-                if *expected_der != actual_der {
-                    return Err(TlsError::General(format!(
-                        "ISSUER_CHANGED for {}: issuer DER mismatch \
-                         (expected {} bytes, got {} bytes)",
-                        self.server_name,
-                        expected_der.len(),
-                        actual_der.len()
-                    )));
-                }
-            }
-            return Ok(None);
-        }
-        if let Some(expected_issuer) = &self.pin_issuer {
-            let actual_issuer = extract_issuer_dn(leaf_der);
-            if actual_issuer != *expected_issuer {
+    /// Check whether the leaf certificate's issuer matches the pinned issuer
+    /// via tamper-proof raw DER comparison. Returns `Err(TlsError::General(..))`
+    /// with an `ISSUER_CHANGED` message when the issuer DER differs; `Ok(())`
+    /// when it matches or no issuer DER is pinned.
+    fn check_issuer_change(&self, leaf_der: &[u8]) -> std::result::Result<(), TlsError> {
+        let Some(expected_der) = &self.pin_issuer_der else {
+            return Ok(());
+        };
+        if let Some(actual_der) = extract_issuer_der(leaf_der) {
+            if *expected_der != actual_der {
                 return Err(TlsError::General(format!(
-                    "ISSUER_CHANGED for {}: expected \"{}\", \
-                     got \"{}\"",
-                    self.server_name, expected_issuer, actual_issuer
+                    "ISSUER_CHANGED for {}: issuer DER mismatch \
+                     (expected {} bytes, got {} bytes)",
+                    self.server_name,
+                    expected_der.len(),
+                    actual_der.len()
                 )));
             }
-            return Ok(Some(actual_issuer));
         }
-        Ok(None)
+        Ok(())
     }
 }
 
@@ -136,10 +112,10 @@ impl ServerCertVerifier for PinnedCertVerifier {
             return Ok(ServerCertVerified::assertion());
         }
 
-        let cached_issuer = self.check_issuer_change(end_entity.as_ref())?;
+        self.check_issuer_change(end_entity.as_ref())?;
 
         let actual_fp = compute_fingerprint(end_entity.as_ref());
-        let actual_issuer = cached_issuer.unwrap_or_else(|| extract_issuer_dn(end_entity.as_ref()));
+        let actual_issuer = extract_issuer_dn(end_entity.as_ref());
         Err(TlsError::General(format!(
             "PIN_MISMATCH for {}: expected {}, got {}, issuer {}",
             self.server_name, self.pin_str, actual_fp, actual_issuer
@@ -224,11 +200,10 @@ pub(crate) fn build_ca_cert_config(ca_pem_path: &Path) -> Result<rustls::ClientC
 /// for certificate pinning instead of CA chain validation.
 pub(crate) fn build_pinned_config(
     pin_sha256: &str,
-    pin_issuer: Option<String>,
     pin_issuer_der: Option<&str>,
     server_name: &str,
 ) -> Result<rustls::ClientConfig> {
-    let verifier = PinnedCertVerifier::new(pin_sha256, pin_issuer, pin_issuer_der, server_name)?;
+    let verifier = PinnedCertVerifier::new(pin_sha256, pin_issuer_der, server_name)?;
 
     let config = super::base_tls_builder("protocol versions")?
         .dangerous()

--- a/src/tls/verifier_tests.rs
+++ b/src/tls/verifier_tests.rs
@@ -22,7 +22,7 @@ fn pinned_verifier_advertises_default_signature_schemes() {
     use rustls::client::danger::ServerCertVerifier;
     let der = gen_self_signed_cert();
     let fp = compute_fingerprint(&der);
-    let verifier = PinnedCertVerifier::new(&fp, None, None, "localhost").unwrap();
+    let verifier = PinnedCertVerifier::new(&fp, None, "localhost").unwrap();
     let schemes = verifier.supported_verify_schemes();
     assert!(
         !schemes.is_empty(),
@@ -35,7 +35,7 @@ fn pinned_verifier_accepts_matching_cert() {
     let der = gen_self_signed_cert();
     let fp = compute_fingerprint(&der);
 
-    let verifier = PinnedCertVerifier::new(&fp, None, None, "localhost").unwrap();
+    let verifier = PinnedCertVerifier::new(&fp, None, "localhost").unwrap();
 
     let cert = CertificateDer::from(der);
     let server_name = ServerName::try_from("localhost").unwrap();
@@ -56,7 +56,7 @@ fn pinned_verifier_rejects_mismatched_cert() {
 
     let der2 = gen_self_signed_cert();
 
-    let verifier = PinnedCertVerifier::new(&fp1, None, None, "localhost").unwrap();
+    let verifier = PinnedCertVerifier::new(&fp1, None, "localhost").unwrap();
 
     let cert = CertificateDer::from(der2);
     let server_name = ServerName::try_from("localhost").unwrap();
@@ -86,7 +86,7 @@ fn ca_cert_config_rejects_missing_file() {
 fn build_pinned_config_succeeds() {
     let der = gen_self_signed_cert();
     let fp = compute_fingerprint(&der);
-    let result = build_pinned_config(&fp, None, None, "localhost");
+    let result = build_pinned_config(&fp, None, "localhost");
     assert!(
         result.is_ok(),
         "build_pinned_config should succeed: {result:?}"
@@ -119,8 +119,7 @@ fn pinned_verifier_accepts_matching_pin_regardless_of_issuer() {
     let der = gen_self_signed_cert();
     let fp = compute_fingerprint(&der);
 
-    let verifier =
-        PinnedCertVerifier::new(&fp, Some("CN=SomeOtherCA".to_owned()), None, "localhost").unwrap();
+    let verifier = PinnedCertVerifier::new(&fp, None, "localhost").unwrap();
 
     let cert = CertificateDer::from(der);
     let server_name = ServerName::try_from("localhost").unwrap();
@@ -143,31 +142,6 @@ fn gen_cert_with_cn(cn: &str) -> Vec<u8> {
         .self_signed(&rcgen::KeyPair::generate().unwrap())
         .unwrap();
     cert.der().to_vec()
-}
-
-#[test]
-fn pinned_verifier_detects_issuer_change() {
-    // Pin mismatch + different issuer → ISSUER_CHANGED
-    let der1 = gen_cert_with_cn("OriginalCA");
-    let fp1 = compute_fingerprint(&der1);
-
-    // Pin to cert1 with cert1's issuer
-    let issuer1 = extract_issuer_dn(&der1);
-    let verifier = PinnedCertVerifier::new(&fp1, Some(issuer1), None, "localhost").unwrap();
-
-    // Present a cert with a different CN (different issuer)
-    let der2 = gen_cert_with_cn("EvilCA");
-    let cert2 = CertificateDer::from(der2);
-    let server_name = ServerName::try_from("localhost").unwrap();
-
-    let result = verifier.verify_server_cert(&cert2, &[], &server_name, &[], UnixTime::now());
-
-    assert!(result.is_err(), "issuer change should be rejected");
-    let err_msg = result.unwrap_err().to_string();
-    assert!(
-        err_msg.contains("ISSUER_CHANGED"),
-        "error should contain ISSUER_CHANGED: {err_msg}"
-    );
 }
 
 #[test]
@@ -201,7 +175,7 @@ fn pinned_verifier_detects_issuer_change_via_der() {
     let issuer_der_bytes = extract_issuer_der(&der1).unwrap();
     let issuer_der_b64 = base64::engine::general_purpose::STANDARD.encode(&issuer_der_bytes);
 
-    let verifier = PinnedCertVerifier::new(&fp1, None, Some(&issuer_der_b64), "localhost").unwrap();
+    let verifier = PinnedCertVerifier::new(&fp1, Some(&issuer_der_b64), "localhost").unwrap();
 
     // Present a cert with a different CN (different issuer DER)
     let der2 = gen_cert_with_cn("EvilCA");
@@ -226,7 +200,7 @@ fn pinned_verifier_allows_pin_mismatch_with_same_issuer_der() {
     let issuer_der_bytes = extract_issuer_der(&der1).unwrap();
     let issuer_der_b64 = base64::engine::general_purpose::STANDARD.encode(&issuer_der_bytes);
 
-    let verifier = PinnedCertVerifier::new(&fp1, None, Some(&issuer_der_b64), "localhost").unwrap();
+    let verifier = PinnedCertVerifier::new(&fp1, Some(&issuer_der_b64), "localhost").unwrap();
 
     // Both certs are self-signed with CN=localhost (same issuer)
     let der2 = gen_self_signed_cert();
@@ -248,7 +222,7 @@ fn pinned_verifier_rejects_invalid_base64_issuer_der() {
     // Invalid base64 → config error
     let der = gen_self_signed_cert();
     let fp = compute_fingerprint(&der);
-    let result = PinnedCertVerifier::new(&fp, None, Some("!!!not-valid-base64!!!"), "localhost");
+    let result = PinnedCertVerifier::new(&fp, Some("!!!not-valid-base64!!!"), "localhost");
     assert!(result.is_err(), "invalid base64 should be rejected");
     let err_msg = result.unwrap_err().to_string();
     assert!(


### PR DESCRIPTION
## Summary

`check_issuer_change` kept an issuer-DN **string-comparison fallback** for pins
created before raw-DER issuer storage existed. Per the project's "replace, don't
deprecate" policy (and TD-015, #241), remove it and rely solely on tamper-proof
raw-DER comparison.

## Changes

- `PinnedCertVerifier`: drop the `pin_issuer` field, the `new()` parameter, and
  the string-comparison branch. `check_issuer_change` now returns `Result<(), _>`.
- `TlsConfig`: drop the runtime `pin_issuer` field (it only fed the removed
  branch).
- `build_pinned_config` and call sites updated.
- Delete the now-redundant string-based issuer-change test; the DER-based test
  `pinned_verifier_detects_issuer_change_via_der` covers it.

## What is kept

`ServerConfig.tls_pin_issuer` stays — it is the **human-readable** issuer shown
by `bzr config show` and in TOFU prompts, not a comparison shim.

## Behavior note

The certificate-fingerprint pin remains the security boundary. Pins created
before raw-DER storage existed (`tls_pin_issuer_der` absent) keep full
fingerprint pinning but no longer emit the secondary `ISSUER_CHANGED` signal
(they fall back to `PIN_MISMATCH`) until re-pinned. Documented in CHANGELOG
under Changed.

This PR also adds the previously-missing CHANGELOG entries for the user-visible
fixes in the TD-005/025 (validation) and TD-006 (clone) PRs.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test`: 1254 unit + 22 + 72 integration pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
