### PR TITLE
refactor: centralize query-save filter-flag conflict list (TD-017)

### DIFF
--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -1987,6 +1987,54 @@ fn parse_query_save_search_alone_is_accepted() {
 }
 
 #[test]
+fn parse_query_save_rejects_from_url_with_filter_flag() {
+    let result = Cli::try_parse_from([
+        "bzr",
+        "query",
+        "save",
+        "saved",
+        "--from-url",
+        "https://bz/buglist.cgi?product=Firefox",
+        "--product",
+        "Firefox",
+    ]);
+
+    match result {
+        Ok(_) => panic!("expected ArgumentConflict, got Ok"),
+        Err(err) => assert!(
+            err.kind() == clap::error::ErrorKind::ArgumentConflict,
+            "expected ArgumentConflict, got {:?}",
+            err.kind()
+        ),
+    }
+}
+
+#[test]
+fn parse_query_save_rejects_from_url_with_bzl_parity_filter() {
+    // Exercises the centralized FILTER_FLAG_ARGS conflict list on the
+    // --from-url side via a bzl-parity filter (target_milestone).
+    let result = Cli::try_parse_from([
+        "bzr",
+        "query",
+        "save",
+        "saved",
+        "--from-url",
+        "https://bz/buglist.cgi?product=Firefox",
+        "--target-milestone",
+        "9.0",
+    ]);
+
+    match result {
+        Ok(_) => panic!("expected ArgumentConflict, got Ok"),
+        Err(err) => assert!(
+            err.kind() == clap::error::ErrorKind::ArgumentConflict,
+            "expected ArgumentConflict, got {:?}",
+            err.kind()
+        ),
+    }
+}
+
+#[test]
 fn parse_bug_update_see_also_add_repeated_flag() {
     let cli = Cli::try_parse_from([
         "bzr",

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -1,5 +1,27 @@
 use clap::Subcommand;
 
+/// Argument IDs of the structured filter flags on `query save`. Centralized so
+/// the mutual-exclusivity lists on `--from-url` / `--search` stay in sync when a
+/// filter flag is added or renamed (rather than hand-maintaining two literal
+/// lists). Keep in lockstep with the `Vec<String>` filter fields on `Save`.
+const FILTER_FLAG_ARGS: [&str; 15] = [
+    "product",
+    "component",
+    "status",
+    "assignee",
+    "creator",
+    "priority",
+    "severity",
+    "whiteboard",
+    "target_milestone",
+    "version",
+    "op_sys",
+    "platform",
+    "resolution",
+    "qa_contact",
+    "url",
+];
+
 #[derive(Subcommand)]
 #[expect(
     clippy::doc_markdown,
@@ -51,7 +73,7 @@ pub enum QueryAction {
         /// where possible; unrecognized parameters are stored
         /// verbatim and passed through at run time. Mutually
         /// exclusive with `--search` and every filter flag.
-        #[arg(long, conflicts_with_all = ["search", "product", "component", "status", "assignee", "creator", "priority", "severity", "whiteboard", "target_milestone", "version", "op_sys", "platform", "resolution", "qa_contact", "url"])]
+        #[arg(long, conflicts_with = "search", conflicts_with_all = FILTER_FLAG_ARGS)]
         from_url: Option<String>,
         /// Free-text search query (creates a `search`-kind saved query).
         ///
@@ -59,7 +81,7 @@ pub enum QueryAction {
         /// filter flags. Stores the query as a free-text search;
         /// `bzr query run <name>` then issues the same search
         /// against the configured server.
-        #[arg(long, conflicts_with_all = ["product", "component", "status", "assignee", "creator", "priority", "severity", "whiteboard", "target_milestone", "version", "op_sys", "platform", "resolution", "qa_contact", "url"])]
+        #[arg(long, conflicts_with_all = FILTER_FLAG_ARGS)]
         search: Option<String>,
         /// Filter by product (repeatable for OR; prefix with ! to exclude)
         #[arg(long)]


### PR DESCRIPTION
## Summary

`QueryAction::Save` hardcoded the structured filter-flag names **twice** — a
16-item `conflicts_with_all` on `--from-url` and a 15-item one on `--search` —
which had to be hand-synced whenever a filter flag was added or renamed (the
drift risk in TD-017, #243).

## Change

Hoist the 15 filter-flag arg IDs into a single `FILTER_FLAG_ARGS` const and
reference it from both arms; `--from-url` adds `conflicts_with = "search"` to
reconstruct its original 16-item set. clap evaluates conflicts at compile time,
so a truly runtime-introspected list isn't possible — centralizing to one const
is the accepted "centralize via derive helpers" remedy from the audit.

Adds regression tests for `--from-url` conflicting with a core filter
(`--product`) and a bzl-parity filter (`--target-milestone`), complementing the
existing `--search` conflict tests.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --lib parse_query_save`: 8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
