### PR TITLE
fix: harden config file permissions on unset-keyring save (TD-023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Security
 
+- `bzr config unset-keyring`: the config file is now rewritten through the same
+  `0o600` (file) / `0o700` (directory) hardening as every other save. Previously
+  this path wrote the file directly, so a config recreated by `unset-keyring`
+  (e.g. after the file had been deleted) could be left world-readable.
 - `bzr attachment download`: the server-supplied attachment file name is now
   reduced to its final path component before being used as a write
   destination, so a malicious `file_name` such as `../../etc/foo` or an

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -290,10 +290,10 @@ fn unset_keyring(name: &str, format: OutputFormat, w: &mut Writers<'_>) -> Resul
     // Idempotent: missing entry is not an error.
     crate::credentials::keyring::delete(&service_name, &account_name)?;
 
-    // Saving would fail validation (the server has no credential source
-    // now). Write TOML directly.
+    // Saving normally would fail validation (the server has no credential
+    // source now), but the on-disk hardening (0o600/0o700) must still apply.
+    config.save_without_validation()?;
     let path = Config::path()?;
-    save_config_without_validation(&config, &path)?;
 
     let human = format!(
         "Removed keychain entry for server '{name}' (service={service_name}, \
@@ -399,28 +399,6 @@ fn migrate_to_keyring(
         format,
         w.out,
     );
-    Ok(())
-}
-
-/// Save a config to disk without running the credential-source validator.
-///
-/// Used by `unset-keyring`, which intentionally leaves the server without
-/// a credential source so the user can re-credential it afterward with
-/// `set-server` or `set-keyring`.
-fn save_config_without_validation(config: &Config, path: &std::path::Path) -> Result<()> {
-    use std::fs;
-    use std::io::Write as IoWrite;
-
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let content = toml::to_string_pretty(config)?;
-    let mut file = fs::OpenOptions::new()
-        .create(true)
-        .truncate(true)
-        .write(true)
-        .open(path)?;
-    file.write_all(content.as_bytes())?;
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -253,6 +253,22 @@ impl Config {
 
     pub fn save(&self) -> Result<()> {
         self.validate()?;
+        self.write_to_disk()
+    }
+
+    /// Persist the config **without** running the credential-source validator.
+    ///
+    /// Used by `unset-keyring`, which intentionally leaves a server without a
+    /// credential source (the user re-credentials it afterward). Applies the
+    /// same `0o600`/`0o700` hardening as [`Self::save`] so a recreated config
+    /// file is never world-readable.
+    pub fn save_without_validation(&self) -> Result<()> {
+        self.write_to_disk()
+    }
+
+    /// Serialize and write the config to its on-disk path, hardening the
+    /// directory (`0o700`) and file (`0o600`) on first creation.
+    fn write_to_disk(&self) -> Result<()> {
         let path = Self::path()?;
         if let Some(parent) = path.parent() {
             let parent_exists = parent.exists();

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -679,3 +679,44 @@ fn config_save_hardens_permissions_for_new_paths() {
     assert_eq!(dir_mode, 0o700);
     assert_eq!(file_mode, 0o600);
 }
+
+#[cfg(unix)]
+#[test]
+fn save_without_validation_hardens_recreated_file() {
+    let _lock = crate::ENV_LOCK.blocking_lock();
+    let tmp = tempfile::tempdir().unwrap();
+    // SAFETY: Tests are serialized via ENV_LOCK; no other threads read this var concurrently.
+    unsafe { env::set_var("XDG_CONFIG_HOME", tmp.path()) };
+
+    // A server left without any credential source (the unset-keyring state):
+    // Config::save() would reject this, so unset-keyring uses
+    // save_without_validation — which must still harden the file.
+    let mut servers = HashMap::new();
+    let mut srv = make_server_config("https://bugzilla.example.com");
+    srv.api_key = None;
+    servers.insert("myserver".to_string(), srv);
+    let config = Config {
+        default_server: Some("myserver".to_string()),
+        servers,
+        templates: HashMap::new(),
+        queries: HashMap::new(),
+    };
+
+    assert!(
+        config.save().is_err(),
+        "credential-less config must fail validation"
+    );
+
+    let config_path = tmp.path().join("bzr").join("config.toml");
+    // Force the recreation scenario: ensure no pre-hardened file exists.
+    let _ = fs::remove_file(&config_path);
+
+    config.save_without_validation().unwrap();
+
+    let file_mode = fs::metadata(&config_path).unwrap().permissions().mode();
+    assert_eq!(
+        file_mode & 0o077,
+        0,
+        "recreated config must not be group/other accessible: {file_mode:o}"
+    );
+}


### PR DESCRIPTION
## Summary

`bzr config unset-keyring` wrote the config through a local
`save_config_without_validation` helper that opened the file with **default**
permissions, skipping the `0o600`/`0o700` hardening `Config::save` applies. A
config recreated by `unset-keyring` (e.g. after the file had been deleted)
could be left world-readable (TD-023, #249).

## Change

- Add `Config::save_without_validation`, which shares `save`'s hardened
  `write_to_disk` path and only skips the credential-source validator (the
  server is intentionally left credential-less by `unset-keyring`).
- `save()` is refactored to `validate()? + write_to_disk()`; both save paths now
  go through the single hardened writer.
- Delete the unhardened local helper; `unset-keyring` calls
  `config.save_without_validation()`.
- Add a Unix-only test asserting a recreated config has `mode & 0o077 == 0`
  (and that the credential-less config fails normal `save()` validation).

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test`: 1256 unit (+1) + 22 + 72 integration pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
