### PR TITLE
refactor: share fields/exclude-fields via flattened FieldArgs (TD-008)

### DIFF
--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -1,4 +1,21 @@
-use clap::Subcommand;
+use clap::{Args, Subcommand};
+
+/// Shared `--fields` / `--exclude-fields` selection, flattened into the bug
+/// query subcommands (`list`, `view`, `search`, `my`) so the pair is defined
+/// once instead of repeated per variant.
+#[derive(Args, Debug, Clone)]
+pub struct FieldArgs {
+    /// Fields to request from the server (comma-separated). In table output,
+    /// selects which columns (or detail rows) to show, in order; under --json,
+    /// the object contains only the selected fields (id only if requested).
+    #[arg(long)]
+    pub fields: Option<String>,
+    /// Fields to drop from the server request (comma-separated). In table
+    /// output, removes those columns/rows; under --json, the object omits the
+    /// dropped fields (including id, if excluded).
+    #[arg(long)]
+    pub exclude_fields: Option<String>,
+}
 
 #[derive(Subcommand)]
 #[expect(
@@ -90,16 +107,8 @@ pub enum BugAction {
         /// Max number of results
         #[arg(long, default_value = "50")]
         limit: u32,
-        /// Fields to request from the server (comma-separated). Table:
-        /// selects which columns to show (in order). --json: the JSON object
-        /// contains only the selected fields (id is included only if requested).
-        #[arg(long)]
-        fields: Option<String>,
-        /// Fields to drop from the server request (comma-separated). Table:
-        /// removes those columns. --json: the JSON object omits the dropped
-        /// fields (including id, if excluded).
-        #[arg(long)]
-        exclude_fields: Option<String>,
+        #[command(flatten)]
+        field_args: FieldArgs,
         /// Filter to bugs created at or after this date.
         ///
         /// Accepts `YYYY-MM-DD` (interpreted as 00:00:00 UTC),
@@ -198,16 +207,8 @@ pub enum BugAction {
         /// security) — those always bail.
         #[arg(long)]
         permissive: bool,
-        /// Fields to request from the server (comma-separated). Table:
-        /// selects which detail rows to show. --json: the JSON object contains
-        /// only the selected fields (id is included only if requested).
-        #[arg(long)]
-        fields: Option<String>,
-        /// Fields to drop from the server request (comma-separated). Table:
-        /// removes those detail rows. --json: the JSON object omits the
-        /// dropped fields (including id, if excluded).
-        #[arg(long)]
-        exclude_fields: Option<String>,
+        #[command(flatten)]
+        field_args: FieldArgs,
     },
     /// Search bugs using Bugzilla quicksearch or by parsing a Bugzilla URL.
     ///
@@ -275,16 +276,8 @@ pub enum BugAction {
         /// Max number of results (default: 50)
         #[arg(long)]
         limit: Option<u32>,
-        /// Fields to request from the server (comma-separated). Table:
-        /// selects which columns to show (in order). --json: the JSON object
-        /// contains only the selected fields (id is included only if requested).
-        #[arg(long)]
-        fields: Option<String>,
-        /// Fields to drop from the server request (comma-separated). Table:
-        /// removes those columns. --json: the JSON object omits the dropped
-        /// fields (including id, if excluded).
-        #[arg(long)]
-        exclude_fields: Option<String>,
+        #[command(flatten)]
+        field_args: FieldArgs,
     },
     /// Show the change history for a single bug.
     ///
@@ -473,16 +466,8 @@ pub enum BugAction {
         /// the limit applies to the single active category.
         #[arg(long, default_value = "50")]
         limit: u32,
-        /// Fields to request from the server (comma-separated). Table:
-        /// selects which columns to show (in order). --json: the JSON object
-        /// contains only the selected fields (id is included only if requested).
-        #[arg(long)]
-        fields: Option<String>,
-        /// Fields to drop from the server request (comma-separated). Table:
-        /// removes those columns. --json: the JSON object omits the dropped
-        /// fields (including id, if excluded).
-        #[arg(long)]
-        exclude_fields: Option<String>,
+        #[command(flatten)]
+        field_args: FieldArgs,
     },
     /// Clone an existing bug, optionally overriding fields.
     ///

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,7 +14,7 @@ mod user;
 mod whoami;
 
 pub use attachment::AttachmentAction;
-pub use bug::BugAction;
+pub use bug::{BugAction, FieldArgs};
 pub use classification::ClassificationAction;
 pub use comment::CommentAction;
 pub use component::ComponentAction;

--- a/src/commands/bug/list.rs
+++ b/src/commands/bug/list.rs
@@ -1,4 +1,4 @@
-use crate::cli::BugAction;
+use crate::cli::{BugAction, FieldArgs};
 use crate::client::BugzillaClient;
 use crate::error::Result;
 use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
@@ -24,8 +24,10 @@ pub(super) async fn handle(
         alias,
         summary,
         limit,
-        fields,
-        exclude_fields,
+        field_args: FieldArgs {
+            fields,
+            exclude_fields,
+        },
         created_since,
         changed_since,
         whiteboard,

--- a/src/commands/bug/list_tests.rs
+++ b/src/commands/bug/list_tests.rs
@@ -20,8 +20,10 @@ fn empty_list_action() -> BugAction {
         alias: None,
         summary: None,
         limit: 50,
-        fields: None,
-        exclude_fields: None,
+        field_args: crate::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
         created_since: None,
         changed_since: None,
         whiteboard: vec![],
@@ -123,8 +125,10 @@ async fn bug_list_passes_every_field_through_to_search_params() {
         alias: Some("my-alias".into()),
         summary: Some("kernel panic".into()),
         limit: 5,
-        fields: Some("id,summary".into()),
-        exclude_fields: Some("comments".into()),
+        field_args: crate::cli::FieldArgs {
+            fields: Some("id,summary".into()),
+            exclude_fields: Some("comments".into()),
+        },
         created_since: Some("2026-04-01".into()),
         changed_since: Some("2026-04-15T00:00:00Z".into()),
         whiteboard: vec!["needs-review".into()],
@@ -185,8 +189,10 @@ async fn bug_list_summary_only_sends_substring_filter() {
         alias: None,
         summary: Some("WARNING CPU default_machine_kexec".into()),
         limit: 50,
-        fields: None,
-        exclude_fields: None,
+        field_args: crate::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
         created_since: None,
         changed_since: None,
         whiteboard: vec![],
@@ -374,10 +380,10 @@ async fn bug_list_table_all_unknown_fields_exits_7_before_network() {
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     let mut action = empty_list_action();
-    let BugAction::List { fields, .. } = &mut action else {
+    let BugAction::List { field_args, .. } = &mut action else {
         unreachable!()
     };
-    *fields = Some("cf_custom".into());
+    field_args.fields = Some("cf_custom".into());
 
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -411,10 +417,10 @@ async fn bug_list_json_fields_trims_output() {
         .await;
 
     let mut action = empty_list_action();
-    let BugAction::List { fields, .. } = &mut action else {
+    let BugAction::List { field_args, .. } = &mut action else {
         unreachable!()
     };
-    *fields = Some("summary".into());
+    field_args.fields = Some("summary".into());
 
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result =
@@ -468,10 +474,10 @@ async fn bug_list_json_all_unknown_fields_exits_7() {
     let (_lock, mock, _tmp) = setup_test_env().await;
 
     let mut action = empty_list_action();
-    let BugAction::List { fields, .. } = &mut action else {
+    let BugAction::List { field_args, .. } = &mut action else {
         unreachable!()
     };
-    *fields = Some("cf_custom".into());
+    field_args.fields = Some("cf_custom".into());
 
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result =

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -20,32 +20,17 @@ mod view;
 /// The `--fields` / `--exclude-fields` column spec for the four field-bearing
 /// bug actions, or `None` for actions that take no field selection.
 fn bug_column_spec(action: &BugAction) -> Option<ColumnSpec<'_>> {
-    match action {
-        BugAction::List {
-            fields,
-            exclude_fields,
-            ..
-        }
-        | BugAction::My {
-            fields,
-            exclude_fields,
-            ..
-        }
-        | BugAction::Search {
-            fields,
-            exclude_fields,
-            ..
-        }
-        | BugAction::View {
-            fields,
-            exclude_fields,
-            ..
-        } => Some(ColumnSpec::new(
-            fields.as_deref(),
-            exclude_fields.as_deref(),
-        )),
-        _ => None,
-    }
+    let (BugAction::List { field_args, .. }
+    | BugAction::My { field_args, .. }
+    | BugAction::Search { field_args, .. }
+    | BugAction::View { field_args, .. }) = action
+    else {
+        return None;
+    };
+    Some(ColumnSpec::new(
+        field_args.fields.as_deref(),
+        field_args.exclude_fields.as_deref(),
+    ))
 }
 
 /// Dispatch bug actions to their respective handlers.

--- a/src/commands/bug/my.rs
+++ b/src/commands/bug/my.rs
@@ -1,4 +1,4 @@
-use crate::cli::BugAction;
+use crate::cli::{BugAction, FieldArgs};
 use crate::client::BugzillaClient;
 use crate::error::Result;
 use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
@@ -17,8 +17,10 @@ pub(super) async fn handle(
         all,
         status,
         limit,
-        fields,
-        exclude_fields,
+        field_args: FieldArgs {
+            fields,
+            exclude_fields,
+        },
     } = action
     else {
         unreachable!()

--- a/src/commands/bug/my_tests.rs
+++ b/src/commands/bug/my_tests.rs
@@ -47,8 +47,10 @@ async fn bug_my_returns_assigned_by_default() {
         all: false,
         status: vec![],
         limit: 50,
-        fields: None,
-        exclude_fields: None,
+        field_args: crate::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
     };
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result =
@@ -86,8 +88,10 @@ async fn bug_my_passes_status_limit_and_field_filters() {
         all: false,
         status: vec!["NEW".into()],
         limit: 7,
-        fields: Some("id,summary".into()),
-        exclude_fields: Some("comments".into()),
+        field_args: crate::cli::FieldArgs {
+            fields: Some("id,summary".into()),
+            exclude_fields: Some("comments".into()),
+        },
     };
     let mut __io2 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -123,8 +127,10 @@ async fn bug_my_created_only_runs_creator_search_not_assigned() {
         all: false,
         status: vec![],
         limit: 50,
-        fields: None,
-        exclude_fields: None,
+        field_args: crate::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
     };
     let mut __io3 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -159,8 +165,10 @@ async fn bug_my_cc_only_runs_cc_search_not_assigned_or_creator() {
         all: false,
         status: vec![],
         limit: 50,
-        fields: None,
-        exclude_fields: None,
+        field_args: crate::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
     };
     let mut __io4 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -202,8 +210,10 @@ async fn bug_my_all_deduplicates() {
         all: true,
         status: vec![],
         limit: 50,
-        fields: None,
-        exclude_fields: None,
+        field_args: crate::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
     };
     let mut __io5 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(

--- a/src/commands/bug/search.rs
+++ b/src/commands/bug/search.rs
@@ -1,4 +1,4 @@
-use crate::cli::BugAction;
+use crate::cli::{BugAction, FieldArgs};
 use crate::error::Result;
 use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
 use crate::output::resources::query::write_query_saved;
@@ -70,8 +70,10 @@ pub(super) async fn handle(
         from_url,
         save_as,
         limit,
-        fields,
-        exclude_fields,
+        field_args: FieldArgs {
+            fields,
+            exclude_fields,
+        },
     } = action
     else {
         unreachable!()

--- a/src/commands/bug/search_tests.rs
+++ b/src/commands/bug/search_tests.rs
@@ -13,8 +13,10 @@ fn from_url_action(url: String, save_as: Option<String>) -> BugAction {
         from_url: Some(url),
         save_as,
         limit: None,
-        fields: None,
-        exclude_fields: None,
+        field_args: crate::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
     }
 }
 
@@ -109,8 +111,10 @@ async fn handle_search_quicksearch_passes_limit_and_field_filters() {
         from_url: None,
         save_as: None,
         limit: Some(5),
-        fields: Some("id,summary".into()),
-        exclude_fields: Some("comments".into()),
+        field_args: crate::cli::FieldArgs {
+            fields: Some("id,summary".into()),
+            exclude_fields: Some("comments".into()),
+        },
     };
     let mut __io3 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(

--- a/src/commands/bug/view.rs
+++ b/src/commands/bug/view.rs
@@ -1,4 +1,4 @@
-use crate::cli::BugAction;
+use crate::cli::{BugAction, FieldArgs};
 use crate::client::BugzillaClient;
 use crate::error::{BzrError, Result};
 use crate::output::resources::bug::{
@@ -60,8 +60,10 @@ pub(super) async fn handle(
     let BugAction::View {
         ids,
         permissive,
-        fields,
-        exclude_fields,
+        field_args: FieldArgs {
+            fields,
+            exclude_fields,
+        },
     } = action
     else {
         unreachable!()

--- a/src/commands/bug/view_tests.rs
+++ b/src/commands/bug/view_tests.rs
@@ -11,8 +11,10 @@ fn make_view_action(ids: &[&str], permissive: bool) -> BugAction {
     BugAction::View {
         ids: ids.iter().map(|s| (*s).to_string()).collect(),
         permissive,
-        fields: None,
-        exclude_fields: None,
+        field_args: crate::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -30,8 +30,10 @@ fn empty_list_action() -> bzr::cli::BugAction {
         alias: None,
         summary: None,
         limit: 50,
-        fields: None,
-        exclude_fields: None,
+        field_args: bzr::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
         created_since: None,
         changed_since: None,
         whiteboard: vec![],
@@ -143,8 +145,10 @@ async fn bug_view_integration() {
     let action = bzr::cli::BugAction::View {
         ids: vec!["42".to_string()],
         permissive: false,
-        fields: None,
-        exclude_fields: None,
+        field_args: bzr::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
     };
     let mut __io3 = bzr::test_helpers::CapturedIo::new();
     let result = bzr::commands::bug::execute(
@@ -181,8 +185,10 @@ async fn bug_search_integration() {
         from_url: None,
         save_as: None,
         limit: None,
-        fields: None,
-        exclude_fields: None,
+        field_args: bzr::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
     };
     let mut __io4 = bzr::test_helpers::CapturedIo::new();
     let result = bzr::commands::bug::execute(
@@ -713,8 +719,10 @@ async fn api_error_propagates() {
     let action = bzr::cli::BugAction::View {
         ids: vec!["99999".to_string()],
         permissive: false,
-        fields: None,
-        exclude_fields: None,
+        field_args: bzr::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
     };
     let result = bzr::commands::bug::execute(
         &action,


### PR DESCRIPTION
## Summary

`BugAction::List`, `View`, `Search`, and `My` each redefined an identical
`--fields` / `--exclude-fields` pair with near-identical doc comments. Extract a
single `FieldArgs` struct and `#[command(flatten)]` it into all four variants,
so the pair (and its help text) is defined once (TD-008, #234).

## Behavior

The CLI surface is **unchanged** — clap flattens the args back into each
subcommand, so `--fields` / `--exclude-fields` still parse identically and keep
their position in `--help`. Handlers destructure
`field_args: FieldArgs { fields, exclude_fields }`, leaving their bodies
untouched. View's slightly different "detail rows" wording is unified into help
text covering both column and detail-row output.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test`: 1258 unit + 22 + 72 integration pass
- `cargo run -p xtask -- man` produces no manpage diff (per-arg help isn't
  rendered into the pages; flag order preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
