### PR TITLE
fix: surface body-read errors in check_response_status (TD-019)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- HTTP error responses whose body cannot be read no longer report an empty
+  body: the read failure is surfaced in the error message while the HTTP status
+  is still reported, instead of being silently swallowed.
 - `bzr bug update --deadline`: the deadline is now validated client-side and a
   malformed value fails fast with exit 7, instead of being forwarded to the
   server. Valid `YYYY-MM-DD` deadlines are unchanged.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -523,10 +523,19 @@ impl BugzillaClient {
     ) -> Result<reqwest::Response> {
         if response.status().is_client_error() || response.status().is_server_error() {
             let status = response.status();
-            let body = response.text().await.unwrap_or_else(|e| {
-                tracing::warn!("failed to read error response body: {e}");
-                String::new()
-            });
+            let body = match response.text().await {
+                Ok(body) => body,
+                // The body is unreadable, but the HTTP status is still
+                // meaningful. Surface the read failure as the body text so the
+                // error is reported with a real diagnostic rather than being
+                // silently swallowed into an empty string.
+                Err(e) => {
+                    return Err(BzrError::HttpStatus {
+                        status: status.as_u16(),
+                        body: format!("<failed to read response body: {e}>"),
+                    });
+                }
+            };
             tracing::debug!(
                 %status,
                 body = &body[..body.len().min(512)],


### PR DESCRIPTION
## Summary

`check_response_status` read the error-response body with
`unwrap_or_else(|e| { warn!(..); String::new() })`, swallowing any body-read
failure into an empty string and reporting a generic empty-body `HttpStatus`
error that hid the actual cause (TD-019, #245).

## Change

Match on the read result: on failure, return an `HttpStatus` error that
preserves the HTTP status code and embeds the read-failure diagnostic as the
body, rather than discarding it. Successful reads are unchanged.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test`: 1258 unit + 22 + 72 integration pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
