### PR TITLE
release: prep v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.4.2] - 2026-05-29
 
 ### Changed
 
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Auth detection against a server with an untrusted or expired TLS certificate
+  now reports the actionable TLS hint instead of an opaque "network error". The
+  `valid_login` probe previously logged send failures generically and skipped
+  the certificate detection that the `whoami` probe performs; both probes now
+  share the same network-error handling.
 - HTTP error responses whose body cannot be read no longer report an empty
   body: the read failure is surfaced in the error message while the HTTP status
   is still reported, instead of being silently swallowed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzr"
-version = "0.4.2-dev"
+version = "0.4.2"
 dependencies = [
  "apple-native-keyring-store",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 
 [package]
 name = "bzr"
-version = "0.4.2-dev"
+version = "0.4.2"
 edition = "2021"
 description = "A CLI for Bugzilla, inspired by gh"
 license = "MIT"


### PR DESCRIPTION
Release prep for v0.4.2.

## Changes

- Bump `version` in `Cargo.toml` from `0.4.2-dev` to `0.4.2`; refresh `Cargo.lock`.
- Date the changelog section: `## [Unreleased]` → `## [0.4.2] - 2026-05-29`.
- Add a missing `Fixed` entry for the auth-detection TLS fix (PR #259, closes #228): the `valid_login` probe now reports the actionable TLS hint instead of an opaque "network error", matching the `whoami` probe.

## Release contents (v0.4.2)

Changed:
- TLS issuer pinning: removed the legacy issuer-DN string-comparison fallback; `ISSUER_CHANGED` detection now relies solely on raw-DER comparison.

Security:
- `bzr config unset-keyring` rewrites the config through the same `0o600`/`0o700` hardening as other saves.
- `bzr attachment download` reduces the server-supplied file name to its final path component, preventing path traversal.

Fixed:
- Auth detection TLS hint (above).
- HTTP error responses with an unreadable body surface the read failure instead of an empty body.
- `bzr bug update --deadline` client-side validation.
- `bzr bug search --from-url` rejects invalid `limit=`.
- `bzr bug clone` reports the new bug ID if the follow-up comment fails.
- `bzr query save` rejects `--search` combined with structured filter flags.
- `bzr bug update` / `bzr attachment update` surface HTTP-200 error envelopes.
- `bzr bug update` with no change flags fails fast.
- XML-RPC self-closing tags parse correctly.
- `bzr config show` counts characters not bytes when masking/truncating.

## Local verification

- `cargo fmt` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test` — 1258 + 22 + 72 passed, 0 failed
- `cargo build --release`; `bzr --version` → `bzr 0.4.2`
- `cargo publish --dry-run` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)