### PR TITLE
security(tls): red-team Surface 1 — confine API key across redirects + invariant guards

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -24,6 +24,7 @@ jobs:
           - fuzz_xmlrpc_parse
           - fuzz_url_parser
           - fuzz_flag_parser
+          - fuzz_tls_der
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+
+- API client redirects are now confined to the configured host. The client
+  attaches the API key as the custom header `X-BUGZILLA-API-KEY`, which reqwest
+  does not strip on a cross-host redirect (it only strips its own known-sensitive
+  headers). A malicious or compromised server could therefore return a redirect
+  to an attacker-controlled host and receive the forwarded API key. The client
+  now refuses to follow any cross-host redirect; same-host redirects are still
+  followed. The query-parameter auth variant was already unaffected.
+
 ## [0.4.2] - 2026-05-29
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +253,7 @@ dependencies = [
  "keyring-core",
  "mutants",
  "percent-encoding",
+ "proptest",
  "quick-xml",
  "rcgen",
  "reqwest",
@@ -1364,6 +1380,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec 0.8.0",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,6 +1510,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1684,6 +1734,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2223,6 +2285,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,6 +2343,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"
@@ -2648,7 +2725,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.9.1",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ dbus-secret-service-keyring-store = { version = "1", features = ["crypto-rust"],
 windows-native-keyring-store = { version = "1", optional = true }
 
 [dev-dependencies]
+proptest = "1"
 rcgen = "0.14"
 tempfile = "3"
 wiremock = ">=0.6, <0.6.5"

--- a/docs/superpowers/specs/2026-06-04-red-team-tls-auth-design.md
+++ b/docs/superpowers/specs/2026-06-04-red-team-tls-auth-design.md
@@ -1,0 +1,105 @@
+# Red-Team Engagement — Surface 1: TLS / Auth
+
+**Date:** 2026-06-04
+**Branch:** `security/red-team-tls-auth`
+**Status:** approved design
+
+## Goal
+
+Act as an adversary against the TLS and authentication surface of `bzr`.
+Enumerate the invariants the trust model relies on, write property-based and
+adversarial tests that try to break each one, fix every reproduced break via
+TDD (failing-then-passing test), and ship one labeled remediation PR per fixed
+defect with the threat model documented.
+
+This is the first of three surfaces. Concurrency and supply-chain follow as
+separate engagements after a checkpoint.
+
+## Threat model
+
+- **Adversary:** an active network MITM, or a malicious/compromised Bugzilla
+  server, that controls (a) the TLS certificate chain presented to `bzr` and
+  (b) the HTTP / XML-RPC response bodies.
+- **Trust boundary:** every byte from the presented certificate and the
+  response body inward is untrusted. The on-disk TOFU pin store and the config
+  file are the trusted state the adversary wants to corrupt, bypass, or
+  misrepresent to the user.
+- **Assets under attack:**
+  1. The pin / issuer trust decision (accept vs reject a certificate).
+  2. The fidelity of the fingerprint / issuer text shown in the
+     trust-on-first-use "certificate changed — re-trust?" prompt, which drives
+     a human security decision.
+  3. Stored credentials (API key) and the confinement of which host they are
+     transmitted to.
+  4. Process liveness — no panic or unbounded work when parsing crafted
+     certificate bytes.
+
+## Invariant catalog
+
+The tests assert these. Each is written failing-first.
+
+- **INV-1 — pin integrity.** A leaf certificate whose SHA-256 differs from the
+  pinned value is *always* rejected by `PinnedCertVerifier::verify_server_cert`,
+  for any certificate bytes. No crafted issuer, DN, or DER length encoding
+  causes an `Ok(ServerCertVerified)` return.
+- **INV-2 — prompt fidelity.** The `expected` / `got` / `issuer` values surfaced
+  by `tls::pin_failure::classify` round-trip faithfully from what the verifier
+  observed. An attacker-controlled issuer DN cannot alter the displayed expected
+  pin, swap the displayed fingerprints, or mask that a mismatch occurred.
+  *(Primary suspected defect: the verifier formats these fields into a single
+  error string using `, got ` / `, issuer ` delimiters, and `pin_failure.rs`
+  recovers them by naive substring search. The issuer DN is attacker-controlled
+  via `extract_issuer_dn`, so it can contain those delimiters.)*
+- **INV-3 — parser totality.** `extract_issuer_der`, `extract_issuer_dn`, and
+  the DER walkers (`parse_der_sequence`, `skip_der_element`, `parse_der_length`,
+  `extract_rdns`, `parse_attribute_type_and_value`) never panic and always
+  terminate on arbitrary byte input.
+- **INV-4 — issuer-change soundness.** When an issuer DER is pinned, a differing
+  issuer is never silently accepted. A parser failure on the leaf degrades to
+  *reject* (never *accept*).
+- **INV-5 — auth confinement.** Credentials / auth headers are attached only to
+  the configured host. The cert-detection probe path sends no auth header and
+  does not follow redirects. (Largely already coded; tests assert it stays
+  true and that the real client's redirect-following cannot leak the API key
+  off-host.)
+
+## Method
+
+- **Property tests** (`proptest`) for INV-1, INV-3, INV-4 — generate arbitrary
+  and structured DER and assert totality plus reject-bias.
+- **Adversarial unit tests** for INV-2 and INV-5 — hand-craft a certificate /
+  issuer DN containing the classifier's own delimiters and assert the prompt
+  cannot be spoofed; assert auth headers stay host-confined.
+- **Fuzz target** for INV-3 added under the existing `fuzz.yml` harness.
+- Every test is written failing-first against current code. A test that
+  reproduces a real break drives a TDD fix (red → green); the fix diff carries
+  that test.
+
+## Orchestration
+
+A multi-agent workflow (user opted in). A `pipeline` per invariant:
+
+1. **Finder** agent — writes the adversarial / property test, runs it against
+   current code, reports whether it reproduced a break. Runs in a git worktree
+   so parallel test-writing does not collide.
+2. **Adversarial verifier** agent — independently confirms each reported break
+   is a real defect and not a test artifact, defaulting to skeptical.
+3. **Synthesis** — the main session collects confirmed breaks.
+
+Confirmed breaks are fixed via TDD locally, one labeled PR per fixed defect.
+
+## Delivery
+
+- New tests land as permanent regression guards even where the invariant holds.
+- One branch + PR per *fixed* defect, labeled `security` and `red-team`, with
+  the threat model in the body. Each PR is confirmed with the user before push.
+- A checkpoint with the user before moving on to the concurrency surface.
+
+## Out of scope (this engagement)
+
+- Concurrency surface (OnceLock cert capture, keyring init races, parallel
+  fetches) — separate engagement.
+- Supply-chain surface (`deny.toml`, lockfile, CI provenance, XML-RPC parsing
+  as malicious input) — separate engagement.
+- Cryptographic review of rustls / ring themselves — out of scope; we trust the
+  vetted crypto primitives and attack only `bzr`'s use of them.

--- a/docs/superpowers/specs/2026-06-04-red-team-tls-auth-design.md
+++ b/docs/superpowers/specs/2026-06-04-red-team-tls-auth-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-04
 **Branch:** `security/red-team-tls-auth`
-**Status:** approved design
+**Status:** approved design (revised after hostile `/challenge` review — see Method)
 
 ## Goal
 
@@ -25,68 +25,133 @@ separate engagements after a checkpoint.
   file are the trusted state the adversary wants to corrupt, bypass, or
   misrepresent to the user.
 - **Assets under attack:**
-  1. The pin / issuer trust decision (accept vs reject a certificate).
-  2. The fidelity of the fingerprint / issuer text shown in the
-     trust-on-first-use "certificate changed — re-trust?" prompt, which drives
-     a human security decision.
+  1. The pin / issuer trust decision (accept vs reject a certificate), including
+     the confinement of the accept-any first-contact path so it never validates
+     real API traffic.
+  2. The integrity of the **persisted pin**: the fingerprint/issuer that
+     `pin_failure::classify` recovers from a `PIN_MISMATCH`/`ISSUER_CHANGED`
+     error is written to the config and becomes the verifier for the *next*
+     connection (`src/commands/shared.rs:185-220`). The asset is that persisted
+     value, not merely the text shown in the prompt — corrupting it would pin a
+     wrong certificate going forward.
   3. Stored credentials (API key) and the confinement of which host they are
-     transmitted to.
+     transmitted to — including across HTTP redirects followed by the real API
+     client.
   4. Process liveness — no panic or unbounded work when parsing crafted
      certificate bytes.
 
 ## Invariant catalog
 
-The tests assert these. Each is written failing-first.
+The tests assert these. Each is written failing-first. Priority reflects the
+hostile `/challenge` review and the empirical pre-checks recorded in Method:
+the *real* sinks (INV-5, INV-2) lead; the defensively-coded paths (INV-0, INV-1,
+INV-3, INV-4) land as regression/fuzz guards.
 
-- **INV-1 — pin integrity.** A leaf certificate whose SHA-256 differs from the
-  pinned value is *always* rejected by `PinnedCertVerifier::verify_server_cert`,
-  for any certificate bytes. No crafted issuer, DN, or DER length encoding
-  causes an `Ok(ServerCertVerified)` return.
-- **INV-2 — prompt fidelity.** The `expected` / `got` / `issuer` values surfaced
-  by `tls::pin_failure::classify` round-trip faithfully from what the verifier
-  observed. An attacker-controlled issuer DN cannot alter the displayed expected
-  pin, swap the displayed fingerprints, or mask that a mismatch occurred.
-  *(Primary suspected defect: the verifier formats these fields into a single
-  error string using `, got ` / `, issuer ` delimiters, and `pin_failure.rs`
-  recovers them by naive substring search. The issuer DN is attacker-controlled
-  via `extract_issuer_dn`, so it can contain those delimiters.)*
-- **INV-3 — parser totality.** `extract_issuer_der`, `extract_issuer_dn`, and
-  the DER walkers (`parse_der_sequence`, `skip_der_element`, `parse_der_length`,
-  `extract_rdns`, `parse_attribute_type_and_value`) never panic and always
-  terminate on arbitrary byte input.
-- **INV-4 — issuer-change soundness.** When an issuer DER is pinned, a differing
-  issuer is never silently accepted. A parser failure on the leaf degrades to
-  *reject* (never *accept*).
-- **INV-5 — auth confinement.** Credentials / auth headers are attached only to
-  the configured host. The cert-detection probe path sends no auth header and
-  does not follow redirects. (Largely already coded; tests assert it stays
-  true and that the real client's redirect-following cannot leak the API key
-  off-host.)
+- **INV-0 — trust-establishment confinement.** The accept-any `CertCapture`
+  verifier (which returns `Ok(ServerCertVerified)` for any certificate) is
+  reachable *only* from `probe_server_cert`, never from the client that carries
+  API traffic; and a default `TlsConfig` (no `insecure`/`ca_cert_path`/
+  `pin_sha256`) yields full system-root CA validation. `CertCapture` is private
+  to `tofu.rs` and `probe_server_cert` builds its own redirect-disabled client.
+  Anchors: `src/tls/tofu.rs:14-60,69-107`, `src/tls/mod.rs:48-66`,
+  `src/commands/shared.rs:35-50,127-169`. *Expected: holds — lands as a
+  regression guard.*
+- **INV-1 — accept-decision branches.** Drop the original proptest framing (it
+  passes vacuously: random bytes never collide with the 32-byte pin preimage,
+  `src/tls/verifier.rs:111-113`). Replace with targeted unit tests on
+  `verify_server_cert`: a matching pin returns `Ok`; a one-bit-flipped pin
+  returns `Err`; `check_issuer_change` runs *only* after a hash mismatch
+  (short-circuit ordering — the matching-pin branch returns before it). Anchor:
+  `src/tls/verifier.rs:100-123`. *Expected: holds — regression guard.*
+- **INV-2 — pin-rotation fidelity & persisted-pin integrity.** Re-pointed from
+  "prompt text spoofing" to the real sink: the `expected`/`actual`/`issuer`
+  values `pin_failure::classify` recovers become the **persisted pin** and the
+  next connection's verifier (`src/commands/shared.rs:185-220`). Assert the
+  persisted pin always equals the genuine `compute_fingerprint` of the presented
+  cert and cannot be corrupted by attacker-controlled issuer text. *Pre-check
+  refuted exploitability (see Method) — the test lands as a fidelity/regression
+  guard, not a reproduced break.* Anchors: `src/tls/verifier.rs:117-122`,
+  `src/tls/pin_failure.rs:40-50`.
+- **INV-3 — parser totality (guard).** Overstated as a prime suspect in the
+  original draft: the DER walkers already use checked arithmetic and bounded
+  length parsing (`src/tls/verifier.rs:304-319`). Keep a `proptest` totality
+  property plus a `cargo-fuzz` target as cheap regression guards. Anchors:
+  `src/tls/verifier.rs:216-399`. *Expected: holds — fuzz/property guard.*
+- **INV-4 — issuer-change soundness.** Unchanged. When an issuer DER is pinned,
+  a differing issuer is never silently accepted; a parser failure on the leaf
+  degrades to *reject* (never *accept*). Anchor: `src/tls/verifier.rs:81-115`.
+- **INV-5 — credential confinement across redirects.** **Primary suspect —
+  pre-check confirmed a real leak (see Method).** The real API client
+  (`build_tls_client`) follows redirects per reqwest defaults and attaches the
+  API key as the custom header `X-BUGZILLA-API-KEY`. reqwest strips only
+  known-sensitive headers (`Authorization`, `Cookie`, …) on a cross-host
+  redirect, not custom ones, so the credential is forwarded to a redirect-target
+  host. Assert the API key (both `Header` and `QueryParam` auth methods) is never
+  sent to a host other than the configured one, including across HTTP redirects.
+  Anchors: `src/tls/mod.rs:69-77`, `src/http.rs:24-59`,
+  `src/client/mod.rs:277-286`.
 
 ## Method
 
-- **Property tests** (`proptest`) for INV-1, INV-3, INV-4 — generate arbitrary
-  and structured DER and assert totality plus reject-bias.
-- **Adversarial unit tests** for INV-2 and INV-5 — hand-craft a certificate /
-  issuer DN containing the classifier's own delimiters and assert the prompt
-  cannot be spoofed; assert auth headers stay host-confined.
-- **Fuzz target** for INV-3 added under the existing `fuzz.yml` harness.
+- **Empirical pre-checks (run 2026-06-04, recorded here, throwaway tests
+  reverted).** Two crate-internal throwaway tests established ground truth
+  before committing the workflow:
+  - *INV-2 probe.* Crafted a `PIN_MISMATCH` error chain whose attacker-controlled
+    issuer field contained the classifier's own `, got ` and `, issuer `
+    delimiters, then ran `pin_failure::classify_chain`. Result:
+    `expected_corrupted=false`, `actual_corrupted=false` — the injected
+    delimiters landed entirely inside `new_issuer`; `expected`/`actual` kept
+    their genuine values. The parser anchors on the earlier (genuine) delimiters
+    first, so the attacker cannot move them. **Refutes exploitability → INV-2
+    demoted to a fidelity guard.**
+  - *INV-5 probe.* With `wiremock`, host A (`127.0.0.1`) returned `301` to host B
+    (`localhost`, a genuinely different `host_str`). A client built by
+    `build_tls_client` sent the request with both `X-BUGZILLA-API-KEY` and
+    `Authorization` set. Result on host B: `X-BUGZILLA-API-KEY = Some("…")`
+    (**leaked**) while `Authorization = None` (reqwest stripped the
+    known-sensitive header on the cross-host hop, but not the custom one). The
+    query-param variant did **not** leak — the `301` `Location` URL replaces the
+    query string, so `Bugzilla_api_key` was absent on host B. **Confirms a real
+    defect, specific to header auth → INV-5 elevated to primary suspect.**
+- **Targeted unit tests** for INV-0, INV-1, INV-4 — assert confinement,
+  accept/reject branches with short-circuit ordering, and reject-bias on parser
+  failure.
+- **Property test** (`proptest`) + **fuzz target** for INV-3 — generate arbitrary
+  and structured DER and assert totality.
+- **Adversarial / regression tests** for INV-2 and INV-5 — the carried versions
+  of the two pre-checks above, hardened into permanent guards.
 - Every test is written failing-first against current code. A test that
   reproduces a real break drives a TDD fix (red → green); the fix diff carries
-  that test.
+  that test. Per the pre-checks, only INV-5 is expected to reproduce a break.
 
 ## Orchestration
 
-A multi-agent workflow (user opted in). A `pipeline` per invariant:
+A multi-agent workflow (user opted in). A `pipeline` per invariant, led in
+priority order so the real sinks are worked first:
 
-1. **Finder** agent — writes the adversarial / property test, runs it against
-   current code, reports whether it reproduced a break. Runs in a git worktree
-   so parallel test-writing does not collide.
+**INV-5 → INV-2 → INV-0 → INV-1 → INV-4 → INV-3 (fuzz guard).**
+
+1. **Finder** agent — writes the adversarial / property / regression test, runs
+   it against current code, reports whether it reproduced a break. Runs in a git
+   worktree so parallel test-writing does not collide.
 2. **Adversarial verifier** agent — independently confirms each reported break
    is a real defect and not a test artifact, defaulting to skeptical.
 3. **Synthesis** — the main session collects confirmed breaks.
 
-Confirmed breaks are fixed via TDD locally, one labeled PR per fixed defect.
+Confirmed breaks are fixed via TDD locally, one labeled PR per fixed defect; the
+user confirms before each push.
+
+## Open implementation decisions (surface during the fix)
+
+- **INV-5 fix shape** — decide with the user during TDD once the failing test is
+  in hand. Candidates:
+  (a) attach a reqwest `redirect::Policy` that strips auth / aborts on host
+      change;
+  (b) disallow off-host redirects on the API client entirely (mirror the probe's
+      `Policy::none()`, or a host-allowlist policy);
+  (c) bind auth attachment to the configured host at send time.
+  Recommended default: (b) — the simplest fail-closed behavior, and consistent
+  with the probe client already using `Policy::none()`.
 
 ## Delivery
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzr"
-version = "0.4.0-dev"
+version = "0.4.3-dev"
 dependencies = [
  "base64",
  "clap",
@@ -131,7 +131,7 @@ dependencies = [
  "tabled",
  "thiserror",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -144,7 +144,7 @@ version = "0.0.0"
 dependencies = [
  "bzr",
  "libfuzzer-sys",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -855,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
 ]
@@ -1174,6 +1174,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -1188,6 +1189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1429,9 +1439,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1444,6 +1469,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,10 +1485,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1462,6 +1505,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -1913,6 +1962,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -41,3 +41,10 @@ path = "fuzz_targets/fuzz_flag_parser.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_tls_der"
+path = "fuzz_targets/fuzz_tls_der.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_tls_der.rs
+++ b/fuzz/fuzz_targets/fuzz_tls_der.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+// INV-3: the best-effort DER issuer walkers must terminate without panicking
+// on arbitrary certificate bytes.
+fuzz_target!(|data: &[u8]| {
+    bzr::fuzz::extract_issuer(data);
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,19 @@ pub mod url_parser;
 pub mod validation;
 pub mod xmlrpc;
 
+/// Fuzz-only entry points. Gated behind `cfg(fuzzing)` so they expose the
+/// otherwise crate-private DER walkers to the `fuzz/` harness without
+/// widening the public API in normal builds.
+#[cfg(fuzzing)]
+pub mod fuzz {
+    /// Drive the best-effort issuer DER walkers on arbitrary bytes. Must
+    /// terminate without panicking for any input.
+    pub fn extract_issuer(data: &[u8]) {
+        let _ = crate::tls::verifier::extract_issuer_der(data);
+        let _ = crate::tls::verifier::extract_issuer_dn(data);
+    }
+}
+
 /// Dispatch a parsed CLI to the appropriate command handler.
 ///
 /// This is the shared dispatch logic used by both the binary (`main.rs`)

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -65,12 +65,44 @@ fn apply_tls_verification(
     Ok(builder)
 }
 
+/// Maximum redirect hops followed by the API client, matching reqwest's
+/// default limit.
+const MAX_REDIRECTS: usize = 10;
+
+/// A redirect policy that follows redirects only while the target host
+/// matches the host of the original request, refusing any cross-host hop.
+///
+/// reqwest strips its own known-sensitive headers (`Authorization`, `Cookie`,
+/// …) on a cross-host redirect but not custom ones, so without this the
+/// `X-BUGZILLA-API-KEY` header would be forwarded to a redirect-target host
+/// and leak the API key. Same-host redirects are still followed, up to
+/// [`MAX_REDIRECTS`].
+fn same_host_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        let origin_host = attempt.previous().first().and_then(|u| u.host_str());
+        let cross_host = origin_host != attempt.url().host_str();
+        let target = attempt.url().clone();
+        if cross_host {
+            return attempt.error(format!(
+                "refusing to follow cross-host redirect to {target} (would leak credentials)"
+            ));
+        }
+        if attempt.previous().len() >= MAX_REDIRECTS {
+            return attempt.error(format!("exceeded {MAX_REDIRECTS} redirects"));
+        }
+        attempt.follow()
+    })
+}
+
 /// Build a `reqwest::Client` with the configured TLS verification mode.
-/// Used for real API calls; follows redirects per reqwest defaults.
+/// Used for real API calls; follows only same-host redirects so the API
+/// key header cannot leak to a redirect-target host (see
+/// [`same_host_redirect_policy`]).
 pub fn build_tls_client(config: &TlsConfig) -> crate::error::Result<reqwest::Client> {
     let builder = reqwest::Client::builder()
         .connect_timeout(crate::http::CONNECT_TIMEOUT)
-        .timeout(crate::http::REQUEST_TIMEOUT);
+        .timeout(crate::http::REQUEST_TIMEOUT)
+        .redirect(same_host_redirect_policy());
     apply_tls_verification(builder, config)?
         .build()
         .map_err(crate::error::BzrError::Http)

--- a/src/tls/mod_tests.rs
+++ b/src/tls/mod_tests.rs
@@ -48,3 +48,110 @@ fn build_tls_client_missing_ca_cert_fails() {
         "should report missing file: {err}"
     );
 }
+
+/// Stand up two loopback mock servers where `origin` issues a `301` to a
+/// different host (`127.0.0.1` vs `localhost`) so a followed redirect is
+/// genuinely cross-host. Returns `(origin, target)`; `target` records every
+/// request that reaches it.
+async fn cross_host_redirect_pair() -> (wiremock::MockServer, wiremock::MockServer) {
+    use wiremock::matchers::any;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let target = MockServer::start().await;
+    Mock::given(any())
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&target)
+        .await;
+    let target_port = target.address().port();
+
+    let origin = MockServer::start().await;
+    let location = format!("http://localhost:{target_port}/landed");
+    Mock::given(any())
+        .respond_with(ResponseTemplate::new(301).insert_header("location", location.as_str()))
+        .mount(&origin)
+        .await;
+
+    (origin, target)
+}
+
+#[tokio::test]
+async fn api_key_header_not_forwarded_across_cross_host_redirect() {
+    let (origin, target) = cross_host_redirect_pair().await;
+    let client = build_tls_client(&TlsConfig::default()).unwrap();
+
+    // Mirror the real client's header-auth attach (http::apply_auth_to_request).
+    let _ = client
+        .get(format!("{}/start", origin.uri()))
+        .header(crate::http::AUTH_HEADER_NAME, "SECRET-API-KEY")
+        .send()
+        .await;
+
+    let leaked = target
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .any(|r| r.headers.contains_key(crate::http::AUTH_HEADER_NAME));
+    assert!(
+        !leaked,
+        "API key header must not be forwarded to a different host across a redirect"
+    );
+}
+
+#[tokio::test]
+async fn api_key_query_param_not_forwarded_across_cross_host_redirect() {
+    let (origin, target) = cross_host_redirect_pair().await;
+    let client = build_tls_client(&TlsConfig::default()).unwrap();
+
+    let _ = client
+        .get(format!("{}/start", origin.uri()))
+        .query(&[(crate::http::AUTH_QUERY_PARAM, "SECRET-QP-KEY")])
+        .send()
+        .await;
+
+    let leaked = target.received_requests().await.unwrap().iter().any(|r| {
+        r.url
+            .query()
+            .is_some_and(|q| q.contains(crate::http::AUTH_QUERY_PARAM))
+    });
+    assert!(
+        !leaked,
+        "API key query param must not be forwarded to a different host across a redirect"
+    );
+}
+
+#[tokio::test]
+async fn same_host_redirect_is_followed_with_credentials() {
+    use wiremock::matchers::{any, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // A single server that 301s /start -> /landed on itself: a genuinely
+    // same-host (same host AND port) redirect, which the policy must follow
+    // and over which the credential is legitimately retained.
+    let server = MockServer::start().await;
+    Mock::given(path("/start"))
+        .respond_with(ResponseTemplate::new(301).insert_header("location", "/landed"))
+        .mount(&server)
+        .await;
+    Mock::given(any())
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let client = build_tls_client(&TlsConfig::default()).unwrap();
+    let resp = client
+        .get(format!("{}/start", server.uri()))
+        .header(crate::http::AUTH_HEADER_NAME, "SECRET-API-KEY")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "same-host redirect should be followed");
+
+    let landed_with_key = server.received_requests().await.unwrap().iter().any(|r| {
+        r.url.path() == "/landed" && r.headers.contains_key(crate::http::AUTH_HEADER_NAME)
+    });
+    assert!(
+        landed_with_key,
+        "same-host redirect should reach /landed carrying the API key header"
+    );
+}

--- a/src/tls/pin_failure_tests.rs
+++ b/src/tls/pin_failure_tests.rs
@@ -59,3 +59,36 @@ fn classifies_der_issuer_change_chain_into_typed_error() {
 fn unrelated_chain_is_not_a_pin_failure() {
     assert!(classify_chain("connection refused").is_none());
 }
+
+#[test]
+fn issuer_injection_cannot_corrupt_recovered_pin() {
+    // INV-2: the verifier formats "expected {pin}, got {fp}, issuer {issuer}".
+    // `pin` and `fp` are sha256//base64 (no comma/space); only `issuer` is
+    // attacker-controlled (via the certificate's issuer DN). An issuer that
+    // embeds the classifier's own delimiters must not move the earlier-anchored
+    // `expected`/`actual` fields — those become the persisted pin on the next
+    // connection. The injected text lands entirely in `new_issuer`.
+    let evil_issuer = "CN=Evil, got sha256//FORGED-ACTUAL==, issuer CN=Forged-Issuer";
+    let chain = format!(
+        "error sending request: PIN_MISMATCH for prod: \
+         expected sha256//REAL-PIN==, got sha256//REAL-FP==, issuer {evil_issuer}"
+    );
+
+    let Some(TlsPinFailure::PinMismatch {
+        expected,
+        actual,
+        new_issuer,
+    }) = classify_chain(&chain)
+    else {
+        panic!("expected pin mismatch failure");
+    };
+    assert_eq!(
+        expected, "sha256//REAL-PIN==",
+        "injected issuer must not corrupt the recovered expected pin"
+    );
+    assert_eq!(
+        actual, "sha256//REAL-FP==",
+        "injected issuer must not corrupt the recovered actual fingerprint"
+    );
+    assert_eq!(new_issuer, evil_issuer);
+}

--- a/src/tls/verifier_tests.rs
+++ b/src/tls/verifier_tests.rs
@@ -428,3 +428,85 @@ fn hex_encode_produces_lowercase_pairs() {
     assert_eq!(hex::encode(&[0x00, 0x0f, 0xff, 0xab]), "000fffab");
     assert_eq!(hex::encode(&[]), "");
 }
+
+// --- INV-1: accept-decision branches ---
+
+#[test]
+fn one_bit_flipped_pin_is_rejected() {
+    // A pin that differs from the genuine fingerprint by a single bit must
+    // never be accepted.
+    let der = gen_self_signed_cert();
+    let mut hash: [u8; 32] = Sha256::digest(&der).into();
+    hash[0] ^= 0x01;
+    let pin = format!(
+        "sha256//{}",
+        base64::engine::general_purpose::STANDARD.encode(hash)
+    );
+
+    let verifier = PinnedCertVerifier::new(&pin, None, "localhost").unwrap();
+    let cert = CertificateDer::from(der);
+    let server_name = ServerName::try_from("localhost").unwrap();
+
+    let result = verifier.verify_server_cert(&cert, &[], &server_name, &[], UnixTime::now());
+    assert!(result.is_err(), "one-bit-flipped pin must be rejected");
+}
+
+#[test]
+fn pin_match_short_circuits_issuer_check() {
+    // The matching-pin branch must return Ok before `check_issuer_change`
+    // runs: pin a cert but store a *different* issuer DER, then present the
+    // pinned cert. If the issuer check ran first this would be ISSUER_CHANGED;
+    // because the pin matches, it is accepted.
+    let der = gen_cert_with_cn("RealCA");
+    let fp = compute_fingerprint(&der);
+
+    let wrong_issuer_der = extract_issuer_der(&gen_cert_with_cn("OtherCA")).unwrap();
+    let wrong_issuer_b64 = base64::engine::general_purpose::STANDARD.encode(&wrong_issuer_der);
+
+    let verifier = PinnedCertVerifier::new(&fp, Some(&wrong_issuer_b64), "localhost").unwrap();
+    let cert = CertificateDer::from(der);
+    let server_name = ServerName::try_from("localhost").unwrap();
+
+    let result = verifier.verify_server_cert(&cert, &[], &server_name, &[], UnixTime::now());
+    assert!(
+        result.is_ok(),
+        "matching pin must short-circuit the issuer check: {result:?}"
+    );
+}
+
+// --- INV-4: issuer-change soundness ---
+
+#[test]
+fn unparseable_leaf_degrades_to_reject() {
+    // A leaf whose issuer DER cannot be extracted (parse failure) must never
+    // be accepted. With a pin that does not match, `check_issuer_change`
+    // returns Ok(()) on the unparseable leaf but the pin mismatch still
+    // yields Err — the failure degrades to *reject*, never *accept*.
+    let der1 = gen_self_signed_cert();
+    let fp1 = compute_fingerprint(&der1);
+    let issuer_der = extract_issuer_der(&der1).unwrap();
+    let issuer_b64 = base64::engine::general_purpose::STANDARD.encode(&issuer_der);
+
+    let verifier = PinnedCertVerifier::new(&fp1, Some(&issuer_b64), "localhost").unwrap();
+    let cert = CertificateDer::from(b"not a certificate".to_vec());
+    let server_name = ServerName::try_from("localhost").unwrap();
+
+    let result = verifier.verify_server_cert(&cert, &[], &server_name, &[], UnixTime::now());
+    assert!(
+        result.is_err(),
+        "unparseable leaf must be rejected, never accepted"
+    );
+}
+
+// --- INV-3: parser totality (property guard) ---
+
+proptest::proptest! {
+    #[test]
+    fn der_walkers_never_panic_on_arbitrary_bytes(data: Vec<u8>) {
+        // The best-effort DER walkers must terminate without panicking on any
+        // input. `extract_issuer_dn` always returns a String; `extract_issuer_der`
+        // returns an Option. Neither may panic.
+        let _ = extract_issuer_der(&data);
+        let _ = extract_issuer_dn(&data);
+    }
+}


### PR DESCRIPTION
## Summary

Red-team engagement, Surface 1 (TLS / auth). Acting as an active network MITM or
a malicious/compromised Bugzilla server, this engagement enumerated the
invariants the trust model relies on, wrote adversarial / property / fuzz tests
against each, and fixed the one reproduced defect via TDD. It also revises the
engagement spec after a hostile `/challenge` review re-prioritized the targets.

## Threat model

- **Adversary:** an active network MITM, or a malicious/compromised Bugzilla
  server, that controls the TLS certificate chain presented to `bzr` and the
  HTTP/XML-RPC response bodies (including redirect `Location` headers).
- **Trust boundary:** every byte from the presented certificate and the response
  inward is untrusted. The on-disk TOFU pin store, the config file, and the
  stored API key are the trusted state the adversary wants to corrupt, bypass,
  or exfiltrate.

## Confirmed defect (fixed here)

**Credential leak on cross-host redirect (INV-5).** The real API client followed
redirects per reqwest defaults and attaches the API key as the custom header
`X-BUGZILLA-API-KEY`. reqwest strips only its own known-sensitive headers
(`Authorization`, `Cookie`, …) on a cross-host redirect, not custom ones — so a
malicious server could return a `301` to an attacker-controlled host and receive
the forwarded key. Proven empirically: across a `127.0.0.1 → localhost` `301`,
the target host received `X-BUGZILLA-API-KEY` while `Authorization` was stripped.

**Fix (fail-closed):** a redirect policy that follows redirects only while the
target host matches the original request host and refuses any cross-host hop.
Same-host redirects are still followed, up to reqwest's default limit. The
query-parameter auth variant was already unaffected (the redirect URL replaces
the query string). Demonstrated red→green: the confinement test fails on the
pre-fix code and passes after the fix.

## Invariant results

| Invariant | Result |
| --- | --- |
| INV-0 trust-establishment confinement | Holds — accept-any verifier is private to the probe path; covered by existing guards |
| INV-1 accept/reject branches | Holds — one-bit-flip rejected; matching pin short-circuits the issuer check |
| INV-2 persisted-pin integrity | Holds — attacker issuer DN cannot corrupt the recovered expected/actual pin |
| INV-3 DER parser totality | Holds — proptest + new `fuzz_tls_der` target (1.28M execs, no crash) |
| INV-4 issuer-change soundness | Holds — unparseable leaf degrades to reject |
| **INV-5 credential confinement** | **Broken → fixed** |

## Changes

- `fix(tls)`: host-confined redirect policy on the API client + confinement tests.
- `test(tls)`: INV-1/2/4 accept/reject, issuer-injection, and reject-bias guards;
  INV-3 proptest totality property.
- `test(fuzz)`: `fuzz_tls_der` target via a `#[cfg(fuzzing)]`-gated `bzr::fuzz`
  entry point (no public-API change in normal builds); wired into `fuzz.yml`.
- `docs`: spec revised after the `/challenge` review (invariant catalog, recorded
  pre-check results, re-sequenced orchestration).
- `build`: add `proptest` dev-dependency; `CHANGELOG.md` Security entry.

## Testing

- `cargo test --workspace`: 1266 lib + 22 + 72 integration tests green.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`,
  `make check-test-layout`: clean.
- `cargo +nightly fuzz run fuzz_tls_der -- -max_total_time=20`: no crash.
- INV-5 fix proven red→green (test fails on pre-fix `src/tls/mod.rs`, passes after).

## Notes

- This is the first of three surfaces; concurrency and supply-chain follow as
  separate engagements after a checkpoint.
