### PR TITLE
security(conc-1): atomic config writes + concurrency invariant guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - run: make check-test-layout
+      - run: make check-no-spawn
 
   clippy:
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
       - run: make check-test-layout
       - run: make check-no-spawn
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   to an attacker-controlled host and receive the forwarded API key. The client
   now refuses to follow any cross-host redirect; same-host redirects are still
   followed. The query-parameter auth variant was already unaffected.
+- Config writes are now atomic. The previous in-place truncate-then-write
+  could leave the config file empty or partial if a concurrent `bzr` process
+  read it mid-write, or if the process crashed between truncate and write —
+  silently dropping all configured servers. The config is now written to a
+  sibling temp file and atomically renamed into place (with a directory fsync
+  on Unix for crash durability), and crash-orphaned temp files are reaped on
+  the next save.
 
 ## [0.4.2] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   silently dropping all configured servers. The config is now written to a
   sibling temp file and atomically renamed into place (with a directory fsync
   on Unix for crash durability), and crash-orphaned temp files are reaped on
-  the next save.
+  the next save. This fixes torn reads, not lost updates: two `bzr` processes
+  editing the config simultaneously still resolve last-writer-wins, so one
+  process's change can be silently overwritten until file locking lands.
 
 ## [0.4.2] - 2026-05-29
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CARGO ?= cargo
 RUST_MIN_VERSION := 1.88.0
 
 .PHONY: setup check-rust ensure-components ensure-coverage-prereqs ensure-mutants-prereq install-hooks \
-        build release test coverage fmt clippy lint check-test-layout clean help man \
+        build release test coverage fmt clippy lint check-test-layout check-no-spawn clean help man \
         mutants mutants-fast mutants-list audit-mutant-skips \
         functional-build functional-start functional-test functional-stop \
         functional-test-bz52 functional-test-bz53 functional-test-all functional-stop-all \
@@ -88,7 +88,7 @@ fmt: ## Format source code
 clippy: ## Run clippy lints
 	$(CARGO) clippy -- -D warnings
 
-lint: fmt clippy check-test-layout ## Run all linters (fmt + clippy + test-layout)
+lint: fmt clippy check-test-layout check-no-spawn ## Run all linters (fmt + clippy + test-layout + no-spawn)
 
 check-test-layout: ## Verify all test code lives in sibling *_tests.rs files
 	@if rg -l '^mod tests \{' src/ 2>/dev/null; then \
@@ -96,6 +96,19 @@ check-test-layout: ## Verify all test code lives in sibling *_tests.rs files
 	  echo "Move tests to a sibling <name>_tests.rs file linked via"; \
 	  echo "  #[cfg(test)] #[path = \"<name>_tests.rs\"] mod tests;"; \
 	  echo "See docs/superpowers/specs/2026-05-05-test-sibling-migration-design.md"; \
+	  exit 1; \
+	fi
+
+check-no-spawn: ## Guard the single-threaded-runtime assumption (CONC-3)
+	@if ! rg -q 'flavor = "current_thread"' src/main.rs; then \
+	  echo "ERROR: src/main.rs no longer declares the current_thread runtime."; \
+	  echo "The concurrency engagement assumes no in-process parallelism."; \
+	  echo "Re-evaluate the CONC-* invariants before changing the runtime flavor."; \
+	  exit 1; \
+	fi
+	@if rg -n 'tokio::spawn|tokio::task::spawn|join!|try_join!|select!|FuturesUnordered|buffer_unordered' src/; then \
+	  echo "ERROR: task fan-out found in src/ — in-process data races become possible."; \
+	  echo "Re-evaluate the CONC-* invariants (config writes, shared state)."; \
 	  exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ clippy: ## Run clippy lints
 lint: fmt clippy check-test-layout check-no-spawn ## Run all linters (fmt + clippy + test-layout + no-spawn)
 
 check-test-layout: ## Verify all test code lives in sibling *_tests.rs files
+	@command -v rg >/dev/null || { echo "ERROR: ripgrep (rg) is required for this guard"; exit 1; }
 	@if rg -l '^mod tests \{' src/ 2>/dev/null; then \
 	  echo "ERROR: inline 'mod tests { ... }' blocks found in src/."; \
 	  echo "Move tests to a sibling <name>_tests.rs file linked via"; \
@@ -100,6 +101,7 @@ check-test-layout: ## Verify all test code lives in sibling *_tests.rs files
 	fi
 
 check-no-spawn: ## Guard the single-threaded-runtime assumption (CONC-3)
+	@command -v rg >/dev/null || { echo "ERROR: ripgrep (rg) is required for this guard"; exit 1; }
 	@if ! rg -q 'flavor = "current_thread"' src/main.rs; then \
 	  echo "ERROR: src/main.rs no longer declares the current_thread runtime."; \
 	  echo "The concurrency engagement assumes no in-process parallelism."; \

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ check-no-spawn: ## Guard the single-threaded-runtime assumption (CONC-3)
 	  echo "Re-evaluate the CONC-* invariants before changing the runtime flavor."; \
 	  exit 1; \
 	fi
+	@# Note: this also matches these words in comments/strings (false-fail, never
+	@# false-pass). If prose trips the guard, reword the prose rather than weaken it.
 	@if rg -n 'tokio::spawn|tokio::task::spawn|join!|try_join!|select!|FuturesUnordered|buffer_unordered' src/; then \
 	  echo "ERROR: task fan-out found in src/ — in-process data races become possible."; \
 	  echo "Re-evaluate the CONC-* invariants (config writes, shared state)."; \

--- a/docs/superpowers/specs/2026-06-04-red-team-concurrency-design.md
+++ b/docs/superpowers/specs/2026-06-04-red-team-concurrency-design.md
@@ -54,8 +54,11 @@ async races) to regression guards and latent-footgun notes.
      config intact. The power-loss case (the previous config must survive a
      crash *after* the rename) additionally requires a directory `fsync`; see
      the Design section.
-  2. **Config edit durability** — a concurrent process's committed change must
-     not be silently overwritten by another process's stale write (lost update).
+  2. **Config edit durability (disjoint fields)** — concurrent edits to
+     *different* fields must both survive; a process must not clobber an unrelated
+     field it never intended to touch by writing back a stale whole-file copy.
+     (Two edits to the *same* field necessarily resolve last-writer-wins; that is
+     correct, not a defect — see CONC-2.)
   3. **Liveness** — the persistence mechanism must not be able to wedge other
      `bzr` invocations (e.g., by holding a lock across an interactive prompt).
 
@@ -82,8 +85,19 @@ single-threaded-runtime paths land as regression guards.
   `0700` (dir) hardening. Anchor: `src/config.rs` `save` / `write_to_disk` /
   `write_private_file`.
 - **CONC-2 (real defect; data-integrity, not exploitable security) — no lost
-  updates.** Concurrent `bzr` processes that mutate config do not silently drop
-  each other's edits. *Severity calibration (challenge finding):* the threat
+  updates to disjoint fields.** Concurrent `bzr` processes that mutate
+  *different* config fields do not clobber each other by writing back a stale
+  whole-file copy. **Scope of the guarantee (challenge finding — the earlier
+  absolute phrasing over-claimed):** this closes the *write-write* race for
+  disjoint fields via reload-under-lock. It does **not** make two concurrent edits
+  to the *same* field both survive — that necessarily resolves last-writer-wins
+  (correct and unavoidable). Nor does it close the **read-decide-write TOCTOU**:
+  `connect_and_configure` reads config *without* the lock to make decisions
+  (resolve server, decide TOFU/rotation), so an intent formed on a stale read can
+  still re-assert a value a concurrent process just changed. The lock guarantees
+  *atomic, non-corrupting, disjoint-field-preserving* writes — not serializability
+  of the read-decide-write span. *Severity calibration (challenge finding):* the
+  threat
   model concedes the malicious server does not control the filesystem and cannot
   force or time a second concurrent invocation, so this is a **robustness /
   data-integrity** defect, not an attacker-exploitable vulnerability — and it is
@@ -149,17 +163,28 @@ single-threaded-runtime paths land as regression guards.
 
 ## Empirical pre-checks (before committing the workflow)
 
-Run these as throwaway tests, record results in the spec's Method section. Both
-are deterministic (they use real OS threads / explicit interleaving in the test,
-independent of the app's single-threaded runtime).
+Run these as throwaway tests, record results in the spec's Method section. The
+CONC-2 lock probe is deterministic (explicit readiness/release signals); the
+CONC-1 probe is *not* a pure race-hammer — see below for why it must use a
+test-only seam to be deterministic rather than relying on hitting a timing
+window.
 
-1. **CONC-1 probe.** Spawn one `std::thread` that repeatedly reads the config via
-   `Config::load()` while the main thread performs many `save()` calls. Assert on
-   **content survival**, not parse success: a read that succeeds but returns a
-   config *missing the known server* is the corruption signal (a zero-byte read
-   parses to an empty default `Config` — see CONC-1). Under the current
-   truncate-then-write path, some reads return the empty/default config.
-   *Expected: reproduces → confirms the corruption defect.*
+1. **CONC-1 probe.** A naive "thread reads in a loop while the main thread saves"
+   is a **probabilistic race-hammer**, not deterministic: on a fast
+   machine/filesystem the truncate→write window may rarely or never be sampled,
+   so it can both fail to reproduce pre-fix (false green) and pass a future
+   regression by luck. Instead, reproduce deterministically via a **test-only
+   seam**: a write hook (e.g., a `#[cfg(test)]` callback invoked between the
+   `truncate` and the `write_all` in the current code path) lets a reader observe
+   the file *guaranteed* mid-write; assert on **content survival** — the read
+   returns a config *missing the known server* (a zero-byte read parses to an
+   empty default `Config`; see CONC-1), never a parse error. The **permanent
+   guard** is also deterministic and does *not* depend on the seam: after the
+   atomic-write fix, assert (a) a partially-written temp file never appears at the
+   real `config.toml` path, and (b) a simulated mid-write failure (injected write
+   error before the rename) leaves the prior `config.toml` byte-identical.
+   *Expected: the seam reproduces the corruption on current code → confirms the
+   defect; the atomic-write guard passes only after the fix.*
 2. **CONC-2 probe (two parts).** (a) *Logic:* explicitly interleave two stale
    load→modify→save sequences (load A; load B; A sets a pin and saves; B sets
    `auth_method` and saves) and assert A's pin survives — this exercises the
@@ -168,10 +193,14 @@ independent of the app's single-threaded runtime).
    two-fd `flock` test self-deadlocks):* a **second OS process** (a small test
    helper binary) acquires the lock and signals readiness (writes a ready-file /
    closes a pipe) and waits for a go-ahead before releasing. The parent, once it
-   sees readiness, calls `try_lock_exclusive()` and asserts it returns
-   `WouldBlock` *while the child holds the lock*, then signals the child to
-   release and asserts the lock now succeeds. **No `sleep`-based timing
-   assertions** — readiness and release are explicit signals, so the test is
+   sees readiness, performs a **try-lock and asserts it reports contention**
+   *while the child holds the lock*, then signals the child to release and asserts
+   the lock now succeeds. (The exact contention signal is `fs4`-version-specific —
+   `try_lock_exclusive` has returned both `Result<()>` with a `lock_contended_error()`
+   sentinel and `Result<bool>` across releases — so the test asserts "reports
+   contention," not a hard-coded `ErrorKind::WouldBlock`; the precise API is pinned
+   and verified at implementation time, see Open decisions.) **No `sleep`-based
+   timing assertions** — readiness and release are explicit signals, so the test is
    deterministic, not a timing race. *Expected: (a) reproduces lost-update on
    current code; (b) becomes the regression test for the lock itself.*
 
@@ -275,7 +304,8 @@ TDD locally; the user confirms before each push.
 
 1. **Flaky lock test.** The mandated two-process test was specified as a sleep
    race ("holds briefly / blocks until release"); rewritten to use a readiness
-   signal + `try_lock_exclusive() == WouldBlock` with no timing assertions.
+   signal + a try-lock contention assertion with no timing assertions. (Round 3
+   refined the contention check to be `fs4`-API-agnostic.)
 2. **Fragile grep guard.** The `check-no-direct-save` grep was binding-name-fragile
    and test-noisy; replaced by **compiler-enforced** privacy (`save()` is private
    to `config`, so bypass fails to compile).
@@ -290,6 +320,22 @@ TDD locally; the user confirms before each push.
    cost/benefit gate, shipping after CONC-1.
 6. **Failing-first contradiction.** Scoped the failing-first rule to CONC-1/CONC-2;
    CONC-4/5 are characterization guards, CONC-3 is a CI check.
+
+**Round 3** found three remaining defects; all addressed above:
+
+1. **CONC-1 probe was a probabilistic race-hammer mislabeled "deterministic."** A
+   read-while-writing loop can miss the truncate→write window (false green) and is
+   not a reliable permanent guard. Reproduce via a `#[cfg(test)]` seam between
+   `truncate` and `write_all`; make the permanent guard deterministic (temp never
+   appears at the real path; injected mid-write failure leaves the old file
+   byte-identical). Dropped the "both deterministic" claim.
+2. **CONC-2 over-claimed its guarantee.** Reload-under-lock preserves *disjoint*
+   field edits only; same-field edits resolve last-writer-wins, and the unlocked
+   read-decide-write span remains a TOCTOU the lock does not close. Narrowed the
+   asset, the invariant, and the stated scope accordingly.
+3. **`fs4` try-lock contention API is version-specific.** The test asserts
+   "reports contention," not a hard-coded `WouldBlock`; pin the version and verify
+   the API before writing the test (added to Open decisions).
 
 ## Delivery
 
@@ -318,6 +364,11 @@ TDD locally; the user confirms before each push.
 - **Windows atomic-replace mechanism** — the Design section scopes this
   (`ReplaceFileW` or `rename`-with-retry, durability scoped to POSIX); confirm the
   exact API and error/retry behavior during implementation.
+- **`fs4` try-lock contention API** — pin the `fs4` version and verify the exact
+  shape of `try_lock_exclusive` (return type and how contention is reported —
+  `lock_contended_error()` sentinel vs a boolean vs `ErrorKind::WouldBlock`)
+  *before* writing the CONC-2 mutual-exclusion test, which asserts "reports
+  contention while held."
 
 ## Out of scope (this engagement)
 

--- a/docs/superpowers/specs/2026-06-04-red-team-concurrency-design.md
+++ b/docs/superpowers/specs/2026-06-04-red-team-concurrency-design.md
@@ -173,18 +173,20 @@ window.
    is a **probabilistic race-hammer**, not deterministic: on a fast
    machine/filesystem the truncate→write window may rarely or never be sampled,
    so it can both fail to reproduce pre-fix (false green) and pass a future
-   regression by luck. Instead, reproduce deterministically via a **test-only
-   seam**: a write hook (e.g., a `#[cfg(test)]` callback invoked between the
-   `truncate` and the `write_all` in the current code path) lets a reader observe
-   the file *guaranteed* mid-write; assert on **content survival** — the read
-   returns a config *missing the known server* (a zero-byte read parses to an
-   empty default `Config`; see CONC-1), never a parse error. The **permanent
-   guard** is also deterministic and does *not* depend on the seam: after the
-   atomic-write fix, assert (a) a partially-written temp file never appears at the
-   real `config.toml` path, and (b) a simulated mid-write failure (injected write
-   error before the rename) leaves the prior `config.toml` byte-identical.
-   *Expected: the seam reproduces the corruption on current code → confirms the
-   defect; the atomic-write guard passes only after the fix.*
+   regression by luck. Instead, reproduce deterministically via a **throwaway
+   test-only seam** (an *optional reproduction aid*, not a lasting test — the fix
+   replaces the truncate+`write_all` path with temp+rename, deleting the seam):
+   a `#[cfg(test)]` callback invoked between the `truncate` and the `write_all` in
+   the current code path lets a reader observe the file *guaranteed* mid-write;
+   assert on **content survival** — the read returns a config *missing the known
+   server* (a zero-byte read parses to an empty default `Config`; see CONC-1),
+   never a parse error. The **permanent guard** carries the regression value and
+   does *not* depend on the seam: after the atomic-write fix, assert (a) a
+   partially-written temp file never appears at the real `config.toml` path, and
+   (b) a simulated mid-write failure (injected write error before the rename)
+   leaves the prior `config.toml` byte-identical. *Expected: the seam reproduces
+   the corruption on current code → confirms the defect; the atomic-write guard
+   passes only after the fix.*
 2. **CONC-2 probe (two parts).** (a) *Logic:* explicitly interleave two stale
    load→modify→save sequences (load A; load B; A sets a pin and saves; B sets
    `auth_method` and saves) and assert A's pin survives — this exercises the
@@ -251,7 +253,17 @@ TDD locally; the user confirms before each push.
     CONC-1 guarantees concurrent-reader atomicity (no empty/partial read) but not
     crash-durability. This platform difference is stated, not hand-waved.
   - A failed write aborts before the replace, leaving the original intact; the
-    temp file is cleaned up on failure.
+    temp is removed on the graceful `Err` path.
+  - *Crash-orphaned temps (challenge finding).* A crash / `SIGKILL` / power loss
+    between temp-create and rename — the threat model's headline adversary — kills
+    the process before any graceful cleanup, and because the temp name is unique
+    (required so concurrent *unlocked* CONC-1 writers don't clobber a shared temp
+    before the CONC-2 lock exists) every such crash leaves a new orphan that
+    accumulates forever. The design therefore **reaps stale temps**: each write
+    sweeps `config.toml.*.tmp` siblings older than a threshold before writing
+    (and, once CONC-2 lands, the sweep runs under the lock so it cannot race a
+    live writer's temp). Orphaned temps may contain a full config including an
+    inline API key, so they are created `0600` and reaped, not left in place.
 - **Advisory lock + reload (CONC-2).** `Config::update_locked(mutator: impl
   FnOnce(&mut Config) -> Result<()>)` becomes the **single write path** (bare
   `save()` is made private to `config`, so no caller can bypass the lock — the
@@ -337,6 +349,17 @@ TDD locally; the user confirms before each push.
    "reports contention," not a hard-coded `WouldBlock`; pin the version and verify
    the API before writing the test (added to Open decisions).
 
+**Round 4** found one defect + one note; both addressed above:
+
+1. **Crash-orphaned temp files were never reaped.** "Cleaned up on failure"
+   covered only the graceful `Err` path; a crash/power-loss (the threat model's
+   headline adversary) between temp-create and rename leaves a unique-named orphan
+   that accumulates forever. The design now reaps stale `config.toml.*.tmp`
+   siblings (under the CONC-2 lock once it lands); added to Open decisions.
+2. **CONC-1 seam demoted.** The truncate/`write_all` seam is now labeled an
+   optional throwaway reproduction aid (the fix deletes that code path); the
+   deterministic permanent guards carry the regression value.
+
 ## Delivery
 
 - New tests land as permanent regression guards even where the invariant holds.
@@ -361,6 +384,10 @@ TDD locally; the user confirms before each push.
 - **Lockfile staleness / cleanup** — whether the lockfile is ever removed, and
   how a stale lock (holder crashed) is handled (`fs4` advisory locks release on
   process exit, so a crashed holder does not leak the lock; confirm).
+- **Temp-file reaping policy** — the age threshold / trigger for sweeping
+  crash-orphaned `config.toml.*.tmp` files (per-write sweep vs. startup sweep),
+  and confirming the sweep is race-safe relative to a concurrent writer's
+  in-flight temp (trivially so once the CONC-2 lock gates writes).
 - **Windows atomic-replace mechanism** — the Design section scopes this
   (`ReplaceFileW` or `rename`-with-retry, durability scoped to POSIX); confirm the
   exact API and error/retry behavior during implementation.

--- a/docs/superpowers/specs/2026-06-04-red-team-concurrency-design.md
+++ b/docs/superpowers/specs/2026-06-04-red-team-concurrency-design.md
@@ -81,9 +81,17 @@ single-threaded-runtime paths land as regression guards.
   atomic `rename` over the target → `fsync(dir)`, preserving `0600` (file) /
   `0700` (dir) hardening. Anchor: `src/config.rs` `save` / `write_to_disk` /
   `write_private_file`.
-- **CONC-2 (real defect) — no lost updates.** Concurrent `bzr` processes that
-  mutate config do not silently drop each other's edits. Fix via a
-  `Config::update_locked(|cfg| …)` API: acquire an exclusive advisory lock
+- **CONC-2 (real defect; data-integrity, not exploitable security) — no lost
+  updates.** Concurrent `bzr` processes that mutate config do not silently drop
+  each other's edits. *Severity calibration (challenge finding):* the threat
+  model concedes the malicious server does not control the filesystem and cannot
+  force or time a second concurrent invocation, so this is a **robustness /
+  data-integrity** defect, not an attacker-exploitable vulnerability — and it is
+  the heaviest lift in the engagement (new `fs4` dependency + sole-write-path
+  refactor across five files + two-process test). It is therefore gated on an
+  explicit cost/benefit check at execution time, and ships **separately** from
+  and **after** CONC-1 (see Delivery). Fix via a `Config::update_locked(|cfg| …)`
+  API: acquire an exclusive advisory lock
   (`fs4`) on a lockfile in the **resolved config directory** (`config.lock`,
   sibling of `config.toml` — *not* a hardcoded `~/.config/bzr` path, so an
   `XDG_CONFIG_HOME` override still shares one lock) → **reload the latest config
@@ -99,12 +107,14 @@ single-threaded-runtime paths land as regression guards.
   `src/commands/config.rs` (`set-default`, `set-server`, `set-keyring`,
   `unset-keyring`, `tls_pin_clear`, `set-default`-path), `src/commands/template.rs`
   (template add/remove), `src/commands/query.rs` (saved-query add/remove), and
-  `src/commands/bug/search.rs` (`--save` query). To make bypass impossible rather
-  than relying on enumeration staying correct, the **lock + reload + atomic write
-  become the only write path**: `save()`/`save_without_validation()` are removed
-  (or made private to `config`), all callers migrate to `update_locked`, and a CI
-  guard (`check-no-direct-save`, a grep) fails the build if a `config.save()`
-  reappears outside `config.rs`.
+  `src/commands/bug/search.rs` (`--save` query). To make bypass impossible, the
+  choke point is **compiler-enforced, not grep-enforced**: `save()` /
+  `save_without_validation()` become **private to the `config` module**, so any
+  external write path fails to *compile*. `update_locked` (the only `pub` write
+  API) is then the sole entry, and all 14 callers migrate to it. A string grep
+  (`config.save()`) was rejected as the guard: it is binding-name-fragile
+  (`let cfg = …; cfg.save()` evades it) and noisy against `*_tests.rs`; Rust
+  visibility gives the guarantee for free.
 - **CONC-2b — lock liveness & re-entrancy.** Two distinct properties:
   (a) *Liveness:* the lock is never held across interactive I/O — the TOFU /
   pin-rotation prompts run *outside* the lock and only produce the values to
@@ -155,11 +165,15 @@ independent of the app's single-threaded runtime).
    `auth_method` and saves) and assert A's pin survives — this exercises the
    reload-merge logic but **not** the lock. (b) *Mutual exclusion (challenge
    finding — a single-process interleave never tests the lock, and an in-process
-   two-fd `flock` test self-deadlocks):* spawn a **second OS process** (a small
-   test helper binary, or a forked `Command`) that takes the lock and holds it
-   briefly, and assert the parent's `update_locked` blocks until release rather
-   than interleaving. *Expected: (a) reproduces lost-update on current code; (b)
-   becomes the regression test for the lock itself.*
+   two-fd `flock` test self-deadlocks):* a **second OS process** (a small test
+   helper binary) acquires the lock and signals readiness (writes a ready-file /
+   closes a pipe) and waits for a go-ahead before releasing. The parent, once it
+   sees readiness, calls `try_lock_exclusive()` and asserts it returns
+   `WouldBlock` *while the child holds the lock*, then signals the child to
+   release and asserts the lock now succeeds. **No `sleep`-based timing
+   assertions** — readiness and release are explicit signals, so the test is
+   deterministic, not a timing race. *Expected: (a) reproduces lost-update on
+   current code; (b) becomes the regression test for the lock itself.*
 
 ## Method
 
@@ -169,12 +183,16 @@ independent of the app's single-threaded runtime).
 - **Targeted unit tests** for CONC-2b (closure is non-interactive; a re-entrant
   `update_locked` is rejected, not deadlocked), CONC-4 (double-init safe), CONC-5
   (second `set()` ignored).
-- **CI grep** for CONC-3 (`check-no-spawn`) and the `check-no-direct-save` guard
-  — build-time checks, not `#[test]`s.
-- Every test is written failing-first against current code. A test that
-  reproduces a real break drives a TDD fix (red → green); the fix diff carries
-  that test. Per the pre-checks, CONC-1 and CONC-2 are expected to reproduce
-  breaks.
+- **CI grep** for CONC-3 (`check-no-spawn`) — a build-time check, not a `#[test]`.
+  (The anti-bypass guard for CONC-2 is *compiler*-enforced via `save()` privacy,
+  not a grep — see CONC-2.)
+- **Failing-first applies to the reproduced defects only.** CONC-1 and CONC-2 are
+  written failing-first and drive a TDD red→green fix (the fix diff carries the
+  test). CONC-4 and CONC-5 are **characterization guards** — the invariant
+  already holds and cannot be made to fail without changing the architecture, so
+  they are *not* failing-first; they lock in current behavior. CONC-3 is a CI
+  check, not a test. (Correcting an earlier blanket "every test is failing-first"
+  claim, which was false for the demoted guards.)
 
 ## Orchestration
 
@@ -188,19 +206,27 @@ TDD locally; the user confirms before each push.
 
 ## Design: atomic write + `update_locked`
 
-- **Atomic write (CONC-1).** Replace the in-place truncate-write in
-  `write_private_file` with: create `config.toml.<unique>.tmp` in the same
-  directory with `0600`, write the full serialized content, `fsync(temp)`,
-  `rename` over `config.toml`, then **`fsync` the containing directory** so the
-  rename survives a crash/power-loss (the temp-file fsync alone does not make the
-  directory entry durable). `rename` within a directory is atomic on POSIX; on
-  Windows plain `rename` over an existing file is *not* guaranteed and may need
-  `ReplaceFileW` or a retry loop (tracked as an open decision). A failed write
-  aborts before the rename, leaving the original intact; the temp file is cleaned
-  up on failure.
+- **Atomic write (CONC-1) — two platform paths.** Both `write_private_file`
+  impls (unix and non-unix; `src/config.rs:333-349`) are replaced.
+  - *Unix:* create `config.toml.<unique>.tmp` in the same directory with mode
+    `0600`, write the full serialized content, `fsync(temp)`, `rename` over
+    `config.toml`, then **`fsync` the containing directory** so the rename
+    survives a crash/power-loss (the temp-file fsync alone does not make the
+    directory entry durable). `rename` within a directory is atomic on POSIX.
+  - *Non-unix (Windows ships in CI):* the current non-unix branch is a bare
+    `fs::write` with **no** permission hardening and no atomicity. Replace with a
+    temp-file write followed by an atomic replace via `ReplaceFileW` (or
+    `std::fs::rename` with a retry loop, since plain `rename`-over-existing is not
+    guaranteed on Windows). There is no portable directory-`fsync` equivalent, so
+    **the power-loss/crash-durability guarantee is scoped to POSIX**; on Windows
+    CONC-1 guarantees concurrent-reader atomicity (no empty/partial read) but not
+    crash-durability. This platform difference is stated, not hand-waved.
+  - A failed write aborts before the replace, leaving the original intact; the
+    temp file is cleaned up on failure.
 - **Advisory lock + reload (CONC-2).** `Config::update_locked(mutator: impl
   FnOnce(&mut Config) -> Result<()>)` becomes the **single write path** (bare
-  `save()` is removed/privatised so no caller can bypass the lock):
+  `save()` is made private to `config`, so no caller can bypass the lock — the
+  compiler enforces it):
   1. open/create `config.lock` *in the resolved config directory* (`0600`) and
      take an exclusive `fs4` lock;
   2. reload the current config from disk;
@@ -211,6 +237,13 @@ TDD locally; the user confirms before each push.
      crashes — `fs4` advisory locks do not leak).
   Call sites that currently do load→(prompt)→mutate→save are refactored so the
   prompt stays outside and the mutation becomes the closure body.
+  **Closure precondition (challenge finding).** Because step 2 reloads from disk,
+  the closure runs against the *on-disk* config, not the caller's in-memory copy.
+  Closures must therefore be **self-contained**: they must not depend on
+  unpersisted in-memory state, and must *upsert* (create-if-absent) any server
+  they touch rather than `get_mut`-and-assume-present — otherwise a "set field on
+  server X" closure silently no-ops when X is not yet on disk. A test covers the
+  "configure a server not yet persisted" case to lock this in.
 - **Dependency.** Add `fs4` (the actively-maintained successor to `fs2`) for
   cross-platform advisory locking, pinned to its current stable version (looked
   up at implementation time). Justification: hand-rolling `flock`/`LockFileEx`
@@ -218,8 +251,7 @@ TDD locally; the user confirms before each push.
 
 ## Challenge-review fixes
 
-A hostile `/challenge` review found six material defects in the first draft; all
-are addressed above:
+**Round 1** found six material defects; all addressed above:
 
 1. **CONC-1 probe tested the wrong signal.** An empty/zero-byte TOML parses to a
    default `Config` (`servers` is `#[serde(default)]`; `Config::load` maps a
@@ -231,8 +263,7 @@ are addressed above:
    `update_locked` explicitly non-reentrant (rejected, not deadlocked).
 3. **CONC-2 writer set was incomplete.** Five files / 14 `save()` sites write
    config (not the two originally named). `update_locked` is now the sole write
-   path, `save()` is removed/privatised, and a `check-no-direct-save` CI guard
-   prevents regressions.
+   path.
 4. **Power-loss gap.** The atomic write now `fsync`s the directory after the
    rename (temp-file fsync alone is insufficient for crash durability).
 5. **CONC-3 was unfalsifiable as a test.** Reclassified as a `check-no-spawn` CI
@@ -240,12 +271,39 @@ are addressed above:
 6. **Lockfile path was hardcoded.** Now derived from the resolved config
    directory so an `XDG_CONFIG_HOME` override still shares one lock.
 
+**Round 2** found six second-order defects; all addressed above:
+
+1. **Flaky lock test.** The mandated two-process test was specified as a sleep
+   race ("holds briefly / blocks until release"); rewritten to use a readiness
+   signal + `try_lock_exclusive() == WouldBlock` with no timing assertions.
+2. **Fragile grep guard.** The `check-no-direct-save` grep was binding-name-fragile
+   and test-noisy; replaced by **compiler-enforced** privacy (`save()` is private
+   to `config`, so bypass fails to compile).
+3. **Reload-under-lock precondition.** Added the requirement that `update_locked`
+   closures be self-contained (upsert, not `get_mut`-assume-present) so a
+   mutation on a not-yet-persisted server doesn't silently no-op; with a test.
+4. **POSIX-only design.** The atomic write now specifies the non-unix/Windows
+   path explicitly (`ReplaceFileW`/retry, no perm/atomicity gap) and scopes the
+   crash-durability guarantee to POSIX rather than hand-waving Windows.
+5. **Severity miscalibration.** CONC-2 reframed as data-integrity/robustness (not
+   exploitable security); split into its own non-`security`-labelled PR behind a
+   cost/benefit gate, shipping after CONC-1.
+6. **Failing-first contradiction.** Scoped the failing-first rule to CONC-1/CONC-2;
+   CONC-4/5 are characterization guards, CONC-3 is a CI check.
+
 ## Delivery
 
 - New tests land as permanent regression guards even where the invariant holds.
-- One branch + PR per *fixed* defect, labeled `security` and `red-team`, with the
-  threat model in the body. Each PR is confirmed with the user before push.
-- A `CHANGELOG.md` Security/Fixed entry is added as the work lands.
+- **Two separate PRs, not one** (severity calibration):
+  - **CONC-1** — the crash/concurrent-read corruption fix — is the genuine
+    data-loss/security deliverable; labeled `security` + `red-team`, threat model
+    in the body, `CHANGELOG.md` **Security** entry. Ships first and independently.
+  - **CONC-2** — the lost-update lock (`fs4` + sole-write-path refactor) — ships
+    second, only after the cost/benefit gate, labeled `red-team` (and *not*
+    `security`, since it is a robustness/data-integrity fix, not an exploitable
+    vuln); `CHANGELOG.md` **Fixed** entry. Honest labeling avoids overstating it.
+- The demotion guards (CONC-3/4/5) ride along with whichever PR is most relevant.
+- Each PR is confirmed with the user before push.
 - A checkpoint with the user before moving on to the supply-chain surface.
 
 ## Open implementation decisions (surface during the fix)
@@ -257,8 +315,9 @@ are addressed above:
 - **Lockfile staleness / cleanup** — whether the lockfile is ever removed, and
   how a stale lock (holder crashed) is handled (`fs4` advisory locks release on
   process exit, so a crashed holder does not leak the lock; confirm).
-- **Windows `rename`-over-existing semantics** — confirm the atomic-replace path
-  on Windows (may need `ReplaceFile`/retry rather than plain `rename`).
+- **Windows atomic-replace mechanism** — the Design section scopes this
+  (`ReplaceFileW` or `rename`-with-retry, durability scoped to POSIX); confirm the
+  exact API and error/retry behavior during implementation.
 
 ## Out of scope (this engagement)
 

--- a/docs/superpowers/specs/2026-06-04-red-team-concurrency-design.md
+++ b/docs/superpowers/specs/2026-06-04-red-team-concurrency-design.md
@@ -2,7 +2,8 @@
 
 **Date:** 2026-06-04
 **Branch:** `security/red-team-concurrency`
-**Status:** approved design
+**Status:** approved design (revised after a hostile `/challenge` review — see
+"Challenge-review fixes")
 
 ## Goal
 
@@ -50,7 +51,9 @@ async races) to regression guards and latent-footgun notes.
 - **Assets under attack:**
   1. **Config file integrity** — a reader must never observe an empty or
      truncated/partial TOML, and an interrupted write must leave the previous
-     config intact.
+     config intact. The power-loss case (the previous config must survive a
+     crash *after* the rename) additionally requires a directory `fsync`; see
+     the Design section.
   2. **Config edit durability** — a concurrent process's committed change must
      not be silently overwritten by another process's stale write (lost update).
   3. **Liveness** — the persistence mechanism must not be able to wedge other
@@ -62,37 +65,68 @@ The tests assert these. Each is written failing-first. Priority reflects the
 reconnaissance: the real on-disk sinks (CONC-1, CONC-2) lead; the
 single-threaded-runtime paths land as regression guards.
 
-- **CONC-1 (flagship, real defect) — write atomicity.** `Config` persistence is
-  atomic: a concurrent reader never observes an empty or partial config, and an
-  interrupted/failed write leaves the previous config bytes intact. *Current
-  code (`src/config.rs`, `write_private_file`) opens the live file with
-  `truncate(true)` and then writes, so a crash or a concurrent read between
-  truncate and write yields an empty or garbled TOML.* Fix: write to a temp file
-  in the same directory → `fsync` → atomic `rename` over the target, preserving
-  `0600` (file) / `0700` (dir) hardening. Anchor: `src/config.rs` `save` /
-  `write_to_disk` / `write_private_file`.
+- **CONC-1 (flagship, real defect) — write atomicity.** A concurrent reader
+  always observes either the complete old config or the complete new config,
+  never an empty/partial one. *Current code (`src/config.rs`,
+  `write_private_file`) opens the live file with `truncate(true)` then `write_all`
+  (`src/config.rs:337-343`), so a read between truncate and write observes a
+  zero-byte file.* **Observable correction (challenge finding):** a zero-byte
+  TOML does **not** fail to parse — `servers` is `#[serde(default)]`, `Option`
+  fields default to `None`, and `Config::load` even maps a missing file to
+  `Ok(Config::default())` (`src/config.rs:249`). So the corruption manifests as a
+  reader silently getting a config with **no servers / missing fields**, *not* a
+  parse error. The invariant and its test therefore assert *content survival* —
+  "a read taken during writes still contains the known server" — never "parsing
+  fails." Fix: write to a temp file in the same directory → `fsync(temp)` →
+  atomic `rename` over the target → `fsync(dir)`, preserving `0600` (file) /
+  `0700` (dir) hardening. Anchor: `src/config.rs` `save` / `write_to_disk` /
+  `write_private_file`.
 - **CONC-2 (real defect) — no lost updates.** Concurrent `bzr` processes that
   mutate config do not silently drop each other's edits. Fix via a
   `Config::update_locked(|cfg| …)` API: acquire an exclusive advisory lock
-  (`fs4`) on `~/.config/bzr/config.lock` → **reload the latest config from
-  disk** → apply the mutation closure → atomically write (CONC-1) → release.
+  (`fs4`) on a lockfile in the **resolved config directory** (`config.lock`,
+  sibling of `config.toml` — *not* a hardcoded `~/.config/bzr` path, so an
+  `XDG_CONFIG_HOME` override still shares one lock) → **reload the latest config
+  from disk** → apply the mutation closure → atomically write (CONC-1) → release.
   Reloading *under the lock* is what actually closes the race: a plain lock
   around only the write still lets two processes load stale state and serialize
-  last-writer-wins. Anchors: load→modify→save sites in
-  `src/commands/shared.rs` (`persist_detected_settings`, `handle_tofu`,
-  `handle_pin_rotation`) and `src/commands/config.rs` (`set-server`,
-  `set-default`, `set-keyring`, `unset-keyring`, `tls_pin_clear`).
-- **CONC-2b — lock liveness.** The advisory lock is never held across
-  interactive I/O. The TOFU / pin-rotation prompts run *outside* the lock and
-  only produce the values to persist; the `update_locked` closure is
-  non-interactive and applies the delta to a freshly-loaded config. This
-  prevents a process parked at a `[y/N/always]` prompt from wedging every other
-  `bzr` invocation, and avoids self-deadlock on re-entry.
+  last-writer-wins.
+  **Complete writer set (challenge finding — the original anchor list was
+  incomplete).** Every `config.save()` / `save_without_validation()` caller must
+  route through `update_locked`, or the guarantee leaks at the omitted site. The
+  full set (verified by grep, 14 sites across five files): `src/commands/shared.rs`
+  (`persist_detected_settings`, `handle_tofu`, `handle_pin_rotation`),
+  `src/commands/config.rs` (`set-default`, `set-server`, `set-keyring`,
+  `unset-keyring`, `tls_pin_clear`, `set-default`-path), `src/commands/template.rs`
+  (template add/remove), `src/commands/query.rs` (saved-query add/remove), and
+  `src/commands/bug/search.rs` (`--save` query). To make bypass impossible rather
+  than relying on enumeration staying correct, the **lock + reload + atomic write
+  become the only write path**: `save()`/`save_without_validation()` are removed
+  (or made private to `config`), all callers migrate to `update_locked`, and a CI
+  guard (`check-no-direct-save`, a grep) fails the build if a `config.save()`
+  reappears outside `config.rs`.
+- **CONC-2b — lock liveness & re-entrancy.** Two distinct properties:
+  (a) *Liveness:* the lock is never held across interactive I/O — the TOFU /
+  pin-rotation prompts run *outside* the lock and only produce the values to
+  persist; the `update_locked` closure is non-interactive and applies the delta
+  to a freshly-loaded config. This prevents a process parked at a `[y/N/always]`
+  prompt from wedging every other `bzr` invocation.
+  (b) *Re-entrancy:* `update_locked` is **explicitly non-reentrant** — `fs4`
+  `flock` treats two `open()` descriptions in the same process as independent, so
+  a nested `update_locked` (a closure that itself calls `update_locked`) would
+  self-deadlock. The design forbids nesting: closures perform only in-memory
+  mutation. A debug assertion / test guards against a re-entrant call. (The
+  earlier draft asserted re-entrancy was *safe*; that was wrong and is corrected
+  here.)
 - **CONC-3 (demoted) — runtime confinement.** The runtime is current-thread with
-  no task fan-out, so in-process data races cannot occur. Guard: a test/assertion
-  documenting the runtime flavor and the absence of `spawn`/`join` fan-out, so a
-  future change to `multi_thread` or an added `tokio::spawn` is flagged for
-  re-evaluation. *Expected: holds — regression guard.*
+  no task fan-out, so in-process data races cannot occur. *Guard (challenge
+  finding — this is not unit-testable: `#[tokio::test]` is current-thread
+  regardless of `main.rs`, and "no `spawn`" is a static property):* a CI grep
+  (`check-no-spawn`, a `make` target / shell check) fails the build if
+  `src/main.rs` stops declaring `flavor = "current_thread"` or if a
+  `tokio::spawn`/`join!`/`select!` fan-out appears in `src/`, forcing a
+  re-evaluation of the in-process-safety assumption. Not a `#[test]`.
+  *Expected: holds — regression guard.*
 - **CONC-4 (demoted) — keyring init idempotence.** `ensure_default_store`
   (`src/credentials/keyring.rs`) uses an unguarded check-then-act, but it is
   idempotent and benign under the current-thread runtime. Guard test that a
@@ -109,22 +143,34 @@ Run these as throwaway tests, record results in the spec's Method section. Both
 are deterministic (they use real OS threads / explicit interleaving in the test,
 independent of the app's single-threaded runtime).
 
-1. **CONC-1 probe.** Spawn one `std::thread` that repeatedly reads and parses the
-   config file while the main thread performs many `Config::save()` calls. Under
-   the current truncate-then-write path, some reads observe an empty/partial file
-   and fail to parse. *Expected: reproduces → confirms the corruption defect.*
-2. **CONC-2 probe.** Explicitly interleave two stale load→modify→save sequences:
-   load A; load B; A sets a pin and saves; B sets `auth_method` and saves. Assert
-   A's pin survives. Under the current code B's stale in-memory write overwrites
-   the file and A's pin is lost. *Expected: reproduces → confirms lost-update.*
+1. **CONC-1 probe.** Spawn one `std::thread` that repeatedly reads the config via
+   `Config::load()` while the main thread performs many `save()` calls. Assert on
+   **content survival**, not parse success: a read that succeeds but returns a
+   config *missing the known server* is the corruption signal (a zero-byte read
+   parses to an empty default `Config` — see CONC-1). Under the current
+   truncate-then-write path, some reads return the empty/default config.
+   *Expected: reproduces → confirms the corruption defect.*
+2. **CONC-2 probe (two parts).** (a) *Logic:* explicitly interleave two stale
+   load→modify→save sequences (load A; load B; A sets a pin and saves; B sets
+   `auth_method` and saves) and assert A's pin survives — this exercises the
+   reload-merge logic but **not** the lock. (b) *Mutual exclusion (challenge
+   finding — a single-process interleave never tests the lock, and an in-process
+   two-fd `flock` test self-deadlocks):* spawn a **second OS process** (a small
+   test helper binary, or a forked `Command`) that takes the lock and holds it
+   briefly, and assert the parent's `update_locked` blocks until release rather
+   than interleaving. *Expected: (a) reproduces lost-update on current code; (b)
+   becomes the regression test for the lock itself.*
 
 ## Method
 
-- **Adversarial / property tests** for CONC-1 and CONC-2 — the hardened versions
-  of the two pre-checks above, kept as permanent regression guards.
-- **Targeted unit tests** for CONC-2b (lock not held across prompts), CONC-3
-  (runtime flavor / no fan-out), CONC-4 (double-init safe), CONC-5 (second
-  `set()` ignored).
+- **Adversarial tests** for CONC-1 (content-survival under concurrent reads) and
+  CONC-2 (reload-merge logic + the two-process mutual-exclusion test), kept as
+  permanent regression guards.
+- **Targeted unit tests** for CONC-2b (closure is non-interactive; a re-entrant
+  `update_locked` is rejected, not deadlocked), CONC-4 (double-init safe), CONC-5
+  (second `set()` ignored).
+- **CI grep** for CONC-3 (`check-no-spawn`) and the `check-no-direct-save` guard
+  — build-time checks, not `#[test]`s.
 - Every test is written failing-first against current code. A test that
   reproduces a real break drives a TDD fix (red → green); the fix diff carries
   that test. Per the pre-checks, CONC-1 and CONC-2 are expected to reproduce
@@ -144,25 +190,55 @@ TDD locally; the user confirms before each push.
 
 - **Atomic write (CONC-1).** Replace the in-place truncate-write in
   `write_private_file` with: create `config.toml.<unique>.tmp` in the same
-  directory with `0600`, write the full serialized content, `fsync`, then
-  `rename` over `config.toml`. `rename` within a directory is atomic on POSIX and
-  on Windows (via replace semantics — to be confirmed during implementation). A
-  failed write aborts before the rename, leaving the original intact; the temp
-  file is cleaned up on failure.
+  directory with `0600`, write the full serialized content, `fsync(temp)`,
+  `rename` over `config.toml`, then **`fsync` the containing directory** so the
+  rename survives a crash/power-loss (the temp-file fsync alone does not make the
+  directory entry durable). `rename` within a directory is atomic on POSIX; on
+  Windows plain `rename` over an existing file is *not* guaranteed and may need
+  `ReplaceFileW` or a retry loop (tracked as an open decision). A failed write
+  aborts before the rename, leaving the original intact; the temp file is cleaned
+  up on failure.
 - **Advisory lock + reload (CONC-2).** `Config::update_locked(mutator: impl
-  FnOnce(&mut Config) -> Result<()>)`:
-  1. open/create `~/.config/bzr/config.lock` (`0600`) and take an exclusive
-     `fs4` lock;
+  FnOnce(&mut Config) -> Result<()>)` becomes the **single write path** (bare
+  `save()` is removed/privatised so no caller can bypass the lock):
+  1. open/create `config.lock` *in the resolved config directory* (`0600`) and
+     take an exclusive `fs4` lock;
   2. reload the current config from disk;
-  3. run `mutator` on it (non-interactive);
+  3. run `mutator` on it (non-interactive; nesting forbidden — a re-entrant call
+     is rejected with an error rather than allowed to self-deadlock);
   4. atomic-write (CONC-1);
-  5. drop the lock (released on guard drop).
+  5. drop the lock (released on guard drop, and on process exit if the holder
+     crashes — `fs4` advisory locks do not leak).
   Call sites that currently do load→(prompt)→mutate→save are refactored so the
   prompt stays outside and the mutation becomes the closure body.
 - **Dependency.** Add `fs4` (the actively-maintained successor to `fs2`) for
   cross-platform advisory locking, pinned to its current stable version (looked
   up at implementation time). Justification: hand-rolling `flock`/`LockFileEx`
   across Unix and Windows is error-prone; `fs4` is a small, focused crate.
+
+## Challenge-review fixes
+
+A hostile `/challenge` review found six material defects in the first draft; all
+are addressed above:
+
+1. **CONC-1 probe tested the wrong signal.** An empty/zero-byte TOML parses to a
+   default `Config` (`servers` is `#[serde(default)]`; `Config::load` maps a
+   missing file to `Ok(default)`), so "reads fail to parse" was a false-negative.
+   The probe/invariant now assert *content survival* (known server present).
+2. **CONC-2 lock was untested / re-entrancy claim was wrong.** A single-process
+   interleave never exercises the lock, and an in-process two-fd `flock` test
+   self-deadlocks. Added a real **two-process** mutual-exclusion test; made
+   `update_locked` explicitly non-reentrant (rejected, not deadlocked).
+3. **CONC-2 writer set was incomplete.** Five files / 14 `save()` sites write
+   config (not the two originally named). `update_locked` is now the sole write
+   path, `save()` is removed/privatised, and a `check-no-direct-save` CI guard
+   prevents regressions.
+4. **Power-loss gap.** The atomic write now `fsync`s the directory after the
+   rename (temp-file fsync alone is insufficient for crash durability).
+5. **CONC-3 was unfalsifiable as a test.** Reclassified as a `check-no-spawn` CI
+   grep, not a `#[test]`.
+6. **Lockfile path was hardcoded.** Now derived from the resolved config
+   directory so an `XDG_CONFIG_HOME` override still shares one lock.
 
 ## Delivery
 

--- a/docs/superpowers/specs/2026-06-04-red-team-concurrency-design.md
+++ b/docs/superpowers/specs/2026-06-04-red-team-concurrency-design.md
@@ -1,0 +1,195 @@
+# Red-Team Engagement — Surface 2: Concurrency
+
+**Date:** 2026-06-04
+**Branch:** `security/red-team-concurrency`
+**Status:** approved design
+
+## Goal
+
+Act as an adversary against the concurrency and shared-state surface of `bzr`.
+Enumerate the invariants the persisted state relies on, write deterministic
+adversarial tests that try to break each one, fix every reproduced break via TDD
+(failing-then-passing test), and ship one labeled remediation PR per fixed defect
+with the threat model documented.
+
+This is the second of three surfaces. Supply-chain follows as a separate
+engagement after a checkpoint.
+
+## Reframe (from reconnaissance)
+
+A surface map of the codebase established two facts that determine where the real
+risk lives:
+
+- The async runtime is `#[tokio::main(flavor = "current_thread")]`
+  (`src/main.rs`) and there are **no** `tokio::spawn`, `join!`, `try_join!`,
+  `select!`, or stream-fan-out call sites anywhere in `src/`. Batch paths
+  (`src/commands/attachment.rs` download loops) are sequential `.await` loops.
+  Therefore **in-process data races cannot occur** — there is no parallelism at
+  runtime.
+- The genuinely shared, mutable, adversary-reachable state is the **on-disk
+  config file** (`~/.config/bzr/config.toml`), written by multiple code paths
+  and potentially by multiple concurrent `bzr` processes. Notably, read-looking
+  commands (`bzr bug search`) rewrite config during the TLS TOFU / pin-rotation
+  flow (`src/commands/shared.rs`), widening the window for surprising writes.
+
+The engagement therefore **leads with the multi-process / crash-during-write
+hazards** and demotes the in-process hypotheses (keyring init, `CertCapture`,
+async races) to regression guards and latent-footgun notes.
+
+## Threat model
+
+- **Adversary:** concurrent `bzr` invocations (the user runs two commands at
+  once, or a long-running interactive command overlaps a quick one), and the
+  abrupt-termination case (crash / `SIGKILL` / power loss) mid-write. A
+  malicious server is a secondary actor: it can *trigger* a config write
+  (TOFU/pin-rotation) at a time of its choosing, but does not control the
+  filesystem.
+- **Trust boundary:** the config file is the trusted persisted state. Its
+  integrity (never empty/partial) and its freshness (concurrent edits not
+  silently lost) are the assets.
+- **Assets under attack:**
+  1. **Config file integrity** — a reader must never observe an empty or
+     truncated/partial TOML, and an interrupted write must leave the previous
+     config intact.
+  2. **Config edit durability** — a concurrent process's committed change must
+     not be silently overwritten by another process's stale write (lost update).
+  3. **Liveness** — the persistence mechanism must not be able to wedge other
+     `bzr` invocations (e.g., by holding a lock across an interactive prompt).
+
+## Invariant catalog
+
+The tests assert these. Each is written failing-first. Priority reflects the
+reconnaissance: the real on-disk sinks (CONC-1, CONC-2) lead; the
+single-threaded-runtime paths land as regression guards.
+
+- **CONC-1 (flagship, real defect) — write atomicity.** `Config` persistence is
+  atomic: a concurrent reader never observes an empty or partial config, and an
+  interrupted/failed write leaves the previous config bytes intact. *Current
+  code (`src/config.rs`, `write_private_file`) opens the live file with
+  `truncate(true)` and then writes, so a crash or a concurrent read between
+  truncate and write yields an empty or garbled TOML.* Fix: write to a temp file
+  in the same directory → `fsync` → atomic `rename` over the target, preserving
+  `0600` (file) / `0700` (dir) hardening. Anchor: `src/config.rs` `save` /
+  `write_to_disk` / `write_private_file`.
+- **CONC-2 (real defect) — no lost updates.** Concurrent `bzr` processes that
+  mutate config do not silently drop each other's edits. Fix via a
+  `Config::update_locked(|cfg| …)` API: acquire an exclusive advisory lock
+  (`fs4`) on `~/.config/bzr/config.lock` → **reload the latest config from
+  disk** → apply the mutation closure → atomically write (CONC-1) → release.
+  Reloading *under the lock* is what actually closes the race: a plain lock
+  around only the write still lets two processes load stale state and serialize
+  last-writer-wins. Anchors: load→modify→save sites in
+  `src/commands/shared.rs` (`persist_detected_settings`, `handle_tofu`,
+  `handle_pin_rotation`) and `src/commands/config.rs` (`set-server`,
+  `set-default`, `set-keyring`, `unset-keyring`, `tls_pin_clear`).
+- **CONC-2b — lock liveness.** The advisory lock is never held across
+  interactive I/O. The TOFU / pin-rotation prompts run *outside* the lock and
+  only produce the values to persist; the `update_locked` closure is
+  non-interactive and applies the delta to a freshly-loaded config. This
+  prevents a process parked at a `[y/N/always]` prompt from wedging every other
+  `bzr` invocation, and avoids self-deadlock on re-entry.
+- **CONC-3 (demoted) — runtime confinement.** The runtime is current-thread with
+  no task fan-out, so in-process data races cannot occur. Guard: a test/assertion
+  documenting the runtime flavor and the absence of `spawn`/`join` fan-out, so a
+  future change to `multi_thread` or an added `tokio::spawn` is flagged for
+  re-evaluation. *Expected: holds — regression guard.*
+- **CONC-4 (demoted) — keyring init idempotence.** `ensure_default_store`
+  (`src/credentials/keyring.rs`) uses an unguarded check-then-act, but it is
+  idempotent and benign under the current-thread runtime. Guard test that a
+  double init is safe; record the latent footgun (would need guarding if a
+  multi-thread runtime is ever adopted). *Expected: holds — regression guard.*
+- **CONC-5 (demoted) — `CertCapture` set-once.** Each probe constructs a fresh
+  `OnceLock` (`src/tls/tofu.rs`), so the set-once "first cert wins" semantics
+  hold even if rustls invokes the verifier more than once. Guard test that a
+  second `set()` is ignored. *Expected: holds — regression guard.*
+
+## Empirical pre-checks (before committing the workflow)
+
+Run these as throwaway tests, record results in the spec's Method section. Both
+are deterministic (they use real OS threads / explicit interleaving in the test,
+independent of the app's single-threaded runtime).
+
+1. **CONC-1 probe.** Spawn one `std::thread` that repeatedly reads and parses the
+   config file while the main thread performs many `Config::save()` calls. Under
+   the current truncate-then-write path, some reads observe an empty/partial file
+   and fail to parse. *Expected: reproduces → confirms the corruption defect.*
+2. **CONC-2 probe.** Explicitly interleave two stale load→modify→save sequences:
+   load A; load B; A sets a pin and saves; B sets `auth_method` and saves. Assert
+   A's pin survives. Under the current code B's stale in-memory write overwrites
+   the file and A's pin is lost. *Expected: reproduces → confirms lost-update.*
+
+## Method
+
+- **Adversarial / property tests** for CONC-1 and CONC-2 — the hardened versions
+  of the two pre-checks above, kept as permanent regression guards.
+- **Targeted unit tests** for CONC-2b (lock not held across prompts), CONC-3
+  (runtime flavor / no fan-out), CONC-4 (double-init safe), CONC-5 (second
+  `set()` ignored).
+- Every test is written failing-first against current code. A test that
+  reproduces a real break drives a TDD fix (red → green); the fix diff carries
+  that test. Per the pre-checks, CONC-1 and CONC-2 are expected to reproduce
+  breaks.
+
+## Orchestration
+
+Led in priority order so the real sinks are worked first:
+
+**CONC-1 → CONC-2 → CONC-2b → CONC-3 → CONC-4 → CONC-5.**
+
+Execution method (direct vs. multi-agent worktree workflow) is decided with the
+user at execution time, consistent with Surface 1. Confirmed breaks are fixed via
+TDD locally; the user confirms before each push.
+
+## Design: atomic write + `update_locked`
+
+- **Atomic write (CONC-1).** Replace the in-place truncate-write in
+  `write_private_file` with: create `config.toml.<unique>.tmp` in the same
+  directory with `0600`, write the full serialized content, `fsync`, then
+  `rename` over `config.toml`. `rename` within a directory is atomic on POSIX and
+  on Windows (via replace semantics — to be confirmed during implementation). A
+  failed write aborts before the rename, leaving the original intact; the temp
+  file is cleaned up on failure.
+- **Advisory lock + reload (CONC-2).** `Config::update_locked(mutator: impl
+  FnOnce(&mut Config) -> Result<()>)`:
+  1. open/create `~/.config/bzr/config.lock` (`0600`) and take an exclusive
+     `fs4` lock;
+  2. reload the current config from disk;
+  3. run `mutator` on it (non-interactive);
+  4. atomic-write (CONC-1);
+  5. drop the lock (released on guard drop).
+  Call sites that currently do load→(prompt)→mutate→save are refactored so the
+  prompt stays outside and the mutation becomes the closure body.
+- **Dependency.** Add `fs4` (the actively-maintained successor to `fs2`) for
+  cross-platform advisory locking, pinned to its current stable version (looked
+  up at implementation time). Justification: hand-rolling `flock`/`LockFileEx`
+  across Unix and Windows is error-prone; `fs4` is a small, focused crate.
+
+## Delivery
+
+- New tests land as permanent regression guards even where the invariant holds.
+- One branch + PR per *fixed* defect, labeled `security` and `red-team`, with the
+  threat model in the body. Each PR is confirmed with the user before push.
+- A `CHANGELOG.md` Security/Fixed entry is added as the work lands.
+- A checkpoint with the user before moving on to the supply-chain surface.
+
+## Open implementation decisions (surface during the fix)
+
+- **`update_locked` refactor depth** — how much of `connect_and_configure`'s
+  in-memory `config` is refreshed after a locked write (the in-memory copy used
+  for subsequent client construction goes stale relative to disk; decide whether
+  to re-read or to keep using the known-applied values).
+- **Lockfile staleness / cleanup** — whether the lockfile is ever removed, and
+  how a stale lock (holder crashed) is handled (`fs4` advisory locks release on
+  process exit, so a crashed holder does not leak the lock; confirm).
+- **Windows `rename`-over-existing semantics** — confirm the atomic-replace path
+  on Windows (may need `ReplaceFile`/retry rather than plain `rename`).
+
+## Out of scope (this engagement)
+
+- Supply-chain surface (`deny.toml`, lockfile, CI provenance, XML-RPC parsing as
+  malicious input) — separate engagement.
+- Adding a multi-threaded runtime or concurrent fetch fan-out — not a current
+  feature; CONC-3 only guards against a *future* such change regressing the
+  in-process-safety assumption.
+- Cross-host filesystem / NFS locking correctness — advisory locks over network
+  filesystems are best-effort; out of scope.

--- a/src/config.rs
+++ b/src/config.rs
@@ -266,8 +266,11 @@ impl Config {
         self.write_to_disk()
     }
 
-    /// Serialize and write the config to its on-disk path, hardening the
-    /// directory (`0o700`) and file (`0o600`) on first creation.
+    /// Serialize and write the config to its on-disk path atomically:
+    /// a uniquely-named sibling temp is written `0o600`, fsync'd (unix),
+    /// renamed over the target (atomic replace), and the directory is
+    /// fsync'd (unix) so the rename survives a crash. A concurrent reader
+    /// therefore always sees either the complete old or complete new file.
     fn write_to_disk(&self) -> Result<()> {
         let path = Self::path()?;
         if let Some(parent) = path.parent() {
@@ -276,13 +279,10 @@ impl Config {
             if !parent_exists {
                 set_private_directory_permissions(parent)?;
             }
+            reap_stale_temps(parent);
         }
         let content = toml::to_string_pretty(self)?;
-        let file_exists = path.exists();
-        write_private_file(&path, &content)?;
-        if !file_exists {
-            set_private_file_permissions(&path)?;
-        }
+        atomic_write(&path, &content)?;
         Self::warn_on_insecure_permissions(&path);
         Ok(())
     }
@@ -329,25 +329,162 @@ impl Config {
     }
 }
 
-#[cfg(unix)]
-fn write_private_file(path: &std::path::Path, content: &str) -> Result<()> {
-    use std::fs::OpenOptions;
-    use std::os::unix::fs::OpenOptionsExt;
-
-    let mut file = OpenOptions::new()
-        .create(true)
-        .truncate(true)
-        .write(true)
-        .mode(0o600)
-        .open(path)?;
-    file.write_all(content.as_bytes())?;
+/// Atomically write `content` to `path`: write a uniquely-named sibling
+/// temp file, durably flush it (unix), then rename it over `path`.
+/// `rename` replaces the destination atomically on POSIX and on Windows
+/// (`MoveFileExW`). The directory is fsync'd on unix so the rename is
+/// durable across a crash; on non-unix the concurrent-reader atomicity
+/// holds but crash-durability is best-effort.
+fn atomic_write(path: &std::path::Path, content: &str) -> Result<()> {
+    // Create + write the temp. `create_new` is collision-tolerant: a stale
+    // same-pid crash-orphan younger than the reaper's age gate could share
+    // the first candidate name, so retry with fresh names before failing.
+    let tmp = write_unique_temp(path, content)?;
+    // Test-only fault seam: simulate a crash/failure *after* the temp is
+    // written but *before* the rename, to deterministically verify that a
+    // failed write leaves the previous config intact (CONC-1 atomicity).
+    #[cfg(test)]
+    if FAIL_AFTER_TEMP.with(std::cell::Cell::get) {
+        let _ = fs::remove_file(&tmp);
+        return Err(BzrError::config("injected post-temp failure (test)"));
+    }
+    if let Err(e) = fs::rename(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    fsync_parent_dir(path);
     Ok(())
 }
 
+#[cfg(test)]
+thread_local! {
+    /// When set, [`atomic_write`] fails after writing the temp but before the
+    /// rename. Lets a test prove a failed write does not destroy the old file.
+    static FAIL_AFTER_TEMP: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Arm/disarm the [`atomic_write`] post-temp fault seam (test-only).
+#[cfg(test)]
+#[expect(
+    dead_code,
+    reason = "called from config_tests.rs; removed once Task 3 adds the caller"
+)]
+pub(crate) fn set_fail_after_temp(on: bool) {
+    FAIL_AFTER_TEMP.with(|f| f.set(on));
+}
+
+/// Max attempts to find an unused temp name. A collision only happens
+/// against a stale same-pid orphan younger than the reaper's age gate, so
+/// a few retries with fresh counter values is always enough.
+const TEMP_CREATE_ATTEMPTS: u32 = 16;
+
+/// A candidate sibling temp path: `config.toml.<pid>.<counter>.tmp`. The
+/// counter is process-global and monotonic, so each call yields a fresh
+/// name; combined with the pid this is unique across concurrent writers.
+fn candidate_temp_path(path: &std::path::Path) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(format!(".{pid}.{n}.tmp"));
+    match path.parent() {
+        Some(dir) => dir.join(name),
+        None => PathBuf::from(name),
+    }
+}
+
+/// Create a fresh `0600` sibling temp (collision-tolerant) and write
+/// `content` to it durably. Returns the temp path on success. On an
+/// `AlreadyExists` collision with a stale orphan, retries with a fresh
+/// name; on a write/flush failure, removes the temp it created and
+/// propagates the error.
+fn write_unique_temp(path: &std::path::Path, content: &str) -> Result<PathBuf> {
+    for _ in 0..TEMP_CREATE_ATTEMPTS {
+        let tmp = candidate_temp_path(path);
+        let mut file = match create_new_private(&tmp) {
+            Ok(file) => file,
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e.into()),
+        };
+        if let Err(e) = file
+            .write_all(content.as_bytes())
+            .and_then(|()| file.sync_all())
+        {
+            let _ = fs::remove_file(&tmp);
+            return Err(e.into());
+        }
+        return Ok(tmp);
+    }
+    Err(BzrError::config(
+        "could not create a unique config temp file after repeated attempts",
+    ))
+}
+
+#[cfg(unix)]
+fn create_new_private(tmp: &std::path::Path) -> std::io::Result<fs::File> {
+    use std::fs::OpenOptions;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(tmp)
+}
+
 #[cfg(not(unix))]
-fn write_private_file(path: &std::path::Path, content: &str) -> Result<()> {
-    fs::write(path, content)?;
-    Ok(())
+fn create_new_private(tmp: &std::path::Path) -> std::io::Result<fs::File> {
+    use std::fs::OpenOptions;
+
+    OpenOptions::new().create_new(true).write(true).open(tmp)
+}
+
+#[cfg(unix)]
+fn fsync_parent_dir(path: &std::path::Path) {
+    if let Some(dir) = path.parent() {
+        if let Ok(handle) = fs::File::open(dir) {
+            let _ = handle.sync_all();
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn fsync_parent_dir(_path: &std::path::Path) {}
+
+/// How old a temp sibling must be before the reaper treats it as a
+/// crash orphan. Comfortably longer than any single atomic write, so a
+/// *live* temp belonging to a concurrent `bzr` process is never reaped.
+const STALE_TEMP_AGE: std::time::Duration = std::time::Duration::from_secs(3600);
+
+/// Remove crash-orphaned `config.toml.*.tmp` siblings **older than
+/// [`STALE_TEMP_AGE`]**. A crash between temp-create and rename leaves a
+/// unique-named orphan that no graceful cleanup reaps; sweep old ones so
+/// they do not accumulate. The age gate is essential: CONC-1 ships before
+/// the CONC-2 lock, so two concurrent processes can each have a fresh
+/// in-flight temp — reaping unconditionally would delete the other's live
+/// temp and make its `rename` fail (lost write). Only temps untouched for
+/// an hour — which no live write produces — are removed.
+fn reap_stale_temps(dir: &std::path::Path) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !(name.starts_with("config.toml.") && name.ends_with(".tmp")) {
+            continue;
+        }
+        let is_old = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|mtime| mtime.elapsed().ok())
+            .is_some_and(|age| age >= STALE_TEMP_AGE);
+        if is_old {
+            let _ = fs::remove_file(entry.path());
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -360,19 +497,6 @@ fn set_private_directory_permissions(path: &std::path::Path) -> Result<()> {
 
 #[cfg(not(unix))]
 fn set_private_directory_permissions(_path: &std::path::Path) -> Result<()> {
-    Ok(())
-}
-
-#[cfg(unix)]
-fn set_private_file_permissions(path: &std::path::Path) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
-    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn set_private_file_permissions(_path: &std::path::Path) -> Result<()> {
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -365,10 +365,6 @@ thread_local! {
 
 /// Arm/disarm the [`atomic_write`] post-temp fault seam (test-only).
 #[cfg(test)]
-#[expect(
-    dead_code,
-    reason = "called from config_tests.rs; removed once Task 3 adds the caller"
-)]
 pub(crate) fn set_fail_after_temp(on: bool) {
     FAIL_AFTER_TEMP.with(|f| f.set(on));
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -279,8 +279,8 @@ impl Config {
             if !parent_exists {
                 set_private_directory_permissions(parent)?;
             }
-            reap_stale_temps(parent);
         }
+        reap_stale_temps(&path);
         let content = toml::to_string_pretty(self)?;
         atomic_write(&path, &content)?;
         Self::warn_on_insecure_permissions(&path);
@@ -374,6 +374,16 @@ pub(crate) fn set_fail_after_temp(on: bool) {
 /// a few retries with fresh counter values is always enough.
 const TEMP_CREATE_ATTEMPTS: u32 = 16;
 
+/// The shared filename prefix for this config's sibling temp files:
+/// `<config-file-name>.` (e.g. `config.toml.`). Both the temp **creator**
+/// ([`candidate_temp_path`]) and the temp **reaper** ([`reap_stale_temps`])
+/// derive their match from this one helper, so the two sides cannot drift:
+/// every name the creator can produce is one the reaper will recognize.
+fn temp_prefix(path: &std::path::Path) -> String {
+    let name = path.file_name().unwrap_or_default().to_string_lossy();
+    format!("{name}.")
+}
+
 /// A candidate sibling temp path: `config.toml.<pid>.<counter>.tmp`. The
 /// counter is process-global and monotonic, so each call yields a fresh
 /// name; combined with the pid this is unique across concurrent writers.
@@ -382,8 +392,7 @@ fn candidate_temp_path(path: &std::path::Path) -> PathBuf {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
     let pid = std::process::id();
-    let mut name = path.file_name().unwrap_or_default().to_os_string();
-    name.push(format!(".{pid}.{n}.tmp"));
+    let name = format!("{}{pid}.{n}.tmp", temp_prefix(path));
     match path.parent() {
         Some(dir) => dir.join(name),
         None => PathBuf::from(name),
@@ -460,15 +469,20 @@ const STALE_TEMP_AGE: std::time::Duration = std::time::Duration::from_secs(3600)
 /// the CONC-2 lock, so two concurrent processes can each have a fresh
 /// in-flight temp — reaping unconditionally would delete the other's live
 /// temp and make its `rename` fail (lost write). Only temps untouched for
-/// an hour — which no live write produces — are removed.
-fn reap_stale_temps(dir: &std::path::Path) {
+/// an hour — which no live write produces — are removed. The match prefix
+/// comes from [`temp_prefix`], the same source [`candidate_temp_path`] uses.
+fn reap_stale_temps(path: &std::path::Path) {
+    let Some(dir) = path.parent() else {
+        return;
+    };
+    let prefix = temp_prefix(path);
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        if !(name.starts_with("config.toml.") && name.ends_with(".tmp")) {
+        if !(name.starts_with(prefix.as_str()) && name.ends_with(".tmp")) {
             continue;
         }
         let is_old = entry

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -841,3 +841,57 @@ fn saved_config_file_is_0600() {
     let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
     assert_eq!(mode, 0o600, "config file must be owner-only");
 }
+
+#[test]
+fn save_reaps_old_crash_orphaned_temp_files() {
+    use std::time::{Duration, SystemTime};
+
+    let _lock = crate::ENV_LOCK.blocking_lock();
+    let tmp = tempfile::TempDir::new().unwrap();
+    unsafe { env::set_var("XDG_CONFIG_HOME", tmp.path()) };
+
+    let dir = tmp.path().join("bzr");
+    std::fs::create_dir_all(&dir).unwrap();
+    // An orphan left by a crash long ago: backdate its mtime past the gate.
+    let orphan = dir.join("config.toml.99999.7.tmp");
+    std::fs::write(&orphan, "stale").unwrap();
+    let old = SystemTime::now() - Duration::from_secs(7200);
+    std::fs::File::options()
+        .write(true)
+        .open(&orphan)
+        .unwrap()
+        .set_modified(old)
+        .unwrap();
+
+    let mut config = Config::default();
+    config
+        .servers
+        .insert("a".to_string(), make_server_config("https://a.test"));
+    config.save().unwrap();
+
+    assert!(!orphan.exists(), "an hour-old orphan temp must be reaped");
+}
+
+#[test]
+fn save_preserves_fresh_temp_files_of_concurrent_writers() {
+    let _lock = crate::ENV_LOCK.blocking_lock();
+    let tmp = tempfile::TempDir::new().unwrap();
+    unsafe { env::set_var("XDG_CONFIG_HOME", tmp.path()) };
+
+    let dir = tmp.path().join("bzr");
+    std::fs::create_dir_all(&dir).unwrap();
+    // A *fresh* sibling temp, as another bzr process would have mid-write.
+    let live = dir.join("config.toml.12345.0.tmp");
+    std::fs::write(&live, "in-flight").unwrap();
+
+    let mut config = Config::default();
+    config
+        .servers
+        .insert("a".to_string(), make_server_config("https://a.test"));
+    config.save().unwrap();
+
+    assert!(
+        live.exists(),
+        "a fresh concurrent-writer temp must NOT be reaped (would lose its write)"
+    );
+}

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -720,3 +720,124 @@ fn save_without_validation_hardens_recreated_file() {
         "recreated config must not be group/other accessible: {file_mode:o}"
     );
 }
+
+#[test]
+fn failed_write_leaves_previous_config_intact() {
+    let _lock = crate::ENV_LOCK.blocking_lock();
+    let tmp = tempfile::TempDir::new().unwrap();
+    unsafe { env::set_var("XDG_CONFIG_HOME", tmp.path()) };
+
+    // Seed v1.
+    let mut v1 = Config::default();
+    v1.servers
+        .insert("v1".to_string(), make_server_config("https://v1.test"));
+    v1.save().unwrap();
+    let before = std::fs::read(Config::path().unwrap()).unwrap();
+
+    // Arm the post-temp fault seam and attempt to write v2; it must fail.
+    set_fail_after_temp(true);
+    let mut v2 = Config::default();
+    v2.servers
+        .insert("v2".to_string(), make_server_config("https://v2.test"));
+    let result = v2.save();
+    set_fail_after_temp(false);
+    assert!(result.is_err(), "armed write must fail");
+
+    // The on-disk config must be byte-identical to v1, and no temp remains.
+    let after = std::fs::read(Config::path().unwrap()).unwrap();
+    assert_eq!(
+        before, after,
+        "failed write must leave the old config intact"
+    );
+    let dir = tmp.path().join("bzr");
+    let temps: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| {
+            std::path::Path::new(n)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("tmp"))
+        })
+        .collect();
+    assert!(
+        temps.is_empty(),
+        "failed write must clean up its temp: {temps:?}"
+    );
+}
+
+#[test]
+fn save_leaves_no_temp_files_and_writes_complete_content() {
+    let _lock = crate::ENV_LOCK.blocking_lock();
+    let tmp = tempfile::TempDir::new().unwrap();
+    unsafe { env::set_var("XDG_CONFIG_HOME", tmp.path()) };
+
+    let mut config = Config::default();
+    config
+        .servers
+        .insert("a".to_string(), make_server_config("https://a.test"));
+    config.save().unwrap();
+
+    let dir = tmp.path().join("bzr");
+    let leftovers: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| {
+            std::path::Path::new(n)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("tmp"))
+        })
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "no temp files should remain: {leftovers:?}"
+    );
+
+    let reloaded = Config::load().unwrap();
+    assert!(
+        reloaded.servers.contains_key("a"),
+        "content must be complete"
+    );
+}
+
+#[test]
+fn overwrite_replaces_content_wholesale() {
+    let _lock = crate::ENV_LOCK.blocking_lock();
+    let tmp = tempfile::TempDir::new().unwrap();
+    unsafe { env::set_var("XDG_CONFIG_HOME", tmp.path()) };
+
+    let mut config = Config::default();
+    config
+        .servers
+        .insert("v1".to_string(), make_server_config("https://v1.test"));
+    config.save().unwrap();
+
+    let mut config2 = Config::default();
+    config2
+        .servers
+        .insert("v2".to_string(), make_server_config("https://v2.test"));
+    config2.save().unwrap();
+
+    let reloaded = Config::load().unwrap();
+    assert!(reloaded.servers.contains_key("v2"));
+    assert!(!reloaded.servers.contains_key("v1"));
+}
+
+#[cfg(unix)]
+#[test]
+fn saved_config_file_is_0600() {
+    let _lock = crate::ENV_LOCK.blocking_lock();
+    let tmp = tempfile::TempDir::new().unwrap();
+    unsafe { env::set_var("XDG_CONFIG_HOME", tmp.path()) };
+
+    let mut config = Config::default();
+    config
+        .servers
+        .insert("a".to_string(), make_server_config("https://a.test"));
+    config.save().unwrap();
+
+    let path = Config::path().unwrap();
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600, "config file must be owner-only");
+}

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -64,15 +64,15 @@ fn config_file_io_operations() {
     assert_eq!(srv.url, "https://bugzilla.example.com");
     assert_eq!(srv.api_key.as_deref(), Some("test-key"));
 
-    // 3. Re-saving an existing config preserves the file's current
-    // permissions; perms are only set on first save.
+    // 3. Re-saving an existing config always produces a 0o600 file because
+    // atomic_write creates the temp with 0o600 and rename replaces the
+    // destination inode entirely (the old inode's permissions are not kept).
     #[cfg(unix)]
     {
         let path = Config::path().unwrap();
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
         original.save().unwrap();
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o644);
+        assert_eq!(mode, 0o600);
     }
 
     // 4. Loading a non-NotFound IO error (e.g. the path is a

--- a/src/credentials/keyring_tests.rs
+++ b/src/credentials/keyring_tests.rs
@@ -32,3 +32,16 @@ fn delete_missing_entry_is_ok() {
     // the wrapper maps to Ok.
     delete("bzr-test-delete", "never-existed").unwrap();
 }
+
+#[test]
+fn install_test_store_is_idempotent_across_repeated_calls() {
+    // CONC-4: the default-store init is check-then-act; under the
+    // current_thread runtime it is benign and idempotent. Calling it
+    // repeatedly must remain safe and leave a usable default store.
+    install_test_store();
+    install_test_store();
+    assert!(
+        keyring_core::get_default_store().is_some(),
+        "a default store must be installed after repeated init"
+    );
+}

--- a/src/tls/tofu_tests.rs
+++ b/src/tls/tofu_tests.rs
@@ -171,15 +171,37 @@ fn cert_capture_verify_tls13_signature_returns_ok() {
 #[test]
 fn cert_capture_keeps_the_first_value_set() {
     // CONC-5: the captured cell is set-once ("first cert wins") even if
-    // the verifier callback fires more than once on a handshake.
+    // the verifier callback fires more than once on a handshake. Drive the
+    // real capture path (`verify_server_cert`) with two distinct certs and
+    // assert the first one is the one retained.
     let capture = CertCapture {
         captured: OnceLock::new(),
         provider: crate::tls::default_provider(),
     };
-    let _ = capture.captured.set((vec![1, 2, 3], "first".to_string()));
-    let _ = capture.captured.set((vec![4, 5, 6], "second".to_string()));
 
-    let (der, issuer) = capture.captured.get().unwrap();
-    assert_eq!(der.as_slice(), &[1, 2, 3], "first DER must win");
-    assert_eq!(issuer.as_str(), "first", "first issuer must win");
+    let der_a = rcgen::CertificateParams::new(vec!["localhost".to_owned()])
+        .unwrap()
+        .self_signed(&rcgen::KeyPair::generate().unwrap())
+        .unwrap()
+        .der()
+        .to_vec();
+    let der_b = rcgen::CertificateParams::new(vec!["localhost".to_owned()])
+        .unwrap()
+        .self_signed(&rcgen::KeyPair::generate().unwrap())
+        .unwrap()
+        .der()
+        .to_vec();
+    assert_ne!(der_a, der_b, "the two certs must be distinct");
+
+    let cert_a = CertificateDer::from(der_a.clone());
+    let cert_b = CertificateDer::from(der_b);
+    let server_name = ServerName::try_from("localhost").unwrap();
+
+    let first = capture.verify_server_cert(&cert_a, &[], &server_name, &[], UnixTime::now());
+    assert!(first.is_ok(), "first verify must accept the cert");
+    let second = capture.verify_server_cert(&cert_b, &[], &server_name, &[], UnixTime::now());
+    assert!(second.is_ok(), "second verify must accept the cert");
+
+    let (der, _issuer) = capture.captured.get().unwrap();
+    assert_eq!(der, &der_a, "the first cert's DER must win");
 }

--- a/src/tls/tofu_tests.rs
+++ b/src/tls/tofu_tests.rs
@@ -167,3 +167,19 @@ fn cert_capture_verify_tls13_signature_returns_ok() {
     let result = capture.verify_tls13_signature(b"msg", &cert, &dss);
     assert!(result.is_ok(), "tls13 signature should be accepted");
 }
+
+#[test]
+fn cert_capture_keeps_the_first_value_set() {
+    // CONC-5: the captured cell is set-once ("first cert wins") even if
+    // the verifier callback fires more than once on a handshake.
+    let capture = CertCapture {
+        captured: OnceLock::new(),
+        provider: crate::tls::default_provider(),
+    };
+    let _ = capture.captured.set((vec![1, 2, 3], "first".to_string()));
+    let _ = capture.captured.set((vec![4, 5, 6], "second".to_string()));
+
+    let (der, issuer) = capture.captured.get().unwrap();
+    assert_eq!(der.as_slice(), &[1, 2, 3], "first DER must win");
+    assert_eq!(issuer.as_str(), "first", "first issuer must win");
+}


### PR DESCRIPTION
## Summary

Red-team engagement, **Surface 2: Concurrency**. Enumerated the invariants the
config/cert/keyring trust state relies on under concurrent access, ran
deterministic pre-checks to separate real defects from defensively-coded paths,
and fixed the one real defect (**CONC-1**: non-atomic config writes) via TDD.
The remaining invariants land as permanent regression/characterization guards.

Design: `docs/superpowers/specs/2026-06-04-red-team-concurrency-design.md`
(hardened through four adversarial `/challenge` rounds before implementation,
and one more `--base main` round against this branch — see Adversarial review).

## Threat model

- **Adversary:** a second `bzr` process (or a crash) racing a config write —
  plus the existing untrusted-server surface from Surface 1.
- **Trust boundary:** the on-disk `config.toml` is trusted state. A concurrent
  reader must never observe it empty or partially written, and a crash mid-write
  must never destroy the previously-saved config.
- **Asset:** the persisted server set / credentials — silently losing them is
  the failure being closed.

## The fixed defect — CONC-1 (atomic config writes)

The previous `write_to_disk` truncated `config.toml` in place and then wrote it.
A concurrent `bzr` process reading mid-write, or a crash between truncate and
write, could observe an **empty or partial** config — silently dropping every
configured server. The config is now written to a uniquely-named `0o600` sibling
temp, fsync'd, atomically `rename`d over the target (POSIX; `MoveFileExW` on
Windows), and the directory is fsync'd on Unix so the rename survives a crash. A
concurrent reader therefore always sees either the complete old or complete new
file. Crash-orphaned temps are reaped on the next save, **age-gated** (1h) so a
live concurrent writer's in-flight temp is never deleted.

**Scope:** this fixes torn reads, not lost updates. Two processes editing
simultaneously still resolve last-writer-wins until file locking lands
(**CONC-2**, deferred — see below). This is stated in the CHANGELOG and the spec.

## Regression / characterization guards (invariants that held)

- **CONC-3** — `make check-no-spawn` CI guard pins the `current_thread` runtime
  assumption: it fails if the runtime flavor changes or task fan-out
  (`tokio::spawn`, `join!`, `buffer_unordered`, …) appears in `src/`, either of
  which would reintroduce in-process data races.
- **CONC-4** — keyring default-store init is idempotent across repeated calls.
- **CONC-5** — `CertCapture` is set-once ("first cert wins"), driven through the
  real `verify_server_cert` path with two distinct certs.

## Deferred (not in this PR)

- **CONC-2** — the lost-update lock (`fs4` advisory lock + reload-under-lock +
  a single sole-write-path refactor). Ships as its own PR after its cost/benefit
  gate and `fs4` API verification, per the spec's delivery plan.

## Changes

- `src/config.rs` — `atomic_write` (temp → fsync → rename → dir-fsync),
  `write_unique_temp` (collision-tolerant `create_new`), `temp_prefix` (single
  source for the create + reap sides), `reap_stale_temps` (age-gated). Removed
  the in-place `write_private_file` / `set_private_file_permissions` paths.
- `src/config_tests.rs` — atomicity-on-failure (deterministic fault seam),
  no-temp-turds, wholesale-overwrite, `0o600` perms, reap-old / preserve-fresh.
- `Makefile` + `.github/workflows/ci.yml` — `check-no-spawn` target + CI step.
- `src/credentials/keyring_tests.rs`, `src/tls/tofu_tests.rs` — CONC-4 / CONC-5
  guards.
- `CHANGELOG.md`, design spec.

## Testing

- `cargo test`: 1274 lib + 22 + 72 integration, 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- `make check-test-layout check-no-spawn`: pass.
- The atomicity guard fails on the pre-fix code (in-place write) and passes after
  (red→green); the fault seam makes it deterministic, not timing-dependent.

## Adversarial review

A `/challenge --base main` pass against this branch surfaced two findings, both
fixed in `3550a65`: the CHANGELOG now discloses the lost-update residual, and the
temp-name prefix is unified across the create and reap sides so they cannot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
