### PR TITLE
Support custom bug fields in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `bzr bug list`, `bug search`, `bug my`, `bug view`, and `query run` now
+  preserve Bugzilla custom fields named `cf_*` when requested through
+  `--fields`. Custom field values are emitted as top-level JSON keys and as
+  dynamic table columns/detail rows instead of being dropped during bug
+  deserialization.
 - Concurrent `bzr` processes editing different config fields no longer clobber
   each other. All config writes now take an exclusive advisory lock on
   `config.lock` and reload the latest config from disk before applying their

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,28 +1349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,21 +1932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
 dependencies = [
  "papergrid",
- "tabled_derive",
  "testing_table",
-]
-
-[[package]]
-name = "tabled_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
-dependencies = [
- "heck",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
 toml = "1"
 dirs = "6"
-tabled = "0.21"
+tabled = { version = "0.21", default-features = false, features = ["std"] }
 thiserror = "2"
 colored = "3"
 tracing = "0.1"

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -185,6 +185,7 @@ List bugs matching filter criteria.
 bzr bug list --product Fedora --status ASSIGNED --limit 20
 bzr bug list --assignee user@example.com
 bzr bug list --product Fedora --fields id,summary,status
+bzr bug list --product Fedora --fields id,summary,cf_release
 # Select table columns
 bzr bug list --product Fedora --fields id,priority,severity,status,summary
 bzr bug list --id 100 --id 200 --id 300
@@ -212,14 +213,22 @@ Filter flags (`--product`, `--component`, `--status`, `--assignee`, `--creator`,
 | `--alias <A>` | No | | Filter by bug alias |
 | `--summary <S>` | No | | Substring match on the Summary field (matches all bug states) |
 | `--limit <N>` | No | 50 | Max results |
-| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
-| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
+| `--fields <F>` | No | | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
 | `--created-since <DATE>` | No | | Filter to bugs whose `creation_time` is `>= DATE`. See [Date format](#date-format) below. |
 | `--changed-since <DATE>` | No | | Filter to bugs whose `last_change_time` is `>= DATE`. See [Date format](#date-format) below. |
 
 #### Date format
 
 `--created-since` and `--changed-since` accept ISO 8601 datetimes (`YYYY-MM-DDTHH:MM:SS`, `YYYY-MM-DDTHH:MM:SSZ`, or `YYYY-MM-DDTHH:MM:SS±HH:MM`) or a bare `YYYY-MM-DD`. Bare dates are treated as `00:00:00 UTC`. Fractional seconds, week dates, and ordinal dates are rejected with exit code 7. The same validator is used by `bzr bug history --since` and `bzr comment list --since`.
+
+#### Field selection and custom fields
+
+`--fields` accepts built-in bug fields and Bugzilla custom fields whose names
+start with `cf_`. Custom fields are not fetched by default; request them
+explicitly, for example `--fields id,summary,cf_release`. If Bugzilla omits a
+requested custom field, it is omitted from JSON output and rendered as an empty
+table cell. Unknown non-custom field names warn or fail as described above.
 
 #### Additional field filters (issue #158)
 
@@ -275,8 +284,8 @@ bzr bug view my-alias --fields id,summary,assigned_to
 |--------|----------|-------------|
 | `<IDS>...` | Yes | One or more bug IDs or aliases. Aliases and numeric IDs may be mixed. |
 | `--permissive` | No | Multi-ID only. Continue past per-bug failures, surfacing them as `Bug #N — UNAVAILABLE` placeholder rows (table) or entries in `failed` (JSON). Exit 0 even if some bugs fail. Has no effect on session-wide failures (transport, auth, security) — those still bail. Setting `--permissive` with a single ID returns input-validation error (exit 7). |
-| `--fields <F>` | No | Comma-separated fields requested from the server; in table output, selects which detail rows to show. Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
-| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those detail rows. Under `--json`, the object omits the dropped fields (including `id`, when excluded). |
+| `--fields <F>` | No | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which detail rows to show. Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
+| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those detail rows. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). |
 
 **Output shapes:**
 
@@ -302,6 +311,7 @@ bzr bug search "kernel panic"
 bzr bug search "ALL kernel panic"                      # include closed/resolved bugs
 bzr bug search "component:NetworkManager priority:high" --limit 10
 bzr bug search "memory leak" --fields id,summary
+bzr bug search "memory leak" --fields id,summary,cf_release
 bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW"
 bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW" --save-as "my-query"
 bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?known_name=my%20search&product=Firefox" --save-as
@@ -317,8 +327,8 @@ bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?known_name=m
 | `--from-url <URL>` | No* | | Execute a search from a Bugzilla buglist.cgi URL. Recognized parameters (product, component, status, etc.) are mapped to structured fields; unrecognized parameters (boolean charts, field-change filters) are passed through to the REST API verbatim. |
 | `--save-as [NAME]` | No | | Save this URL query for future reuse. If `NAME` is omitted, uses the URL's `known_name` parameter as the query name. Requires `--from-url`. |
 | `--limit <N>` | No | 50 | Max results. When `--from-url` is used, the URL's own limit parameter takes precedence unless overridden here. |
-| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
-| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
+| `--fields <F>` | No | | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
 
 *One of `<QUERY>` or `--from-url` must be provided.
 
@@ -359,8 +369,8 @@ bzr bug my --status NEW --status '!RESOLVED'  # mixed positive and negated
 | `--all` | No | | Show all bugs related to me (assigned + created + CC'd) |
 | `--status <S>` | No | | Filter by status (repeatable; `!` prefix to exclude) |
 | `--limit <N>` | No | 50 | Max results per category. With `--all`, each of the three categories (assigned, created, CC'd) is queried separately up to this limit; duplicates across categories are removed. |
-| `--fields <F>` | No | | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
-| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
+| `--fields <F>` | No | | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
+| `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
 
 ### `bzr bug create`
 
@@ -1286,8 +1296,8 @@ bzr query save recent-firefox --product Firefox --changed-since 2026-04-01
 | `--severity <S>` | No* | Filter by severity (repeatable; prefix with `!` to exclude) |
 | `--search <Q>` | No* | Free-text search query |
 | `--limit <N>` | No | Max results |
-| `--fields <F>` | No | Stored with the query (comma-separated); at run time sets the fields requested from the server and selects table columns. Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
-| `--exclude-fields <F>` | No | Stored with the query (comma-separated); at run time drops those fields from the server request and removes table columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). |
+| `--fields <F>` | No | Stored with the query (comma-separated built-in fields or Bugzilla custom fields named `cf_*`); at run time sets the fields requested from the server and selects table columns. Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
+| `--exclude-fields <F>` | No | Stored with the query (comma-separated); at run time drops those fields from the server request and removes table columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). |
 | `--created-since <DATE>` | No | Save a `creation_time >= DATE` filter into the query. Same accepted forms as [`bzr bug list --created-since`](#date-format). |
 | `--changed-since <DATE>` | No | Save a `last_change_time >= DATE` filter into the query. Same accepted forms as [`bzr bug list --changed-since`](#date-format). |
 
@@ -1344,6 +1354,7 @@ bzr query run firefox-new --limit 10
 
 # Run with field selection
 bzr query run firefox-new --fields id,summary,status
+bzr query run firefox-new --fields id,summary,cf_release
 
 # Run against a different server
 bzr query run my-query --server other-server --limit 50
@@ -1356,8 +1367,8 @@ bzr query run recent-firefox --changed-since 2026-05-01
 |--------|----------|-------------|
 | `<NAME>` | Yes | Query name |
 | `--limit <N>` | No | Override the saved limit |
-| `--fields <F>` | No | Comma-separated fields requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
-| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including `id`, when excluded). |
+| `--fields <F>` | No | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
+| `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). |
 | `--server <NAME>` | No | Override the server to run the query against. Takes precedence over the server stored in the saved query. The global `--server` flag takes precedence over this flag. |
 | `--created-since <DATE>` | No | Override the saved `creation_time` filter for this run. Same accepted forms as [`bzr bug list --created-since`](#date-format). |
 | `--changed-since <DATE>` | No | Override the saved `last_change_time` filter for this run. Same accepted forms as [`bzr bug list --changed-since`](#date-format). |

--- a/docs/superpowers/plans/2026-06-08-custom-fields-output.md
+++ b/docs/superpowers/plans/2026-06-08-custom-fields-output.md
@@ -1,0 +1,444 @@
+# Custom Field Values in Bug Output Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve Bugzilla custom fields named `cf_*` in bug responses and
+render them when users request them with `--fields` / `--exclude-fields`.
+
+**Architecture:** Keep the existing fixed `Bug` model for built-in fields, but
+add a public `custom_fields: BTreeMap<String, serde_json::Value>` that captures
+only flattened response keys beginning with `cf_`. Replace the current
+built-in-only field selection helpers with a partition that distinguishes
+built-ins, custom fields, and unknown fields. REST deserialization, XML-RPC
+fallback, JSON projection, table columns, detail rows, validation, and warnings
+all consume that same partition so `cf_*` behaves as a first-class dynamic field
+family without accepting arbitrary extension keys.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-custom-fields-output-design.md`
+
+---
+
+## Background
+
+The prior `--fields` work already exists in this branch:
+
+- `src/output/resources/bug.rs` has `ColumnSpec`, a built-in `BugColumn`
+  registry, dynamic table rendering, JSON projection, and preflight validation.
+- `src/commands/bug/mod.rs` validates field selection before network I/O for
+  list-style bug commands, while keeping `bug view` lenient.
+- `src/commands/bug/list.rs`, `src/commands/bug/search.rs`,
+  `src/commands/bug/my.rs`, and `src/commands/query.rs` already canonicalize
+  aliases before sending `include_fields` / `exclude_fields`.
+- `src/commands/bug/view.rs` has separate single-ID and multi-ID paths. Watch
+  this file carefully: single-ID currently uses canonicalized field values for
+  both fetch and render, while multi-ID uses canonicalized values for fetch and
+  raw values for render. The custom-field implementation should make this
+  intentional and consistent.
+
+Today, unknown include tokens pass through to Bugzilla on the wire, which is
+good for `cf_release`, but the returned field is dropped because `Bug` derives
+`Deserialize` with only known built-in fields. The output layer then classifies
+`cf_release` as unknown, warning or failing before it can render.
+
+---
+
+## File Structure
+
+**Modify:**
+
+- `src/types/bug.rs` - add `BugWire`, manual `Deserialize` and `Serialize` for
+  `Bug`, and the `custom_fields` map.
+- `src/types/bug_tests.rs` - cover REST deserialization, sparse defaults,
+  top-level serialization, ordering, and non-`cf_*` extension dropping.
+- `src/xmlrpc/client.rs` - capture XML-RPC `cf_*` members in `value_to_bug` and
+  convert XML-RPC values to `serde_json::Value`.
+- `src/xmlrpc/client_tests.rs` - cover XML-RPC custom strings, arrays, doubles,
+  base64, and ignored non-custom extras.
+- `src/client/bug_tests.rs` - lock down the wire-only `id` fetch requirement
+  for custom-only field selections.
+- `src/output/resources/bug.rs` - replace built-in-only selection helpers with
+  a field partition, add `SelectedBugField`, render custom values in table and
+  detail output, and update JSON projection/validation/warnings.
+- `src/output/resources/bug_tests.rs` - add output behavior tests for custom
+  JSON, validation, warnings, table columns, ordering, dedupe, and detail rows.
+- `src/commands/bug/list_tests.rs` - command coverage for custom fields in JSON
+  and table output.
+- `src/commands/bug/my_tests.rs` - command coverage for custom fields through
+  the `whoami`-driven personal bug searches.
+- `src/commands/bug/search_tests.rs` - `--from-url` custom field behavior and
+  `columnlist` non-import behavior.
+- `src/commands/bug/view_tests.rs` - single and multi-ID projection plus table
+  detail rows for requested custom fields.
+- `src/commands/query_tests.rs` - saved query fields containing `cf_*` are
+  honored by `query run`.
+- `tests/integration.rs` - update the documentation guard that currently treats
+  custom field visibility as impossible.
+- `src/cli/bug.rs`, `src/cli/query.rs`, `docs/bzr-cli.md` - document that
+  `--fields` / `--exclude-fields` accept built-ins and `cf_*` custom fields.
+- `CHANGELOG.md` - add an Unreleased entry for user-visible output behavior.
+
+**No new dependencies.** `serde_json`, `base64`, and `BTreeMap` are already
+available.
+
+**Commit safety:** Tasks 4-6 change one public behavior surface: whether `cf_*`
+field selections are accepted and rendered. If implementing one task per commit,
+do not commit a state where validation accepts a custom field that the active
+output mode still cannot project or render. Either keep Task 4's partition work
+internal until Tasks 5 and 6 land, or squash Tasks 4-6 into one behavior commit.
+
+---
+
+## Task 1: Add failing REST `Bug` model tests
+
+**Files:**
+
+- Modify: `src/types/bug_tests.rs`
+
+- [ ] Add a helper that builds a minimal bug JSON object with `id`, `summary`,
+  and one or two `cf_*` keys.
+- [ ] Add a test that deserializing a REST bug captures `cf_release` in
+  `bug.custom_fields`.
+- [ ] Add a sparse-response test for `{"id": 42, "cf_release": "9.6"}` that
+  proves missing built-ins keep the same defaults as the current `Bug`
+  deserializer.
+- [ ] Add a test that unknown non-custom extension keys are dropped.
+- [ ] Add a serialization test that `cf_release` is emitted as a top-level key,
+  not under `"custom_fields"`.
+- [ ] Add an ordering test: built-in keys come first in the existing `Bug`
+  struct order, then custom keys in sorted `BTreeMap` order.
+- [ ] Update any `Bug` test fixtures in this file to initialize
+  `custom_fields: BTreeMap::new()`.
+- [ ] Run `cargo test --lib types::bug_tests`.
+
+Expected result: tests fail to compile because `Bug::custom_fields` does not
+exist and `Bug` still derives serialization/deserialization.
+
+---
+
+## Task 2: Implement REST custom-field capture
+
+**Files:**
+
+- Modify: `src/types/bug.rs`
+- Modify as needed: any test helpers that construct `Bug` directly
+
+- [ ] Add `use std::collections::BTreeMap;` and keep the existing serde imports
+  explicit.
+- [ ] Add `pub custom_fields: BTreeMap<String, serde_json::Value>` to `Bug`.
+- [ ] Stop deriving `Serialize` and `Deserialize` directly for `Bug`.
+- [ ] Introduce a private `BugWire` struct that mirrors every current built-in
+  `Bug` field, including all existing `#[serde(default)]` behavior.
+- [ ] Add `#[serde(flatten)] extra: BTreeMap<String, serde_json::Value>` to
+  `BugWire`.
+- [ ] Implement `Deserialize` for `Bug` by deserializing `BugWire`, filtering
+  `extra` to keys with an exact `cf_` prefix, and copying built-ins into `Bug`.
+- [ ] Implement `Serialize` for `Bug` manually with `SerializeMap`, emitting
+  built-ins in the current struct order and custom fields afterward in
+  `BTreeMap` order.
+- [ ] Make sure manual serialization does not emit absent optional fields or
+  empty lists differently than the existing derived serialization. If the
+  current derived output includes `null` and empty arrays, preserve that.
+- [ ] Update all direct `Bug { ... }` literals in tests and production code to
+  populate `custom_fields: BTreeMap::new()`.
+- [ ] Run `cargo test --lib types::bug_tests`.
+
+Expected result: the new type tests pass.
+
+---
+
+## Task 3: Add XML-RPC custom-field capture
+
+**Files:**
+
+- Modify: `src/xmlrpc/client.rs`
+- Modify: `src/xmlrpc/client_tests.rs`
+
+- [ ] Add failing tests that `value_to_bug` captures `cf_release` from an
+  XML-RPC struct and ignores a non-custom extension member.
+- [ ] Add tests for representative XML-RPC custom values:
+  string, integer, boolean, datetime, array, struct, finite double, non-finite
+  double, and base64.
+- [ ] Add `xmlrpc_value_to_json(value: &Value) -> serde_json::Value`.
+- [ ] Convert XML-RPC values as specified:
+  string to JSON string, integer to JSON number, boolean to JSON boolean,
+  datetime to JSON string, arrays and structs recursively, finite doubles to
+  JSON numbers, non-finite doubles to JSON strings, and base64 to a base64
+  encoded JSON string using the existing `base64` dependency.
+- [ ] Add `custom_fields_from_xmlrpc(m: &BTreeMap<String, Value>)` that keeps
+  only keys starting with `cf_`.
+- [ ] Populate `Bug { custom_fields, ... }` in `value_to_bug`.
+- [ ] Run `cargo test --lib xmlrpc::client_tests`.
+
+Expected result: XML-RPC tests pass, and malformed or unusual custom values do
+not fail an otherwise valid bug response.
+
+---
+
+## Task 4: Replace built-in-only field selection with partitions
+
+**Files:**
+
+- Modify: `src/output/resources/bug.rs`
+- Modify: `src/output/resources/bug_tests.rs`
+
+- [ ] Add failing tests that:
+  - `validate_json_field_selection` accepts all-custom includes.
+  - `warn_unknown_fields` is silent for `cf_release`.
+  - `warn_unknown_fields` still warns for non-custom typos.
+  - `--fields summary,cf_release,typo` warns only for `typo`.
+  - the new field partition classifies `cf_release` as custom rather than
+  unknown.
+- [ ] Add `SelectedBugField<'a>` with `BuiltIn(&'static BugColumn)` and
+  `Custom(&'a str)`.
+- [ ] Add `FieldPartition<'a>` with `ordered`, `built_ins`, `custom`, and
+  `unknown`.
+- [ ] Implement a parser that trims blank tokens, deduplicates requested fields
+  by effective identity, preserves first occurrence order, resolves aliases to
+  built-ins, classifies exact `cf_` prefix tokens as custom, and classifies
+  everything else as unknown.
+- [ ] Replace `partition_include` callers with `FieldPartition`.
+- [ ] Keep `canonical_field_list` behavior mostly unchanged: built-in aliases
+  map to canonical field names, and `cf_*` tokens pass through exactly.
+- [ ] Update `canonical_excludes` so it returns both canonical built-in keys and
+  exact custom keys, while continuing to ignore unknown non-custom excludes.
+- [ ] Update JSON validation so all-custom includes are valid and all-unknown
+  non-custom includes still exit 7 for list-style JSON commands.
+- [ ] Add validation tests for `--fields cf_release --exclude-fields cf_release`
+  in list-style JSON mode. It should exit 7 because the effective selected set
+  is empty.
+- [ ] Add validation coverage for excluding every default built-in with no
+  include list. It should still exit 7 in JSON even though custom fields could
+  theoretically exist, because no custom fields were requested.
+- [ ] Update warning logic to ignore `cf_*` tokens.
+- [ ] Run `cargo test --lib output::resources::bug_tests`.
+
+Expected result: selection and validation tests pass before rendering support is
+added.
+
+---
+
+## Task 5: Update JSON projection for custom fields
+
+**Files:**
+
+- Modify: `src/output/resources/bug.rs`
+- Modify: `src/output/resources/bug_tests.rs`
+
+- [ ] Add failing tests that:
+  - `bug_to_json` includes `cf_release` when selected.
+  - `bug_to_json` excludes `cf_release` when excluded.
+  - `bug_to_json` with `--fields summary,cf_release` keeps both keys.
+  - `bug_to_json` with `--fields cf_release` emits no `id` unless requested.
+  - `bug_to_json` with `--fields cf_missing` does not synthesize `null` or an
+  empty string when the server omitted the custom key; the projected object may
+  be `{}`.
+  - full-object JSON orders built-ins before sorted custom fields.
+- [ ] Update `bug_to_json` include mode to keep canonical built-in keys plus
+  exact custom keys.
+- [ ] Update exclude mode to remove canonical built-in keys plus exact custom
+  keys.
+- [ ] Keep projection warning-free; command preflight owns warnings because it
+  has stderr access.
+- [ ] Run `cargo test --lib output::resources::bug_tests`.
+
+Expected result: JSON projection tests pass.
+
+---
+
+## Task 6: Render custom fields in table output
+
+**Files:**
+
+- Modify: `src/output/resources/bug.rs`
+- Modify: `src/output/resources/bug_tests.rs`
+
+- [ ] Add failing tests that:
+  - `validate_table_columns` accepts all-custom includes once custom table
+  rendering is implemented.
+  - `validate_table_columns` still rejects all-unknown non-custom includes.
+  - `write_bugs` renders requested custom columns.
+  - mixed built-in/custom include order is preserved.
+  - repeated include tokens render once, keeping the first occurrence.
+  - string, number, boolean, null, array, and object custom values render as
+  specified.
+  - a requested custom column whose value is missing on a bug renders as an
+  empty cell instead of falling back, warning, or panicking.
+  - default table output does not render captured custom fields.
+- [ ] Add a `render_custom_value(&serde_json::Value) -> String` helper:
+  strings as-is, numbers and booleans via `to_string`, null as empty, arrays
+  and objects as compact JSON.
+- [ ] Update list-style table rendering to use `SelectedBugField::ordered`
+  instead of `Vec<&BugColumn>`.
+- [ ] Render custom column headers as uppercased field names, for example
+  `cf_release` to `CF_RELEASE`.
+- [ ] Preserve the current default table columns when no include list is
+  supplied.
+- [ ] Ensure `--exclude-fields cf_release` removes a requested custom column.
+- [ ] Assert that excluding the only requested custom column is rejected before
+  rendering, not rendered as an empty table.
+- [ ] Run `cargo test --lib output::resources::bug_tests`.
+
+Expected result: table list custom-field tests pass.
+
+---
+
+## Task 7: Render custom fields in bug detail output
+
+**Files:**
+
+- Modify: `src/output/resources/bug.rs`
+- Modify: `src/output/resources/bug_tests.rs`
+
+- [ ] Add failing tests that:
+  - `bug view` detail output renders a requested custom row.
+  - no-include detail output does not render captured custom fields.
+  - custom detail rows follow selected built-in rows and preserve include-list
+  order.
+  - duplicate custom include tokens render one row.
+  - a requested custom detail row whose value is missing renders with an empty
+  value instead of being treated as an unknown field.
+- [ ] Update `field_selected` or replace it with partition-driven detail logic
+  so built-in detail rows keep current behavior.
+- [ ] Render requested custom rows after built-in rows only when they appear in
+  the include list and are not excluded.
+- [ ] Use the same `render_custom_value` helper as list-style table output.
+- [ ] Keep the `Bug #<id>` heading always present, even when no detail rows are
+  selected.
+- [ ] Run `cargo test --lib output::resources::bug_tests`.
+
+Expected result: detail output custom-field tests pass.
+
+---
+
+## Task 8: Add command-level coverage
+
+**Files:**
+
+- Modify: `src/commands/bug/list_tests.rs`
+- Modify: `src/commands/bug/my_tests.rs`
+- Modify: `src/commands/bug/search_tests.rs`
+- Modify: `src/commands/bug/view_tests.rs`
+- Modify: `src/commands/query_tests.rs`
+- Modify: `src/client/bug_tests.rs`
+- Modify if needed: `src/commands/bug/view.rs`
+
+- [ ] Add `bug list --fields id,cf_release --json` test coverage proving the
+  REST request sends `include_fields=id,cf_release` and output emits
+  `cf_release`.
+- [ ] Add `bug list --fields cf_release --json` coverage proving `id` is added
+  to the REST request as an internal fetch requirement but does not appear in
+  output projection.
+- [ ] Add client-level `force_id_fields` coverage for custom-only includes:
+  `Some("cf_release")` becomes `id,cf_release`, while `id` remains removable
+  from the output projection layer.
+- [ ] Add client-level coverage that default bug searches still use the existing
+  `BUG_DEFAULT_FIELDS` request and do not fetch or discover all server custom
+  fields when `--fields` is absent.
+- [ ] Add table-mode `bug list --fields id,cf_release` coverage proving a
+  `CF_RELEASE` column renders.
+- [ ] Add `bug my --fields id,cf_release --json` coverage proving every
+  generated personal search carries the custom field request and projected
+  output includes `cf_release`.
+- [ ] Add `bug search --from-url ... --fields id,cf_release --json` coverage
+  proving custom fields survive URL-imported search execution.
+- [ ] Add `bug search --from-url` coverage proving URL `columnlist` still does
+  not infer custom fields without explicit `--fields`.
+- [ ] Add `query run` coverage for a saved query whose stored `fields` includes
+  `cf_release`.
+- [ ] Add single-ID `bug view --fields cf_release --json` coverage proving only
+  the custom key emits.
+- [ ] Add multi-ID `bug view --fields id,cf_release --json` coverage proving
+  each object in the `bugs` array is projected.
+- [ ] Add table detail coverage proving `bug view --fields cf_release` renders
+  a custom row.
+- [ ] Fix any single-ID vs multi-ID `bug view` spec drift uncovered by these
+  tests. Fetch parameters should use canonicalized built-in aliases; render
+  selection should still understand aliases and exact `cf_*` tokens.
+- [ ] Run:
+
+```bash
+cargo test --lib commands::bug::list_tests
+cargo test --lib commands::bug::my_tests
+cargo test --lib commands::bug::search_tests
+cargo test --lib commands::bug::view_tests
+cargo test --lib commands::query_tests
+```
+
+Expected result: command paths pass and warnings fire only for unknown
+non-custom field tokens.
+
+---
+
+## Task 9: Update integration guard, docs, and changelog
+
+**Files:**
+
+- Modify: `tests/integration.rs`
+- Modify: `src/cli/bug.rs`
+- Modify: `src/cli/query.rs`
+- Modify: `docs/bzr-cli.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] Replace the integration/documentation guard that currently says custom
+  `cf_*` fields cannot become visible via `--json`.
+- [ ] Add or update CLI help for bug/list/search/view/my and query save/run:
+  `--fields` can request built-in bug fields and Bugzilla custom fields named
+  `cf_*`.
+- [ ] Document that custom fields are returned only when requested, or when the
+  server returns them despite the requested field list.
+- [ ] Document that unknown non-custom fields still warn or fail as before.
+- [ ] Add an `[Unreleased]` changelog bullet under `### Changed` or `### Added`
+  describing custom `cf_*` output support.
+- [ ] Run `cargo test --test integration custom` or the nearest focused test
+  names for the updated guard.
+
+Expected result: user-facing docs match implemented behavior without suggesting
+schema discovery or arbitrary extension-field support.
+
+---
+
+## Task 10: Final verification
+
+- [ ] Re-read the diff for unnecessary abstraction, repeated logic, unclear
+  names, and accidental broadening to non-`cf_*` extension fields.
+- [ ] Run focused tests:
+
+```bash
+cargo test --lib types::bug_tests
+cargo test --lib client::bug_tests
+cargo test --lib xmlrpc::client_tests
+cargo test --lib output::resources::bug_tests
+cargo test --lib commands::bug::list_tests
+cargo test --lib commands::bug::my_tests
+cargo test --lib commands::bug::search_tests
+cargo test --lib commands::bug::view_tests
+cargo test --lib commands::query_tests
+cargo test --test integration custom
+```
+
+- [ ] Run format and lint:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+- [ ] If the focused integration filter finds no tests by name, run the exact
+  updated integration test names directly or run `cargo test --test integration`
+  before finishing.
+- [ ] Review `docs/bzr-cli.md` examples for consistency with gh-style JSON
+  projection: `id` appears only when requested.
+
+---
+
+## Out of Scope
+
+- Arbitrary non-`cf_*` extension-field preservation.
+- Server-side validation that a given custom field exists.
+- New custom-field filters beyond current Bugzilla query passthrough support.
+- Bug create/update support for custom fields.
+- Changes to comment, attachment, product, user, or field output.
+- Importing Bugzilla UI `columnlist` display metadata from `buglist.cgi` URLs.

--- a/docs/superpowers/specs/2026-06-08-custom-fields-output-design.md
+++ b/docs/superpowers/specs/2026-06-08-custom-fields-output-design.md
@@ -1,0 +1,438 @@
+# Custom field values in bug output
+
+**Date:** 2026-06-08
+**Branch:** `feature/custom-fields-design`
+**Source:** user request after confirming `--from-url` works but custom field values
+are not returned by `bzr`
+**Follows:** `2026-05-27-json-field-trimming-design.md`
+
+## Goal
+
+Allow users to request Bugzilla custom fields with `--fields cf_*` and receive
+those per-bug values directly in `bzr` output.
+
+Today `bzr` already passes unknown field tokens through to Bugzilla's
+`include_fields`, so a request such as:
+
+```bash
+bzr --json bug list --product Kernel --fields id,summary,cf_release
+```
+
+can ask the server for `cf_release`. The value is still lost because the REST
+response is deserialized into a fixed `Bug` struct and unknown JSON keys are
+dropped. The output layer also treats `cf_*` as unknown, so JSON projection and
+table rendering cannot display it.
+
+After this change, the same command returns top-level custom field keys:
+
+```json
+[
+  {
+    "id": 123,
+    "summary": "panic during boot",
+    "cf_release": "9.6"
+  }
+]
+```
+
+## Decisions
+
+1. **Custom fields stay top-level in JSON.** `cf_*` keys appear beside built-in
+   bug fields, matching Bugzilla's REST shape and the field names users pass to
+   `--fields`.
+2. **Only Bugzilla custom fields are captured.** Preserve response keys whose
+   names start with `cf_`. Continue dropping unrelated extension keys instead of
+   turning `Bug` into an arbitrary raw payload.
+3. **No new CLI flag.** Existing `--fields` and `--exclude-fields` are the user
+   interface for custom fields. Saved queries and `--from-url` inherit the same
+   behavior when the user provides `--fields`, because those values already flow
+   through `include_fields`.
+4. **`cf_*` is a recognized dynamic field family.** A `cf_*` include token is no
+   longer "unknown" for validation or warnings. Unknown non-`cf_*` tokens keep
+   the existing warning/error behavior.
+5. **`id` remains an internal fetch requirement only.** `force_id_fields` still
+   adds `id` to the wire request when necessary, but output projection honors the
+   user's field selection literally. `--fields cf_release --json` does not emit
+   `id` unless the user requested it.
+6. **Custom output order is mode-specific and deterministic.** JSON keeps the
+   current built-in-field contract: built-ins appear in struct order, not request
+   order, and custom fields appear after built-ins sorted by field name. Table
+   output keeps the existing CLI contract: `--fields` controls column order, so
+   requested custom columns appear wherever the user placed them.
+7. **Default output does not fetch all custom fields.** With no `--fields`, the
+   REST client continues to send `BUG_DEFAULT_FIELDS`. Custom field values appear
+   when requested, or when a server returns a `cf_*` key despite the requested
+   field list.
+
+## Non-goals
+
+- No support for arbitrary non-`cf_*` extension fields.
+- No schema discovery or validation that a given `cf_*` field exists on the
+  server. Bugzilla remains authoritative: it may return the value, omit it, or
+  reject the request.
+- No new custom-field filters beyond what Bugzilla already supports through
+  structured URL parameters and raw `--from-url` passthrough.
+- No change to bug create/update custom field support. This spec is read/output
+  only.
+- No change to comment, attachment, product, user, or field output.
+- No automatic import of Bugzilla UI `columnlist` values from `buglist.cgi`
+  URLs. The URL parser currently treats `columnlist` as display metadata and
+  ignores it. Users who run `--from-url` must still pass `--fields cf_name` or
+  save a query with `query save --from-url ... --fields cf_name` to request
+  custom field values.
+
+## Behavior
+
+### JSON output
+
+When a bug response contains a custom field:
+
+```json
+{
+  "id": 123,
+  "summary": "panic during boot",
+  "cf_release": "9.6"
+}
+```
+
+`bzr` preserves `cf_release` in the bug's internal custom-field map.
+
+Projection rules:
+
+- `--fields id,cf_release --json` emits `id` and `cf_release` if present.
+- `--fields cf_release --json` emits only `cf_release` if present.
+- `--fields cf_missing --json` is valid; if the server omits the key, the
+  resulting bug object may be `{}`.
+- `--fields summary,cf_release,typo --json` warns about `typo`, not about
+  `cf_release`.
+- `--exclude-fields cf_release --json` removes `cf_release` from any returned
+  bug object.
+
+Single `bug view --json`, multi-ID `bug view --json`, `bug list`, `bug my`,
+`bug search`, and `query run` all use the same projection behavior.
+
+### Table output
+
+Requested custom fields render as dynamic columns in list-style table output:
+
+```bash
+bzr bug list --product Kernel --fields id,summary,cf_release
+```
+
+Expected table columns:
+
+```text
+ID  SUMMARY            CF_RELEASE
+123 panic during boot  9.6
+```
+
+Requested custom fields also render as detail rows in `bug view` table output.
+Detail output keeps the existing always-present `Bug #<id>` heading; `--fields`
+controls the field rows below that heading.
+
+```text
+Bug #123
+panic during boot
+
+  Status        NEW
+  cf_release    9.6
+```
+
+Custom value rendering for table cells and detail rows:
+
+- strings render as their string value
+- numbers and booleans render with `to_string()`
+- `null` renders as an empty cell
+- arrays and objects render as compact JSON
+
+### Validation and warnings
+
+Field selection validation needs to distinguish three categories:
+
+1. built-in fields, resolved through the existing `COLUMNS` registry
+2. custom fields, recognized by an exact `cf_` prefix
+3. unknown fields, everything else
+
+Rules:
+
+- All-unknown include still exits 7 for list-style commands:
+  `--fields typo,other_typo`.
+- All-custom include is valid and performs network I/O:
+  `--fields cf_release,cf_target`.
+- Partial unknown warns once and keeps valid fields:
+  `--fields summary,cf_release,typo` warns only for `typo`.
+- `bug view` keeps its existing zero-field leniency, but still warns for unknown
+  non-`cf_*` include tokens.
+- `--fields cf_release --exclude-fields cf_release` exits 7 for list-style JSON
+  and table output because the effective selected set is empty.
+- With no include list, JSON validation still measures the default universe as
+  built-in fields only. `--exclude-fields` for every built-in field exits 7 even
+  if custom fields could theoretically appear, because `bzr` did not request any
+  custom fields by default.
+
+## Architecture
+
+### Data model
+
+Extend `Bug` with a custom-field map:
+
+```rust
+pub struct Bug {
+    pub id: u64,
+    pub summary: String,
+    // existing built-in fields...
+    pub rep_platform: Option<String>,
+    pub custom_fields: BTreeMap<String, serde_json::Value>,
+}
+```
+
+The public map contains only keys starting with `cf_`.
+
+Implementation contract:
+
+1. Add a private `BugWire` helper for deserialization. It carries the existing
+   built-in fields plus `#[serde(flatten)] extra:
+   BTreeMap<String, serde_json::Value>`. Its built-in fields must mirror the
+   current `Bug` serde defaults exactly, including sparse responses such as
+   `{"id": 42}` and `{"id": 42, "cf_release": "9.6"}`.
+2. Implement `Deserialize` for `Bug` by converting `BugWire` into `Bug` and
+   filtering `extra` down to keys whose names start with `cf_`.
+3. Implement `Serialize` for `Bug` manually. Do not derive `Serialize` for a
+   public `custom_fields` field, because that can emit a nested
+   `"custom_fields"` key if `#[serde(flatten)]` is missed and would violate the
+   output contract. Manual serialization emits built-ins in the current struct
+   order, then `custom_fields` entries in `BTreeMap` order.
+4. Keep `custom_fields` public for tests and internal output helpers, but never
+   emit it as a literal JSON key.
+
+This keeps non-custom extension data out of the public type while preserving
+Bugzilla's top-level `cf_*` shape.
+
+### REST client
+
+No change is needed to request construction for the happy path:
+
+- `canonical_field_list` already passes unknown tokens through unchanged.
+- `force_id_fields` already ensures deserialization has `id`.
+- REST response parsing goes through `Bug`, so custom-field capture belongs in
+  the type deserializer rather than in `client/bug.rs`.
+
+The default `BUG_DEFAULT_FIELDS` should not gain custom fields. Users must
+request specific `cf_*` names.
+
+`--from-url` is not a request-construction exception. `columnlist` remains
+ignored display metadata. A URL-imported search requests custom fields only when
+the user also supplies `--fields` at run time, or when the saved query contains a
+stored `fields` value from `query save --from-url ... --fields ...`.
+
+### XML-RPC client
+
+`xmlrpc::client::value_to_bug` manually constructs `Bug`, so it must also fill
+`custom_fields`.
+
+Add a small XML-RPC to JSON converter for values under keys starting with
+`cf_`:
+
+- string -> JSON string
+- integer -> JSON number
+- boolean -> JSON boolean
+- datetime -> JSON string using the existing formatted value
+- array -> JSON array, recursively converted
+- struct -> JSON object, recursively converted
+- double -> JSON number when finite, otherwise JSON string
+- base64 -> base64-encoded JSON string using the existing `base64` dependency
+
+The goal is parity with REST for common Bugzilla custom field values: text,
+single-select strings, multi-select arrays, booleans, and numeric values. The
+converter must not fail an otherwise valid bug response solely because a custom
+field uses XML-RPC base64; lossy-but-readable output is better than dropping the
+bug in hybrid fallback.
+
+### Field registry and selection
+
+The current `BugColumn` registry only models built-in fields. Introduce a small
+selection type so the output layer can carry both built-in and dynamic fields:
+
+```rust
+enum SelectedBugField<'a> {
+    BuiltIn(&'static BugColumn),
+    Custom(&'a str),
+}
+```
+
+Parsing helpers should preserve token order and also expose the partitions needed
+for validation and warnings:
+
+```rust
+struct FieldPartition<'a> {
+    ordered: Vec<SelectedBugField<'a>>,
+    built_ins: Vec<&'static BugColumn>,
+    custom: Vec<&'a str>,
+    unknown: Vec<&'a str>,
+}
+```
+
+Use the partition in all places that currently call `partition_include` or
+`resolve_bug_column` for include-list validation, warnings, and rendering.
+`ordered` is the source of truth for table column order; `built_ins`, `custom`,
+and `unknown` are derived views used by validation, JSON projection, and warning
+messages.
+
+`canonical_field_list` can remain mostly unchanged: built-in aliases map to
+canonical Bugzilla field names, and `cf_*` tokens pass through unchanged.
+
+For table rendering, preserve the user's include-list order across built-in and
+custom fields. `--fields cf_release,id,summary` renders `CF_RELEASE`, `ID`,
+`SUMMARY` in that order. Duplicate include tokens are rendered once, keeping the
+first occurrence. For JSON projection, keep the existing JSON-order contract:
+struct-order built-ins first, sorted custom fields after them.
+
+### JSON projection
+
+`bug_to_json` should continue to project a serialized object, but the serialized
+object now includes flattened `cf_*` keys.
+
+Include mode:
+
+1. Resolve built-in aliases to canonical names.
+2. Keep exact `cf_*` tokens.
+3. Retain only keys in that effective set.
+
+Exclude mode:
+
+1. Resolve built-in aliases to canonical names.
+2. Remove exact `cf_*` tokens.
+3. Ignore unknown non-`cf_*` excludes, matching current behavior.
+
+No projection layer should warn. Warnings stay in the command preflight gate
+where `w.err` is available.
+
+### Table rendering
+
+List-style output should render both built-in columns and requested custom
+columns. The custom column header is the uppercased field name, for example
+`cf_release` -> `CF_RELEASE`.
+
+Detail output should render requested custom fields as rows after the selected
+built-in rows. With no include list, detail output should not print every
+captured custom field. With an include list, render only the custom fields named
+in that include list, after built-in rows and in include-list order with
+duplicates removed. This keeps default `bug view` stable and avoids accidentally
+exposing server-specific fields.
+
+## Tests
+
+### Unit tests
+
+`src/types/bug_tests.rs`:
+
+- REST JSON deserialization captures `cf_release`.
+- REST JSON deserialization of `{"id": 42, "cf_release": "9.6"}` still defaults
+  missing built-in fields the same way `{"id": 42}` does today.
+- REST JSON deserialization drops non-`cf_*` unknown extension keys.
+- serializing `Bug` emits custom fields as top-level keys, not nested under
+  `custom_fields`.
+- serialized JSON orders built-ins before sorted custom fields.
+- default `Bug` test helpers initialize `custom_fields` empty.
+
+`src/xmlrpc/client_tests.rs`:
+
+- XML-RPC bug parsing captures `cf_release`.
+- XML-RPC arrays for multi-select custom fields become JSON arrays.
+- XML-RPC doubles and base64 custom fields serialize without failing the whole
+  bug parse.
+- non-`cf_*` XML-RPC extras are ignored.
+
+`src/output/resources/bug_tests.rs`:
+
+- `bug_to_json` includes selected custom fields.
+- `bug_to_json` excludes selected custom fields.
+- `bug_to_json` with `--fields summary,cf_release` keeps both.
+- all-custom `validate_json_field_selection` succeeds.
+- all-unknown non-custom include still fails for list-style output.
+- partial unknown warns only for non-custom fields.
+- table output renders requested custom columns.
+- table output preserves mixed built-in/custom include order.
+- table output deduplicates repeated include tokens by first occurrence.
+- detail output renders requested custom rows.
+- detail output with no include list does not render captured custom fields.
+
+### Command tests
+
+`src/commands/bug/list_tests.rs`:
+
+- `bug list --fields id,cf_release --json` sends `include_fields=id,cf_release`
+  on the wire and emits `cf_release`.
+- `bug list --fields cf_release --json` does not emit `id`.
+- table mode renders a `CF_RELEASE` column.
+
+`src/commands/bug/search_tests.rs`:
+
+- `bug search --from-url ... --fields id,cf_release --json` emits the custom
+  field.
+- `bug search --from-url` does not infer fields from URL `columnlist`; users must
+  pass `--fields` if they want custom values returned.
+
+`src/commands/query_tests.rs`:
+
+- saved query fields containing `cf_release` are honored by `query run`.
+
+`src/commands/bug/view_tests.rs`:
+
+- single `bug view --fields cf_release --json` emits only `cf_release`.
+- multi-ID `bug view --fields id,cf_release --json` projects each bug inside
+  the `bugs` array.
+- table detail output includes the custom row when requested.
+
+### Integration/docs tests
+
+Update the documentation guard in `tests/integration.rs` that currently says
+custom `cf_*` fields cannot become visible via `--json`. Replace it with a
+guard that prevents misleading payload wording while allowing accurate custom
+field documentation.
+
+Add or update docs in `docs/bzr-cli.md` and `src/cli/bug.rs`:
+
+- `--fields` can request built-in fields and Bugzilla custom fields named
+  `cf_*`.
+- custom fields are returned only when requested or when the server returns them.
+- unknown non-custom fields still warn or fail as before.
+
+Add a `CHANGELOG.md` entry when the implementation lands, since this changes
+user-visible output behavior.
+
+## Implementation order
+
+1. Add failing tests for REST `Bug` deserialization and top-level serialization.
+2. Add `custom_fields` to `Bug` with filtered `cf_*` capture.
+3. Add XML-RPC custom-field capture.
+4. Teach field selection helpers that `cf_*` is a dynamic field family.
+5. Update JSON projection to retain/remove custom fields.
+6. Add table list/detail rendering for requested custom fields.
+7. Update command/integration tests.
+8. Update CLI help, `docs/bzr-cli.md`, and `CHANGELOG.md`.
+9. Run focused tests:
+
+```bash
+cargo test types::bug_tests
+cargo test xmlrpc::client_tests
+cargo test output::resources::bug_tests
+cargo test commands::bug::list_tests
+cargo test commands::bug::search_tests
+cargo test commands::bug::view_tests
+cargo test commands::query_tests
+cargo test --test integration custom
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+## Resolved tradeoffs
+
+1. `bug view` with no `--fields` does not show captured custom fields even if
+   the server returns them anyway. Stable default output is more important than
+   opportunistically exposing server-specific fields.
+2. Custom table headers use uppercase field names, for example `CF_RELEASE`,
+   matching the existing table header style.
+3. Any exact `cf_` prefix is treated as a custom field token. `bzr` does not
+   validate whether `cf_` itself or any other `cf_*` name is a real Bugzilla
+   field; Bugzilla remains authoritative.

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -8,6 +8,7 @@ pub struct FieldArgs {
     /// Fields to request from the server (comma-separated). In table output,
     /// selects which columns (or detail rows) to show, in order; under --json,
     /// the object contains only the selected fields (id only if requested).
+    /// Built-in fields and Bugzilla custom fields named `cf_*` are valid.
     #[arg(long)]
     pub fields: Option<String>,
     /// Fields to drop from the server request (comma-separated). In table
@@ -43,9 +44,10 @@ pub enum BugAction {
     /// select and remove columns (in the given order). Under `--json` the
     /// output object is trimmed to the selected fields (gh-style):
     /// `--fields summary` returns `{"summary": ...}` with no `id` unless you
-    /// ask for it, and `--exclude-fields id` drops `id`. With no selection the
-    /// full object is returned. Unknown fields (typos, custom `cf_*` fields
-    /// that have no table column) are skipped with a warning.
+    /// ask for it, and `--exclude-fields id` drops `id`. Built-in fields and
+    /// Bugzilla custom fields named `cf_*` are valid; custom fields are shown
+    /// when requested and returned by the server. Unknown non-custom fields
+    /// are skipped with a warning, or rejected if nothing known remains.
     ///
     /// `--created-since` / `--changed-since` filter by Bugzilla's
     /// `creation_time` / `last_change_time` fields. Both accept ISO
@@ -170,6 +172,7 @@ pub enum BugAction {
     /// bugs over REST); `--exclude-fields` is the inverse. Under `--json`
     /// the returned object is trimmed to the selected fields (gh-style) on
     /// every transport, since trimming happens client-side after the fetch.
+    /// Built-in fields and Bugzilla custom fields named `cf_*` are valid.
     /// On XML-RPC servers the full bug is fetched regardless of the field
     /// list, so there the selection only controls which detail rows (table)
     /// or object keys (JSON) appear, not what is sent over the wire.

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -107,10 +107,12 @@ pub enum QueryAction {
         /// Max number of results
         #[arg(long)]
         limit: Option<u32>,
-        /// Only return these fields (comma-separated)
+        /// Only return these fields (comma-separated). Built-in fields and
+        /// Bugzilla custom fields named `cf_*` are valid.
         #[arg(long)]
         fields: Option<String>,
-        /// Exclude these fields (comma-separated)
+        /// Exclude these fields (comma-separated), including custom `cf_*`
+        /// fields when requested.
         #[arg(long)]
         exclude_fields: Option<String>,
         /// Filter to bugs created at or after this date (saved into the query).
@@ -244,11 +246,12 @@ pub enum QueryAction {
         /// Fields to request from the server (comma-separated). Table:
         /// selects which columns to show (in order). --json: the JSON object
         /// contains only the selected fields (id is included only if requested).
+        /// Built-in fields and Bugzilla custom fields named `cf_*` are valid.
         #[arg(long)]
         fields: Option<String>,
         /// Fields to drop from the server request (comma-separated). Table:
         /// removes those columns. --json: the JSON object omits the dropped
-        /// fields (including id, if excluded).
+        /// fields (including custom `cf_*` fields and id, if excluded).
         #[arg(long)]
         exclude_fields: Option<String>,
         /// Override the server to run against

--- a/src/commands/bug/list_tests.rs
+++ b/src/commands/bug/list_tests.rs
@@ -383,7 +383,7 @@ async fn bug_list_table_all_unknown_fields_exits_7_before_network() {
     let BugAction::List { field_args, .. } = &mut action else {
         unreachable!()
     };
-    field_args.fields = Some("cf_custom".into());
+    field_args.fields = Some("not_a_field".into());
 
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -442,6 +442,114 @@ async fn bug_list_json_fields_trims_output() {
 }
 
 #[tokio::test]
+async fn bug_list_json_custom_field_is_requested_and_emitted() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("include_fields", "id,cf_release"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1, "summary": "Test bug", "cf_release": "9.6"}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut action = empty_list_action();
+    let BugAction::List { field_args, .. } = &mut action else {
+        unreachable!()
+    };
+    field_args.fields = Some("id,cf_release".into());
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+
+    assert!(
+        result.is_ok(),
+        "json custom field path succeeds: {result:?}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    assert_eq!(parsed[0]["id"], 1);
+    assert_eq!(parsed[0]["cf_release"], "9.6");
+    assert!(parsed[0].get("summary").is_none());
+}
+
+#[tokio::test]
+async fn bug_list_json_custom_only_field_does_not_emit_forced_id() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("include_fields", "id,cf_release"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1, "cf_release": "9.6"}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut action = empty_list_action();
+    let BugAction::List { field_args, .. } = &mut action else {
+        unreachable!()
+    };
+    field_args.fields = Some("cf_release".into());
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+
+    assert!(result.is_ok(), "json custom-only path succeeds: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    let obj = parsed[0].as_object().unwrap();
+    assert_eq!(
+        obj.keys().map(String::as_str).collect::<Vec<_>>(),
+        vec!["cf_release"]
+    );
+    assert_eq!(obj["cf_release"], "9.6");
+}
+
+#[tokio::test]
+async fn bug_list_table_renders_custom_field_column() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("include_fields", "id,cf_release"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1, "cf_release": "9.6"}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut action = empty_list_action();
+    let BugAction::List { field_args, .. } = &mut action else {
+        unreachable!()
+    };
+    field_args.fields = Some("id,cf_release".into());
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+        &mut __io.writers(),
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "table custom field path succeeds: {result:?}"
+    );
+    assert!(
+        __io.out_str().contains("CF_RELEASE") && __io.out_str().contains("9.6"),
+        "custom field table output:\n{}",
+        __io.out_str()
+    );
+}
+
+#[tokio::test]
 async fn bug_list_json_without_fields_does_not_warn() {
     // --json with no field selection: full object, no unknown-field warning.
     let (_lock, mock, _tmp) = setup_test_env().await;
@@ -477,7 +585,7 @@ async fn bug_list_json_all_unknown_fields_exits_7() {
     let BugAction::List { field_args, .. } = &mut action else {
         unreachable!()
     };
-    field_args.fields = Some("cf_custom".into());
+    field_args.fields = Some("not_a_field".into());
 
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result =

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -49,15 +49,17 @@ pub async fn execute(
     // JSON mode (where output is trimmed gh-style to the selected keys). Either
     // way the exit code is independent of subcommand or server reachability.
     // `bug view` is exempt from this zero-field error in both modes: a sparse
-    // (or empty `{}`) single-bug result is coherent, not an error. Unknown
-    // `--fields` tokens (typos, custom `cf_*` fields) warn once on stderr;
-    // under JSON the warning fires for every action including `view`, since a
-    // typo would otherwise silently yield `{}`.
+    // (or empty `{}`) single-bug result is coherent, not an error. Custom
+    // `cf_*` fields are recognized dynamic fields. Other unknown `--fields`
+    // tokens warn once on stderr for JSON output and for `bug view` table
+    // output, since those lenient paths would otherwise hide a typo.
     if let Some(spec) = bug_column_spec(action) {
         let is_view = matches!(action, BugAction::View { .. });
         match format {
             OutputFormat::Table => {
-                if !is_view {
+                if is_view {
+                    warn_unknown_fields(spec, w.err);
+                } else {
                     validate_table_columns(spec)?;
                 }
             }

--- a/src/commands/bug/search_tests.rs
+++ b/src/commands/bug/search_tests.rs
@@ -53,6 +53,78 @@ async fn handle_search_from_url_executes() {
 }
 
 #[tokio::test]
+async fn handle_search_from_url_with_custom_fields_emits_custom_field() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("product", "TestProduct"))
+        .and(query_param("include_fields", "id,cf_release"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1, "summary": "Test bug", "cf_release": "9.6"}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let server_url = mock.uri();
+    let url = format!("{server_url}/buglist.cgi?product=TestProduct");
+    let mut action = from_url_action(url, None);
+    let BugAction::Search { field_args, .. } = &mut action else {
+        unreachable!()
+    };
+    field_args.fields = Some("id,cf_release".into());
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+
+    assert!(result.is_ok(), "from-url custom search failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    assert_eq!(parsed[0]["id"], 1);
+    assert_eq!(parsed[0]["cf_release"], "9.6");
+    assert!(parsed[0].get("summary").is_none());
+}
+
+#[tokio::test]
+async fn handle_search_from_url_does_not_infer_custom_fields_from_columnlist() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    let default_fields = concat!(
+        "id,summary,status,resolution,dupe_of,product,component,version,",
+        "assigned_to,priority,severity,creation_time,last_change_time,creator,",
+        "url,whiteboard,keywords,blocks,depends_on,cc,op_sys,rep_platform,deadline"
+    );
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("product", "TestProduct"))
+        .and(query_param("include_fields", default_fields))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1, "summary": "Test bug", "status": "NEW"}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let server_url = mock.uri();
+    let url = format!(
+        "{server_url}/buglist.cgi?product=TestProduct&columnlist=bug_id,short_desc,cf_release"
+    );
+    let action = from_url_action(url, None);
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+
+    assert!(
+        result.is_ok(),
+        "from-url columnlist search failed: {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn handle_search_from_url_preserves_url_limit_when_cli_unset() {
     // URL specifies limit=10 and CLI passes nothing — the URL limit
     // must reach the server unchanged, not be overwritten by the

--- a/src/commands/bug/view_tests.rs
+++ b/src/commands/bug/view_tests.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::unwrap_used)]
 
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::BugAction;
@@ -32,6 +32,17 @@ fn ok_bug_body(id: u64, summary: &str) -> serde_json::Value {
             "component": "General",
             "creation_time": "2025-01-01T00:00:00Z",
             "last_change_time": "2025-01-01T00:00:00Z"
+        }]
+    })
+}
+
+fn ok_bug_body_with_custom(id: u64, summary: &str) -> serde_json::Value {
+    serde_json::json!({
+        "bugs": [{
+            "id": id,
+            "summary": summary,
+            "status": "NEW",
+            "cf_release": "9.6"
         }]
     })
 }
@@ -98,6 +109,115 @@ async fn view_single_unchanged_json() {
     assert_eq!(parsed["id"], 42);
     assert!(parsed.get("bugs").is_none());
     assert!(parsed.get("failed").is_none());
+}
+
+#[tokio::test]
+async fn view_single_json_custom_only_field_omits_forced_id() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42"))
+        .and(query_param("include_fields", "id,cf_release"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(ok_bug_body_with_custom(42, "Test bug")),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut action = make_view_action(&["42"], false);
+    let BugAction::View { field_args, .. } = &mut action else {
+        unreachable!()
+    };
+    field_args.fields = Some("cf_release".into());
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+
+    assert!(result.is_ok(), "single view custom JSON failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    let obj = parsed.as_object().unwrap();
+    assert_eq!(
+        obj.keys().map(String::as_str).collect::<Vec<_>>(),
+        vec!["cf_release"]
+    );
+    assert_eq!(obj["cf_release"], "9.6");
+}
+
+#[tokio::test]
+async fn view_single_table_renders_requested_custom_row() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42"))
+        .and(query_param("include_fields", "id,cf_release"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(ok_bug_body_with_custom(42, "Test bug")),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut action = make_view_action(&["42"], false);
+    let BugAction::View { field_args, .. } = &mut action else {
+        unreachable!()
+    };
+    field_args.fields = Some("cf_release".into());
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+        &mut __io.writers(),
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "single view custom table failed: {result:?}"
+    );
+    assert!(
+        __io.out_str().contains("cf_release") && __io.out_str().contains("9.6"),
+        "custom detail row:\n{}",
+        __io.out_str()
+    );
+}
+
+#[tokio::test]
+async fn view_single_table_warns_for_unknown_field() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42"))
+        .and(query_param("include_fields", "id,sumary"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_bug_body(42, "Test bug")))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut action = make_view_action(&["42"], false);
+    let BugAction::View { field_args, .. } = &mut action else {
+        unreachable!()
+    };
+    field_args.fields = Some("sumary".into());
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+        &mut __io.writers(),
+    )
+    .await;
+
+    assert!(result.is_ok(), "single view typo table failed: {result:?}");
+    assert!(
+        __io.err_str().contains("ignoring unknown field(s): sumary"),
+        "unknown field warning:\n{}",
+        __io.err_str()
+    );
 }
 
 #[tokio::test]
@@ -228,6 +348,47 @@ async fn view_multi_strict_json_all_succeed_emits_wrapped_shape() {
     assert_eq!(parsed["failed"].as_array().unwrap().len(), 0);
     assert_eq!(parsed["bugs"][0]["id"], 1);
     assert_eq!(parsed["bugs"][1]["id"], 2);
+}
+
+#[tokio::test]
+async fn view_multi_strict_json_projects_custom_fields_inside_wrapper() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    for (id, summary, release) in [(1, "first", "9.6"), (2, "second", "9.7")] {
+        Mock::given(method("GET"))
+            .and(path(format!("/rest/bug/{id}")))
+            .and(query_param("include_fields", "id,cf_release"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "bugs": [{
+                    "id": id,
+                    "summary": summary,
+                    "status": "NEW",
+                    "cf_release": release
+                }]
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+    }
+
+    let mut action = make_view_action(&["1", "2"], false);
+    let BugAction::View { field_args, .. } = &mut action else {
+        unreachable!()
+    };
+    field_args.fields = Some("id,cf_release".into());
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+
+    assert!(result.is_ok(), "multi view custom JSON failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    assert_eq!(parsed["bugs"][0]["id"], 1);
+    assert_eq!(parsed["bugs"][0]["cf_release"], "9.6");
+    assert!(parsed["bugs"][0].get("summary").is_none());
+    assert_eq!(parsed["bugs"][1]["id"], 2);
+    assert_eq!(parsed["bugs"][1]["cf_release"], "9.7");
+    assert_eq!(parsed["failed"].as_array().unwrap().len(), 0);
 }
 
 #[tokio::test]

--- a/src/commands/query_tests.rs
+++ b/src/commands/query_tests.rs
@@ -434,6 +434,55 @@ async fn query_run_executes_saved_query() {
 }
 
 #[tokio::test]
+async fn query_run_honors_saved_custom_fields() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    let mut save_action = product_save_action("custom-fields-test", "TestProduct", 10);
+    let QueryAction::Save { fields, .. } = &mut save_action else {
+        unreachable!()
+    };
+    *fields = Some("id,cf_release".into());
+
+    let mut save_io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &save_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut save_io.writers(),
+    )
+    .await;
+    assert!(result.is_ok(), "query save failed: {result:?}");
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("include_fields", "id,cf_release"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1, "summary": "Test bug", "cf_release": "9.6"}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let run_action = run_action("custom-fields-test");
+    let mut run_io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &run_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut run_io.writers(),
+    )
+    .await;
+
+    assert!(result.is_ok(), "query run failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(run_io.out_str().trim()).unwrap();
+    assert_eq!(parsed[0]["id"], 1);
+    assert_eq!(parsed[0]["cf_release"], "9.6");
+    assert!(parsed[0].get("summary").is_none());
+}
+
+#[tokio::test]
 async fn query_run_with_limit_override() {
     let (_lock, mock, _tmp) = setup_test_env().await;
 

--- a/src/output/formatting.rs
+++ b/src/output/formatting.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use colored::Colorize;
 use serde::Serialize;
-use tabled::{Table, Tabled};
+use tabled::builder::Builder;
 
 use crate::types::OutputFormat;
 
@@ -31,27 +31,44 @@ pub(super) fn write_formatted<T, W>(
     }
 }
 
+pub(super) fn write_table_records<W: Write + ?Sized>(
+    headers: &[&str],
+    rows: impl IntoIterator<Item = Vec<String>>,
+    out: &mut W,
+) {
+    let mut builder = Builder::default();
+    builder.push_record(headers.iter().copied());
+    for row in rows {
+        builder.push_record(row);
+    }
+    let _ = writeln!(out, "{}", builder.build());
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct TableSpec<'a> {
+    pub empty_msg: &'a str,
+    pub headers: &'a [&'a str],
+}
+
 /// Render a slice as JSON or a `tabled` table, printing `empty_msg` instead of
-/// an empty table when there are no items. `to_row` maps each item to a
-/// `Tabled` row type.
-pub(super) fn write_table_or_empty<T, R, W>(
+/// an empty table when there are no items. `to_record` maps each item to one
+/// display row.
+pub(super) fn write_table_or_empty<T, W>(
     items: &[T],
     format: OutputFormat,
     out: &mut W,
-    empty_msg: &str,
-    to_row: impl Fn(&T) -> R,
+    table: TableSpec<'_>,
+    to_record: impl Fn(&T) -> Vec<String>,
 ) where
     T: Serialize,
-    R: Tabled,
     W: Write + ?Sized,
 {
     write_formatted(items, format, out, |items, out| {
         if items.is_empty() {
-            let _ = writeln!(out, "{empty_msg}");
+            let _ = writeln!(out, "{}", table.empty_msg);
             return;
         }
-        let rows: Vec<R> = items.iter().map(to_row).collect();
-        let _ = writeln!(out, "{}", Table::new(rows));
+        write_table_records(table.headers, items.iter().map(to_record), out);
     });
 }
 

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -1,6 +1,8 @@
+use std::collections::HashSet;
 use std::io::Write;
 
 use colored::Colorize;
+use serde_json::Value;
 use tabled::builder::Builder;
 
 use crate::output::formatting::{
@@ -51,9 +53,9 @@ impl BugColumn {
 /// the historical fixed table.
 const DEFAULT_COLUMNS: &[&str] = &["id", "status", "priority", "assignee", "summary"];
 
-/// The full set of fields renderable as table columns. Tokens are matched
-/// case-insensitively against `aliases`. Fields absent here (e.g. custom
-/// `cf_*` fields) have no table representation.
+/// The full set of built-in fields renderable as table columns. Tokens are
+/// matched case-insensitively against `aliases`; custom `cf_*` fields are
+/// dynamic columns resolved outside this registry.
 const COLUMNS: &[BugColumn] = &[
     BugColumn {
         aliases: &["id"],
@@ -172,6 +174,41 @@ const COLUMNS: &[BugColumn] = &[
     },
 ];
 
+#[derive(Clone, Copy)]
+enum SelectedBugField<'a> {
+    BuiltIn(&'static BugColumn),
+    Custom(&'a str),
+}
+
+impl<'a> SelectedBugField<'a> {
+    fn key(self) -> &'a str {
+        match self {
+            SelectedBugField::BuiltIn(column) => column.canonical(),
+            SelectedBugField::Custom(name) => name,
+        }
+    }
+
+    fn header(self) -> String {
+        match self {
+            SelectedBugField::BuiltIn(column) => column.header.to_string(),
+            SelectedBugField::Custom(name) => name.to_ascii_uppercase(),
+        }
+    }
+
+    fn render(self, bug: &Bug) -> String {
+        match self {
+            SelectedBugField::BuiltIn(column) => (column.render)(bug),
+            SelectedBugField::Custom(name) => render_custom_value(bug.custom_fields.get(name)),
+        }
+    }
+}
+
+struct FieldPartition<'a> {
+    ordered: Vec<SelectedBugField<'a>>,
+    custom: Vec<&'a str>,
+    unknown: Vec<&'a str>,
+}
+
 fn join_ids(ids: &[u64]) -> String {
     ids.iter()
         .map(std::string::ToString::to_string)
@@ -217,32 +254,71 @@ fn default_columns() -> Vec<&'static BugColumn> {
         .collect()
 }
 
-/// Split a comma list into (resolved columns, unknown tokens), trimming and
-/// skipping blanks. Shared by `resolve_columns` and `validate_table_columns`
-/// so the renderer and the pre-flight validator can't drift.
-fn partition_include(list: &str) -> (Vec<&'static BugColumn>, Vec<&str>) {
-    let mut knowns = Vec::new();
-    let mut unknowns = Vec::new();
+fn default_selected_columns() -> Vec<SelectedBugField<'static>> {
+    default_columns()
+        .into_iter()
+        .map(SelectedBugField::BuiltIn)
+        .collect()
+}
+
+fn is_custom_field(token: &str) -> bool {
+    token.starts_with("cf_")
+}
+
+/// Split a comma list into built-in fields, custom fields, and unknown tokens,
+/// trimming and skipping blanks. Shared by renderers and pre-flight validators
+/// so output and validation use the same field taxonomy.
+fn partition_include(list: &str) -> FieldPartition<'_> {
+    let mut partition = FieldPartition {
+        ordered: Vec::new(),
+        custom: Vec::new(),
+        unknown: Vec::new(),
+    };
+    let mut seen = HashSet::new();
     for token in list.split(',') {
         let token = token.trim();
         if token.is_empty() {
             continue;
         }
         match resolve_bug_column(token) {
-            Some(col) => knowns.push(col),
-            None => unknowns.push(token),
+            Some(column) => {
+                if seen.insert(column.canonical()) {
+                    partition.ordered.push(SelectedBugField::BuiltIn(column));
+                }
+            }
+            None if is_custom_field(token) => {
+                if seen.insert(token) {
+                    partition.ordered.push(SelectedBugField::Custom(token));
+                    partition.custom.push(token);
+                }
+            }
+            None => partition.unknown.push(token),
         }
     }
-    (knowns, unknowns)
+    partition
 }
 
-/// Apply `spec.exclude` to `columns` in place, dropping any column whose
-/// header matches an excluded token.
-fn apply_exclude(columns: &mut Vec<&'static BugColumn>, exclude: Option<&str>) {
+fn selected_keys<'a>(fields: &[SelectedBugField<'a>]) -> HashSet<&'a str> {
+    fields.iter().map(|field| (*field).key()).collect()
+}
+
+fn excluded_keys(exclude: Option<&str>) -> HashSet<&str> {
+    let Some(list) = exclude else {
+        return HashSet::new();
+    };
+    partition_include(list)
+        .ordered
+        .iter()
+        .map(|field| (*field).key())
+        .collect()
+}
+
+/// Apply `spec.exclude` to `fields` in place, dropping matching built-in or
+/// custom selections.
+fn apply_exclude(fields: &mut Vec<SelectedBugField<'_>>, exclude: Option<&str>) {
     if let Some(list) = exclude {
-        let excluded: Vec<&'static BugColumn> =
-            list.split(',').filter_map(resolve_bug_column).collect();
-        columns.retain(|c| !excluded.iter().any(|e| e.header == c.header));
+        let excluded = excluded_keys(Some(list));
+        fields.retain(|field| !excluded.contains((*field).key()));
     }
 }
 
@@ -251,25 +327,25 @@ fn apply_exclude(columns: &mut Vec<&'static BugColumn>, exclude: Option<&str>) {
 /// token is unknown, falls back to the default column set so output stays
 /// useful. Infallible by design — the fully-degenerate cases (zero columns)
 /// are rejected up front by [`validate_table_columns`].
-fn resolve_columns<E: Write + ?Sized>(
-    spec: ColumnSpec<'_>,
+fn resolve_columns<'a, E: Write + ?Sized>(
+    spec: ColumnSpec<'a>,
     err: &mut E,
-) -> Vec<&'static BugColumn> {
+) -> Vec<SelectedBugField<'a>> {
     let mut columns = match spec.include {
-        None => default_columns(),
+        None => default_selected_columns(),
         Some(list) => {
-            let (knowns, unknowns) = partition_include(list);
-            if !unknowns.is_empty() {
+            let partition = partition_include(list);
+            if !partition.unknown.is_empty() {
                 let _ = writeln!(
                     err,
-                    "warning: ignoring field(s) with no table column: {}",
-                    unknowns.join(", ")
+                    "warning: ignoring unknown field(s): {}",
+                    partition.unknown.join(", ")
                 );
             }
-            if knowns.is_empty() {
-                default_columns()
+            if partition.ordered.is_empty() {
+                default_selected_columns()
             } else {
-                knowns
+                partition.ordered
             }
         }
     };
@@ -284,22 +360,21 @@ fn resolve_columns<E: Write + ?Sized>(
 /// some not) is allowed and handled as a warning at render time.
 pub fn validate_table_columns(spec: ColumnSpec<'_>) -> crate::error::Result<()> {
     let mut columns = match spec.include {
-        None => default_columns(),
+        None => default_selected_columns(),
         Some(list) => {
-            let (knowns, unknowns) = partition_include(list);
-            if knowns.is_empty() {
-                if unknowns.is_empty() {
+            let partition = partition_include(list);
+            if partition.ordered.is_empty() {
+                if partition.unknown.is_empty() {
                     // All-blank like ",," — treat as no selection, not an error.
-                    default_columns()
+                    default_selected_columns()
                 } else {
                     return Err(crate::error::BzrError::InputValidation(format!(
-                        "none of the requested fields can be shown as table columns: {}; \
-                         these fields have no table representation",
-                        unknowns.join(", ")
+                        "none of the requested fields are known bug fields: {}",
+                        partition.unknown.join(", ")
                     )));
                 }
             } else {
-                knowns
+                partition.ordered
             }
         }
     };
@@ -313,16 +388,15 @@ pub fn validate_table_columns(spec: ColumnSpec<'_>) -> crate::error::Result<()> 
 }
 
 /// The canonical exclude key set: each `--exclude-fields` token resolved to its
-/// canonical Bugzilla field name. Unknown tokens (e.g. custom `cf_*` fields)
-/// name no key in the serialized object and are dropped here, matching table
-/// mode's [`apply_exclude`].
-fn canonical_excludes(exclude: Option<&str>) -> Vec<&'static str> {
+/// serialized key. Unknown non-custom tokens name no key and are dropped here,
+/// matching table mode's [`apply_exclude`].
+fn canonical_excludes(exclude: Option<&str>) -> Vec<&str> {
     match exclude {
         None => Vec::new(),
-        Some(list) => list
-            .split(',')
-            .filter_map(resolve_bug_column)
-            .map(BugColumn::canonical)
+        Some(list) => partition_include(list)
+            .ordered
+            .iter()
+            .map(|field| (*field).key())
             .collect(),
     }
 }
@@ -362,14 +436,14 @@ pub fn bugs_to_json(bugs: &[Bug], spec: ColumnSpec<'_>) -> Vec<serde_json::Value
 /// fields still passes. Partial-unknown (some valid, some not) is allowed and
 /// handled as a warning via [`warn_unknown_fields`].
 pub fn validate_json_field_selection(spec: ColumnSpec<'_>) -> crate::error::Result<()> {
-    let mut keys: std::collections::HashSet<&'static str> = match spec.include {
+    let mut keys: HashSet<&str> = match spec.include {
         Some(list) => {
-            let (knowns, _unknowns) = partition_include(list);
-            if knowns.is_empty() && list.split(',').all(|t| t.trim().is_empty()) {
+            let partition = partition_include(list);
+            if partition.ordered.is_empty() && list.split(',').all(|t| t.trim().is_empty()) {
                 // Blank include like "" / ",," — treat as no selection.
                 COLUMNS.iter().map(BugColumn::canonical).collect()
             } else {
-                knowns.iter().map(|c| c.canonical()).collect()
+                selected_keys(&partition.ordered)
             }
         }
         None => COLUMNS.iter().map(BugColumn::canonical).collect(),
@@ -387,21 +461,21 @@ pub fn validate_json_field_selection(spec: ColumnSpec<'_>) -> crate::error::Resu
     Ok(())
 }
 
-/// Warn once on stderr about `--fields` tokens that name no known bug field
-/// (e.g. a typo or a custom `cf_*` field). Genericized off "table column" so it
-/// reads correctly under both table and JSON output. Only inspects the include
-/// list — unknown `--exclude-fields` tokens are inert and silently ignored,
-/// matching table mode's [`apply_exclude`].
+/// Warn once on stderr about `--fields` tokens that name no known bug field.
+/// Custom `cf_*` fields are dynamic known fields, so only non-custom unknowns
+/// reach this warning. Only inspects the include list; unknown
+/// `--exclude-fields` tokens are inert and silently ignored, matching table
+/// mode's [`apply_exclude`].
 pub fn warn_unknown_fields<E: Write + ?Sized>(spec: ColumnSpec<'_>, err: &mut E) {
     let Some(list) = spec.include else {
         return;
     };
-    let (_knowns, unknowns) = partition_include(list);
-    if !unknowns.is_empty() {
+    let partition = partition_include(list);
+    if !partition.unknown.is_empty() {
         let _ = writeln!(
             err,
             "warning: ignoring unknown field(s): {}",
-            unknowns.join(", ")
+            partition.unknown.join(", ")
         );
     }
 }
@@ -424,6 +498,28 @@ fn field_selected(spec: ColumnSpec<'_>, field: &str) -> bool {
     included && !excluded
 }
 
+fn render_custom_value(value: Option<&Value>) -> String {
+    match value {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Number(n)) => n.to_string(),
+        Some(Value::Bool(b)) => b.to_string(),
+        Some(value @ (Value::Array(_) | Value::Object(_))) => value.to_string(),
+        Some(Value::Null) | None => String::new(),
+    }
+}
+
+fn selected_custom_detail_fields(spec: ColumnSpec<'_>) -> Vec<&str> {
+    let Some(include) = spec.include else {
+        return Vec::new();
+    };
+    let excluded = excluded_keys(spec.exclude);
+    partition_include(include)
+        .custom
+        .into_iter()
+        .filter(|name| !excluded.contains(name))
+        .collect()
+}
+
 pub fn write_bugs<W: Write + ?Sized, E: Write + ?Sized>(
     bugs: &[Bug],
     spec: ColumnSpec<'_>,
@@ -440,9 +536,9 @@ pub fn write_bugs<W: Write + ?Sized, E: Write + ?Sized>(
             }
             let columns = resolve_columns(spec, err);
             let mut builder = Builder::default();
-            builder.push_record(columns.iter().map(|c| c.header.to_string()));
+            builder.push_record(columns.iter().map(|field| (*field).header()));
             for bug in bugs {
-                builder.push_record(columns.iter().map(|c| (c.render)(bug)));
+                builder.push_record(columns.iter().map(|field| (*field).render(bug)));
             }
             let _ = writeln!(out, "{}", builder.build());
         }
@@ -516,6 +612,9 @@ fn write_bug_detail_table(bug: &Bug, spec: ColumnSpec<'_>, out: &mut (impl Write
     }
     if field_selected(spec, "depends_on") {
         write_id_list_field(out, "Depends on", &bug.depends_on);
+    }
+    for name in selected_custom_detail_fields(spec) {
+        write_field(out, name, &render_custom_value(bug.custom_fields.get(name)));
     }
 }
 

--- a/src/output/resources/bug_tests.rs
+++ b/src/output/resources/bug_tests.rs
@@ -28,7 +28,17 @@ fn make_bug(id: u64, summary: &str, status: &str) -> Bug {
         cc: vec!["watcher@example.com".into()],
         op_sys: None,
         rep_platform: None,
+        custom_fields: std::collections::BTreeMap::new(),
     }
+}
+
+fn make_bug_with_custom(id: u64, summary: &str, status: &str) -> Bug {
+    let mut bug = make_bug(id, summary, status);
+    bug.custom_fields
+        .insert("cf_release".into(), serde_json::json!("9.6"));
+    bug.custom_fields
+        .insert("cf_score".into(), serde_json::json!(12));
+    bug
 }
 
 fn make_history_entry() -> HistoryEntry {
@@ -203,12 +213,12 @@ fn write_bugs_exclude_fields_drops_default_column() {
 fn write_bugs_unknown_field_warns_and_falls_back() {
     let bugs = vec![make_bug(1, "summary text", "NEW")];
     let spec = ColumnSpec {
-        include: Some("cf_custom_thing"),
+        include: Some("not_a_field"),
         exclude: None,
     };
     let (out, err) = capture_bugs_spec(OutputFormat::Table, &bugs, spec);
     assert!(
-        err.contains("cf_custom_thing"),
+        err.contains("not_a_field"),
         "warns about unknown field: {err:?}"
     );
     // All requested columns were unknown -> fall back to the default set.
@@ -246,6 +256,58 @@ fn write_bugs_assignee_alias_still_selects_column() {
     let (out, err) = capture_bugs_spec(OutputFormat::Table, &bugs, spec);
     assert!(out.contains("ASSIGNEE"), "alias resolves column:\n{out}");
     assert!(err.is_empty(), "no warning: {err:?}");
+}
+
+#[test]
+fn write_bugs_table_renders_requested_custom_column() {
+    let bugs = vec![make_bug_with_custom(1, "summary text", "NEW")];
+    let spec = ColumnSpec {
+        include: Some("id,cf_release"),
+        exclude: None,
+    };
+    let (out, err) = capture_bugs_spec(OutputFormat::Table, &bugs, spec);
+
+    assert!(err.is_empty(), "custom fields are known: {err:?}");
+    assert!(out.contains("CF_RELEASE"), "custom header rendered:\n{out}");
+    assert!(out.contains("9.6"), "custom value rendered:\n{out}");
+}
+
+#[test]
+fn write_bugs_table_preserves_mixed_custom_order() {
+    let bugs = vec![make_bug_with_custom(1, "summary text", "NEW")];
+    let spec = ColumnSpec {
+        include: Some("cf_release,id,summary"),
+        exclude: None,
+    };
+    let (out, _err) = capture_bugs_spec(OutputFormat::Table, &bugs, spec);
+    let header = out
+        .lines()
+        .find(|line| line.contains("CF_RELEASE"))
+        .unwrap();
+
+    let custom_pos = header.find("CF_RELEASE").unwrap();
+    let id_pos = header.find("ID").unwrap();
+    let summary_pos = header.find("SUMMARY").unwrap();
+    assert!(
+        custom_pos < id_pos && id_pos < summary_pos,
+        "header order follows --fields:\n{out}"
+    );
+}
+
+#[test]
+fn write_bugs_table_deduplicates_repeated_custom_fields() {
+    let bugs = vec![make_bug_with_custom(1, "summary text", "NEW")];
+    let spec = ColumnSpec {
+        include: Some("id,cf_release,cf_release,summary"),
+        exclude: None,
+    };
+    let (out, _err) = capture_bugs_spec(OutputFormat::Table, &bugs, spec);
+    let header = out
+        .lines()
+        .find(|line| line.contains("CF_RELEASE"))
+        .unwrap();
+
+    assert_eq!(header.matches("CF_RELEASE").count(), 1, "{out}");
 }
 
 // ── canonical_field_list ─────────────────────────────────────────
@@ -359,6 +421,7 @@ fn write_bug_detail_table_shows_dupe_of() {
         cc: vec![],
         op_sys: None,
         rep_platform: None,
+        custom_fields: std::collections::BTreeMap::new(),
     };
     let mut out = Vec::new();
 
@@ -400,6 +463,7 @@ fn write_bug_detail_table_handles_minimal_bug() {
         cc: vec![],
         op_sys: None,
         rep_platform: None,
+        custom_fields: std::collections::BTreeMap::new(),
     };
     let output = capture_bug_detail(OutputFormat::Table, &bug);
     assert!(output.contains("Unicode summary — déjà vu"));
@@ -453,6 +517,38 @@ fn detail_exclude_drops_row() {
     let out = capture_detail_spec(&bug, spec);
     assert!(out.contains("Status"), "status retained:\n{out}");
     assert!(!out.contains("Priority"), "priority excluded:\n{out}");
+}
+
+#[test]
+fn detail_include_renders_requested_custom_row() {
+    let bug = make_bug_with_custom(7, "boom", "ASSIGNED");
+    let spec = ColumnSpec {
+        include: Some("status,cf_release"),
+        exclude: None,
+    };
+    let out = capture_detail_spec(&bug, spec);
+
+    assert!(out.contains("Status"), "built-in row retained:\n{out}");
+    assert!(
+        out.contains("cf_release"),
+        "custom row label rendered:\n{out}"
+    );
+    assert!(out.contains("9.6"), "custom row value rendered:\n{out}");
+}
+
+#[test]
+fn detail_default_does_not_render_captured_custom_fields() {
+    let bug = make_bug_with_custom(7, "boom", "ASSIGNED");
+    let out = capture_detail_spec(&bug, ColumnSpec::default());
+
+    assert!(
+        !out.contains("cf_release"),
+        "custom label hidden by default:\n{out}"
+    );
+    assert!(
+        !out.contains("9.6"),
+        "custom value hidden by default:\n{out}"
+    );
 }
 
 // ── write_json (pretty) ──────────────────────────────────────────
@@ -562,6 +658,7 @@ fn sample_bug(id: u64, summary: &str) -> Bug {
         cc: vec![],
         op_sys: None,
         rep_platform: None,
+        custom_fields: std::collections::BTreeMap::new(),
     }
 }
 
@@ -639,7 +736,16 @@ fn validate_table_columns_ok_for_default_spec() {
 #[test]
 fn validate_table_columns_ok_for_partial_unknown_include() {
     let spec = ColumnSpec {
-        include: Some("id,cf_custom"),
+        include: Some("id,not_a_field"),
+        exclude: None,
+    };
+    assert!(validate_table_columns(spec).is_ok());
+}
+
+#[test]
+fn validate_table_columns_ok_for_all_custom_include() {
+    let spec = ColumnSpec {
+        include: Some("cf_custom"),
         exclude: None,
     };
     assert!(validate_table_columns(spec).is_ok());
@@ -648,13 +754,13 @@ fn validate_table_columns_ok_for_partial_unknown_include() {
 #[test]
 fn validate_table_columns_errors_for_all_unknown_include() {
     let spec = ColumnSpec {
-        include: Some("cf_custom"),
+        include: Some("not_a_field"),
         exclude: None,
     };
     let err = validate_table_columns(spec).unwrap_err();
     assert_eq!(err.exit_code(), 7);
     assert!(
-        err.to_string().contains("cf_custom"),
+        err.to_string().contains("not_a_field"),
         "names the offending field: {err}"
     );
 }
@@ -674,6 +780,16 @@ fn validate_table_columns_errors_when_exclude_removes_sole_include() {
     let spec = ColumnSpec {
         include: Some("id"),
         exclude: Some("id"),
+    };
+    let err = validate_table_columns(spec).unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+}
+
+#[test]
+fn validate_table_columns_errors_when_exclude_removes_sole_custom_include() {
+    let spec = ColumnSpec {
+        include: Some("cf_release"),
+        exclude: Some("cf_release"),
     };
     let err = validate_table_columns(spec).unwrap_err();
     assert_eq!(err.exit_code(), 7);
@@ -801,14 +917,55 @@ fn bug_to_json_no_selection_is_full_object() {
 fn bug_to_json_partial_unknown_keeps_known_only() {
     let bug = make_bug(1, "s", "NEW");
     let spec = ColumnSpec {
-        include: Some("summary,cf_x"),
+        include: Some("summary,not_a_field"),
         exclude: None,
     };
     let v = bug_to_json(&bug, spec);
     let map = v.as_object().unwrap();
     assert!(map.contains_key("summary"));
-    assert!(!map.contains_key("cf_x"));
+    assert!(!map.contains_key("not_a_field"));
     assert_eq!(map.len(), 1);
+}
+
+#[test]
+fn bug_to_json_include_keeps_selected_custom_field() {
+    let bug = make_bug_with_custom(1, "s", "NEW");
+    let spec = ColumnSpec {
+        include: Some("cf_release"),
+        exclude: None,
+    };
+    let v = bug_to_json(&bug, spec);
+
+    assert_eq!(keys_of(&v), vec!["cf_release"]);
+    assert_eq!(v["cf_release"], "9.6");
+}
+
+#[test]
+fn bug_to_json_include_keeps_builtin_and_custom_fields() {
+    let bug = make_bug_with_custom(1, "s", "NEW");
+    let spec = ColumnSpec {
+        include: Some("summary,cf_release"),
+        exclude: None,
+    };
+    let v = bug_to_json(&bug, spec);
+
+    assert_eq!(keys_of(&v), vec!["summary", "cf_release"]);
+    assert_eq!(v["summary"], "s");
+    assert_eq!(v["cf_release"], "9.6");
+}
+
+#[test]
+fn bug_to_json_exclude_drops_selected_custom_field() {
+    let bug = make_bug_with_custom(1, "s", "NEW");
+    let spec = ColumnSpec {
+        include: None,
+        exclude: Some("cf_release"),
+    };
+    let v = bug_to_json(&bug, spec);
+    let map = v.as_object().unwrap();
+
+    assert!(!map.contains_key("cf_release"));
+    assert!(map.contains_key("cf_score"));
 }
 
 #[test]
@@ -830,6 +987,18 @@ fn bug_to_json_projection_preserves_struct_order_not_request_order() {
     assert_eq!(
         keys_of(&bug_to_json(&bug, spec)),
         vec!["id", "summary", "status"]
+    );
+}
+
+#[test]
+fn bug_to_json_full_object_places_custom_fields_after_built_ins() {
+    let bug = make_bug_with_custom(1, "s", "NEW");
+    let keys = keys_of(&bug_to_json(&bug, ColumnSpec::default()));
+
+    assert_eq!(&keys[..BUG_STRUCT_KEY_ORDER.len()], BUG_STRUCT_KEY_ORDER);
+    assert_eq!(
+        &keys[BUG_STRUCT_KEY_ORDER.len()..],
+        ["cf_release", "cf_score"]
     );
 }
 
@@ -880,11 +1049,20 @@ fn validate_json_default_spec_ok() {
 #[test]
 fn validate_json_all_unknown_include_errs() {
     let spec = ColumnSpec {
-        include: Some("cf_x,cf_y"),
+        include: Some("not_a_field,also_not_a_field"),
         exclude: None,
     };
     let err = validate_json_field_selection(spec).unwrap_err();
     assert_eq!(err.exit_code(), 7);
+}
+
+#[test]
+fn validate_json_all_custom_include_ok() {
+    let spec = ColumnSpec {
+        include: Some("cf_x,cf_y"),
+        exclude: None,
+    };
+    assert!(validate_json_field_selection(spec).is_ok());
 }
 
 #[test]
@@ -897,6 +1075,16 @@ fn validate_json_exclude_every_key_errs() {
     let spec = ColumnSpec {
         include: None,
         exclude: Some(all.as_str()),
+    };
+    let err = validate_json_field_selection(spec).unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+}
+
+#[test]
+fn validate_json_errors_when_exclude_removes_sole_custom_include() {
+    let spec = ColumnSpec {
+        include: Some("cf_release"),
+        exclude: Some("cf_release"),
     };
     let err = validate_json_field_selection(spec).unwrap_err();
     assert_eq!(err.exit_code(), 7);
@@ -917,7 +1105,7 @@ fn validate_json_exclude_table_defaults_ok() {
 #[test]
 fn validate_json_partial_unknown_include_ok() {
     let spec = ColumnSpec {
-        include: Some("summary,cf_x"),
+        include: Some("summary,not_a_field"),
         exclude: None,
     };
     assert!(validate_json_field_selection(spec).is_ok());
@@ -948,16 +1136,19 @@ fn capture_unknown_warning(spec: ColumnSpec<'_>) -> String {
 #[test]
 fn warn_unknown_fields_warns_for_unknown_include_token() {
     let w = capture_unknown_warning(ColumnSpec {
-        include: Some("summary,cf_x"),
+        include: Some("summary,not_a_field"),
         exclude: None,
     });
-    assert!(w.contains("ignoring unknown field(s): cf_x"), "{w:?}");
+    assert!(
+        w.contains("ignoring unknown field(s): not_a_field"),
+        "{w:?}"
+    );
 }
 
 #[test]
 fn warn_unknown_fields_silent_for_all_known() {
     let w = capture_unknown_warning(ColumnSpec {
-        include: Some("summary,status"),
+        include: Some("summary,status,cf_x"),
         exclude: None,
     });
     assert!(w.is_empty(), "no warning when all known: {w:?}");
@@ -976,12 +1167,12 @@ fn warn_unknown_fields_silent_without_include() {
 fn write_bugs_partial_unknown_warns_with_new_wording_and_shows_known() {
     let bugs = vec![make_bug(1, "summary text", "NEW")];
     let spec = ColumnSpec {
-        include: Some("id,cf_x"),
+        include: Some("id,not_a_field"),
         exclude: None,
     };
     let (out, err) = capture_bugs_spec(OutputFormat::Table, &bugs, spec);
     assert!(
-        err.contains("ignoring field(s) with no table column: cf_x"),
+        err.contains("ignoring unknown field(s): not_a_field"),
         "new warning wording: {err:?}"
     );
     assert!(out.contains("ID"), "known column shown:\n{out}");

--- a/src/output/resources/field.rs
+++ b/src/output/resources/field.rs
@@ -1,19 +1,30 @@
 use std::io::Write;
 
 use serde::Serialize;
-use tabled::{Table, Tabled};
 
-use crate::output::formatting::{write_formatted, yes_no};
+use crate::output::formatting::{write_formatted, write_table_records, yes_no};
 use crate::types::{FieldValue, OutputFormat};
 
-#[derive(Tabled)]
-struct FieldValueRow {
-    #[tabled(rename = "NAME")]
-    name: String,
-    #[tabled(rename = "ACTIVE")]
-    active: String,
-    #[tabled(rename = "CAN CHANGE TO")]
-    can_change_to: String,
+const FIELD_VALUE_HEADERS: &[&str] = &["NAME", "ACTIVE", "CAN CHANGE TO"];
+const FIELD_ALIAS_HEADERS: &[&str] = &["ALIAS", "API FIELD NAME"];
+
+fn field_value_record(value: &FieldValue) -> Vec<String> {
+    let transitions = value
+        .can_change_to
+        .as_ref()
+        .map(|transitions| {
+            transitions
+                .iter()
+                .map(|transition| transition.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default();
+    vec![
+        value.name.clone(),
+        yes_no(value.is_active).into(),
+        transitions,
+    ]
 }
 
 pub fn write_field_values<W: Write + ?Sized>(
@@ -22,35 +33,17 @@ pub fn write_field_values<W: Write + ?Sized>(
     out: &mut W,
 ) {
     write_formatted(values, format, out, |values, out| {
-        let rows: Vec<FieldValueRow> = values
-            .iter()
-            .map(|v| {
-                let transitions = v
-                    .can_change_to
-                    .as_ref()
-                    .map(|t| {
-                        t.iter()
-                            .map(|s| s.name.as_str())
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    })
-                    .unwrap_or_default();
-                FieldValueRow {
-                    name: v.name.clone(),
-                    active: yes_no(v.is_active).into(),
-                    can_change_to: transitions,
-                }
-            })
-            .collect();
-        let _ = writeln!(out, "{}", Table::new(rows));
+        write_table_records(
+            FIELD_VALUE_HEADERS,
+            values.iter().map(field_value_record),
+            out,
+        );
     });
 }
 
-#[derive(Serialize, Tabled)]
+#[derive(Serialize)]
 struct FieldAliasRow {
-    #[tabled(rename = "ALIAS")]
     alias: &'static str,
-    #[tabled(rename = "API FIELD NAME")]
     api_name: &'static str,
 }
 
@@ -64,7 +57,12 @@ pub fn write_field_aliases<W: Write + ?Sized>(
         .map(|&(alias, api_name)| FieldAliasRow { alias, api_name })
         .collect();
     write_formatted(&rows, format, out, |rows, out| {
-        let _ = writeln!(out, "{}", Table::new(rows));
+        write_table_records(
+            FIELD_ALIAS_HEADERS,
+            rows.iter()
+                .map(|row| vec![row.alias.to_string(), row.api_name.to_string()]),
+            out,
+        );
     });
 }
 

--- a/src/output/resources/product.rs
+++ b/src/output/resources/product.rs
@@ -1,12 +1,12 @@
 use std::fmt::Write as _;
 use std::io::Write;
 
-use tabled::Tabled;
-
 use crate::output::formatting::{
-    truncate, write_formatted, write_table_or_empty, DESCRIPTION_TRUNCATE_WIDTH,
+    truncate, write_formatted, write_table_or_empty, TableSpec, DESCRIPTION_TRUNCATE_WIDTH,
 };
 use crate::types::{OutputFormat, Product};
+
+const PRODUCT_HEADERS: &[&str] = &["ID", "NAME", "DESCRIPTION", "COMPONENTS"];
 
 fn format_named_list(heading: &str, items: &[(impl AsRef<str>, bool)]) -> String {
     if items.is_empty() {
@@ -47,15 +47,10 @@ fn format_product_detail(product: &Product) -> String {
     output
 }
 
-#[derive(Tabled)]
 struct ProductRow {
-    #[tabled(rename = "ID")]
     id: u64,
-    #[tabled(rename = "NAME")]
     name: String,
-    #[tabled(rename = "DESCRIPTION")]
     description: String,
-    #[tabled(rename = "COMPONENTS")]
     components: usize,
 }
 
@@ -68,8 +63,27 @@ fn product_row(p: &Product) -> ProductRow {
     }
 }
 
+fn product_record(product: &Product) -> Vec<String> {
+    let row = product_row(product);
+    vec![
+        row.id.to_string(),
+        row.name,
+        row.description,
+        row.components.to_string(),
+    ]
+}
+
 pub fn write_products<W: Write + ?Sized>(products: &[Product], format: OutputFormat, out: &mut W) {
-    write_table_or_empty(products, format, out, "No products found.", product_row);
+    write_table_or_empty(
+        products,
+        format,
+        out,
+        TableSpec {
+            empty_msg: "No products found.",
+            headers: PRODUCT_HEADERS,
+        },
+        product_record,
+    );
 }
 
 pub fn write_product_detail<W: Write + ?Sized>(

--- a/src/output/resources/product_tests.rs
+++ b/src/output/resources/product_tests.rs
@@ -2,7 +2,6 @@
 
 use super::*;
 use crate::types::Product;
-use tabled::Table;
 
 fn make_product(id: u64, name: &str) -> Product {
     Product {
@@ -54,16 +53,11 @@ fn write_products_json_one_product() {
 #[test]
 fn product_row_conversion() {
     let product = make_product(5, "Gadget");
-    let row = ProductRow {
-        id: product.id,
-        name: product.name.clone(),
-        description: truncate(&product.description, 60),
-        components: product.components.len(),
-    };
-    let table = Table::new(vec![row]).to_string();
-    assert!(table.contains('5'));
-    assert!(table.contains("Gadget"));
-    assert!(table.contains('1')); // 1 component
+    let row = product_row(&product);
+    assert_eq!(row.id, 5);
+    assert_eq!(row.name, "Gadget");
+    assert_eq!(row.description, truncate(&product.description, 60));
+    assert_eq!(row.components, 1);
 }
 
 // ── write_product_detail ─────────────────────────────────────────

--- a/src/output/resources/user.rs
+++ b/src/output/resources/user.rs
@@ -1,38 +1,28 @@
 use std::io::Write;
 
 use colored::Colorize;
-use tabled::Tabled;
 
 use crate::output::formatting::{
-    opt_yes_no, write_field, write_formatted, write_optional_field, write_table_or_empty,
+    opt_yes_no, write_field, write_formatted, write_optional_field, write_table_or_empty, TableSpec,
 };
 use crate::types::{BugzillaUser, OutputFormat, WhoamiResponse};
 
-#[derive(Tabled)]
+const USER_HEADERS: &[&str] = &["ID", "NAME", "REAL NAME", "EMAIL"];
+const DETAILED_USER_HEADERS: &[&str] = &["ID", "NAME", "REAL NAME", "EMAIL", "CAN LOGIN", "GROUPS"];
+
 struct UserRow {
-    #[tabled(rename = "ID")]
     id: u64,
-    #[tabled(rename = "NAME")]
     name: String,
-    #[tabled(rename = "REAL NAME")]
     real_name: String,
-    #[tabled(rename = "EMAIL")]
     email: String,
 }
 
-#[derive(Tabled)]
 struct DetailedUserRow {
-    #[tabled(rename = "ID")]
     id: u64,
-    #[tabled(rename = "NAME")]
     name: String,
-    #[tabled(rename = "REAL NAME")]
     real_name: String,
-    #[tabled(rename = "EMAIL")]
     email: String,
-    #[tabled(rename = "CAN LOGIN")]
     can_login: String,
-    #[tabled(rename = "GROUPS")]
     groups: String,
 }
 
@@ -64,8 +54,34 @@ fn detailed_row(user: &BugzillaUser) -> DetailedUserRow {
     }
 }
 
+fn basic_record(user: &BugzillaUser) -> Vec<String> {
+    let row = basic_row(user);
+    vec![row.id.to_string(), row.name, row.real_name, row.email]
+}
+
+fn detailed_record(user: &BugzillaUser) -> Vec<String> {
+    let row = detailed_row(user);
+    vec![
+        row.id.to_string(),
+        row.name,
+        row.real_name,
+        row.email,
+        row.can_login,
+        row.groups,
+    ]
+}
+
 pub fn write_users<W: Write + ?Sized>(users: &[BugzillaUser], format: OutputFormat, out: &mut W) {
-    write_table_or_empty(users, format, out, "No users found.", basic_row);
+    write_table_or_empty(
+        users,
+        format,
+        out,
+        TableSpec {
+            empty_msg: "No users found.",
+            headers: USER_HEADERS,
+        },
+        basic_record,
+    );
 }
 
 pub fn write_users_detailed<W: Write + ?Sized>(
@@ -73,7 +89,16 @@ pub fn write_users_detailed<W: Write + ?Sized>(
     format: OutputFormat,
     out: &mut W,
 ) {
-    write_table_or_empty(users, format, out, "No users found.", detailed_row);
+    write_table_or_empty(
+        users,
+        format,
+        out,
+        TableSpec {
+            empty_msg: "No users found.",
+            headers: DETAILED_USER_HEADERS,
+        },
+        detailed_record,
+    );
 }
 
 pub fn write_whoami<W: Write + ?Sized>(whoami: &WhoamiResponse, format: OutputFormat, out: &mut W) {

--- a/src/output/resources/user_tests.rs
+++ b/src/output/resources/user_tests.rs
@@ -2,7 +2,6 @@
 
 use super::*;
 use crate::types::{BugzillaUser, UserGroup, WhoamiResponse};
-use tabled::Table;
 
 fn make_user(id: u64, name: &str, can_login: Option<bool>, groups: Vec<&str>) -> BugzillaUser {
     BugzillaUser {
@@ -35,14 +34,8 @@ fn make_whoami() -> WhoamiResponse {
 
 #[test]
 fn user_row_excludes_detail_columns() {
-    let user = make_user(1, "alice", Some(true), vec!["admin"]);
-    let row = UserRow {
-        id: user.id,
-        name: user.name.clone(),
-        real_name: user.real_name.clone().unwrap_or_default(),
-        email: user.email.clone().unwrap_or_default(),
-    };
-    let table = Table::new(vec![row]).to_string();
+    let users = [make_user(1, "alice", Some(true), vec!["admin"])];
+    let table = capture_users(OutputFormat::Table, &users);
     assert!(table.contains("ID"));
     assert!(table.contains("NAME"));
     assert!(table.contains("EMAIL"));
@@ -57,8 +50,7 @@ fn detailed_user_row_includes_groups_and_login() {
         make_user(2, "bob", Some(false), vec![]),
         make_user(3, "carol", None, vec!["testers"]),
     ];
-    let rows: Vec<DetailedUserRow> = users.iter().map(detailed_row).collect();
-    let table = Table::new(rows).to_string();
+    let table = capture_users_detailed(OutputFormat::Table, &users);
     assert!(table.contains("CAN LOGIN"));
     assert!(table.contains("GROUPS"));
     assert!(table.contains("Yes"));

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -1,6 +1,16 @@
-use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::BTreeMap;
+
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
 
 use super::common::FlagUpdate;
+
+const BUG_BUILT_IN_FIELD_COUNT: usize = 23;
+
+fn is_custom_field_name(name: &str) -> bool {
+    name.starts_with("cf_")
+}
 
 #[derive(Clone, Copy)]
 enum FilterField {
@@ -49,54 +59,174 @@ fn deserialize_null_string<'de, D: Deserializer<'de>>(d: D) -> Result<String, D:
     Option::<String>::deserialize(d).map(Option::unwrap_or_default)
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub struct Bug {
     pub id: u64,
-    #[serde(default)]
     pub summary: String,
-    #[serde(default)]
     pub status: String,
-    #[serde(default)]
     pub resolution: Option<String>,
-    #[serde(default)]
     pub dupe_of: Option<u64>,
-    #[serde(default)]
     pub deadline: Option<String>,
-    #[serde(default)]
     pub product: Option<String>,
-    #[serde(default)]
     pub component: Option<String>,
-    #[serde(default)]
     pub version: Option<String>,
-    #[serde(default)]
     pub assigned_to: Option<String>,
-    #[serde(default)]
     pub priority: Option<String>,
-    #[serde(default)]
     pub severity: Option<String>,
-    #[serde(default)]
     pub creation_time: Option<String>,
-    #[serde(default)]
     pub last_change_time: Option<String>,
-    #[serde(default)]
     pub creator: Option<String>,
-    #[serde(default)]
     pub url: Option<String>,
-    #[serde(default)]
     pub whiteboard: Option<String>,
-    #[serde(default)]
     pub keywords: Vec<String>,
-    #[serde(default)]
     pub blocks: Vec<u64>,
-    #[serde(default)]
     pub depends_on: Vec<u64>,
-    #[serde(default)]
     pub cc: Vec<String>,
-    #[serde(default)]
     pub op_sys: Option<String>,
-    #[serde(default)]
     pub rep_platform: Option<String>,
+    pub custom_fields: BTreeMap<String, Value>,
+}
+
+#[derive(Deserialize)]
+struct BugWire {
+    id: u64,
+    #[serde(default)]
+    summary: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    resolution: Option<String>,
+    #[serde(default)]
+    dupe_of: Option<u64>,
+    #[serde(default)]
+    deadline: Option<String>,
+    #[serde(default)]
+    product: Option<String>,
+    #[serde(default)]
+    component: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    assigned_to: Option<String>,
+    #[serde(default)]
+    priority: Option<String>,
+    #[serde(default)]
+    severity: Option<String>,
+    #[serde(default)]
+    creation_time: Option<String>,
+    #[serde(default)]
+    last_change_time: Option<String>,
+    #[serde(default)]
+    creator: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    whiteboard: Option<String>,
+    #[serde(default)]
+    keywords: Vec<String>,
+    #[serde(default)]
+    blocks: Vec<u64>,
+    #[serde(default)]
+    depends_on: Vec<u64>,
+    #[serde(default)]
+    cc: Vec<String>,
+    #[serde(default)]
+    op_sys: Option<String>,
+    #[serde(default)]
+    rep_platform: Option<String>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, Value>,
+}
+
+impl From<BugWire> for Bug {
+    fn from(wire: BugWire) -> Self {
+        Bug {
+            id: wire.id,
+            summary: wire.summary,
+            status: wire.status,
+            resolution: wire.resolution,
+            dupe_of: wire.dupe_of,
+            deadline: wire.deadline,
+            product: wire.product,
+            component: wire.component,
+            version: wire.version,
+            assigned_to: wire.assigned_to,
+            priority: wire.priority,
+            severity: wire.severity,
+            creation_time: wire.creation_time,
+            last_change_time: wire.last_change_time,
+            creator: wire.creator,
+            url: wire.url,
+            whiteboard: wire.whiteboard,
+            keywords: wire.keywords,
+            blocks: wire.blocks,
+            depends_on: wire.depends_on,
+            cc: wire.cc,
+            op_sys: wire.op_sys,
+            rep_platform: wire.rep_platform,
+            custom_fields: wire
+                .extra
+                .into_iter()
+                .filter(|(name, _)| is_custom_field_name(name))
+                .collect(),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Bug {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        BugWire::deserialize(deserializer).map(Self::from)
+    }
+}
+
+impl Serialize for Bug {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let custom_field_count = self
+            .custom_fields
+            .keys()
+            .filter(|name| is_custom_field_name(name))
+            .count();
+        let mut map =
+            serializer.serialize_map(Some(BUG_BUILT_IN_FIELD_COUNT + custom_field_count))?;
+        map.serialize_entry("id", &self.id)?;
+        map.serialize_entry("summary", &self.summary)?;
+        map.serialize_entry("status", &self.status)?;
+        map.serialize_entry("resolution", &self.resolution)?;
+        map.serialize_entry("dupe_of", &self.dupe_of)?;
+        map.serialize_entry("deadline", &self.deadline)?;
+        map.serialize_entry("product", &self.product)?;
+        map.serialize_entry("component", &self.component)?;
+        map.serialize_entry("version", &self.version)?;
+        map.serialize_entry("assigned_to", &self.assigned_to)?;
+        map.serialize_entry("priority", &self.priority)?;
+        map.serialize_entry("severity", &self.severity)?;
+        map.serialize_entry("creation_time", &self.creation_time)?;
+        map.serialize_entry("last_change_time", &self.last_change_time)?;
+        map.serialize_entry("creator", &self.creator)?;
+        map.serialize_entry("url", &self.url)?;
+        map.serialize_entry("whiteboard", &self.whiteboard)?;
+        map.serialize_entry("keywords", &self.keywords)?;
+        map.serialize_entry("blocks", &self.blocks)?;
+        map.serialize_entry("depends_on", &self.depends_on)?;
+        map.serialize_entry("cc", &self.cc)?;
+        map.serialize_entry("op_sys", &self.op_sys)?;
+        map.serialize_entry("rep_platform", &self.rep_platform)?;
+        for (name, value) in self
+            .custom_fields
+            .iter()
+            .filter(|(name, _)| is_custom_field_name(name))
+        {
+            map.serialize_entry(name, value)?;
+        }
+        map.end()
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/types/bug_tests.rs
+++ b/src/types/bug_tests.rs
@@ -9,6 +9,7 @@ fn bug_deserializes_minimal() {
     assert_eq!(bug.id, 42);
     assert!(bug.summary.is_empty());
     assert!(bug.keywords.is_empty());
+    assert!(bug.custom_fields.is_empty());
 }
 
 #[test]
@@ -28,6 +29,81 @@ fn bug_deserializes_deadline() {
     let serialized = serde_json::to_value(&bug).unwrap();
 
     assert_eq!(serialized["deadline"], "2026-12-31");
+}
+
+#[test]
+fn bug_deserializes_custom_fields() {
+    let json = r#"{"id": 42, "summary": "s", "cf_release": "9.6"}"#;
+    let bug: Bug = serde_json::from_str(json).unwrap();
+
+    assert_eq!(bug.custom_fields["cf_release"], "9.6");
+}
+
+#[test]
+fn bug_deserializes_sparse_custom_fields_with_defaults() {
+    let json = r#"{"id": 42, "cf_release": "9.6"}"#;
+    let bug: Bug = serde_json::from_str(json).unwrap();
+
+    assert_eq!(bug.id, 42);
+    assert!(bug.summary.is_empty());
+    assert!(bug.status.is_empty());
+    assert!(bug.keywords.is_empty());
+    assert_eq!(bug.custom_fields["cf_release"], "9.6");
+}
+
+#[test]
+fn bug_deserialization_drops_non_custom_extension_keys() {
+    let json = r#"{"id": 42, "x_extension": "ignored", "cf_release": "9.6"}"#;
+    let bug: Bug = serde_json::from_str(json).unwrap();
+
+    assert!(!bug.custom_fields.contains_key("x_extension"));
+    assert!(bug.custom_fields.contains_key("cf_release"));
+}
+
+#[test]
+fn bug_serializes_custom_fields_as_top_level_keys() {
+    let mut bug: Bug = serde_json::from_str(r#"{"id": 42}"#).unwrap();
+    bug.custom_fields
+        .insert("cf_release".into(), serde_json::json!("9.6"));
+
+    let serialized = serde_json::to_value(&bug).unwrap();
+
+    assert_eq!(serialized["cf_release"], "9.6");
+    assert!(serialized.get("custom_fields").is_none());
+}
+
+#[test]
+fn bug_serialization_drops_non_custom_entries_from_public_map() {
+    let mut bug: Bug = serde_json::from_str(r#"{"id": 42}"#).unwrap();
+    bug.custom_fields
+        .insert("cf_release".into(), serde_json::json!("9.6"));
+    bug.custom_fields
+        .insert("x_extension".into(), serde_json::json!("ignored"));
+
+    let serialized = serde_json::to_value(&bug).unwrap();
+
+    assert_eq!(serialized["cf_release"], "9.6");
+    assert!(serialized.get("x_extension").is_none());
+}
+
+#[test]
+fn bug_serializes_custom_fields_after_built_ins_sorted_by_name() {
+    let mut bug: Bug = serde_json::from_str(r#"{"id": 42, "summary": "s"}"#).unwrap();
+    bug.custom_fields
+        .insert("cf_zeta".into(), serde_json::json!("z"));
+    bug.custom_fields
+        .insert("cf_alpha".into(), serde_json::json!("a"));
+
+    let serialized = serde_json::to_value(&bug).unwrap();
+    let keys: Vec<&str> = serialized
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+
+    assert_eq!(&keys[0..3], ["id", "summary", "status"]);
+    assert_eq!(&keys[keys.len() - 2..], ["cf_alpha", "cf_zeta"]);
 }
 
 #[test]

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -337,7 +337,40 @@ fn value_to_bug(val: &Value) -> Result<Bug> {
         cc: get_str_array(m, "cc"),
         op_sys: get_nonempty_str(m, "op_sys"),
         rep_platform: get_nonempty_str(m, "rep_platform"),
+        custom_fields: custom_fields_from_xmlrpc(m),
     })
+}
+
+fn custom_fields_from_xmlrpc(m: &BTreeMap<String, Value>) -> BTreeMap<String, serde_json::Value> {
+    m.iter()
+        .filter(|(name, _)| name.starts_with("cf_"))
+        .map(|(name, value)| (name.clone(), xmlrpc_value_to_json(value)))
+        .collect()
+}
+
+fn xmlrpc_value_to_json(value: &Value) -> serde_json::Value {
+    match value {
+        Value::String(s) | Value::DateTime(s) => serde_json::Value::String(s.clone()),
+        Value::Int(n) => serde_json::Value::Number(serde_json::Number::from(*n)),
+        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Double(n) => serde_json::Number::from_f64(*n).map_or_else(
+            || serde_json::Value::String(n.to_string()),
+            serde_json::Value::Number,
+        ),
+        Value::Base64(bytes) => serde_json::Value::String(base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            bytes,
+        )),
+        Value::Array(values) => {
+            serde_json::Value::Array(values.iter().map(xmlrpc_value_to_json).collect())
+        }
+        Value::Struct(values) => serde_json::Value::Object(
+            values
+                .iter()
+                .map(|(name, value)| (name.clone(), xmlrpc_value_to_json(value)))
+                .collect(),
+        ),
+    }
 }
 
 /// Navigate a `Bug.*` XML-RPC response from `top -> bugs -> {bug_id_str}`.

--- a/src/xmlrpc/client_tests.rs
+++ b/src/xmlrpc/client_tests.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use super::{
     add_vec_filters, extract_bugs, extract_id, get_datetime_str, get_int_array, get_nonempty_str,
-    get_str_array, value_to_comment, value_to_group_info, XmlRpcClient,
+    get_str_array, value_to_bug, value_to_comment, value_to_group_info, XmlRpcClient,
 };
 use crate::error::BzrError;
 use crate::test_helpers::xmlrpc_bug_response;
@@ -353,6 +353,55 @@ fn extract_bugs_rejects_non_array_payload() {
     payload.insert("bugs".into(), Value::String("wrong".into()));
     let err = extract_bugs(&Value::Struct(payload)).unwrap_err();
     assert!(err.to_string().contains("expected bugs array"));
+}
+
+#[test]
+fn value_to_bug_captures_custom_fields() {
+    let mut payload = BTreeMap::new();
+    payload.insert("id".into(), Value::Int(42));
+    payload.insert("summary".into(), Value::String("custom".into()));
+    payload.insert("cf_release".into(), Value::String("9.6".into()));
+    payload.insert("x_extension".into(), Value::String("ignored".into()));
+
+    let bug = value_to_bug(&Value::Struct(payload)).unwrap();
+
+    assert_eq!(bug.custom_fields["cf_release"], serde_json::json!("9.6"));
+    assert!(!bug.custom_fields.contains_key("x_extension"));
+}
+
+#[test]
+fn value_to_bug_converts_custom_field_arrays() {
+    let mut payload = BTreeMap::new();
+    payload.insert("id".into(), Value::Int(42));
+    payload.insert(
+        "cf_targets".into(),
+        Value::Array(vec![
+            Value::String("9.6".into()),
+            Value::String("9.7".into()),
+        ]),
+    );
+
+    let bug = value_to_bug(&Value::Struct(payload)).unwrap();
+
+    assert_eq!(
+        bug.custom_fields["cf_targets"],
+        serde_json::json!(["9.6", "9.7"])
+    );
+}
+
+#[test]
+fn value_to_bug_converts_custom_field_scalars_without_failing() {
+    let mut payload = BTreeMap::new();
+    payload.insert("id".into(), Value::Int(42));
+    payload.insert("cf_score".into(), Value::Double(12.5));
+    payload.insert("cf_bad_score".into(), Value::Double(f64::INFINITY));
+    payload.insert("cf_data".into(), Value::Base64(vec![1, 2, 3]));
+
+    let bug = value_to_bug(&Value::Struct(payload)).unwrap();
+
+    assert_eq!(bug.custom_fields["cf_score"], serde_json::json!(12.5));
+    assert_eq!(bug.custom_fields["cf_bad_score"], serde_json::json!("inf"));
+    assert_eq!(bug.custom_fields["cf_data"], serde_json::json!("AQID"));
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2428,11 +2428,8 @@ async fn bug_list_issue_158_mixed_positive_and_negation_reaches_wire() {
 }
 
 /// Guards the #206 `--json` prose against misleading phrasings. `--json` now
-/// trims output to the selected fields, but a few specific phrases stay
-/// forbidden: the older marketing-style "trims the payload" wordings, and any
-/// claim that custom `cf_*` fields become visible via `--json` ("to see them")
-/// — they can't, since `Bug` is a fixed struct with no `#[serde(flatten)]`.
-/// None of these may reappear in the CLI help or the manual.
+/// trims output to the selected fields, but the older marketing-style
+/// "trims the payload" wordings should not reappear in the CLI help or manual.
 #[test]
 fn cli_and_docs_avoid_misleading_trim_phrasing() {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -2440,7 +2437,6 @@ fn cli_and_docs_avoid_misleading_trim_phrasing() {
         "trims the payload",
         "trim the response payload",
         "trims JSON output",
-        "to see them",
         "JSON: fields to return",
         "JSON: fields to exclude",
     ];
@@ -2492,7 +2488,7 @@ async fn e2e_bug_list_json_all_unknown_fields_exits_7() {
         "--product",
         "Firefox",
         "--fields",
-        "cf_nope,cf_alsonope",
+        "not_a_field,also_not_a_field",
     ])
     .await;
 
@@ -2529,13 +2525,13 @@ async fn e2e_bug_list_json_partial_unknown_warns_and_projects() {
         "--product",
         "Firefox",
         "--fields",
-        "summary,cf_x",
+        "summary,not_a_field",
     ])
     .await;
 
     assert!(result.is_ok(), "partial-unknown should succeed: {result:?}");
     assert!(
-        err.contains("ignoring unknown field(s): cf_x"),
+        err.contains("ignoring unknown field(s): not_a_field"),
         "stderr warning: {err:?}"
     );
     let parsed = serde_json::from_str::<serde_json::Value>(out.trim()).unwrap();
@@ -2544,6 +2540,46 @@ async fn e2e_bug_list_json_partial_unknown_warns_and_projects() {
         vec!["summary"],
         "projected to summary only:\n{out}"
     );
+}
+
+/// A custom `cf_*` field is a valid dynamic selection: it is requested from the
+/// server and emitted when Bugzilla returns it.
+#[tokio::test]
+async fn e2e_bug_list_json_custom_field_is_emitted() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("include_fields", "id,cf_release"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 7, "summary": "boom", "cf_release": "9.6"}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let (result, out, err) = dispatch_cli_with_io(&[
+        "bzr",
+        "--server",
+        "test",
+        "--json",
+        "bug",
+        "list",
+        "--product",
+        "Firefox",
+        "--fields",
+        "cf_release",
+    ])
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "custom field selection should succeed: {result:?}"
+    );
+    assert!(err.is_empty(), "custom field should not warn: {err:?}");
+    let parsed = serde_json::from_str::<serde_json::Value>(out.trim()).unwrap();
+    assert_eq!(json_keys(&parsed[0]), vec!["cf_release"]);
+    assert_eq!(parsed[0]["cf_release"], "9.6");
 }
 
 /// `bug view --json` with an all-unknown field stays lenient: exit 0, an empty


### PR DESCRIPTION
## Summary

- Preserve Bugzilla `cf_*` fields in bug responses from REST and XML-RPC.
- Render requested custom fields as top-level JSON keys, table columns, and `bug view` detail rows.
- Treat `cf_*` field selections as known dynamic fields while keeping unknown non-custom warnings/errors.
- Update CLI docs, help text, changelog, and design/implementation notes.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

## Follow-up

- #283 tracks possible write-side custom field support for create/update/clone/template workflows.
