### PR TITLE
ci: pin taiki-e/install-action to tagged v2.81.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,9 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2
         with:
           key: sonarqube
-      - uses: taiki-e/install-action@49ba71bf46962339e6e5c0a7a4ec3ed4c8af28ac  # cargo-llvm-cov
+      - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154  # v2.81.8
+        with:
+          tool: cargo-llvm-cov
       - name: Generate coverage report
         run: cargo llvm-cov --locked --workspace --all-features --lcov --output-path lcov.info
       - name: SonarQube Scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,13 +197,13 @@ jobs:
 
       - name: Install cargo-deb
         if: matrix.pkg_deb
-        uses: taiki-e/install-action@49ba71bf46962339e6e5c0a7a4ec3ed4c8af28ac
+        uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154  # v2.81.8
         with:
           tool: cargo-deb
 
       - name: Install cargo-generate-rpm
         if: matrix.pkg_rpm
-        uses: taiki-e/install-action@49ba71bf46962339e6e5c0a7a4ec3ed4c8af28ac
+        uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154  # v2.81.8
         with:
           tool: cargo-generate-rpm
 


### PR DESCRIPTION
## What

Repins `taiki-e/install-action` from the untagged commit `49ba71bf` to the **v2.81.8** release SHA `0631aa65` across all three usages, each with a matching `# v2.81.8` version comment.

| File | Before | After |
|------|--------|-------|
| `ci.yml:169` | `@49ba71bf  # cargo-llvm-cov` | `@0631aa65  # v2.81.8` + `with: tool: cargo-llvm-cov` |
| `release.yml:200` | `@49ba71bf` (no comment) | `@0631aa65  # v2.81.8` |
| `release.yml:206` | `@49ba71bf` (no comment) | `@0631aa65  # v2.81.8` |

## Why

`49ba71bf` (commit "cargo-llvm-cov", 2026-04-27) is an **untagged** intermediate commit on the action's `main` branch — it matches no release tag, so no honest `# vX.Y.Z` comment could be written for it. The `release.yml` pins had no version comment at all, and `ci.yml`'s `# cargo-llvm-cov` documented the tool rather than the action version. Pinning to the `v2.81.8` release SHA makes the pins truthful, auditable, and consistent with the repo's other actions (e.g. `# v8.1.0`).

The `ci.yml` step also lacked a `with: tool:` block — `taiki-e/install-action` needs one (or the sub-action path form), so the tool name only survived in the trailing comment. Moving it into `with: tool: cargo-llvm-cov` makes the step self-documenting and functionally correct.

`actionlint` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)