### PR TITLE
ci(release): ship Homebrew bottles for the tap formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -504,6 +504,151 @@ jobs:
           git commit -m "bzr ${TAG#v}"
           git push
 
+  # Build real Homebrew bottles for the just-published formula. A bottle is
+  # *poured* (extracted into the Cellar) rather than built, so it bypasses
+  # FormulaInstaller#build and the build sandbox entirely -- including the
+  # sandbox's deny_read_home pass, which raises on any $HOME entry containing
+  # characters like '(' or ')'. Without bottles, even a binary-download
+  # formula runs its `install` method under that sandbox and breaks for
+  # users whose home directory holds such a path.
+  #
+  # Chicken-and-egg: bottling needs the formula installed, which needs the
+  # formula already in the tap. So this job runs AFTER `homebrew` pushes the
+  # (bottle-less) formula, builds the bottle on each target OS, uploads the
+  # tarball to the release, and emits the bottle JSON as an artifact. The
+  # `bottles-merge` job then folds the `bottle do` block back into the tap
+  # formula. If any leg fails the merge is skipped and the formula stays
+  # bottle-less -- i.e. it degrades to today's source/binary-download path.
+  #
+  # macOS is bottled on the OLDEST available arm runner (macos-14 / Sonoma)
+  # on purpose: Homebrew's bottle resolution falls back to older macOS tags,
+  # so an arm64_sonoma bottle is also poured on Sequoia/Tahoe, whereas a
+  # bottle built on the newest OS would leave older-OS users on the source
+  # path. Intel macOS is intentionally not bottled (no prebuilt Intel binary).
+  bottles:
+    name: Build bottle (${{ matrix.label }})
+    needs: homebrew
+    if: ${{ !contains(github.ref_name, '-') }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write   # upload bottle tarballs to the GitHub release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            label: arm64 macOS
+          - os: ubuntu-latest
+            label: x86_64 Linux
+          - os: ubuntu-24.04-arm
+            label: arm64 Linux
+    steps:
+      - name: Set up Homebrew on PATH (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          # GitHub's ubuntu images ship Homebrew at /home/linuxbrew; install
+          # it if a future image (or the arm runner) does not.
+          if [ ! -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+            NONINTERACTIVE=1 /bin/bash -c \
+              "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          fi
+          echo "/home/linuxbrew/.linuxbrew/bin" >> "$GITHUB_PATH"
+          # The Linux binary dynamically links libdbus (keyring default
+          # feature); `brew test` runs `bzr --version`, so the runtime lib
+          # must be present or the loader fails before main().
+          sudo apt-get update && sudo apt-get install -y libdbus-1-3
+
+      - name: Build, bottle, and upload
+        env:
+          TAG: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          BASE="https://github.com/randomparity/bzr/releases/download/${TAG}"
+
+          brew tap randomparity/tap
+          brew install --build-bottle randomparity/tap/bzr
+
+          workdir="$(mktemp -d)"
+          cd "$workdir"
+          # --root-url bakes the GitHub-release download base into the JSON so
+          # the later `--merge` writes a `bottle do` block that resolves to
+          # these assets.
+          brew bottle --json --no-rebuild --root-url "$BASE" randomparity/tap/bzr
+
+          # `brew bottle` writes a DOUBLE-dash local file
+          # (bzr--<ver>.<tag>.bottle.tar.gz); Homebrew downloads the
+          # SINGLE-dash form from root_url. Rename before upload so the asset
+          # name matches what `brew install` will request.
+          dd_file="$(ls bzr--"${VERSION}".*.bottle.tar.gz)"
+          sd_file="${dd_file/--/-}"
+          mv "$dd_file" "$sd_file"
+
+          gh release upload "$TAG" "$sd_file" --repo randomparity/bzr --clobber
+
+          mkdir -p "$GITHUB_WORKSPACE/bottle-json"
+          cp ./*.json "$GITHUB_WORKSPACE/bottle-json/"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: bottle-json-${{ matrix.os }}
+          path: bottle-json/*.json
+          if-no-files-found: error
+
+  # Fold the per-platform bottle metadata into the tap formula. `brew bottle
+  # --merge --write` reads the JSONs (each carrying its tag, sha256, cellar,
+  # and root_url) and inserts a single `bottle do` block into the tapped
+  # formula. We then push that formula back to the tap -- a second tap commit
+  # for the release, layered on top of the bottle-less one from `homebrew`.
+  bottles-merge:
+    name: Add bottle block to formula
+    needs: bottles
+    if: ${{ !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Set up Homebrew on PATH
+        run: echo "/home/linuxbrew/.linuxbrew/bin" >> "$GITHUB_PATH"
+
+      - name: Download bottle JSONs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          pattern: bottle-json-*
+          path: bottle-json
+          merge-multiple: true
+
+      - name: Merge bottle block and push to tap
+        env:
+          TAG: ${{ github.ref_name }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Tap (read-only https clone) so `--merge` can resolve and edit the
+          # formula at $(brew --repository randomparity/tap)/Formula/bzr.rb.
+          brew tap randomparity/tap
+          brew bottle --merge --write --no-commit bottle-json/*.json
+
+          tap_dir="$(brew --repository randomparity/tap)"
+          cd "$tap_dir"
+          # A bottle block exists => Homebrew pours instead of building, and a
+          # broken formula here would hard-fail every install with no source
+          # fallback. Gate the push on the formula at least parsing as Ruby.
+          ruby -c Formula/bzr.rb
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin \
+            "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/randomparity/homebrew-tap.git"
+          git add Formula/bzr.rb
+          if git diff --staged --quiet; then
+            echo "Formula already carries the bottle block for ${TAG}; nothing to commit."
+            exit 0
+          fi
+          git commit -m "bzr ${TAG#v}: add bottles"
+          git push origin HEAD:main
+
   # Open a post-release version-bump PR on main. Stable releases only
   # (`-` filters out pre-release tags). Folded into release.yml for the
   # same GITHUB_TOKEN-doesn't-fire-downstream-events reason as the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Packaging
+
+- The Homebrew formula now ships real bottles (precompiled, poured binaries)
+  for Apple Silicon macOS, x86_64 Linux, and arm64 Linux. Homebrew pours a
+  bottle straight into the Cellar instead of running the formula's build
+  phase, so `brew install`/`brew upgrade` no longer enters Homebrew's build
+  sandbox. This sidesteps a recent Homebrew change (build-phase
+  `deny_read_home`, which raises on any `$HOME` entry containing characters
+  like `(`/`)`) that broke source installs for some users, and makes installs
+  faster. `release.yml` builds the bottles on per-OS runners after the formula
+  is published, uploads them to the GitHub release, and adds the `bottle do`
+  block to the tap formula. Intel macOS still builds from source (no prebuilt
+  Intel binary is produced).
+
 ## [0.4.3] - 2026-06-10
 
 ### Security


### PR DESCRIPTION
## What

Adds two jobs to `release.yml` so stable releases publish real Homebrew **bottles** for **arm64 macOS**, **x86_64 Linux**, and **arm64 Linux**, plus a CHANGELOG entry.

## Why

`brew upgrade randomparity/tap/bzr` crashes for some users with:

```
Error: Invalid character '(' in path: /Users/.../Box-Box (Archive)
  sandbox.rb:414 Sandbox#path_filter
  ...
  formula_installer.rb:1145 FormulaInstaller#build
```

Root cause is upstream, not the formula:

- **Homebrew #17700** made `path_filter` *intentionally raise* on paths containing `"' ( ) \n \`.
- **Homebrew #22413** (May 2026) started applying `deny_read_home` during the formula **build phase** of ordinary installs.

Combined, any non-bottled install now enumerates `$HOME` and dies on the first entry containing a paren. `HOMEBREW_NO_SANDBOX=1` does not disable this in the hardened version. The current formula ships a prebuilt binary but is **not bottled**, so Homebrew still runs its `install` method under the build sandbox.

A **bottle is poured** (extracted straight into the Cellar) and never enters `FormulaInstaller#build`, so it skips the sandbox — and the `deny_read_home` pass — entirely. Bottling is the only formula-side fix and also speeds up installs.

## How

- **`bottles`** (matrix: `macos-14`, `ubuntu-latest`, `ubuntu-24.04-arm`) runs after `homebrew` publishes the formula. Each leg `brew install --build-bottle`s, `brew bottle`s with `--root-url` set to the GitHub release, renames the double-dash local artifact to the single-dash form Homebrew downloads, uploads it to the release, and emits the bottle JSON as an artifact.
- **`bottles-merge`** downloads the JSONs, runs `brew bottle --merge --write` to insert the `bottle do` block, syntax-checks the formula (`ruby -c`), and pushes it back to the tap.

macOS is bottled on the **oldest** arm runner (Sonoma) on purpose — Homebrew's tag fallback pours an `arm64_sonoma` bottle on Sequoia/Tahoe too. Intel macOS is intentionally not bottled (no prebuilt Intel binary exists; it stays a source build).

## Safety / degradation

- Both jobs are stable-only (`if: !contains(ref_name, '-')`), matching the existing `homebrew` job.
- If any bottle leg fails, `bottles-merge` is skipped and the formula stays bottle-less → **degrades to today's behavior**, no regression.
- `brew bottle --merge` writes shas/cellar from the actual uploaded artifacts, so the block matches by construction; the `ruby -c` gate blocks a syntactically broken formula from reaching users.

## Validation notes (please read before relying on it)

This pipeline can only be fully exercised by a real tagged release, so the first stable release after merge validates it end-to-end. Areas most likely to need a tweak:

1. `brew bottle --merge` placement against the `on_macos`/`on_linux` conditional formula.
2. Homebrew-on-Linux **arm64** maturity on `ubuntu-24.04-arm`.
3. `arm64_sonoma` → newer-macOS tag fallback.

Linux bottles also surface a pre-existing gap: the Linux binary dynamically links **libdbus** (keyring default feature) but the formula declares no `depends_on "dbus"`. Out of scope here (the bottle runners install `libdbus-1-3` so `brew test` passes), but worth a follow-up so Linux pours don't fail on hosts without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)