### PR TITLE
fix(packaging): statically link libdbus for Linux bottle binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@193d6aa1dbbc28bd2c0a6b0e327cfdce68baaf6e  # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2
       - run: cargo build --release --locked
+      - name: Verify vendored-keyring drops the libdbus dependency
+        run: |
+          set -euo pipefail
+          # The release workflow builds the x86_64/aarch64 Linux artifacts with
+          # --features vendored-keyring so the Homebrew bottle binary is
+          # self-contained. Prove here, on native Linux, that the feature both
+          # builds and statically links libdbus (no NEEDED libdbus-1.so entry).
+          cargo build --release --locked --features vendored-keyring
+          if readelf -d target/release/bzr | grep -i 'NEEDED.*dbus'; then
+            echo "::error::vendored-keyring binary still links libdbus dynamically; vendoring did not take effect"
+            exit 1
+          fi
+          echo "vendored-keyring: no libdbus NEEDED entry — OK"
 
   manpages:
     name: Manpages
@@ -130,7 +143,16 @@ jobs:
       - name: Check
         env:
           PKG_CONFIG_ALLOW_CROSS: "1"
-        run: cross check --locked --target ${{ matrix.target }}
+        run: |
+          # aarch64 ships its release binary with vendored libdbus (it feeds a
+          # Homebrew bottle), so check that target the same way -- this also
+          # exercises the vendored libdbus C cross-compile that only otherwise
+          # runs at release time.
+          FEATURES=()
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
+            FEATURES=(--features vendored-keyring)
+          fi
+          cross check --locked --target ${{ matrix.target }} "${FEATURES[@]}"
 
   windows-cross-check:
     name: Cross-check aarch64-pc-windows-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,12 +76,16 @@ jobs:
             archive: tar.gz
             pkg_deb: true
             pkg_rpm: true
+            # Statically link libdbus: this binary feeds the Homebrew bottle,
+            # which cannot declare a system-library dependency.
+            vendored_keyring: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             use_cross: true
             archive: tar.gz
             pkg_deb: true
             pkg_rpm: true
+            vendored_keyring: true
           - target: powerpc64le-unknown-linux-gnu
             os: ubuntu-latest
             use_cross: false
@@ -144,6 +148,14 @@ jobs:
           # target `.pc` files.
           PKG_CONFIG_ALLOW_CROSS: "1"
         run: |
+          # Self-contained libdbus for the targets that feed Homebrew bottles
+          # (x86_64/aarch64 Linux); other targets keep dynamic linking and the
+          # .deb/.rpm declare libdbus as a package dependency. ppc64le (qemu)
+          # carries no bottle, so it is not vendored.
+          FEATURES=()
+          if [ "${{ matrix.vendored_keyring }}" = "true" ]; then
+            FEATURES=(--features vendored-keyring)
+          fi
           if [ "${{ matrix.use_qemu }}" = "true" ]; then
             # Use the latest stable Rust image so the container's rustc tracks
             # `dtolnay/rust-toolchain@stable` used by the rest of the matrix.
@@ -159,9 +171,9 @@ jobs:
             # otherwise hit "Permission denied" on target/.
             sudo chown -R "$(id -u):$(id -g)" target
           elif [ "${{ matrix.use_cross }}" = "true" ]; then
-            cross build --release --locked --target ${{ matrix.target }}
+            cross build --release --locked --target ${{ matrix.target }} "${FEATURES[@]}"
           else
-            cargo build --release --locked --target ${{ matrix.target }}
+            cargo build --release --locked --target ${{ matrix.target }} "${FEATURES[@]}"
           fi
         shell: bash
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   is published, uploads them to the GitHub release, and adds the `bottle do`
   block to the tap formula. Intel macOS still builds from source (no prebuilt
   Intel binary is produced).
+- The x86_64 and arm64 Linux release binaries now statically link libdbus
+  (new opt-in `vendored-keyring` Cargo feature, enabled only for these targets
+  in CI). A Homebrew bottle is poured as-is and cannot declare a system-library
+  dependency, so the binary that feeds the Linux bottles must carry no runtime
+  `libdbus-1.so` requirement. Local builds and the `.deb`/`.rpm` packages are
+  unchanged — they keep dynamic linking, with the system dependency declared in
+  package metadata as before.
 
 ## [0.4.3] - 2026-06-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
+ "openssl",
  "sha2",
  "zeroize",
 ]
@@ -568,6 +569,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1053,6 +1069,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
+ "cc",
  "pkg-config",
 ]
 
@@ -1257,10 +1274,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -2290,6 +2354,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,14 @@ keyring = [
     "dep:rpassword",
     "dep:windows-native-keyring-store",
 ]
+# Statically link libdbus into the binary so it carries no runtime
+# libdbus-1.so dependency. Off by default (local Linux builds keep using the
+# faster system libdbus). Enabled in CI only for the prebuilt x86_64/aarch64
+# Linux release artifacts that feed Homebrew bottles: a bottle is poured as-is
+# and, unlike the .deb/.rpm packages, cannot declare a system-library
+# dependency, so the binary must be self-contained. The weak `?` keeps this a
+# no-op on macOS/Windows, where the Secret Service store is not compiled.
+vendored-keyring = ["dbus-secret-service-keyring-store?/vendored"]
 # Exposes test helpers from the library for integration tests.
 # Activated automatically via dev-dependency below.
 test-helpers = ["dep:wiremock", "dep:tempfile"]


### PR DESCRIPTION
## What

Adds an opt-in `vendored-keyring` Cargo feature that statically links libdbus into the binary, and enables it for the **x86_64 + arm64 Linux release builds** that feed Homebrew bottles. Follow-up to #289.

## Why

The Linux binary links libdbus dynamically through the keyring chain:

```
dbus-secret-service-keyring-store → dbus-secret-service v4 → dbus → libdbus-sys (C bindings)
```

So it has a hard `NEEDED libdbus-1.so.3`. The `.deb` (`libc6, libdbus-1-3`) and `.rpm` (`dbus-libs`) already declare that system dependency, but **a Homebrew bottle is poured as-is and cannot declare one** — so a bottle install would fail at runtime on a host lacking system libdbus.

`depends_on "dbus"` in the formula would *not* fix it: the bottle binary is built by plain CI cargo with no RPATH into `$(brew --prefix)/lib`, so the loader only ever searches system paths. The dependency has to be removed at the binary level.

## How

- **New `vendored-keyring` feature** (`Cargo.toml`): `["dbus-secret-service-keyring-store?/vendored"]`. Turns on `libdbus-sys/vendored`, which compiles libdbus from the crate's bundled C source via `cc` and links it statically. dbus-rs documents `vendored` as the recommended cross-compile path, and it needs only a C compiler — no expat/autotools/pkg-config.
  - The weak `?` makes it a **no-op on macOS/Windows** (the Secret Service store is `[target.'cfg(target_os = "linux")']`-gated).
  - bzr uses `crypto-rust`, so the crate's `openssl?/vendored` stays inert. The openssl crates added to `Cargo.lock` are **pinned but never compiled** (verified: only `openssl-probe`, unrelated, appears in the active dependency tree).
- **`release.yml`**: a `vendored_keyring: true` matrix flag adds `--features vendored-keyring` to the x86_64 (native) and aarch64 (cross) builds only. ppc64le/s390x (no bottle) and macOS/Windows are untouched and keep dynamic linking.
- **`ci.yml` guards** (the real validation, on native Linux, every PR):
  - The `build` job builds `--features vendored-keyring` and asserts via `readelf -d` that the binary has **no libdbus `NEEDED` entry** — catches both a non-propagating feature and a broken vendored compile.
  - The aarch64 `cross-check` now runs with the feature, exercising the vendored libdbus **C cross-compile** that otherwise only runs at release time.

## Scope / non-goals

- Local dev builds and the `.deb`/`.rpm` packages are **unchanged** — still dynamic, still declaring the system dep. Only the two bottle-feeding targets vendor.
- Not switching to a pure-Rust (zbus) Secret Service backend: the keyring-core ecosystem's Secret Service store is the C-based `dbus-secret-service-keyring-store`; there's no drop-in zbus store, and `linux-keyutils` has different (non-persistent) semantics. Vendoring keeps identical behavior with a one-feature change.

## Verification

- `actionlint` clean on both workflows (SC2086 handled via bash arrays).
- `cargo fmt --check`, `cargo clippy --features vendored-keyring`, `cargo metadata --locked` all clean.
- `cargo tree --target x86_64-unknown-linux-gnu --features vendored-keyring` confirms `libdbus-sys` pulls its `vendored`/`cc` edge and openssl stays inactive.
- The native-Linux `readelf` assertion in CI is the authoritative check (cross-host `cargo tree --target` from macOS is unreliable for target-gated feature display, so I encoded the assertion where it runs natively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)