### PR TITLE
release: prep v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.4.4] - 2026-06-12
 
 ### Packaging
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzr"
-version = "0.4.4-dev"
+version = "0.4.4"
 dependencies = [
  "apple-native-keyring-store",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 
 [package]
 name = "bzr"
-version = "0.4.4-dev"
+version = "0.4.4"
 edition = "2021"
 description = "A CLI for Bugzilla, inspired by gh"
 license = "MIT"


### PR DESCRIPTION
Release prep for **v0.4.4**. Bumps `Cargo.toml` `0.4.4-dev` → `0.4.4`, refreshes `Cargo.lock`, and dates the CHANGELOG entry (`## [0.4.4] - 2026-06-12`).

## Release contents (packaging only — no API/CLI changes)

- **Homebrew bottles** for arm64 macOS, x86_64 Linux, and arm64 Linux (#289). Installs are now poured, skipping Homebrew's build sandbox (which a recent upstream change broke for `$HOME` paths containing `(`/`)`).
- **Vendored libdbus** for the x86_64/arm64 Linux release binaries (#290), so the Homebrew bottle binary carries no runtime `libdbus-1.so` dependency.

This is the **first release exercising the bottle pipeline and the vendored Linux builds**. Both were validated in CI on #289/#290.

## Local checks (RELEASING.md step 5)

- `cargo fmt --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test` ✓ (73+ tests)
- `cargo build --release` ✓
- `cargo publish --dry-run` ✓ (packaged & verified)

After merge, tagging `v0.4.4` on the merge commit triggers `release.yml` (build → release → installer-smoke → homebrew → bottles → bottles-merge) and `publish-crates.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)