### PR TITLE
fix(comment): honour `-` as stdin on body flags; add comment add --body-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `bzr comment add` now accepts `--body-file <PATH>` to read the comment body
+  from a UTF-8 file, matching `bug create --description-file` and
+  `bug update --comment-file`. A path of `-` reads from stdin. `--body` and
+  `--body-file` are mutually exclusive.
 - Bundled agent skills for driving `bzr` from AI coding agents, with a
   runtime-free installer. Five skills (`bzr-reference`, `bzr-setup`,
   `bzr-file-bug`, `bzr-triage-bug`, `bzr-search-report`) live under
@@ -17,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `~/.claude/skills`) with a `.bzr-skill-managed` ownership sentinel. CI runs a
   command-surface drift check against the built binary. Replaces the previous
   `docs/skills.md` and `docs/bob-skills.md` guides.
+
+### Fixed
+
+- `--body`, `--description`, and `--comment` (and their `--*-file` companions)
+  now honour the `-` convention, reading the body from stdin instead of posting
+  or sending a literal `-`. Previously `bzr comment add <id> --body -` posted a
+  literal `-`. (#295)
 
 ## [0.4.4] - 2026-06-12
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -108,7 +108,7 @@ bzr [--server <NAME>] [--output table|json] [--json] [--no-color] [--quiet] [--a
 │                       [--depends-on-remove <IDs>]
 ├── comment
 │   ├── list <BUG_ID> [--since <DATE>]
-│   ├── add <BUG_ID> [--body <TEXT>]
+│   ├── add <BUG_ID> [--body <TEXT>] [--body-file <PATH>]
 │   ├── tag <COMMENT_ID> [--add <TAG>...] [--remove <TAG>...]
 │   └── search-tags <QUERY>
 ├── attachment
@@ -426,6 +426,8 @@ Highest priority first:
 3. Piped stdin — when stdin is not a TTY (e.g. `echo body | bzr bug create ...`).
 4. `$EDITOR` — when stdin is a TTY and no explicit source is supplied. The buffer is pre-filled with `--summary` (if given) and any saved-template `description` body, followed by a `git commit -v`-style sentinel divider with informational field reminders.
 
+A value of `-` for `--description` or `--description-file` reads the description from stdin (e.g. `... --description -`).
+
 `--description` and `--description-file` are mutually exclusive (clap rejects with exit code 2). An empty piped stdin (when no other source is supplied) aborts with exit code 7.
 
 #### Exit codes (this command)
@@ -476,7 +478,7 @@ Agent note: cloning without overrides copies metadata from the source bug, which
 
 Modify fields on an existing bug. Supports multiple IDs for batch updates.
 
-A comment may be posted atomically with the update via `--comment` or `--comment-file`; this avoids the need for a separate `bzr comment add` call.
+A comment may be posted atomically with the update via `--comment` or `--comment-file`; this avoids the need for a separate `bzr comment add` call. A value of `-` for either flag reads the comment from stdin.
 
 ```bash
 bzr bug update 12345 --status ASSIGNED --assignee dev@example.com
@@ -527,8 +529,8 @@ bzr bug update 100 200 300 --status RESOLVED --resolution WONTFIX
 | `--groups-remove <G>` | No | Remove groups (comma-separated; requires permission) |
 | `--see-also-add <URL>` | No | Add a see-also URL (repeat for multiple; no comma-list) |
 | `--see-also-remove <URL>` | No | Remove a see-also URL (repeat for multiple) |
-| `--comment <BODY>` | No | Post a comment atomically with the field changes (mutually exclusive with `--comment-file`) |
-| `--comment-file <PATH>` | No | Read the comment body from a UTF-8 file (mutually exclusive with `--comment`; missing or non-UTF-8 paths exit 7) |
+| `--comment <BODY>` | No | Post a comment atomically with the field changes; `-` reads stdin (mutually exclusive with `--comment-file`) |
+| `--comment-file <PATH>` | No | Read the comment body from a UTF-8 file; `-` reads stdin (mutually exclusive with `--comment`; missing or non-UTF-8 paths exit 7) |
 | `--comment-private` | No | Mark the comment private (requires `--comment` or `--comment-file`) |
 
 When updating multiple bugs, failures on individual bugs do not abort the batch. A summary is printed showing which bugs succeeded and which failed.
@@ -556,22 +558,25 @@ bzr --json comment list 12345
 
 ### `bzr comment add`
 
-Add a comment to a bug. If `--body` is omitted: reads from stdin when piped (`echo "text" | bzr comment add 12345`), or opens `$EDITOR` (falls back to `vi`) at a TTY. Add `--private` to mark the comment as visible only to users with elevated permissions on the server.
+Add a comment to a bug. The body is resolved in this order: `--body <TEXT>`, `--body-file <PATH>`, piped stdin, then `$EDITOR` (falls back to `vi`) at a TTY. A value of `-` for `--body` or `--body-file` reads from stdin. `--body` and `--body-file` are mutually exclusive (clap rejects with exit code 2). Add `--private` to mark the comment as visible only to users with elevated permissions on the server.
 
 ```bash
 bzr comment add 12345 --body "Confirmed on Fedora 42"
 bzr comment add 12345                                 # opens editor
 echo "Automated comment" | bzr comment add 12345      # reads stdin
+echo "Automated comment" | bzr comment add 12345 --body -   # explicit stdin
+bzr comment add 12345 --body-file notes.txt           # reads a file
 bzr comment add 12345 --body "internal note" --private  # private
 ```
 
 | Option | Required | Description |
 |--------|----------|-------------|
 | `<BUG_ID>` | Yes | Bug ID |
-| `--body <TEXT>` | No | Comment text (reads stdin or opens `$EDITOR` if omitted) |
+| `--body <TEXT>` | No | Comment text; `-` reads stdin. Reads piped stdin or opens `$EDITOR` if both body flags omitted |
+| `--body-file <PATH>` | No | Read the comment body from a UTF-8 file; `-` reads stdin (mutually exclusive with `--body`; missing or non-UTF-8 paths exit 7) |
 | `--private` | No | Mark the comment as private (visible only to users with elevated permissions) |
 
-Agent note: `bzr comment add <BUG_ID>` without `--body` is not agent-friendly at a TTY because it opens `$EDITOR`. Prefer `bzr comment add <BUG_ID> --body "text"`. If you already have generated text on stdin, `echo "text" | bzr comment add <BUG_ID>` is also safe.
+Agent note: `bzr comment add <BUG_ID>` without `--body` is not agent-friendly at a TTY because it opens `$EDITOR`. Prefer `bzr comment add <BUG_ID> --body "text"`. If you already have generated text on stdin, `echo "text" | bzr comment add <BUG_ID>` (or `--body -`) is also safe.
 
 ### `bzr comment tag`
 

--- a/docs/superpowers/specs/2026-06-19-body-stdin-dash-convention-design.md
+++ b/docs/superpowers/specs/2026-06-19-body-stdin-dash-convention-design.md
@@ -64,42 +64,70 @@ Three commands and one shared resolver:
 
 ## Decision
 
-### Shared resolver
+### Shared resolver — pure classifier + thin materializer
+
+The logic is split so the new branching (dash detection, mutual exclusion,
+source selection) is a **pure function** that needs no real file descriptor,
+and only a trivial wrapper touches I/O. This is what makes the change
+unit-testable in the repo's in-process integration harness (see "Test plan").
 
 Add to `commands/shared.rs`:
 
 ```rust
-/// Read all of stdin to a String. Shared by the `-` (dash) convention and
-/// the flag-omitted auto-stdin paths.
-pub(crate) fn read_stdin_to_string() -> Result<String>;
+/// Where a body string comes from. Pure result of classifying the
+/// inline + file flag pair; carries no I/O.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum BodySource {
+    /// A literal inline value (`--body "text"`).
+    Literal(String),
+    /// Read all of stdin (`--body -` or `--*-file -`).
+    Stdin,
+    /// Read a UTF-8 file (`--*-file PATH`, PATH != "-").
+    File(std::path::PathBuf),
+    /// Neither source supplied; caller applies its own fallback.
+    None,
+}
 
-/// Resolve a body from an inline flag value and/or a `--*-file` path,
-/// honouring the `-` = stdin convention for both. Returns `Ok(None)` when
-/// neither source was supplied, so the caller applies its own fallback
-/// (piped stdin, `$EDITOR`, or "no body"). The two sources are mutually
-/// exclusive.
-pub(crate) fn resolve_body_source(
+/// Pure classifier. No file descriptors are touched. `inline_flag` /
+/// `file_flag` name the originating options for the mutual-exclusion error.
+/// The two sources are mutually exclusive; clap `conflicts_with` makes the
+/// both-present arm unreachable in normal use, but the classifier guards
+/// regardless so correctness does not depend on the CLI layer.
+pub(crate) fn classify_body_source(
     inline: Option<&str>,
     file: Option<&std::path::Path>,
     inline_flag: &str,
     file_flag: &str,
+) -> Result<BodySource>;
+
+/// Read all of stdin to a String. Shared by the materializer and the
+/// flag-omitted auto-stdin paths.
+pub(crate) fn read_stdin_to_string() -> Result<String>;
+
+/// Thin materializer: turn a classified source into the actual body, or
+/// `Ok(None)` for `BodySource::None` so the caller applies its fallback.
+/// The only place that performs stdin/file I/O for explicit flags.
+pub(crate) fn materialize_body_source(
+    source: BodySource,
+    file_flag: &str,
 ) -> Result<Option<String>>;
 ```
 
-`resolve_body_source` semantics:
+`classify_body_source` semantics (pure — fully unit-tested):
 
 | `inline`        | `file`          | Result                                   |
 | --------------- | --------------- | ---------------------------------------- |
-| `Some("-")`     | `None`          | `Ok(Some(stdin))`                        |
-| `Some(s)`       | `None`          | `Ok(Some(s))`                            |
-| `None`          | `Some("-")`     | `Ok(Some(stdin))`                        |
-| `None`          | `Some(path)`    | `Ok(Some(read_file_with_context(path)))` |
+| `Some("-")`     | `None`          | `Ok(BodySource::Stdin)`                  |
+| `Some(s)`       | `None`          | `Ok(BodySource::Literal(s))`             |
+| `None`          | `Some("-")`     | `Ok(BodySource::Stdin)`                  |
+| `None`          | `Some(path)`    | `Ok(BodySource::File(path))`             |
 | `Some(_)`       | `Some(_)`       | `Err(InputValidation, "X and Y are mutually exclusive")` |
-| `None`          | `None`          | `Ok(None)`                               |
+| `None`          | `None`          | `Ok(BodySource::None)`                   |
 
-The `Some(_), Some(_)` arm is a defence-in-depth guard; clap `conflicts_with`
-makes it unreachable in normal use, but the resolver must not depend on the
-CLI layer for correctness.
+`materialize_body_source` maps `Literal(s) → Some(s)`, `Stdin →
+Some(read_stdin_to_string())`, `File(p) → Some(read_file_with_context(p, file_flag))`,
+`None → None`. Call sites compose the two:
+`materialize_body_source(classify_body_source(...)?, file_flag)?`.
 
 ### `-` reads stdin unconditionally
 
@@ -116,17 +144,17 @@ idioms semantically distinct.
 
 ### Call-site wiring
 
+Each call site composes `materialize_body_source(classify_body_source(...)?, file_flag)?`:
+
 - **`comment add`** — add `--body-file: Option<PathBuf>` with
-  `conflicts_with = "body"`. Resolve via
-  `resolve_body_source(body, body_file, "--body", "--body-file")?`; on `None`,
-  fall back to the existing `read_comment_body()` (piped stdin / `$EDITOR`).
-  The existing `text.trim().is_empty()` check is unchanged.
-- **`bug create`** — `resolve_description` first calls
-  `resolve_body_source(description, description_file, "--description", "--description-file")?`;
-  on `None` it keeps the existing piped-stdin fallback and `Ok(None)` (→
-  `$EDITOR`) tail.
+  `conflicts_with = "body"`. On `Some(text)`, use it; on `None`, fall back to
+  the existing `read_comment_body()` (piped stdin / `$EDITOR`). The existing
+  `text.trim().is_empty()` check is unchanged.
+- **`bug create`** — `resolve_description` composes the resolver for
+  `--description` / `--description-file`; on `None` it keeps the existing
+  piped-stdin fallback and `Ok(None)` (→ `$EDITOR`) tail.
 - **`bug update`** — `resolve_comment` replaces its `match (comment, comment_file)`
-  with `resolve_body_source(...)`, preserving the existing `comment_private`
+  with the composed resolver, preserving the existing `comment_private`
   and empty-body checks afterwards. `resolve_comment` is called once at
   params-build time (before the per-bug loop), so the single stdin read is
   correct for batch updates.
@@ -156,9 +184,13 @@ Behaviour per path is preserved, not newly unified:
   (`text.trim().is_empty()` → exit 7) after resolution, so `--body -` /
   `--comment -` over empty stdin errors exactly like an empty literal.
 - `bug create` keeps its existing empty-piped-stdin error on the *flag-omitted*
-  path. An explicit `--description -` over empty stdin yields an empty
-  description, identical to today's `--description ""` — no new validation is
-  added.
+  path. An explicit `--description -` (or `--description-file`) over empty input
+  yields an empty description, identical to today's `--description ""`. This
+  asymmetry is **intentional**: explicit sources pass through unvalidated (the
+  caller asked for exactly this content), while the flag-omitted convenience
+  path guards against the "piped from an empty producer by mistake" case. The
+  server still rejects a genuinely empty required description with exit 4, so no
+  data-loss path is opened.
 
 ## Considered & rejected
 
@@ -176,15 +208,33 @@ Behaviour per path is preserved, not newly unified:
 
 ## Test plan
 
-Unit tests (sibling `*_tests.rs`) drive the resolver directly with injected
-values — no real stdin needed for the literal/file/mutual-exclusion arms:
+The classifier carries all the new branching, so the behaviour that #295 is
+about is covered by pure unit tests with **no** file descriptor or process
+spawn required.
 
-- `resolve_body_source`: inline literal; inline `-` (stdin behaviour exercised
-  via integration, see below); file path; file `-`; mutual-exclusion error;
-  both-None → `None`.
-- `read_file_with_context` for `--body-file` missing/unreadable path → exit 7.
-- Mutual-exclusion error messages name the correct flags for each command.
+Unit tests (sibling `shared_tests.rs`) on `classify_body_source` — pure, no I/O:
 
-stdin-dependent arms (`--body -`, `--body-file -`) are exercised through the
-binary in `tests/integration.rs` (or a functional test) by piping to a
-child process, since `read_stdin_to_string` reads the real fd 0.
+- `Some("-"), None` → `Stdin`
+- `Some("text"), None` → `Literal("text")`
+- `None, Some("-")` → `Stdin`
+- `None, Some("path")` → `File("path")`
+- `Some(_), Some(_)` → `Err` whose message names both flags (one case per
+  command's flag pair, to lock the messages).
+- `None, None` → `None`
+
+Unit tests on `materialize_body_source`:
+
+- `File(missing_path)` → `InputValidation` (exit 7), message names the file flag.
+- `Literal`/`None` map straight through (no I/O).
+- (`Stdin` is the one arm that reads fd 0; see below.)
+
+Integration (`tests/integration.rs`, in-process against wiremock, the
+established pattern): assert that `comment add --body "literal"`,
+`--body-file <tmpfile>`, and the mutual-exclusion error each behave correctly
+end-to-end through `dispatch`. These need no stdin.
+
+The single `Stdin` materialization (`read_stdin_to_string` reading real fd 0)
+is the only arm not reachable in-process. It is the thinnest possible function
+(read fd 0 to a String); one focused test redirects fd 0 to a temp file/pipe
+to confirm it returns the bytes. No binary spawn and no new harness is
+introduced.

--- a/docs/superpowers/specs/2026-06-19-body-stdin-dash-convention-design.md
+++ b/docs/superpowers/specs/2026-06-19-body-stdin-dash-convention-design.md
@@ -1,0 +1,190 @@
+# Design: `-` (dash) stdin convention for body-input flags
+
+- **Issue:** #295 — "test comment is not posting to bugzilla"
+- **Date:** 2026-06-19
+- **Status:** Accepted
+
+## Problem
+
+A user ran:
+
+```sh
+echo "Test comment from command line" | bzr comment add 203732 --body -
+```
+
+and expected the piped text to be posted. Instead, the literal string `-`
+was posted as the comment body.
+
+The cause is in `commands/comment.rs`: the body is resolved as
+
+```rust
+let text = match body {
+    Some(t) => t.clone(),       // --body "-" lands here as the literal "-"
+    None => read_comment_body()?, // stdin/editor only when --body is omitted
+};
+```
+
+`--body -` makes clap set `body = Some("-")`, so the literal dash is posted.
+The stdin path only runs when `--body` is omitted entirely. The reporter's
+mental model — `-` as a stand-in for stdin — is the widespread Unix
+convention (`cat -`, `git apply -`, `kubectl apply -f -`), which `bzr`
+currently honours nowhere.
+
+## Goals
+
+1. `bzr comment add <id> --body -` reads the comment body from stdin.
+2. The same `-`-means-stdin convention applies consistently to the other
+   body-input flags: `bug create --description` and `bug update --comment`.
+3. Add a `--body-file PATH` companion to `comment add`, matching the existing
+   `--description-file` / `--comment-file` pattern, where `PATH` of `-` also
+   means stdin.
+4. The `-` convention also works on the existing file companions:
+   `--description-file -` and `--comment-file -` read stdin.
+5. No regression to the flag-omitted behaviours (auto-read piped stdin, or
+   open `$EDITOR` at a TTY) for `comment add` and `bug create`.
+
+## Non-goals
+
+- Changing `attachment add --comment` (a one-line annotation, not a body
+  composed from stdin). Out of scope for #295.
+- Adding empty-body validation where none exists today. Each call site keeps
+  its current empty-body handling (see "Empty input" below).
+- Introducing a `docs/adr/` tree. This repo records decisions as dated specs;
+  this document is that record.
+
+## Scope of change
+
+Three commands and one shared resolver:
+
+| Command       | Inline flag     | File flag (`-` = stdin)        | Flag-omitted fallback        |
+| ------------- | --------------- | ------------------------------ | ---------------------------- |
+| `comment add` | `--body`        | `--body-file` (**new**)        | piped stdin, else `$EDITOR`  |
+| `bug create`  | `--description` | `--description-file` (exists)  | piped stdin, else `$EDITOR`  |
+| `bug update`  | `--comment`     | `--comment-file` (exists)      | none (no comment)            |
+
+## Decision
+
+### Shared resolver
+
+Add to `commands/shared.rs`:
+
+```rust
+/// Read all of stdin to a String. Shared by the `-` (dash) convention and
+/// the flag-omitted auto-stdin paths.
+pub(crate) fn read_stdin_to_string() -> Result<String>;
+
+/// Resolve a body from an inline flag value and/or a `--*-file` path,
+/// honouring the `-` = stdin convention for both. Returns `Ok(None)` when
+/// neither source was supplied, so the caller applies its own fallback
+/// (piped stdin, `$EDITOR`, or "no body"). The two sources are mutually
+/// exclusive.
+pub(crate) fn resolve_body_source(
+    inline: Option<&str>,
+    file: Option<&std::path::Path>,
+    inline_flag: &str,
+    file_flag: &str,
+) -> Result<Option<String>>;
+```
+
+`resolve_body_source` semantics:
+
+| `inline`        | `file`          | Result                                   |
+| --------------- | --------------- | ---------------------------------------- |
+| `Some("-")`     | `None`          | `Ok(Some(stdin))`                        |
+| `Some(s)`       | `None`          | `Ok(Some(s))`                            |
+| `None`          | `Some("-")`     | `Ok(Some(stdin))`                        |
+| `None`          | `Some(path)`    | `Ok(Some(read_file_with_context(path)))` |
+| `Some(_)`       | `Some(_)`       | `Err(InputValidation, "X and Y are mutually exclusive")` |
+| `None`          | `None`          | `Ok(None)`                               |
+
+The `Some(_), Some(_)` arm is a defence-in-depth guard; clap `conflicts_with`
+makes it unreachable in normal use, but the resolver must not depend on the
+CLI layer for correctness.
+
+### `-` reads stdin unconditionally
+
+When the value is `-`, stdin is read directly (`read_stdin_to_string`) with
+**no** `is_terminal` check. This is the deliberate distinction from omitting
+the flag:
+
+- **Flag omitted** → "read stdin *if piped*, otherwise open `$EDITOR`."
+- **`--body -`** → "read stdin, full stop." At a TTY with nothing piped this
+  blocks for keyboard input until EOF (Ctrl-D), exactly like `cat -`.
+
+This is the standard, expected behaviour of an explicit `-` and keeps the two
+idioms semantically distinct.
+
+### Call-site wiring
+
+- **`comment add`** — add `--body-file: Option<PathBuf>` with
+  `conflicts_with = "body"`. Resolve via
+  `resolve_body_source(body, body_file, "--body", "--body-file")?`; on `None`,
+  fall back to the existing `read_comment_body()` (piped stdin / `$EDITOR`).
+  The existing `text.trim().is_empty()` check is unchanged.
+- **`bug create`** — `resolve_description` first calls
+  `resolve_body_source(description, description_file, "--description", "--description-file")?`;
+  on `None` it keeps the existing piped-stdin fallback and `Ok(None)` (→
+  `$EDITOR`) tail.
+- **`bug update`** — `resolve_comment` replaces its `match (comment, comment_file)`
+  with `resolve_body_source(...)`, preserving the existing `comment_private`
+  and empty-body checks afterwards. `resolve_comment` is called once at
+  params-build time (before the per-bug loop), so the single stdin read is
+  correct for batch updates.
+
+The three existing ad-hoc stdin reads (`comment.rs::read_comment_body`,
+`bug/create.rs::resolve_description`, and the new dash path) are consolidated
+onto `read_stdin_to_string`.
+
+## Consequences
+
+- A body that is literally the single character `-` can no longer be supplied
+  via `--body -` (it now means stdin). Mitigation: pipe it
+  (`printf - | bzr comment add <id>`) or use `--body-file` with a file whose
+  contents are `-`. A single-dash body has no real use case; this is the same
+  trade-off every `-`-as-stdin tool accepts.
+- `comment add` gains a `--body-file` flag → the man page, `docs/bzr-cli.md`,
+  the command-surface drift check, and `CHANGELOG.md` must be updated in the
+  same PR.
+- The behaviour is now uniform across the three body commands, removing the
+  prior inconsistency where stdin was reachable only by omitting the flag.
+
+## Empty input
+
+Behaviour per path is preserved, not newly unified:
+
+- `comment add` and `bug update` already reject an empty/whitespace body
+  (`text.trim().is_empty()` → exit 7) after resolution, so `--body -` /
+  `--comment -` over empty stdin errors exactly like an empty literal.
+- `bug create` keeps its existing empty-piped-stdin error on the *flag-omitted*
+  path. An explicit `--description -` over empty stdin yields an empty
+  description, identical to today's `--description ""` — no new validation is
+  added.
+
+## Considered & rejected
+
+- **`--body-file` only (gh-style), keep `--body` literal.** Rejected: it does
+  not fix the reporter's exact `--body -` invocation, which would still post a
+  literal `-`. The chosen design does both.
+- **`-` only on `comment add`.** Rejected (operator decision): leaves
+  `bug create --description -` / `bug update --comment -` inconsistent.
+- **Reject `--body -` with a "did you mean to omit --body?" error.** Rejected:
+  the user's invocation is a reasonable convention; honour it rather than
+  teach-by-error.
+- **Honour `-` only when stdin is non-TTY, else error.** Rejected: an explicit
+  `-` blocking for TTY input is the standard, least-surprising behaviour and
+  keeps the dash path semantically distinct from the flag-omitted path.
+
+## Test plan
+
+Unit tests (sibling `*_tests.rs`) drive the resolver directly with injected
+values — no real stdin needed for the literal/file/mutual-exclusion arms:
+
+- `resolve_body_source`: inline literal; inline `-` (stdin behaviour exercised
+  via integration, see below); file path; file `-`; mutual-exclusion error;
+  both-None → `None`.
+- `read_file_with_context` for `--body-file` missing/unreadable path → exit 7.
+- Mutual-exclusion error messages name the correct flags for each command.
+
+stdin-dependent arms (`--body -`, `--body-file -`) are exercised through the
+binary in `tests/integration.rs` (or a functional test) by piping to a
+child process, since `read_stdin_to_string` reads the real fd 0.

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -566,7 +566,8 @@ pub enum BugAction {
     ///
     /// `--comment <BODY>` (or `--comment-file <PATH>`) posts a comment
     /// atomically with the field changes — a single `Bug.update`
-    /// round-trip rather than a separate `bzr comment add` call.
+    /// round-trip rather than a separate `bzr comment add` call. A
+    /// value of `-` for either flag reads the comment from stdin.
     /// `--comment-private` marks it private. Empty / whitespace-only
     /// bodies are rejected (exit 7).
     ///
@@ -669,17 +670,19 @@ pub enum BugAction {
         whiteboard: Option<String>,
         /// Post a comment atomically with the field changes.
         ///
-        /// Mutually exclusive with `--comment-file`. Use
-        /// `--comment-private` to mark the comment private. Empty /
-        /// whitespace-only bodies are rejected (exit 7).
+        /// A value of `-` reads the comment from stdin. Mutually
+        /// exclusive with `--comment-file`. Use `--comment-private`
+        /// to mark the comment private. Empty / whitespace-only
+        /// bodies are rejected (exit 7).
         #[arg(long, value_name = "BODY", conflicts_with = "comment_file")]
         comment: Option<String>,
         /// Read the comment body from a UTF-8 file.
         ///
-        /// Mutually exclusive with `--comment`. The file must exist
-        /// and be readable; non-existent paths or non-UTF-8 contents
-        /// fail with exit code 7. Empty / whitespace-only contents
-        /// are also rejected.
+        /// A path of `-` reads from stdin. Mutually exclusive with
+        /// `--comment`. The file must exist and be readable;
+        /// non-existent paths or non-UTF-8 contents fail with exit
+        /// code 7. Empty / whitespace-only contents are also
+        /// rejected.
         #[arg(long, value_name = "PATH", conflicts_with = "comment")]
         comment_file: Option<std::path::PathBuf>,
         /// Mark the comment private (visible only to users with

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -321,7 +321,9 @@ pub enum BugAction {
     ///   3. piped stdin (when stdin is not a TTY)
     ///   4. `$EDITOR` (when stdin is a TTY and none of the above)
     ///
-    /// `--description` and `--description-file` are mutually
+    /// A value of `-` for `--description` or `--description-file`
+    /// reads the description from stdin. `--description` and
+    /// `--description-file` are mutually
     /// exclusive. When the editor flow is active, `--summary` is
     /// optional: the first non-empty line of the buffer becomes
     /// the summary and the rest becomes the description. A
@@ -385,14 +387,15 @@ pub enum BugAction {
         /// Version
         #[arg(long)]
         version: Option<String>,
-        /// Bug description
+        /// Bug description (a value of `-` reads from stdin)
         #[arg(long, conflicts_with = "description_file")]
         description: Option<String>,
         /// Read the bug description from a UTF-8 file.
         ///
-        /// Mutually exclusive with `--description`. The file path
-        /// must exist and be readable; non-existent paths or
-        /// non-UTF-8 contents fail with exit code 7.
+        /// A path of `-` reads from stdin. Mutually exclusive with
+        /// `--description`. The file path must exist and be readable;
+        /// non-existent paths or non-UTF-8 contents fail with exit
+        /// code 7.
         #[arg(long, value_name = "PATH", conflicts_with = "description")]
         description_file: Option<std::path::PathBuf>,
         /// Priority

--- a/src/cli/comment.rs
+++ b/src/cli/comment.rs
@@ -29,11 +29,13 @@ pub enum CommentAction {
 
     /// Add a comment to a bug.
     ///
-    /// The comment body is read from one of three sources, in order
-    /// of precedence: `--body "..."` if provided, stdin when piped,
-    /// or `$EDITOR` when stdin is a terminal and `--body` is not
-    /// set. Empty bodies are rejected with exit code 7 (input
-    /// validation).
+    /// The comment body is resolved in this order of precedence:
+    /// `--body "..."`, `--body-file PATH`, piped stdin, then
+    /// `$EDITOR` (when stdin is a terminal and no flag is set). A
+    /// value of `-` for `--body` or `--body-file` reads the body
+    /// from stdin (`echo text | bzr comment add 1 --body -`).
+    /// `--body` and `--body-file` are mutually exclusive. Empty
+    /// bodies are rejected with exit code 7 (input validation).
     ///
     /// Comments are immutable once posted -- subsequent edits or
     /// retractions are not possible via the REST API. To flag a
@@ -42,7 +44,8 @@ pub enum CommentAction {
     /// Examples:
     ///
     ///   bzr comment add 12345 --body "Reproduced on RHEL 9.4"
-    ///   echo "see also #6789" | bzr comment add 12345
+    ///   echo "see also #6789" | bzr comment add 12345 --body -
+    ///   bzr comment add 12345 --body-file notes.txt
     ///   bzr comment add 12345     # opens $EDITOR
     ///
     /// See bzr-comment-list(1) for the existing thread and
@@ -53,12 +56,19 @@ pub enum CommentAction {
         bug_id: u64,
         /// Comment text.
         ///
-        /// When omitted, bzr reads the body from stdin if it's
-        /// piped, otherwise it opens `$EDITOR` (or `vi` if
-        /// `$EDITOR` is unset) for interactive composition.
-        /// Empty bodies are rejected with exit code 7.
-        #[arg(long)]
+        /// A value of `-` reads the body from stdin. Mutually
+        /// exclusive with `--body-file`. When both are omitted, bzr
+        /// reads from stdin if it's piped, otherwise it opens
+        /// `$EDITOR` (or `vi` if `$EDITOR` is unset). Empty bodies
+        /// are rejected with exit code 7.
+        #[arg(long, conflicts_with = "body_file")]
         body: Option<String>,
+        /// Read the comment body from a UTF-8 file.
+        ///
+        /// A path of `-` reads from stdin. Mutually exclusive with
+        /// `--body`; missing or non-UTF-8 paths exit 7.
+        #[arg(long, value_name = "PATH", conflicts_with = "body")]
+        body_file: Option<std::path::PathBuf>,
         /// Mark the comment as private (visible only to users with
         /// elevated permissions on the server).
         #[arg(long = "private")]

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -568,11 +568,13 @@ fn parse_comment_add_with_body() {
                 CommentAction::Add {
                     bug_id,
                     body,
+                    body_file,
                     private,
                 },
         } => {
             assert_eq!(bug_id, 42);
             assert_eq!(body.as_deref(), Some("This is a comment"));
+            assert!(body_file.is_none());
             assert!(!private);
         }
         _ => panic!("expected Comment Add"),
@@ -597,11 +599,13 @@ fn parse_comment_add_with_private() {
                 CommentAction::Add {
                     bug_id,
                     body,
+                    body_file,
                     private,
                 },
         } => {
             assert_eq!(bug_id, 42);
             assert_eq!(body.as_deref(), Some("secret note"));
+            assert!(body_file.is_none());
             assert!(private);
         }
         _ => panic!("expected Comment Add"),

--- a/src/commands/bug/create.rs
+++ b/src/commands/bug/create.rs
@@ -1,4 +1,4 @@
-use std::io::{IsTerminal, Read};
+use std::io::IsTerminal;
 
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
@@ -124,18 +124,20 @@ fn resolve_description(
     description: Option<&str>,
     description_file: Option<&std::path::Path>,
 ) -> Result<Option<String>> {
-    if let Some(d) = description {
-        return Ok(Some(d.to_owned()));
-    }
-    if let Some(p) = description_file {
-        return Ok(Some(crate::commands::shared::read_file_with_context(
-            p,
+    let explicit = crate::commands::shared::materialize_body_source(
+        crate::commands::shared::classify_body_source(
+            description,
+            description_file,
+            "--description",
             "--description-file",
-        )?));
+        )?,
+        "--description-file",
+    )?;
+    if explicit.is_some() {
+        return Ok(explicit);
     }
     if !std::io::stdin().is_terminal() {
-        let mut buf = String::new();
-        std::io::stdin().lock().read_to_string(&mut buf)?;
+        let buf = crate::commands::shared::read_stdin_to_string()?;
         if buf.trim().is_empty() {
             return Err(crate::error::BzrError::InputValidation(
                 "no description supplied (piped stdin is empty)".into(),

--- a/src/commands/bug/create_tests.rs
+++ b/src/commands/bug/create_tests.rs
@@ -757,3 +757,16 @@ async fn bug_create_template_description_does_not_fall_back_outside_editor_flow(
         "expected InputValidation (template body should not auto-fill outside the editor flow), got {err:?}"
     );
 }
+
+#[test]
+fn resolve_description_conflict_errors() {
+    let err =
+        super::resolve_description(Some("x"), Some(std::path::Path::new("/tmp/x"))).unwrap_err();
+    match err {
+        BzrError::InputValidation(msg) => {
+            assert!(msg.contains("--description"), "names inline flag: {msg}");
+            assert!(msg.contains("--description-file"), "names file flag: {msg}");
+        }
+        other => panic!("expected InputValidation, got {other:?}"),
+    }
+}

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -67,19 +67,15 @@ fn resolve_comment(
     comment_file: Option<&std::path::Path>,
     comment_private: bool,
 ) -> Result<Option<crate::types::CommentUpdate>> {
-    let body = match (comment, comment_file) {
-        (Some(_), Some(_)) => {
-            return Err(crate::error::BzrError::InputValidation(
-                "--comment and --comment-file are mutually exclusive".into(),
-            ));
-        }
-        (Some(s), None) => Some(s.to_string()),
-        (None, Some(path)) => Some(crate::commands::shared::read_file_with_context(
-            path,
+    let body = crate::commands::shared::materialize_body_source(
+        crate::commands::shared::classify_body_source(
+            comment,
+            comment_file,
+            "--comment",
             "--comment-file",
-        )?),
-        (None, None) => None,
-    };
+        )?,
+        "--comment-file",
+    )?;
     if body.is_none() && comment_private {
         return Err(crate::error::BzrError::InputValidation(
             "--comment-private requires --comment or --comment-file".into(),

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -604,6 +604,22 @@ fn build_update_params_rejects_whitespace_only_comment() {
 }
 
 #[test]
+fn build_update_params_rejects_comment_and_comment_file_together() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("body.txt");
+    std::fs::write(&path, "from a file").unwrap();
+    let action = make_update_action_with_comment(vec![1], Some("inline"), Some(&path), false);
+    let err = super::build_update_params(&action).unwrap_err();
+    match err {
+        crate::error::BzrError::InputValidation(msg) => {
+            assert!(msg.contains("--comment"), "names inline flag: {msg}");
+            assert!(msg.contains("--comment-file"), "names file flag: {msg}");
+        }
+        other => panic!("expected InputValidation, got {other:?}"),
+    }
+}
+
+#[test]
 fn build_update_params_reads_comment_file() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("body.txt");

--- a/src/commands/comment.rs
+++ b/src/commands/comment.rs
@@ -1,4 +1,4 @@
-use std::io::{IsTerminal, Read};
+use std::io::IsTerminal;
 
 use crate::cli::CommentAction;
 use crate::commands::editor;
@@ -32,10 +32,20 @@ pub async fn execute(
         CommentAction::Add {
             bug_id,
             body,
+            body_file,
             private,
         } => {
-            let text = match body {
-                Some(t) => t.clone(),
+            let resolved = super::shared::materialize_body_source(
+                super::shared::classify_body_source(
+                    body.as_deref(),
+                    body_file.as_deref(),
+                    "--body",
+                    "--body-file",
+                )?,
+                "--body-file",
+            )?;
+            let text = match resolved {
+                Some(t) => t,
                 None => read_comment_body()?,
             };
             if text.trim().is_empty() {
@@ -93,11 +103,8 @@ pub async fn execute(
 
 /// Read comment body from stdin (pipe) or $EDITOR (TTY).
 fn read_comment_body() -> Result<String> {
-    let stdin = std::io::stdin();
-    if !stdin.is_terminal() {
-        let mut buf = String::new();
-        stdin.lock().read_to_string(&mut buf)?;
-        return Ok(buf);
+    if !std::io::stdin().is_terminal() {
+        return super::shared::read_stdin_to_string();
     }
     let raw = editor::launch("<!-- Enter your comment above this line -->\n", "comment")?;
     Ok(filter_comment_body(&raw))

--- a/src/commands/comment_tests.rs
+++ b/src/commands/comment_tests.rs
@@ -67,6 +67,7 @@ async fn comment_add_with_body() {
     let action = CommentAction::Add {
         bug_id: 42,
         body: Some("Test comment".to_string()),
+        body_file: None,
         private: false,
     };
     let result = super::execute(
@@ -89,6 +90,7 @@ async fn comment_add_empty_body_is_rejected() {
     let action = CommentAction::Add {
         bug_id: 42,
         body: Some("   ".to_string()),
+        body_file: None,
         private: false,
     };
     let result = super::execute(
@@ -173,6 +175,7 @@ async fn comment_add_api_error_returns_error() {
     let action = CommentAction::Add {
         bug_id: 42,
         body: Some("Test comment".to_string()),
+        body_file: None,
         private: false,
     };
     let result = super::execute(

--- a/src/commands/shared.rs
+++ b/src/commands/shared.rs
@@ -411,6 +411,78 @@ pub async fn connect_and_configure(
     Ok(client)
 }
 
+/// Where a body string comes from. Pure result of classifying the
+/// inline + file flag pair; carries no I/O.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum BodySource {
+    /// A literal inline value (`--body "text"`).
+    Literal(String),
+    /// Read all of stdin (`--body -` or `--*-file -`).
+    Stdin,
+    /// Read a UTF-8 file (`--*-file PATH`, PATH != "-").
+    File(std::path::PathBuf),
+    /// Neither source supplied; the caller applies its own fallback.
+    None,
+}
+
+/// Classify an inline flag value and/or a `--*-file` path into a
+/// [`BodySource`], honouring the `-` = stdin convention for both. The two
+/// sources are mutually exclusive; clap `conflicts_with` makes the
+/// both-present case unreachable in normal use, but this guards regardless so
+/// correctness does not depend on the CLI layer. `inline_flag` / `file_flag`
+/// name the originating options for the mutual-exclusion error message.
+pub(crate) fn classify_body_source(
+    inline: Option<&str>,
+    file: Option<&std::path::Path>,
+    inline_flag: &str,
+    file_flag: &str,
+) -> Result<BodySource> {
+    match (inline, file) {
+        (Some(_), Some(_)) => Err(BzrError::InputValidation(format!(
+            "{inline_flag} and {file_flag} are mutually exclusive"
+        ))),
+        (Some("-"), None) => Ok(BodySource::Stdin),
+        (Some(s), None) => Ok(BodySource::Literal(s.to_string())),
+        (None, Some(path)) => {
+            if path == std::path::Path::new("-") {
+                Ok(BodySource::Stdin)
+            } else {
+                Ok(BodySource::File(path.to_path_buf()))
+            }
+        }
+        (None, None) => Ok(BodySource::None),
+    }
+}
+
+/// Read everything from `reader` into a `String`, mapping I/O failures
+/// (including non-UTF-8 input) to a `BzrError`.
+fn read_to_string_from(reader: &mut impl std::io::Read) -> Result<String> {
+    let mut buf = String::new();
+    reader.read_to_string(&mut buf)?;
+    Ok(buf)
+}
+
+/// Read all of stdin to a `String`. Shared by the `-` (dash) convention and
+/// the flag-omitted auto-stdin paths.
+pub(crate) fn read_stdin_to_string() -> Result<String> {
+    read_to_string_from(&mut std::io::stdin().lock())
+}
+
+/// Turn a classified [`BodySource`] into the actual body, or `Ok(None)` for
+/// [`BodySource::None`] so the caller applies its own fallback. This is the
+/// only place that performs stdin/file I/O for the explicit body flags.
+pub(crate) fn materialize_body_source(
+    source: BodySource,
+    file_flag: &str,
+) -> Result<Option<String>> {
+    match source {
+        BodySource::Literal(s) => Ok(Some(s)),
+        BodySource::Stdin => Ok(Some(read_stdin_to_string()?)),
+        BodySource::File(path) => Ok(Some(read_file_with_context(&path, file_flag)?)),
+        BodySource::None => Ok(None),
+    }
+}
+
 /// Read a UTF-8 file, mapping any I/O error to an `InputValidation` error that
 /// names the originating CLI flag and the path. `flag` is the user-facing
 /// option name (e.g. `--description-file`) used to prefix the message.

--- a/src/commands/shared_tests.rs
+++ b/src/commands/shared_tests.rs
@@ -849,3 +849,103 @@ async fn cached_path_skips_probe_when_insecure() {
         "cached path with insecure flag should skip probe"
     );
 }
+
+use super::{classify_body_source, materialize_body_source, BodySource};
+
+#[test]
+fn classify_inline_literal() {
+    let got = classify_body_source(Some("hello"), None, "--body", "--body-file").unwrap();
+    assert_eq!(got, BodySource::Literal("hello".to_string()));
+}
+
+#[test]
+fn classify_inline_dash_is_stdin() {
+    let got = classify_body_source(Some("-"), None, "--body", "--body-file").unwrap();
+    assert_eq!(got, BodySource::Stdin);
+}
+
+#[test]
+fn classify_file_path() {
+    let got = classify_body_source(
+        None,
+        Some(std::path::Path::new("/tmp/x")),
+        "--body",
+        "--body-file",
+    )
+    .unwrap();
+    assert_eq!(got, BodySource::File(std::path::PathBuf::from("/tmp/x")));
+}
+
+#[test]
+fn classify_file_dash_is_stdin() {
+    let got = classify_body_source(
+        None,
+        Some(std::path::Path::new("-")),
+        "--body",
+        "--body-file",
+    )
+    .unwrap();
+    assert_eq!(got, BodySource::Stdin);
+}
+
+#[test]
+fn classify_none() {
+    let got = classify_body_source(None, None, "--body", "--body-file").unwrap();
+    assert_eq!(got, BodySource::None);
+}
+
+#[test]
+fn classify_both_is_mutually_exclusive_error() {
+    let err = classify_body_source(
+        Some("x"),
+        Some(std::path::Path::new("/tmp/x")),
+        "--comment",
+        "--comment-file",
+    )
+    .unwrap_err();
+    match err {
+        BzrError::InputValidation(msg) => {
+            assert!(msg.contains("--comment"), "names inline flag: {msg}");
+            assert!(msg.contains("--comment-file"), "names file flag: {msg}");
+        }
+        other => panic!("expected InputValidation, got {other:?}"),
+    }
+}
+
+#[test]
+fn read_to_string_from_reads_bytes() {
+    let mut src = &b"piped body\n"[..];
+    let got = super::read_to_string_from(&mut src).unwrap();
+    assert_eq!(got, "piped body\n");
+}
+
+#[test]
+fn read_to_string_from_rejects_non_utf8() {
+    let mut src = &[0xff, 0xfe][..];
+    assert!(super::read_to_string_from(&mut src).is_err());
+}
+
+#[test]
+fn materialize_literal_passes_through() {
+    let got = materialize_body_source(BodySource::Literal("hi".into()), "--body-file").unwrap();
+    assert_eq!(got, Some("hi".to_string()));
+}
+
+#[test]
+fn materialize_none_is_none() {
+    let got = materialize_body_source(BodySource::None, "--body-file").unwrap();
+    assert_eq!(got, None);
+}
+
+#[test]
+fn materialize_missing_file_is_input_validation() {
+    let err = materialize_body_source(
+        BodySource::File(std::path::PathBuf::from("/no/such/file/here")),
+        "--body-file",
+    )
+    .unwrap_err();
+    match err {
+        BzrError::InputValidation(msg) => assert!(msg.contains("--body-file"), "{msg}"),
+        other => panic!("expected InputValidation, got {other:?}"),
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -289,6 +289,62 @@ async fn comment_list_integration() {
     assert_eq!(parsed[0]["text"], "First comment");
 }
 
+#[tokio::test]
+async fn comment_add_body_file_posts_file_contents() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/7/comment"))
+        .and(wiremock::matchers::body_string_contains("from a file"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({"id": 99})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("body.txt");
+    std::fs::write(&file, "comment from a file\n").unwrap();
+
+    let action = bzr::cli::CommentAction::Add {
+        bug_id: 7,
+        body: None,
+        body_file: Some(file),
+        private: false,
+    };
+    let mut __io_bf = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::commands::comment::execute(
+        &action,
+        Some("test"),
+        bzr::types::OutputFormat::Json,
+        None,
+        &mut __io_bf.writers(),
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "comment add --body-file should succeed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn comment_add_body_and_body_file_conflict() {
+    // clap conflicts_with surfaces as a parse error — no server needed.
+    let parsed = bzr::cli::Cli::try_parse_from([
+        "bzr",
+        "comment",
+        "add",
+        "7",
+        "--body",
+        "x",
+        "--body-file",
+        "/tmp/x",
+    ]);
+    assert!(
+        parsed.is_err(),
+        "clap should reject --body with --body-file"
+    );
+}
+
 // ── Whoami command ────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -1015,6 +1071,7 @@ async fn comment_add_integration() {
     let action = bzr::cli::CommentAction::Add {
         bug_id: 42,
         body: Some("This is a test comment".to_string()),
+        body_file: None,
         private: false,
     };
     let mut __io19 = bzr::test_helpers::CapturedIo::new();


### PR DESCRIPTION
## What

Adds the `-`-means-stdin convention to `bzr`'s body-input flags and a new `--body-file` companion for `comment add`.

Previously `echo "text" | bzr comment add <id> --body -` posted a literal `-` as the comment body, because `--body -` was treated as the literal string `-` and the stdin path only ran when `--body` was omitted entirely.

## Changes

- New shared resolver in `commands/shared.rs`:
  - `classify_body_source` — a pure function mapping the `(inline, file)` flag pair to a `BodySource` enum (`Literal`/`Stdin`/`File`/`None`), honouring `-` = stdin for both and guarding the mutually-exclusive case independently of clap.
  - `materialize_body_source` — a thin wrapper that performs the stdin/file I/O.
  - `read_stdin_to_string` / `read_to_string_from` — consolidate the three previously-duplicated stdin reads.
- `comment add` gains `--body-file <PATH>` (mutually exclusive with `--body`); a value of `-` for either flag reads from stdin.
- `bug create --description` / `--description-file` and `bug update --comment` / `--comment-file` accept `-` for stdin via the same resolver.
- Docs (`docs/bzr-cli.md`), CHANGELOG, and clap doc comments updated.

A value of `-` reads stdin unconditionally (like `cat -`), which is the deliberate distinction from omitting the flag (read stdin only if piped, else `$EDITOR`). Literal, file, mutual-exclusion (identical error message), and empty-body (exit 7) handling are preserved across all three commands.

## Tests

- Pure unit tests on `classify_body_source` (all arms incl. mutual exclusion) and `read_to_string_from` (incl. non-UTF-8 rejection) in `shared_tests.rs`.
- Integration tests for `comment add --body-file` and the `--body`/`--body-file` conflict.
- Full suite green (1323 lib + 75 integration), `make lint` and `make skills-test` clean.

Closes #295