### PR TITLE
feat(completion): add `bzr completion <shell>` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `bzr completion <bash|zsh|fish|powershell|elvish>` prints a shell completion
+  script to stdout, generated from bzr's live clap command tree so it always
+  matches the installed binary's subcommands and flags. README and
+  `docs/bzr-cli.md` document a one-line install per shell. (#299)
 - `bzr comment add` now accepts `--body-file <PATH>` to read the comment body
   from a UTF-8 file, matching `bug create --description-file` and
   `bug update --comment-file`. A path of `-` reads from stdin. `--body` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "base64",
  "bzr",
  "clap",
+ "clap_complete",
  "colored",
  "dbus-secret-service-keyring-store",
  "dirs",
@@ -326,6 +327,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ test-helpers = ["dep:wiremock", "dep:tempfile"]
 [dependencies]
 base64 = "0.22"
 clap = { version = ">=4.5.60, <4.7", features = ["derive"] }
+clap_complete = ">=4.5.0, <4.7"
 reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots"], default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["std"] }
 rustls-native-certs = "0.8"

--- a/README.md
+++ b/README.md
@@ -231,6 +231,27 @@ To regenerate them from a source checkout:
 make man          # writes to man/man1/
 ```
 
+### Shell completion
+
+`bzr completion <SHELL>` prints a completion script to stdout for `bash`,
+`zsh`, `fish`, `powershell`, or `elvish`. The script is generated from bzr's
+live command tree, so it always matches the installed binary. Install with one
+line per shell:
+
+```bash
+# bash (the directory must exist and bash-completion must be active)
+bzr completion bash > ~/.local/share/bash-completion/completions/bzr
+
+# zsh (~/.zfunc must be on $fpath before compinit; restart the shell after)
+bzr completion zsh > ~/.zfunc/_bzr
+
+# fish
+bzr completion fish > ~/.config/fish/completions/bzr.fish
+
+# powershell (append to your profile)
+bzr completion powershell >> $PROFILE
+```
+
 ### See also
 
 - [`RELEASING.md`](RELEASING.md) — what each release artifact is, how it gets built, and how to verify SHA256 sums and SLSA attestations.

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -23,6 +23,7 @@ For installation and quick start, see [README.md](../README.md).
 - [Credential storage](#credential-storage)
 - [template](#bzr-template----bug-template-management)
 - [query](#bzr-query----saved-query-management)
+- [completion](#bzr-completion----shell-completion)
 - [Flag Syntax](#flag-syntax)
 - [JSON Output](#json-output)
 - [Configuration File Format](#configuration-file-format)
@@ -161,16 +162,17 @@ bzr [--server <NAME>] [--output table|json] [--json] [--no-color] [--quiet] [--a
 │   ├── list
 │   ├── show <NAME>
 │   └── delete <NAME>
-└── query
-    ├── save <NAME> (--from-url <URL> | [--product <P>...] [--component <C>...] [--status <S>...]
-    │               [--assignee <A>...] [--creator <C>...] [--priority <P>...] [--severity <S>...]
-    │               [--search <Q>]) [--limit <N>] [--fields <F>] [--exclude-fields <F>]
-    │               [--created-since <D>] [--changed-since <D>]
-    ├── list
-    ├── show <NAME>
-    ├── delete <NAME>
-    └── run <NAME> [--limit <N>] [--fields <F>] [--exclude-fields <F>] [--server <NAME>]
-                   [--created-since <D>] [--changed-since <D>]
+├── query
+│   ├── save <NAME> (--from-url <URL> | [--product <P>...] [--component <C>...] [--status <S>...]
+│   │               [--assignee <A>...] [--creator <C>...] [--priority <P>...] [--severity <S>...]
+│   │               [--search <Q>]) [--limit <N>] [--fields <F>] [--exclude-fields <F>]
+│   │               [--created-since <D>] [--changed-since <D>]
+│   ├── list
+│   ├── show <NAME>
+│   ├── delete <NAME>
+│   └── run <NAME> [--limit <N>] [--fields <F>] [--exclude-fields <F>] [--server <NAME>]
+│                  [--created-since <D>] [--changed-since <D>]
+└── completion <bash|zsh|fish|powershell>
 ```
 
 ---
@@ -1383,6 +1385,38 @@ as overrides. Passing a flag replaces the saved value for that
 field; omitting it keeps the saved value. There is no clear
 sentinel — to clear a saved field, edit the config or re-save the
 query.
+
+---
+
+## `bzr completion` -- Shell Completion
+
+Generate a shell completion script and print it to stdout. The script is
+produced from bzr's live clap command tree, so it always matches the
+installed binary's subcommands and flags. This command is local: it makes
+no network calls and needs no configured server.
+
+```
+bzr completion <SHELL>
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<SHELL>` | Yes | One of `bash`, `zsh`, `fish`, `powershell`, or `elvish`. |
+
+An unrecognized shell name exits 2 with the list of accepted values.
+
+### Install
+
+| Shell | One-line install |
+|-------|------------------|
+| bash | `bzr completion bash > ~/.local/share/bash-completion/completions/bzr` |
+| zsh | `bzr completion zsh > ~/.zfunc/_bzr` (ensure `~/.zfunc` is on `$fpath`, then restart the shell) |
+| fish | `bzr completion fish > ~/.config/fish/completions/bzr.fish` |
+| powershell | `bzr completion powershell >> $PROFILE` |
+
+For bash, the target directory must exist and `bash-completion` must be
+installed and sourced by your shell startup. For zsh, the file name must be
+`_bzr` and live in a directory listed in `$fpath` before `compinit` runs.
 
 ---
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -479,6 +479,34 @@ pub enum Commands {
         #[command(subcommand)]
         action: QueryAction,
     },
+
+    /// Generate a shell completion script.
+    ///
+    /// Emits a completion script for the named shell to stdout. The script
+    /// is generated from bzr's live command tree, so it always matches the
+    /// installed binary's subcommands and flags. This command is local: it
+    /// makes no network calls and needs no configured server.
+    ///
+    /// Install (pick your shell):
+    ///
+    ///   # bash (current user)
+    ///   bzr completion bash > ~/.local/share/bash-completion/completions/bzr
+    ///
+    ///   # zsh (ensure the dir is on $fpath, then restart the shell)
+    ///   bzr completion zsh > ~/.zfunc/_bzr
+    ///
+    ///   # fish
+    ///   bzr completion fish > ~/.config/fish/completions/bzr.fish
+    ///
+    ///   # powershell (add to your $PROFILE)
+    ///   bzr completion powershell >> $PROFILE
+    ///
+    /// See bzr-completion(1) for per-shell install detail.
+    #[command(verbatim_doc_comment)]
+    Completion {
+        /// Shell to generate completions for.
+        shell: clap_complete::Shell,
+    },
 }
 
 #[cfg(test)]

--- a/src/commands/completion.rs
+++ b/src/commands/completion.rs
@@ -1,0 +1,26 @@
+//! Completion command — emits a shell completion script to stdout.
+//!
+//! Purely local: no config, network, or auth. The script is generated from
+//! the clap `Command` tree so it always matches the binary's real surface.
+
+use clap::CommandFactory;
+use clap_complete::{generate, Shell};
+
+use crate::cli::Cli;
+use crate::error::Result;
+use crate::output::writers::Writers;
+
+/// Write a completion script for `shell` to stdout.
+///
+/// The script is generated from the live clap `Command` tree, so it stays in
+/// sync with the binary's subcommands and flags without manual maintenance.
+pub fn execute(shell: Shell, w: &mut Writers<'_>) -> Result<()> {
+    let mut cmd = Cli::command();
+    let bin_name = cmd.get_name().to_string();
+    generate(shell, &mut cmd, bin_name, &mut w.out);
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "completion_tests.rs"]
+mod tests;

--- a/src/commands/completion_tests.rs
+++ b/src/commands/completion_tests.rs
@@ -1,0 +1,55 @@
+use clap_complete::Shell;
+
+use crate::test_helpers::CapturedIo;
+
+fn script_for(shell: Shell) -> String {
+    let mut io = CapturedIo::new();
+    let result = super::execute(shell, &mut io.writers());
+    assert!(result.is_ok(), "completion generation should succeed");
+    io.out_str().to_string()
+}
+
+#[test]
+fn bash_script_is_nonempty_and_names_binary() {
+    let script = script_for(Shell::Bash);
+    assert!(!script.is_empty(), "bash script should not be empty");
+    assert!(
+        script.contains("bzr"),
+        "bash script should reference the bzr binary name"
+    );
+    assert!(
+        script.contains("complete"),
+        "bash script should register a completion function"
+    );
+}
+
+#[test]
+fn zsh_script_is_nonempty_and_names_binary() {
+    let script = script_for(Shell::Zsh);
+    assert!(!script.is_empty(), "zsh script should not be empty");
+    assert!(script.contains("bzr"), "zsh script should reference bzr");
+    assert!(
+        script.contains("#compdef bzr"),
+        "zsh script should carry a #compdef directive"
+    );
+}
+
+#[test]
+fn fish_script_is_nonempty_and_names_binary() {
+    let script = script_for(Shell::Fish);
+    assert!(!script.is_empty(), "fish script should not be empty");
+    assert!(
+        script.contains("bzr"),
+        "fish script should reference the bzr binary name"
+    );
+}
+
+#[test]
+fn powershell_script_is_nonempty_and_names_binary() {
+    let script = script_for(Shell::PowerShell);
+    assert!(!script.is_empty(), "powershell script should not be empty");
+    assert!(
+        script.contains("bzr"),
+        "powershell script should reference the bzr binary name"
+    );
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod attachment;
 pub mod bug;
 pub mod classification;
 pub mod comment;
+pub mod completion;
 pub mod component;
 pub mod config;
 mod editor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ pub async fn dispatch(
         cli::Commands::Query { action } => {
             commands::query::execute(action, server, format, api, w).await
         }
+        cli::Commands::Completion { shell } => commands::completion::execute(*shell, w),
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2783,3 +2783,45 @@ async fn e2e_bug_list_json_exclude_id_drops_key_but_parses() {
     assert!(!keys.contains(&"id"), "id dropped from output:\n{out}");
     assert_eq!(parsed[0]["summary"], "keep me", "summary retained:\n{out}");
 }
+
+// ── Completion command ────────────────────────────────────────────────
+
+/// `bzr completion <shell>` must parse and dispatch end-to-end (not just
+/// the `commands::completion::execute` helper) and emit a non-empty script
+/// naming the binary. Guards the `Commands::Completion` variant and the
+/// `dispatch()` arm against silent removal/misrouting. Local-only: no
+/// server, config, or env mutation, so it needs no `ENV_LOCK`.
+#[tokio::test]
+async fn completion_bash_parses_and_dispatches() {
+    let cli = bzr::cli::Cli::try_parse_from(["bzr", "completion", "bash"])
+        .expect("completion bash should parse");
+
+    let mut __io = bzr::test_helpers::CapturedIo::new();
+    let result = bzr::dispatch(&cli, bzr::types::OutputFormat::Table, &mut __io.writers()).await;
+    assert!(
+        result.is_ok(),
+        "completion dispatch should succeed: {result:?}"
+    );
+
+    let script = __io.out_str();
+    assert!(
+        !script.is_empty(),
+        "bash completion script should not be empty"
+    );
+    assert!(
+        script.contains("bzr"),
+        "bash completion script should name the bzr binary:\n{script}"
+    );
+    assert!(
+        script.contains("complete"),
+        "bash completion script should register a completion function:\n{script}"
+    );
+}
+
+/// An unknown shell name is rejected at parse time (clap value enum),
+/// before any dispatch happens.
+#[tokio::test]
+async fn completion_rejects_unknown_shell() {
+    let parsed = bzr::cli::Cli::try_parse_from(["bzr", "completion", "klingon"]);
+    assert!(parsed.is_err(), "clap should reject an unknown shell name");
+}


### PR DESCRIPTION
## Summary

Adds `bzr completion <SHELL>` (closes #299), a `gh`-style shell-completion
generator. The script is produced from bzr's live clap command tree via
`clap_complete`, so it always matches the installed binary's subcommands and
flags — no hand-maintained completion files to drift.

| Field | Value |
|-------|-------|
| Issue | #299 (High / S) |
| Shells | `bash`, `zsh`, `fish`, `powershell`, `elvish` |
| Surface | new top-level `completion` command; new `clap_complete` dependency |

## Acceptance criteria

- [x] `bzr completion bash\|zsh\|fish\|powershell` prints a valid script and exits 0 (also supports `elvish` via `clap_complete::Shell`).
- [x] README documents a one-line install per shell (also in `docs/bzr-cli.md`).
- [ ] (Stretch) dynamic completion for server/template/query names — **not** included; out of scope for this PR.

## Implementation notes

- `Commands::Completion { shell: clap_complete::Shell }` in `src/cli/mod.rs`; a `commands::completion` module generates the script to the command layer's stdout writer (honoring the project's `writeln!`-to-`Writers` convention, not `println!`).
- Dispatch arm in `src/lib.rs` is synchronous (local-only: no server/config/network), routed alongside the async command arms.
- Manpage `bzr-completion.1` auto-generates from the clap tree (`clap_mangen`), so the `See bzr-completion(1)` reference resolves.

## Tests

- Unit (`src/commands/completion_tests.rs`): script generation per shell, asserting non-empty output and shell-specific markers (`complete`, `#compdef bzr`).
- Integration (`tests/integration.rs`): full `Cli::parse_from(["bzr","completion","bash"])` → `dispatch()` path, plus unknown-shell rejection at parse time. This guards the enum variant and dispatch arm against silent removal.

## Validation

`cargo clippy --locked --features test-helpers -- -D warnings` and `cargo test --features test-helpers` both pass clean.

## Notes for reviewer

- The dynamic-completion stretch goal and packaged `.deb`/`.rpm` completion files from the issue's "Proposed" section are intentionally deferred (acceptance criteria 1–2 are fully met).
- Generated scripts are not run through a shell syntax-checker in tests (would require spawning `bash`/`zsh`, platform-fragile); `clap_complete` owns escaping and only clean short-help strings are embedded as completion descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
