### PR TITLE
feat(config): add remove-server and rename-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `bzr config remove-server <NAME>` deletes a server alias (and its OS-keychain
+  entry, if any). Removing the current default is refused while other servers
+  remain; removing the only server clears the default. `bzr config
+  rename-server <OLD> <NEW>` renames an alias, preserving credentials —
+  including moving the keychain secret when it is stored under the default
+  (server-name) account — and updates `default_server` if it pointed at the old
+  name. Both emit the standard mutation JSON (`removed` / `renamed`). (#300)
 - `bzr completion <bash|zsh|fish|powershell|elvish>` prints a shell completion
   script to stdout, generated from bzr's live clap command tree so it always
   matches the installed binary's subcommands and flags. README and

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -154,6 +154,8 @@ bzr [--server <NAME>] [--output table|json] [--json] [--no-color] [--quiet] [--a
 │   ├── unset-keyring <NAME>
 │   ├── migrate-to-keyring <NAME> [--yes]
 │   ├── set-default <NAME>
+│   ├── remove-server <NAME>
+│   ├── rename-server <OLD> <NEW>
 │   └── show
 ├── template
 │   ├── save <NAME> [--product <P>] [--component <C>] [--version <V>] [--priority <P>]
@@ -1098,6 +1100,39 @@ Change which server is used when `--server` is not specified.
 bzr config set-default mozilla
 ```
 
+### `bzr config remove-server <NAME>`
+
+Remove a server alias from the config. Deletes the `[servers.<NAME>]` block
+and, if the server stored its API key in the OS keychain, removes that
+keychain entry too (idempotently — a missing entry is not an error). The
+server must exist.
+
+Removing the current **default** server is refused while other servers
+remain — set a new default first with `bzr config set-default <other>`.
+Removing the **only** configured server is allowed and leaves the config
+with no default. Emits the standard mutation JSON (`"action": "removed"`)
+under `--json`.
+
+```bash
+bzr config remove-server staging
+bzr --json config remove-server throwaway
+```
+
+### `bzr config rename-server <OLD> <NEW>`
+
+Rename a server alias, preserving all of its fields. `<OLD>` must exist and
+`<NEW>` must not. If the API key lives in the OS keychain under the default
+account (the server name), the stored secret is moved to the new account so
+credentials keep working; an explicitly configured `--account` is left as-is.
+If `default_server` pointed at `<OLD>`, it is updated to `<NEW>`. Emits the
+standard mutation JSON (`"action": "renamed"`, with `previous_name`) under
+`--json`.
+
+```bash
+bzr config rename-server stage staging
+bzr --json config rename-server old-name new-name
+```
+
 ### `bzr config show`
 
 Display the current configuration (API keys are masked). Supports `--json` for structured output.
@@ -1496,7 +1531,14 @@ Template mutations use `name` instead of `id`:
 {"name":"security-bug","action":"deleted"}
 ```
 
-All mutation responses include `resource` and `action` fields. Most include `id` for the created/updated resource. Note: `comment tag` responses use `comment_id`, not `id`. Membership responses (`group_membership`) have no `id` field. Template responses use `name` instead of `id`.
+Server config mutations key on `name` and carry `config_file`; `rename-server` also includes `previous_name`:
+
+```json
+{"name":"staging","config_file":"~/.config/bzr/config.toml","resource":"server","action":"removed"}
+{"name":"new-name","previous_name":"old-name","config_file":"~/.config/bzr/config.toml","resource":"server","action":"renamed"}
+```
+
+All mutation responses include `resource` and `action` fields. Most include `id` for the created/updated resource. Note: `comment tag` responses use `comment_id`, not `id`. Membership responses (`group_membership`) have no `id` field. Template responses use `name` instead of `id`. Server config responses (`remove-server`/`rename-server`) key on `name` (and `previous_name` for renames) with no `id`.
 
 ### Error output
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -308,4 +308,53 @@ pub enum ConfigAction {
         #[arg(long)]
         yes: bool,
     },
+
+    /// Remove a named server from the local config.
+    ///
+    /// Deletes the `[servers.<name>]` block and, if the server stored
+    /// its API key in the OS keychain, removes that keychain entry too
+    /// (idempotently — a missing entry is not an error). The server
+    /// must exist.
+    ///
+    /// Removing the current default server is refused while other
+    /// servers remain: set a new default first with
+    /// `bzr config set-default <other>`. Removing the only configured
+    /// server is allowed and leaves the config with no default.
+    ///
+    /// Examples:
+    ///
+    ///   bzr config remove-server staging
+    ///   bzr --json config remove-server throwaway
+    ///
+    /// See bzr-config-set-default(1) to reassign the default before
+    /// removing it and bzr-config-rename-server(1) to rename instead.
+    #[command(verbatim_doc_comment)]
+    RemoveServer {
+        /// Server alias name (must exist).
+        name: String,
+    },
+
+    /// Rename a server alias, preserving its credentials.
+    ///
+    /// Moves the `[servers.<old>]` block to `[servers.<new>]` with every
+    /// field intact. If the server's API key lives in the OS keychain
+    /// under the default account (the server name), the stored secret is
+    /// moved to the new account so credentials keep working. If
+    /// `default_server` pointed at `<old>`, it is updated to `<new>`.
+    ///
+    /// `<old>` must exist and `<new>` must not already exist.
+    ///
+    /// Examples:
+    ///
+    ///   bzr config rename-server stage staging
+    ///   bzr --json config rename-server old-name new-name
+    ///
+    /// See bzr-config-remove-server(1) to delete a server instead.
+    #[command(verbatim_doc_comment)]
+    RenameServer {
+        /// Current server alias (must exist).
+        old: String,
+        /// New server alias (must not already exist).
+        new: String,
+    },
 }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -104,7 +104,132 @@ pub async fn execute(
             };
             migrate_to_keyring(spec, *yes, format, w)
         }
+        ConfigAction::RemoveServer { name } => remove_server(name.as_str(), format, w),
+        ConfigAction::RenameServer { old, new } => {
+            rename_server(old.as_str(), new.as_str(), format, w)
+        }
     }
+}
+
+/// Remove a server alias from the config, dropping any keychain entry.
+fn remove_server(name: &str, format: OutputFormat, w: &mut Writers<'_>) -> Result<()> {
+    // Advisory snapshot: read unvalidated so an unrelated credential-less
+    // server (left by `unset-keyring`) does not block the removal.
+    let config = Config::read_unvalidated()?;
+    let server = config
+        .servers
+        .get(name)
+        .ok_or_else(|| crate::error::BzrError::config(format!("server '{name}' not found")))?;
+
+    // Refuse to remove the current default while other servers remain — that
+    // would silently leave bzr with no default. Removing the only server is
+    // allowed and clears the pointer.
+    let is_default = config.default_server.as_deref() == Some(name);
+    if is_default && config.servers.len() > 1 {
+        return Err(crate::error::BzrError::config(format!(
+            "server '{name}' is the current default; set a different default first \
+             with `bzr config set-default <name>` before removing it"
+        )));
+    }
+
+    // Drop the keychain entry if the server kept its key there (idempotent —
+    // a missing entry is not an error).
+    if let Some(keyring_ref) = server.api_key_keyring.as_ref() {
+        let service = keyring_ref.service_or_default().to_string();
+        let account = keyring_ref.account_or_default(name).to_string();
+        crate::credentials::keyring::delete(&service, &account)?;
+    }
+
+    // `update_locked_without_validation`: removal never introduces a
+    // credential-less server, and the whole-config validator would otherwise
+    // reject the write whenever any *other* server is credential-less (the
+    // state `unset-keyring` deliberately leaves on disk).
+    Config::update_locked_without_validation(|config| {
+        config.servers.remove(name);
+        if config.default_server.as_deref() == Some(name) {
+            config.default_server = None;
+        }
+        Ok(())
+    })?;
+    let path = Config::path()?;
+
+    let human = format!("Removed server '{name}'.\nConfig file: {}", path.display());
+    write_result(
+        &ConfigResult::removed(name, path.to_string_lossy()),
+        &human,
+        format,
+        w.out,
+    );
+    Ok(())
+}
+
+/// Rename a server alias, preserving credentials (including a keychain move
+/// when the secret is stored under the default, server-name account).
+fn rename_server(old: &str, new: &str, format: OutputFormat, w: &mut Writers<'_>) -> Result<()> {
+    if old == new {
+        return Err(crate::error::BzrError::config(
+            "new name must differ from the current name",
+        ));
+    }
+    // Advisory snapshot: read unvalidated so an unrelated credential-less
+    // server (left by `unset-keyring`) does not block the rename.
+    let config = Config::read_unvalidated()?;
+    let server = config
+        .servers
+        .get(old)
+        .ok_or_else(|| crate::error::BzrError::config(format!("server '{old}' not found")))?;
+    if config.servers.contains_key(new) {
+        return Err(crate::error::BzrError::config(format!(
+            "server '{new}' already exists; choose a different name or remove it first"
+        )));
+    }
+
+    // When the key lives in the keychain under the *default* account (the
+    // server name), move the secret to the new account so the rename does not
+    // orphan it. Retrieve+store happen before the config write; the old
+    // entry is deleted only after the rename commits, so a failure anywhere
+    // never loses the secret.
+    let keyring_move = match server.api_key_keyring.as_ref() {
+        Some(kr) if kr.account.is_none() => {
+            let service = kr.service_or_default().to_string();
+            let secret = crate::credentials::keyring::retrieve(&service, old)?;
+            crate::credentials::keyring::store(&service, new, &secret)?;
+            Some(service)
+        }
+        _ => None,
+    };
+
+    // `update_locked_without_validation`: a rename preserves the credential
+    // source, so it cannot create a credential-less server, but the validator
+    // would reject the write if any *other* server is already credential-less.
+    Config::update_locked_without_validation(|config| {
+        let server_cfg = config
+            .servers
+            .remove(old)
+            .ok_or_else(|| crate::error::BzrError::config(format!("server '{old}' disappeared")))?;
+        config.servers.insert(new.to_owned(), server_cfg);
+        if config.default_server.as_deref() == Some(old) {
+            config.default_server = Some(new.to_owned());
+        }
+        Ok(())
+    })?;
+
+    if let Some(service) = keyring_move {
+        crate::credentials::keyring::delete(&service, old)?;
+    }
+    let path = Config::path()?;
+
+    let human = format!(
+        "Renamed server '{old}' to '{new}'.\nConfig file: {}",
+        path.display()
+    );
+    write_result(
+        &ConfigResult::renamed(old, new, path.to_string_lossy()),
+        &human,
+        format,
+        w.out,
+    );
+    Ok(())
 }
 
 struct SetServerArgs<'a> {

--- a/src/commands/config_tests.rs
+++ b/src/commands/config_tests.rs
@@ -586,3 +586,327 @@ async fn unset_keyring_removes_secret_and_clears_config() {
     // Keychain entry is gone (idempotent delete returns Ok).
     crate::credentials::keyring::delete("bzr", "unset-test").unwrap();
 }
+
+// ── remove-server (#300) ──────────────────────────────────────────────
+
+/// Run a `ConfigAction` capturing stdout, returning the parsed JSON.
+async fn run_action_json(action: ConfigAction) -> serde_json::Value {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await
+    .unwrap();
+    let out = __cap_io.out_str().to_string();
+    serde_json::from_str(out.trim()).unwrap()
+}
+
+fn load_config_unvalidated() -> Config {
+    let path = Config::path().unwrap();
+    let content = std::fs::read_to_string(&path).unwrap();
+    toml::from_str(&content).unwrap()
+}
+
+#[tokio::test]
+async fn remove_server_deletes_non_default_entry() {
+    let (_lock, _tmp) = setup_config_env().await;
+    seed_inline_server("keep", "https://keep.example.com", "k").await;
+    seed_inline_server("drop", "https://drop.example.com", "d").await;
+    // "keep" became default (first added); set it explicitly to be safe.
+    execute(
+        &ConfigAction::SetDefault {
+            name: "keep".into(),
+        },
+        None,
+        OutputFormat::Json,
+        None,
+        &mut crate::test_helpers::CapturedIo::new().writers(),
+    )
+    .await
+    .unwrap();
+
+    let json = run_action_json(ConfigAction::RemoveServer {
+        name: "drop".into(),
+    })
+    .await;
+    assert_eq!(json["action"], "removed");
+    assert_eq!(json["name"], "drop");
+    assert_eq!(json["resource"], "server");
+
+    let config = load_config_unvalidated();
+    assert!(!config.servers.contains_key("drop"));
+    assert!(config.servers.contains_key("keep"));
+    assert_eq!(config.default_server.as_deref(), Some("keep"));
+}
+
+#[tokio::test]
+async fn remove_server_missing_errors() {
+    let (_lock, _tmp) = setup_config_env().await;
+    seed_inline_server("only", "https://only.example.com", "x").await;
+
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    let result = execute(
+        &ConfigAction::RemoveServer {
+            name: "ghost".into(),
+        },
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
+    assert!(matches!(result, Err(BzrError::Config(_))));
+}
+
+#[tokio::test]
+async fn remove_server_default_with_others_refuses() {
+    let (_lock, _tmp) = setup_config_env().await;
+    seed_inline_server("a", "https://a.example.com", "x").await;
+    seed_inline_server("b", "https://b.example.com", "y").await;
+    // "a" is the default (first added).
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    let result = execute(
+        &ConfigAction::RemoveServer { name: "a".into() },
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
+    assert!(matches!(result, Err(BzrError::Config(_))));
+    // Nothing was removed.
+    let config = load_config_unvalidated();
+    assert!(config.servers.contains_key("a"));
+}
+
+#[tokio::test]
+async fn remove_server_only_server_clears_default() {
+    let (_lock, _tmp) = setup_config_env().await;
+    seed_inline_server("solo", "https://solo.example.com", "x").await;
+
+    let json = run_action_json(ConfigAction::RemoveServer {
+        name: "solo".into(),
+    })
+    .await;
+    assert_eq!(json["action"], "removed");
+
+    let config = load_config_unvalidated();
+    assert!(config.servers.is_empty());
+    assert!(config.default_server.is_none());
+}
+
+#[tokio::test]
+async fn remove_server_deletes_keyring_entry() {
+    let (_lock, _tmp) = setup_config_env().await;
+    crate::credentials::keyring::install_test_store();
+    seed_inline_server("kr", "https://kr.example.com", "inline").await;
+    seed_keyring_secret("kr", "kr-secret").await;
+    // Confirm the secret is present before removal.
+    assert_eq!(
+        crate::credentials::keyring::retrieve("bzr", "kr").unwrap(),
+        "kr-secret"
+    );
+
+    run_action_json(ConfigAction::RemoveServer { name: "kr".into() }).await;
+
+    let config = load_config_unvalidated();
+    assert!(!config.servers.contains_key("kr"));
+    // Keychain entry is gone — retrieve now fails.
+    assert!(crate::credentials::keyring::retrieve("bzr", "kr").is_err());
+}
+
+// ── rename-server (#300) ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn rename_server_preserves_inline_credentials() {
+    let (_lock, _tmp) = setup_config_env().await;
+    seed_inline_server("stage", "https://stage.example.com", "secret-key").await;
+
+    let json = run_action_json(ConfigAction::RenameServer {
+        old: "stage".into(),
+        new: "staging".into(),
+    })
+    .await;
+    assert_eq!(json["action"], "renamed");
+    assert_eq!(json["name"], "staging");
+    assert_eq!(json["previous_name"], "stage");
+
+    let config = load_config_unvalidated();
+    assert!(!config.servers.contains_key("stage"));
+    let server = &config.servers["staging"];
+    assert_eq!(server.url, "https://stage.example.com");
+    assert_eq!(server.api_key.as_deref(), Some("secret-key"));
+    // Renamed server was the only one, so it stays the default.
+    assert_eq!(config.default_server.as_deref(), Some("staging"));
+}
+
+#[tokio::test]
+async fn rename_server_updates_default_pointer() {
+    let (_lock, _tmp) = setup_config_env().await;
+    seed_inline_server("a", "https://a.example.com", "x").await;
+    seed_inline_server("b", "https://b.example.com", "y").await;
+    // "a" is default; rename it and confirm the pointer follows.
+    run_action_json(ConfigAction::RenameServer {
+        old: "a".into(),
+        new: "a2".into(),
+    })
+    .await;
+    let config = load_config_unvalidated();
+    assert_eq!(config.default_server.as_deref(), Some("a2"));
+    assert!(config.servers.contains_key("a2"));
+    assert!(config.servers.contains_key("b"));
+}
+
+#[tokio::test]
+async fn rename_server_old_missing_errors() {
+    let (_lock, _tmp) = setup_config_env().await;
+    seed_inline_server("real", "https://real.example.com", "x").await;
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    let result = execute(
+        &ConfigAction::RenameServer {
+            old: "ghost".into(),
+            new: "new".into(),
+        },
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
+    assert!(matches!(result, Err(BzrError::Config(_))));
+}
+
+#[tokio::test]
+async fn rename_server_new_exists_errors() {
+    let (_lock, _tmp) = setup_config_env().await;
+    seed_inline_server("a", "https://a.example.com", "x").await;
+    seed_inline_server("b", "https://b.example.com", "y").await;
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    let result = execute(
+        &ConfigAction::RenameServer {
+            old: "a".into(),
+            new: "b".into(),
+        },
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
+    assert!(matches!(result, Err(BzrError::Config(_))));
+}
+
+#[tokio::test]
+async fn rename_server_moves_keyring_secret() {
+    let (_lock, _tmp) = setup_config_env().await;
+    crate::credentials::keyring::install_test_store();
+    seed_inline_server("oldname", "https://kr.example.com", "inline").await;
+    seed_keyring_secret("oldname", "kr-secret").await;
+
+    run_action_json(ConfigAction::RenameServer {
+        old: "oldname".into(),
+        new: "newname".into(),
+    })
+    .await;
+
+    let config = load_config_unvalidated();
+    assert!(config.servers.contains_key("newname"));
+    assert!(config.servers["newname"].api_key_keyring.is_some());
+    // Secret reachable under the new default account, gone under the old.
+    assert_eq!(
+        crate::credentials::keyring::retrieve("bzr", "newname").unwrap(),
+        "kr-secret"
+    );
+    assert!(crate::credentials::keyring::retrieve("bzr", "oldname").is_err());
+}
+
+/// Regression (#300): managing one server must succeed even when an
+/// unrelated server is credential-less on disk (the state `unset-keyring`
+/// leaves behind). `update_locked`'s whole-config validation would reject
+/// the write; remove/rename must use the non-validating path.
+#[tokio::test]
+async fn remove_server_succeeds_with_other_credential_less_server() {
+    let (_lock, _tmp) = setup_config_env().await;
+    crate::credentials::keyring::install_test_store();
+    seed_inline_server("keepme", "https://keep.example.com", "k").await;
+    seed_inline_server("dropme", "https://drop.example.com", "d").await;
+    // Make "keepme" credential-less via unset-keyring after moving it to keyring.
+    seed_keyring_secret("keepme", "s").await;
+    execute(
+        &ConfigAction::UnsetKeyring {
+            name: "keepme".into(),
+        },
+        None,
+        OutputFormat::Json,
+        None,
+        &mut crate::test_helpers::CapturedIo::new().writers(),
+    )
+    .await
+    .unwrap();
+    // "dropme" is the default? No — "keepme" added first is default. Remove dropme.
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    let result = execute(
+        &ConfigAction::RemoveServer {
+            name: "dropme".into(),
+        },
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "remove must not fail because an unrelated server is credential-less: {result:?}"
+    );
+    let config = load_config_unvalidated();
+    assert!(!config.servers.contains_key("dropme"));
+    assert!(config.servers.contains_key("keepme"));
+}
+
+/// Regression (#300): rename must also succeed when an unrelated server is
+/// credential-less on disk (same `read_unvalidated` + non-validating write
+/// path as remove).
+#[tokio::test]
+async fn rename_server_succeeds_with_other_credential_less_server() {
+    let (_lock, _tmp) = setup_config_env().await;
+    crate::credentials::keyring::install_test_store();
+    seed_inline_server("keepme", "https://keep.example.com", "k").await;
+    seed_inline_server("rename-me", "https://r.example.com", "r").await;
+    seed_keyring_secret("keepme", "s").await;
+    execute(
+        &ConfigAction::UnsetKeyring {
+            name: "keepme".into(),
+        },
+        None,
+        OutputFormat::Json,
+        None,
+        &mut crate::test_helpers::CapturedIo::new().writers(),
+    )
+    .await
+    .unwrap();
+
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    let result = execute(
+        &ConfigAction::RenameServer {
+            old: "rename-me".into(),
+            new: "renamed".into(),
+        },
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "rename must not fail because an unrelated server is credential-less: {result:?}"
+    );
+    let config = load_config_unvalidated();
+    assert!(config.servers.contains_key("renamed"));
+    assert!(!config.servers.contains_key("rename-me"));
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -257,7 +257,12 @@ impl Config {
     /// Read and parse the config from disk WITHOUT validating it or warning on
     /// permissions. Maps a missing file to `Config::default()`. Used by
     /// `update_locked` (which validates the post-mutation state) and by `load`.
-    fn read_unvalidated() -> Result<Config> {
+    ///
+    /// `pub(crate)` so `config remove-server`/`rename-server` can take an
+    /// advisory snapshot (existence, default pointer, keyring ref) without
+    /// `load`'s credential validator rejecting an unrelated credential-less
+    /// server — the legitimate state `unset-keyring` leaves on disk.
+    pub(crate) fn read_unvalidated() -> Result<Config> {
         let path = Self::path()?;
         match fs::read_to_string(&path) {
             Ok(content) => Ok(toml::from_str(&content)?),

--- a/src/output/result_types.rs
+++ b/src/output/result_types.rs
@@ -55,6 +55,8 @@ pub enum ActionKind {
     Added,
     #[serde(rename = "removed")]
     Removed,
+    #[serde(rename = "renamed")]
+    Renamed,
     #[serde(rename = "downloaded")]
     Downloaded,
 }
@@ -161,6 +163,9 @@ impl TagResult {
 #[non_exhaustive]
 pub struct ConfigResult {
     pub name: String,
+    /// Prior alias for a `rename-server` operation; omitted otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -180,6 +185,7 @@ impl ConfigResult {
     ) -> Self {
         Self {
             name: name.into(),
+            previous_name: None,
             url: Some(url.into()),
             is_default: Some(is_default),
             config_file: config_file.into(),
@@ -195,11 +201,43 @@ impl ConfigResult {
     pub fn default_set(name: impl Into<String>, config_file: impl Into<String>) -> Self {
         Self {
             name: name.into(),
+            previous_name: None,
             url: None,
             is_default: None,
             config_file: config_file.into(),
             resource: ResourceKind::Server,
             action: ActionKind::Updated,
+        }
+    }
+
+    /// Result for `config remove-server`: the server alias that was removed.
+    pub fn removed(name: impl Into<String>, config_file: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            previous_name: None,
+            url: None,
+            is_default: None,
+            config_file: config_file.into(),
+            resource: ResourceKind::Server,
+            action: ActionKind::Removed,
+        }
+    }
+
+    /// Result for `config rename-server`: `name` is the new alias and
+    /// `previous_name` carries the old one.
+    pub fn renamed(
+        old_name: impl Into<String>,
+        new_name: impl Into<String>,
+        config_file: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: new_name.into(),
+            previous_name: Some(old_name.into()),
+            url: None,
+            is_default: None,
+            config_file: config_file.into(),
+            resource: ResourceKind::Server,
+            action: ActionKind::Renamed,
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds the two missing server-management verbs (closes #300). Previously a
server alias could be added and made default, but never removed or renamed
without hand-editing `config.toml` and reasoning about keyring entries and the
`default_server` pointer — awkward for humans and a blocker for agents that
provision throwaway servers.

| Command | Behavior |
|---------|----------|
| `config remove-server <NAME>` | Deletes the `[servers.<NAME>]` block + its keychain entry (idempotent). Refuses to remove the default while others remain; clears the default when removing the only server. |
| `config rename-server <OLD> <NEW>` | Renames the alias preserving all fields, moves the keychain secret when stored under the default account, and updates `default_server` if it pointed at `<OLD>`. |

## Acceptance criteria

- [x] `remove-server` deletes the block, drops its keyring entry, and errors clearly when removing the default (while other servers remain).
- [x] `rename-server` preserves credentials (incl. keychain move) and updates `default_server`.
- [x] Both emit the standard mutation JSON under `--json` (`removed` / `renamed`).

## Implementation notes

- **Credential-less-server robustness:** both verbs take an advisory snapshot via `Config::read_unvalidated()` (made `pub(crate)`) and persist via `update_locked_without_validation`. `Config::load()` / `update_locked` run the credential validator, which rejects a write while *any* server is credential-less — the legitimate state `unset-keyring` leaves on disk. Using the non-validating path means managing server A is not blocked by an unrelated credential-less server B. (Caught and fixed during adversarial review; regression tests on both paths.)
- **Keychain-move safety (rename):** `retrieve(old)` → `store(new)` → config write → `delete(old)`. The old entry is deleted only after the rename commits, so a failure never loses the secret. Only triggered when the keyring account is defaulted (`account: None` → server name); an explicit `--account` is account-stable and needs no move.
- Adds `ActionKind::Renamed` and an optional `previous_name` field to `ConfigResult`.

## Tests

12 new unit tests in `src/commands/config_tests.rs`: remove (non-default, missing-errors, default-with-others-refuses, only-server-clears-default, keychain-delete), rename (inline-preserve, default-pointer-follows, old-missing, new-exists, keychain-move), plus two regression tests for the credential-less-other-server case (remove + rename).

## Review notes (intentional decisions)

- `remove-server` **errors** on a missing server (matching the `unset-keyring`/`set-default` siblings) rather than being a no-op.
- Residual low-severity items accepted: a rename keychain-move can leave a stale secret under the new account if the config write fails after `store` (no cross-store transactionality available; old still works); advisory existence checks are pre-lock, consistent with the sibling keyring handlers and the `update_locked` contract (keychain steps run before the lock).

## Validation

`cargo clippy --locked --features test-helpers -- -D warnings` and `cargo test --features test-helpers` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
