### PR TITLE
feat(classification): add classification list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `bzr classification list` enumerates the server's classifications (ID, name,
+  description, product count; full objects under `--json`). Bugzilla has no
+  bulk classification endpoint, so names come from the `classification` field's
+  legal values and each is fetched for detail. When classifications are
+  disabled (only `Unclassified` exists) bzr prints a note to stderr. (#319)
 - `bzr config remove-server <NAME>` deletes a server alias (and its OS-keychain
   entry, if any). Removing the current default is refused while other servers
   remain; removing the only server clears the default. `bzr config

--- a/agent-skills/skills/bzr-reference/reference/commands.yml
+++ b/agent-skills/skills/bzr-reference/reference/commands.yml
@@ -10,7 +10,7 @@ user: search create update
 group: add-user remove-user list-users view create update
 whoami:
 server: info
-classification: view
+classification: list view
 component: create update
 template: save list show delete
 query: save list show delete run

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -143,6 +143,7 @@ bzr [--server <NAME>] [--output table|json] [--json] [--no-color] [--quiet] [--a
 ├── server
 │   └── info
 ├── classification
+│   ├── list
 │   └── view <NAME>
 ├── component
 │   ├── create --product <P> --name <N> --description <D> --default-assignee <E>
@@ -999,6 +1000,21 @@ bzr --json server info
 ---
 
 ## `bzr classification` -- Classification Operations
+
+### `bzr classification list`
+
+List the server's classifications with their ID, name, description, and
+product count. JSON output is the full classification array.
+
+Bugzilla has no bulk classification endpoint, so bzr reads the names from the
+`classification` field's legal values and fetches each one's detail.
+Classifications are an optional feature; when they are disabled the only
+entry is `Unclassified`, and bzr prints a note to stderr.
+
+```bash
+bzr classification list
+bzr --json classification list | jq '.[].name'
+```
 
 ### `bzr classification view`
 

--- a/src/cli/classification.rs
+++ b/src/cli/classification.rs
@@ -2,6 +2,26 @@ use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum ClassificationAction {
+    /// List the server's classifications.
+    ///
+    /// Enumerates every classification with its ID, name, description, and
+    /// product count. Bugzilla has no bulk classification endpoint, so bzr
+    /// reads the names from the `classification` field's legal values and
+    /// fetches each one's detail.
+    ///
+    /// Classifications are an optional Bugzilla feature. On servers where
+    /// they are disabled, the only entry is "Unclassified"; bzr prints a
+    /// note to stderr in that case.
+    ///
+    /// Examples:
+    ///
+    ///   bzr classification list
+    ///   bzr classification list --json | jq '.[].name'
+    ///
+    /// See bzr-classification-view(1) for one classification's full detail.
+    #[command(verbatim_doc_comment)]
+    List,
+
     /// View a classification by name or ID.
     ///
     /// Prints the classification's description and the products it

--- a/src/client/classification.rs
+++ b/src/client/classification.rs
@@ -23,6 +23,30 @@ impl BugzillaClient {
                 id: name.to_string(),
             })
     }
+
+    /// Enumerate the server's classifications.
+    ///
+    /// Bugzilla has no bulk "list classifications" REST endpoint, so the
+    /// names are read from the `classification` bug field's legal values and
+    /// each is then fetched for its full detail (id, description, products).
+    /// Results are ordered by the field's `sort_key`, then name. On servers
+    /// with classifications disabled the field exposes only `Unclassified`.
+    pub async fn list_classifications(&self) -> Result<Vec<Classification>> {
+        let values = self.get_field_values("classification").await?;
+        let mut classifications = Vec::with_capacity(values.len());
+        for value in values {
+            if value.name.is_empty() {
+                continue;
+            }
+            classifications.push(self.get_classification(&value.name).await?);
+        }
+        classifications.sort_by(|a, b| {
+            a.sort_key
+                .cmp(&b.sort_key)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        Ok(classifications)
+    }
 }
 
 #[cfg(test)]

--- a/src/client/classification_tests.rs
+++ b/src/client/classification_tests.rs
@@ -30,3 +30,43 @@ async fn get_classification_returns_data() {
     assert_eq!(cls.products.len(), 1);
     assert_eq!(cls.products[0].name, "Widget");
 }
+
+#[tokio::test]
+async fn list_classifications_enumerates_via_field_values() {
+    let mock = MockServer::start().await;
+    // Names come from the `classification` bug-field's legal values.
+    Mock::given(method("GET"))
+        .and(path("/rest/field/bug/classification"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "fields": [{
+                "values": [
+                    {"name": "Acme", "sort_key": 5},
+                    {"name": "Unclassified", "sort_key": 0}
+                ]
+            }]
+        })))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/classification/Acme"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "classifications": [{"id": 2, "name": "Acme", "description": "Acme group", "sort_key": 5, "products": []}]
+        })))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/classification/Unclassified"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "classifications": [{"id": 1, "name": "Unclassified", "description": "Default", "sort_key": 0, "products": []}]
+        })))
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let list = client.list_classifications().await.unwrap();
+    assert_eq!(list.len(), 2);
+    // Sorted by sort_key: Unclassified (0) before Acme (5).
+    assert_eq!(list[0].name, "Unclassified");
+    assert_eq!(list[1].name, "Acme");
+    assert_eq!(list[1].id, 2);
+}

--- a/src/commands/classification.rs
+++ b/src/commands/classification.rs
@@ -1,6 +1,6 @@
 use crate::cli::ClassificationAction;
 use crate::error::Result;
-use crate::output::resources::classification::write_classification;
+use crate::output::resources::classification::{write_classification, write_classifications};
 use crate::output::writers::Writers;
 use crate::types::ApiMode;
 use crate::types::OutputFormat;
@@ -15,6 +15,23 @@ pub async fn execute(
     let client = super::shared::connect_and_configure(server, api).await?;
 
     match action {
+        ClassificationAction::List => {
+            let classifications = client.list_classifications().await?;
+            // A lone "Unclassified" is Bugzilla's signal that classifications
+            // are disabled on this server.
+            let disabled = matches!(
+                classifications.as_slice(),
+                [only] if only.name.eq_ignore_ascii_case("Unclassified")
+            );
+            if disabled {
+                let _ = writeln!(
+                    w.err,
+                    "Note: only the default 'Unclassified' classification exists; \
+                     this server likely has classifications disabled."
+                );
+            }
+            write_classifications(&classifications, format, w.out);
+        }
         ClassificationAction::View { name } => {
             let classification = client.get_classification(name).await?;
             write_classification(&classification, format, w.out);

--- a/src/commands/classification_tests.rs
+++ b/src/commands/classification_tests.rs
@@ -67,3 +67,84 @@ async fn classification_view_http_500_returns_error() {
     .await;
     assert!(result.is_err());
 }
+
+#[tokio::test]
+async fn classification_list_returns_sorted_json() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/field/bug/classification"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "fields": [{"values": [
+                {"name": "Acme", "sort_key": 5},
+                {"name": "Unclassified", "sort_key": 0}
+            ]}]
+        })))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/classification/Acme"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "classifications": [{"id": 2, "name": "Acme", "description": "Acme group", "sort_key": 5,
+                "products": [{"id": 9, "name": "W", "description": "w"}]}]
+        })))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/classification/Unclassified"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "classifications": [{"id": 1, "name": "Unclassified", "description": "Default", "sort_key": 0, "products": []}]
+        })))
+        .mount(&mock)
+        .await;
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &ClassificationAction::List,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io.writers(),
+    )
+    .await;
+    assert!(result.is_ok(), "list should succeed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    assert_eq!(parsed.as_array().unwrap().len(), 2);
+    assert_eq!(parsed[0]["name"], "Unclassified");
+    assert_eq!(parsed[1]["name"], "Acme");
+    assert_eq!(parsed[1]["products"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn classification_list_notes_disabled_when_only_unclassified() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/field/bug/classification"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "fields": [{"values": [{"name": "Unclassified", "sort_key": 0}]}]
+        })))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/classification/Unclassified"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "classifications": [{"id": 1, "name": "Unclassified", "description": "Default", "sort_key": 0, "products": []}]
+        })))
+        .mount(&mock)
+        .await;
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &ClassificationAction::List,
+        None,
+        OutputFormat::Table,
+        None,
+        &mut __io.writers(),
+    )
+    .await;
+    assert!(result.is_ok());
+    assert!(
+        __io.err_str().contains("classifications disabled"),
+        "expected disabled note on stderr, got: {}",
+        __io.err_str()
+    );
+}

--- a/src/output/resources/classification.rs
+++ b/src/output/resources/classification.rs
@@ -2,8 +2,40 @@ use std::io::Write;
 
 use colored::Colorize;
 
-use crate::output::formatting::{truncate, write_formatted, DESCRIPTION_TRUNCATE_WIDTH};
+use crate::output::formatting::{
+    truncate, write_formatted, write_table_or_empty, TableSpec, DESCRIPTION_TRUNCATE_WIDTH,
+};
 use crate::types::{Classification, OutputFormat};
+
+const CLASSIFICATION_HEADERS: &[&str] = &["ID", "NAME", "DESCRIPTION", "PRODUCTS"];
+
+fn classification_record(c: &Classification) -> Vec<String> {
+    vec![
+        c.id.to_string(),
+        c.name.clone(),
+        truncate(&c.description, DESCRIPTION_TRUNCATE_WIDTH),
+        c.products.len().to_string(),
+    ]
+}
+
+/// Render a flat list of classifications (id, name, description, product
+/// count). JSON output is the full `Classification` array.
+pub fn write_classifications<W: Write + ?Sized>(
+    items: &[Classification],
+    format: OutputFormat,
+    out: &mut W,
+) {
+    write_table_or_empty(
+        items,
+        format,
+        out,
+        TableSpec {
+            empty_msg: "No classifications found.",
+            headers: CLASSIFICATION_HEADERS,
+        },
+        classification_record,
+    );
+}
 
 pub fn write_classification<W: Write + ?Sized>(
     classification: &Classification,


### PR DESCRIPTION
## Summary

Adds `bzr classification list` (closes #319). Previously `classification view <NAME>` existed but there was no way to enumerate the classifications you can view.

## Acceptance criteria

- [x] Classifications are enumerable.
- [x] A clear message when the server has classifications disabled (only `Unclassified` exists → note on stderr).

## Implementation notes

- **Enumeration:** Bugzilla has no bulk classification REST endpoint. `BugzillaClient::list_classifications` reads the names from the `classification` bug field's legal values (`GET /field/bug/classification`), then fetches each one's full detail (`GET /classification/<name>`), ordering by `sort_key` then name for deterministic output. This is what distinguishes it from `bzr field list classification` (which only lists names).
- **Disabled signal:** when the only classification is `Unclassified`, bzr prints a hedged note to stderr. The note never touches stdout/JSON.
- **Output:** reuses the shared `write_table_or_empty` renderer — table columns `ID NAME DESCRIPTION PRODUCTS`; `--json` emits the full `Classification` array.

## Review notes

- N+1 fetch is intentional (no bulk endpoint; classification counts are tiny). A failed per-classification fetch fails the list rather than silently dropping an entry, matching the project's fail-fast / no-silent-failure stance.
- `resolve_field_alias("classification")` verified to pass through unchanged, so the field lookup is correct.

## Tests

Client: `list_classifications_enumerates_via_field_values` (sorted enumeration). Command: `classification_list_returns_sorted_json` and `classification_list_notes_disabled_when_only_unclassified`.

## Validation

`cargo clippy --locked --features test-helpers -- -D warnings`, `cargo test --features test-helpers`, and the agent-skills drift check pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
