### PR TITLE
feat(component): add component list and component view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `bzr component list --product <P>` and `bzr component view <product> <component>`
+  make components directly discoverable (ID, name, description, default
+  assignee, active flag) instead of only via `product view`. Both read the
+  product's component set; `--json` emits the component array / object. (#316)
 - `bzr attachment view <ATTACHMENT_ID>` shows a single attachment's metadata
   (summary, bug, file name, content type, size, flags, creator, timestamps)
   without downloading its bytes. On REST the `data` field is excluded

--- a/agent-skills/skills/bzr-reference/reference/commands.yml
+++ b/agent-skills/skills/bzr-reference/reference/commands.yml
@@ -11,6 +11,6 @@ group: add-user remove-user list-users view create update
 whoami:
 server: info
 classification: list view
-component: create update
+component: list view create update
 template: save list show delete
 query: save list show delete run

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -147,6 +147,8 @@ bzr [--server <NAME>] [--output table|json] [--json] [--no-color] [--quiet] [--a
 │   ├── list
 │   └── view <NAME>
 ├── component
+│   ├── list --product <P>
+│   ├── view <PRODUCT> <COMPONENT>
 │   ├── create --product <P> --name <N> --description <D> --default-assignee <E>
 │   └── update <ID> [--name <N>] [--description <D>] [--default-assignee <E>]
 ├── config
@@ -1042,6 +1044,27 @@ bzr --json classification view "Unclassified"
 ---
 
 ## `bzr component` -- Component Operations
+
+### `bzr component list`
+
+List a product's components with their ID, name, description, default
+assignee, and active flag. Reads the same data as `bzr product view
+<product>`; JSON output is the full component array.
+
+```bash
+bzr component list --product Fedora
+bzr --json component list --product Fedora | jq '.[].name'
+```
+
+### `bzr component view`
+
+View a single component by exact name within a product. JSON output is the
+`Component` object. Errors if the product has no component with that name.
+
+```bash
+bzr component view Fedora kernel
+bzr --json component view Fedora kernel
+```
 
 ### `bzr component create`
 

--- a/src/cli/component.rs
+++ b/src/cli/component.rs
@@ -6,6 +6,47 @@ use clap::Subcommand;
     reason = "doc examples are literal shell commands; wrapping URLs in <> or identifiers in backticks would degrade copy-paste UX"
 )]
 pub enum ComponentAction {
+    /// List a product's components.
+    ///
+    /// Reads the product's component set (the same data shown by
+    /// `bzr product view <product>`) and prints each component's ID,
+    /// name, description, default assignee, and active flag. JSON output
+    /// is the full component array.
+    ///
+    /// Examples:
+    ///
+    ///   bzr component list --product MyApp
+    ///   bzr --json component list --product MyApp | jq '.[].name'
+    ///
+    /// See bzr-component-view(1) for a single component's detail.
+    #[command(verbatim_doc_comment)]
+    List {
+        /// Product name
+        #[arg(long)]
+        product: String,
+    },
+
+    /// View a single component within a product.
+    ///
+    /// Looks the component up by exact name within the given product and
+    /// prints its ID, description, default assignee, and active flag. JSON
+    /// output is the `Component` object. Errors if the product has no
+    /// component with that name.
+    ///
+    /// Examples:
+    ///
+    ///   bzr component view MyApp Backend
+    ///   bzr --json component view MyApp Backend
+    ///
+    /// See bzr-component-list(1) to enumerate a product's components.
+    #[command(verbatim_doc_comment)]
+    View {
+        /// Product name
+        product: String,
+        /// Component name (exact match)
+        name: String,
+    },
+
     /// Create a new component within a product (admin only).
     ///
     /// Requires Bugzilla admin permissions on the target product.

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -1,5 +1,6 @@
 use crate::cli::ComponentAction;
-use crate::error::Result;
+use crate::error::{BzrError, Result};
+use crate::output::resources::component::{write_component, write_components};
 use crate::output::result_types::{write_result, ActionResult, ResourceKind};
 use crate::output::writers::Writers;
 use crate::types::ApiMode;
@@ -16,6 +17,22 @@ pub async fn execute(
     let client = super::shared::connect_and_configure(server, api).await?;
 
     match action {
+        ComponentAction::List { product } => {
+            let product = client.get_product(product).await?;
+            write_components(&product.components, format, w.out);
+        }
+        ComponentAction::View { product, name } => {
+            let product = client.get_product(product).await?;
+            let component = product
+                .components
+                .iter()
+                .find(|c| c.name == *name)
+                .ok_or_else(|| BzrError::NotFound {
+                    resource: "component",
+                    id: name.clone(),
+                })?;
+            write_component(component, format, w.out);
+        }
         ComponentAction::Create {
             product,
             name,

--- a/src/commands/component_tests.rs
+++ b/src/commands/component_tests.rs
@@ -1,11 +1,91 @@
 #![expect(clippy::unwrap_used)]
 
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::ComponentAction;
+use crate::error::BzrError;
 use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
+
+/// Mock `GET /rest/product?names=MyApp` returning a product with two
+/// components.
+async fn mount_product_with_components(mock: &wiremock::MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/rest/product"))
+        .and(query_param("names", "MyApp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "products": [{
+                "id": 1,
+                "name": "MyApp",
+                "description": "App",
+                "is_active": true,
+                "components": [
+                    {"id": 10, "name": "Backend", "description": "be", "is_active": true,
+                     "default_assignee": "dev@example.com"},
+                    {"id": 11, "name": "Frontend", "description": "fe", "is_active": false,
+                     "default_assignee": null}
+                ],
+                "versions": [],
+                "milestones": []
+            }]
+        })))
+        .mount(mock)
+        .await;
+}
+
+#[tokio::test]
+async fn component_list_returns_components() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mount_product_with_components(&mock).await;
+
+    let action = ComponentAction::List {
+        product: "MyApp".into(),
+    };
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut __io.writers()).await;
+    assert!(result.is_ok(), "list should succeed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    assert_eq!(parsed.as_array().unwrap().len(), 2);
+    assert_eq!(parsed[0]["name"], "Backend");
+}
+
+#[tokio::test]
+async fn component_view_returns_one_component() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mount_product_with_components(&mock).await;
+
+    let action = ComponentAction::View {
+        product: "MyApp".into(),
+        name: "Frontend".into(),
+    };
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut __io.writers()).await;
+    assert!(result.is_ok(), "view should succeed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    assert_eq!(parsed["id"], 11);
+    assert_eq!(parsed["name"], "Frontend");
+}
+
+#[tokio::test]
+async fn component_view_unknown_name_is_not_found() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mount_product_with_components(&mock).await;
+
+    let action = ComponentAction::View {
+        product: "MyApp".into(),
+        name: "Nonexistent".into(),
+    };
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut __io.writers()).await;
+    assert!(matches!(
+        result,
+        Err(BzrError::NotFound {
+            resource: "component",
+            ..
+        })
+    ));
+}
 
 #[tokio::test]
 async fn component_create_succeeds() {

--- a/src/output/resources/component.rs
+++ b/src/output/resources/component.rs
@@ -1,0 +1,55 @@
+use std::io::Write;
+
+use colored::Colorize;
+
+use crate::output::formatting::{
+    truncate, write_field, write_formatted, write_optional_field, write_table_or_empty, TableSpec,
+    DESCRIPTION_TRUNCATE_WIDTH,
+};
+use crate::types::{Component, OutputFormat};
+
+const COMPONENT_HEADERS: &[&str] = &["ID", "NAME", "DESCRIPTION", "ASSIGNEE", "ACTIVE"];
+
+fn component_record(c: &Component) -> Vec<String> {
+    vec![
+        c.id.to_string(),
+        c.name.clone(),
+        truncate(&c.description, DESCRIPTION_TRUNCATE_WIDTH),
+        c.default_assignee
+            .clone()
+            .unwrap_or_else(|| "-".to_string()),
+        if c.is_active { "yes" } else { "no" }.to_string(),
+    ]
+}
+
+/// Render a flat list of components (id, name, description, assignee,
+/// active). JSON output is the full `Component` array.
+pub fn write_components<W: Write + ?Sized>(items: &[Component], format: OutputFormat, out: &mut W) {
+    write_table_or_empty(
+        items,
+        format,
+        out,
+        TableSpec {
+            empty_msg: "No components found.",
+            headers: COMPONENT_HEADERS,
+        },
+        component_record,
+    );
+}
+
+/// Render one component's detail. JSON output is the `Component` object.
+pub fn write_component<W: Write + ?Sized>(c: &Component, format: OutputFormat, out: &mut W) {
+    write_formatted(c, format, out, |c, out| {
+        let _ = writeln!(out, "{} {}", "Component".bold(), c.name.bold());
+        write_field(out, "ID", &c.id.to_string());
+        if !c.description.is_empty() {
+            write_field(out, "Description", &c.description);
+        }
+        write_optional_field(out, "Default assignee", c.default_assignee.as_deref());
+        write_field(out, "Active", if c.is_active { "yes" } else { "no" });
+    });
+}
+
+#[cfg(test)]
+#[path = "component_tests.rs"]
+mod tests;

--- a/src/output/resources/component_tests.rs
+++ b/src/output/resources/component_tests.rs
@@ -1,0 +1,107 @@
+#![expect(clippy::unwrap_used)]
+
+use super::*;
+use crate::types::Component;
+
+fn make_component(id: u64, name: &str, active: bool) -> Component {
+    Component {
+        id,
+        name: name.into(),
+        description: "A component".into(),
+        is_active: active,
+        default_assignee: Some("dev@example.com".into()),
+    }
+}
+
+#[test]
+fn component_record_maps_fields() {
+    let row = component_record(&make_component(7, "Backend", false));
+    assert_eq!(row[0], "7");
+    assert_eq!(row[1], "Backend");
+    assert_eq!(row[3], "dev@example.com");
+    assert_eq!(row[4], "no");
+}
+
+#[test]
+fn component_record_dashes_missing_assignee() {
+    let mut c = make_component(1, "X", true);
+    c.default_assignee = None;
+    let row = component_record(&c);
+    assert_eq!(row[3], "-");
+    assert_eq!(row[4], "yes");
+}
+
+#[test]
+fn write_components_table_lists_rows() {
+    let items = vec![
+        make_component(1, "Alpha", true),
+        make_component(2, "Beta", true),
+    ];
+    let mut buf: Vec<u8> = Vec::new();
+    write_components(&items, OutputFormat::Table, &mut buf);
+    let out = String::from_utf8(buf).unwrap();
+    assert!(out.contains("Alpha"));
+    assert!(out.contains("Beta"));
+    assert!(out.contains("NAME"));
+}
+
+#[test]
+fn write_components_table_empty_message() {
+    let items: Vec<Component> = vec![];
+    let mut buf: Vec<u8> = Vec::new();
+    write_components(&items, OutputFormat::Table, &mut buf);
+    assert!(String::from_utf8(buf)
+        .unwrap()
+        .contains("No components found."));
+}
+
+#[test]
+fn write_components_json_is_array() {
+    let items = vec![make_component(3, "Gamma", true)];
+    let mut buf: Vec<u8> = Vec::new();
+    write_components(&items, OutputFormat::Json, &mut buf);
+    let parsed: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+    assert_eq!(parsed[0]["id"], 3);
+    assert_eq!(parsed[0]["name"], "Gamma");
+}
+
+#[test]
+fn write_component_table_shows_fields() {
+    let mut buf: Vec<u8> = Vec::new();
+    write_component(
+        &make_component(9, "Core", false),
+        OutputFormat::Table,
+        &mut buf,
+    );
+    let out = String::from_utf8(buf).unwrap();
+    assert!(out.contains("Core"));
+    assert!(out.contains("9"));
+    assert!(out.contains("no"));
+}
+
+#[test]
+fn write_component_json_is_object() {
+    let mut buf: Vec<u8> = Vec::new();
+    write_component(
+        &make_component(4, "Delta", true),
+        OutputFormat::Json,
+        &mut buf,
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+    assert_eq!(parsed["id"], 4);
+    assert_eq!(parsed["name"], "Delta");
+}
+
+#[test]
+fn write_component_table_omits_empty_description() {
+    let mut c = make_component(5, "Empty", true);
+    c.description = String::new();
+    let mut buf: Vec<u8> = Vec::new();
+    write_component(&c, OutputFormat::Table, &mut buf);
+    let out = String::from_utf8(buf).unwrap();
+    assert!(out.contains("Empty"));
+    assert!(
+        !out.contains("Description"),
+        "empty description must be omitted: {out}"
+    );
+}

--- a/src/output/resources/mod.rs
+++ b/src/output/resources/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod attachment;
 pub(crate) mod bug;
 pub(crate) mod classification;
 pub(crate) mod comment;
+pub(crate) mod component;
 pub(crate) mod config;
 pub(crate) mod field;
 pub(crate) mod group;


### PR DESCRIPTION
## Summary

Adds `bzr component list --product <P>` and `bzr component view <product> <component>` (closes #316). Components were creatable/updatable but only discoverable indirectly via `product view`.

## Acceptance criteria

- [x] Components are listable/viewable directly without parsing `product view` output.

## Implementation notes

- Both reuse the existing `get_product` fetch (the issue's suggested approach: "read from the product detail the client already fetches"). `list` renders `product.components`; `view` finds the component by **exact** name within the product.
- New `output::resources::component` module: `write_components` (table via the shared `write_table_or_empty`, columns `ID NAME DESCRIPTION ASSIGNEE ACTIVE`) and `write_component` (detail). `--json` emits the `Component` array / object.
- NotFound is distinguished: unknown product → `NotFound{product}`; unknown component → `NotFound{component}`.

## Known limitation (inherited)

`get_product` notes that components "may require `include_fields` on some Bugzilla versions to be populated." `component list`/`view` inherit that behavior from `product view`; on the affected servers the same caveat applies. Out of scope to change the shared fetch here.

## Tests

Output layer: `component_record` mapping (incl. missing-assignee `-`), `write_components` table (rows + empty message) and JSON, `write_component` table (incl. empty-description omission) and JSON. Command layer: `component_list_returns_components`, `component_view_returns_one_component`, `component_view_unknown_name_is_not_found`.

## Validation

`cargo clippy --locked --features test-helpers -- -D warnings`, `cargo test --features test-helpers`, and the agent-skills drift check pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
