### PR TITLE
docs(name): record decision to keep the bzr command name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   difference?" confusion. Use `bzr whoami` (the form the docs already
   promote). `whoami` now takes no subcommand. (#323)
 
+### Documentation
+
+- Recorded the decision to keep `bzr` as the command name despite the
+  historical collision with GNU Bazaar (retired in 2025; its successor Breezy
+  uses `brz`), with rationale in `docs/decisions/0001-bzr-command-name.md` and
+  a README note plus shell-alias workaround. (#322)
+
 ### Added
 
 - `bzr component list --product <P>` and `bzr component view <product> <component>`

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 A command-line interface for Bugzilla servers, written in Rust. Inspired by the GitHub CLI (`gh`), `bzr` lets you search, view, create, and update bugs, manage comments and attachments, and switch between multiple Bugzilla instances — all from your terminal.
 
+> **A note on the name.** `bzr` was historically the command for [GNU Bazaar](https://en.wikipedia.org/wiki/GNU_Bazaar), a version-control system. Bazaar's last release was in 2016, Canonical [announced its retirement in 2025](https://blog.launchpad.net/general/phasing-out-bazaar-code-hosting), and its maintained successor **Breezy renamed its command to `brz`** — so the `bzr` name is effectively being vacated by the VCS world. This project keeps `bzr` (it reads as "Bugzilla" the way `gh` reads as "GitHub"). If you also have GNU Bazaar/Breezy installed and want to keep using `bzr` for it, alias this tool instead, e.g. `alias bz=bzr`. See [the decision record](docs/decisions/0001-bzr-command-name.md) for the full rationale.
+
 ## Features
 
 - **Bug management** — list, search, view, create, clone, update, and batch-update bugs; view change history

--- a/docs/decisions/0001-bzr-command-name.md
+++ b/docs/decisions/0001-bzr-command-name.md
@@ -1,0 +1,49 @@
+# 0001 — Keep `bzr` as the command name despite the GNU Bazaar collision
+
+- Status: Accepted
+- Date: 2026-06-19
+- Issue: [#322](https://github.com/randomparity/bzr/issues/322)
+
+## Context
+
+`bzr` was historically the command name for **GNU Bazaar**, a distributed
+version-control system sponsored by Canonical. Anyone with Bazaar installed,
+or with muscle memory from it, hits a literal name clash with this Bugzilla
+CLI. The question is whether to (a) keep `bzr` and document the collision,
+(b) ship an alternate alias such as `bugzilla` alongside `bzr`, or
+(c) rename the primary command.
+
+## Decision
+
+Keep `bzr` as the primary (and only) command name. Document the collision and
+a shell-alias workaround in the README for the rare user who also has GNU
+Bazaar installed.
+
+## Rationale
+
+- **The VCS world is vacating the name.** GNU Bazaar's last release was 2.7.0
+  in February 2016. Canonical announced Bazaar's retirement in 2025 and is
+  sunsetting Bazaar code hosting on Launchpad (December 2025). Bazaar's
+  maintained successor, **Breezy, deliberately renamed its command from `bzr`
+  to `brz`** to avoid clashes, and distributions have followed: Fedora 32
+  (2019) replaced the `bzr` package with Breezy, shipping `/usr/bin/bzr` as a
+  symlink to `brz`. In practice the `bzr` command name is being abandoned by
+  the VCS ecosystem, so the long-term collision risk is low and shrinking.
+- **`bzr` is established for this project.** The crate, binary, repository,
+  man pages, agent skills, and every doc and example are built around `bzr`.
+  It is short, memorable, and reads naturally as "Bugzilla" the way `gh` reads
+  as "GitHub" — the explicit model for this tool. Renaming would churn the
+  entire surface for little benefit.
+- **A second binary is maintenance burden, not a fix.** Shipping a `bugzilla`
+  alias alongside `bzr` doubles the packaged-binary surface (deb/rpm/Homebrew,
+  completions, man pages) and does not remove the `bzr` collision it is meant
+  to address; users would still type `bzr`. The collision is best handled per
+  user, by the user who actually has both tools, via a shell alias.
+
+## Consequences
+
+- No code or packaging change. `bzr` remains the single command name.
+- The README gains a short note about the name and a copy-paste shell-alias
+  workaround for users who also use GNU Bazaar / Breezy.
+- If a future, widely-installed tool reintroduces a `bzr` command, this
+  decision can be revisited; nothing here forecloses adding an alias later.


### PR DESCRIPTION
## Summary

Records the decision for the `bzr` binary-name collision with GNU Bazaar (closes #322). This is a documentation-only change — no code.

## Decision

Keep `bzr` as the single command name; document the collision and a shell-alias workaround.

## Rationale (verified)

- GNU Bazaar's last release was 2.7.0 (Feb 2016); Canonical [announced its retirement in 2025](https://blog.launchpad.net/general/phasing-out-bazaar-code-hosting) and is sunsetting Launchpad Bazaar hosting (Dec 2025).
- Bazaar's maintained successor **Breezy renamed its command to `brz`**, and distros followed (Fedora 32 ships `/usr/bin/bzr` as a symlink to `brz`). The VCS world is vacating the `bzr` name.
- `bzr` is established across the crate/binary/repo/man pages/skills/docs and reads as "Bugzilla" the way `gh` reads as "GitHub". A second `bugzilla` binary would be packaging/maintenance burden without removing the `bzr` collision it targets.

## Changes

- `docs/decisions/0001-bzr-command-name.md` — ADR with status, context, decision, rationale, consequences.
- README — a short "note on the name" with the alias workaround.
- CHANGELOG — Documentation entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
