### PR TITLE
feat(config): add --config flag and BZR_CONFIG env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Global `--config <PATH>` flag and `BZR_CONFIG` environment variable select an
+  alternate `config.toml` for reads and writes. Precedence: `--config` >
+  `BZR_CONFIG` > `$XDG_CONFIG_HOME/bzr/config.toml` (or the platform config
+  dir). Sandboxes CI, throwaway agent runs, and per-profile configs without
+  manipulating `$HOME`/`$XDG_CONFIG_HOME`. (#304)
 - `bzr component list --product <P>` and `bzr component view <product> <component>`
   make components directly discoverable (ID, name, description, default
   assignee, active flag) instead of only via `product view`. Both read the

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ bzr --output json field list status | jq '.[] | select(.name == "NEW") | .can_ch
 
 ## Configuration & Authentication
 
-Configuration is stored in `~/.config/bzr/config.toml` with support for multiple named servers. See [docs/bzr-cli.md](docs/bzr-cli.md#configuration-file-format) for the full file format.
+Configuration is stored in `~/.config/bzr/config.toml` with support for multiple named servers. Point bzr at a different file with the global `--config <PATH>` flag or the `BZR_CONFIG` environment variable (the flag wins) — handy for CI, throwaway agent runs, and per-profile configs. See [docs/bzr-cli.md](docs/bzr-cli.md#configuration-file-format) for the full file format.
 
 ## Authentication
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -37,6 +37,7 @@ For installation and quick start, see [README.md](../README.md).
 | `--server <NAME>` | Use a specific server from config instead of the default |
 | `--output <FORMAT>` | Output format: `table` or `json`. Defaults to table at a TTY; auto-selects json when stdout is not a TTY. |
 | `--json` | Shorthand for `--output json` |
+| `--config <PATH>` | Use an alternate `config.toml` for reads and writes. Takes precedence over `BZR_CONFIG`; both override the default config directory. |
 | `--no-color` | Disable colored output. Color is also suppressed automatically when stdout is not a TTY. |
 | `--quiet` | Suppress stdout and tracing logs (exit code confirms success) |
 | `--api <MODE>` | Override API transport: `rest`, `xmlrpc`, or `hybrid`. Auto-detected from server version if not set. |
@@ -51,6 +52,7 @@ Agent note: at an interactive TTY, `bzr` defaults to table output. For agent wor
 | Variable | Description |
 |----------|-------------|
 | `BZR_OUTPUT` | Default output format (`table` or `json`). Overridden by `--output` or `--json`. |
+| `BZR_CONFIG` | Full path to an alternate `config.toml`. Overrides the default config directory; overridden by `--config`. |
 | `NO_COLOR` | Disable colored output (any value). Supported natively by the `colored` crate. |
 | `CLICOLOR` | Set to `0` to disable colored output (standard convention respected by the `colored` crate). |
 | `CLICOLOR_FORCE` | Set to `1` to force colored output even when stdout is not a TTY. |
@@ -80,7 +82,7 @@ Agent note: at an interactive TTY, `bzr` defaults to table output. For agent wor
 ## Command Tree
 
 ```
-bzr [--server <NAME>] [--output table|json] [--json] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [-v...]
+bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [-v...]
 ├── bug
 │   ├── list [--product <P>...] [--component <C>...] [--status <S>...] [--assignee <A>...]
 │   │        [--creator <C>...] [--priority <P>...] [--severity <S>...] [--id <ID>...]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -93,6 +93,17 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub json: bool,
 
+    /// Use an alternate config file instead of the default.
+    ///
+    /// Points bzr at a specific `config.toml` for both reads and writes,
+    /// sandboxing the invocation from the user's normal config. Takes
+    /// precedence over the `BZR_CONFIG` environment variable, which in turn
+    /// overrides the default `$XDG_CONFIG_HOME/bzr/config.toml` (or the
+    /// platform config directory). Useful for CI, throwaway agent runs, and
+    /// per-profile configs.
+    #[arg(long, value_name = "PATH", global = true)]
+    pub config: Option<std::path::PathBuf>,
+
     /// Disable colored output.
     ///
     /// bzr also honors the `NO_COLOR` and `CLICOLOR=0` environment

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -926,6 +926,18 @@ fn parse_quiet_flag() {
 }
 
 #[test]
+fn parse_config_path_flag() {
+    let cli = Cli::try_parse_from(["bzr", "--config", "/tmp/agent.toml", "whoami"]).unwrap();
+    assert_eq!(
+        cli.config.as_deref(),
+        Some(std::path::Path::new("/tmp/agent.toml"))
+    );
+    // Absent by default.
+    let none = Cli::try_parse_from(["bzr", "whoami"]).unwrap();
+    assert!(none.config.is_none());
+}
+
+#[test]
 fn quiet_help_mentions_tracing_is_suppressed() {
     let help = Cli::command().render_long_help().to_string();
     assert!(help.contains("tracing logs are also suppressed"), "{help}");

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,11 +3,17 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
+use std::sync::RwLock;
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::{BzrError, Result};
 use crate::types::{ApiMode, AuthMethod, BugTemplate, SavedQuery};
+
+/// Process-wide override for the config file path, set from the global
+/// `--config <PATH>` flag. Takes precedence over `BZR_CONFIG` and the default
+/// config directory. `RwLock` (not `OnceLock`) so tests can set and clear it.
+static CONFIG_PATH_OVERRIDE: RwLock<Option<PathBuf>> = RwLock::new(None);
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 #[non_exhaustive]
@@ -229,13 +235,42 @@ impl ServerConfig {
 }
 
 impl Config {
+    /// Resolve the path to the config file.
+    ///
+    /// Precedence: the `--config <PATH>` override (set via
+    /// [`Self::set_path_override`]) > the `BZR_CONFIG` environment variable
+    /// (a full path to the config file) > `$XDG_CONFIG_HOME/bzr/config.toml` >
+    /// the platform default config dir. The first two point directly at the
+    /// file; the last two name a directory under which `bzr/config.toml` is
+    /// used.
     pub fn path() -> Result<PathBuf> {
+        if let Ok(guard) = CONFIG_PATH_OVERRIDE.read() {
+            if let Some(path) = guard.as_ref() {
+                return Ok(path.clone());
+            }
+        }
+        if let Some(env_path) = std::env::var_os("BZR_CONFIG") {
+            if !env_path.is_empty() {
+                return Ok(PathBuf::from(env_path));
+            }
+        }
         let config_dir = std::env::var_os("XDG_CONFIG_HOME")
             .map(PathBuf::from)
             .filter(|p| p.is_absolute())
             .or_else(dirs::config_dir)
             .ok_or_else(|| BzrError::config("cannot determine config directory"))?;
         Ok(config_dir.join("bzr").join("config.toml"))
+    }
+
+    /// Install (or clear) the `--config <PATH>` override that takes precedence
+    /// over `BZR_CONFIG` and the default config directory.
+    ///
+    /// Called once from `main` after argument parsing. Passing `None` clears
+    /// the override (used by tests to restore the default resolution).
+    pub fn set_path_override(path: Option<PathBuf>) {
+        if let Ok(mut guard) = CONFIG_PATH_OVERRIDE.write() {
+            *guard = path;
+        }
     }
 
     /// Resolve the config directory (`<config>/bzr`), creating it `0700` on

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -1023,3 +1023,56 @@ fn update_locked_reloads_a_credential_less_config_and_can_heal_it() {
         Some("BZR_KEY")
     );
 }
+
+/// `Config::path()` precedence (#304): `--config` override > `BZR_CONFIG`
+/// env > `$XDG_CONFIG_HOME/bzr/config.toml`. Combined into one test under
+/// `ENV_LOCK` to avoid env races, and cleans up the override + env so later
+/// tests see default resolution.
+#[test]
+fn config_path_resolution_precedence() {
+    let _lock = crate::ENV_LOCK.blocking_lock();
+    Config::set_path_override(None);
+    // SAFETY: serialized via ENV_LOCK; no other thread reads these concurrently.
+    unsafe {
+        env::remove_var("BZR_CONFIG");
+        env::set_var("XDG_CONFIG_HOME", "/tmp/bzr-xdg-test-home");
+    }
+
+    // Default: XDG dir + bzr/config.toml.
+    assert_eq!(
+        Config::path().unwrap(),
+        PathBuf::from("/tmp/bzr-xdg-test-home/bzr/config.toml")
+    );
+
+    // BZR_CONFIG (full file path) overrides the default dir.
+    unsafe { env::set_var("BZR_CONFIG", "/tmp/bzr-env-config.toml") };
+    assert_eq!(
+        Config::path().unwrap(),
+        PathBuf::from("/tmp/bzr-env-config.toml")
+    );
+
+    // The --config override beats BZR_CONFIG.
+    Config::set_path_override(Some(PathBuf::from("/tmp/bzr-flag-config.toml")));
+    assert_eq!(
+        Config::path().unwrap(),
+        PathBuf::from("/tmp/bzr-flag-config.toml")
+    );
+
+    // Clearing the override falls back to BZR_CONFIG.
+    Config::set_path_override(None);
+    assert_eq!(
+        Config::path().unwrap(),
+        PathBuf::from("/tmp/bzr-env-config.toml")
+    );
+
+    // An empty BZR_CONFIG is ignored (falls through to the default dir).
+    unsafe { env::set_var("BZR_CONFIG", "") };
+    assert_eq!(
+        Config::path().unwrap(),
+        PathBuf::from("/tmp/bzr-xdg-test-home/bzr/config.toml")
+    );
+
+    // Cleanup: restore default resolution for subsequent tests.
+    unsafe { env::remove_var("BZR_CONFIG") };
+    Config::set_path_override(None);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,9 @@ use bzr::types::OutputFormat;
 async fn main() -> ExitCode {
     let cli = Cli::parse();
 
+    // Apply the global --config override before anything reads the config.
+    bzr::config::Config::set_path_override(cli.config.clone());
+
     let filter =
         match tracing_filter_directive(cli.quiet, cli.verbose, std::env::var("RUST_LOG").is_ok()) {
             Some(directive) => EnvFilter::new(directive),

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -34,6 +34,7 @@ fn base_cli(command: Commands) -> Cli {
         server: None,
         output: None,
         json: false,
+        config: None,
         no_color: false,
         quiet: false,
         api: None,


### PR DESCRIPTION
## Summary

Adds a global `--config <PATH>` flag and `BZR_CONFIG` environment variable to select an alternate `config.toml` (closes #304). The config path was previously fixed at `~/.config/bzr/config.toml`; agents and CI had to manipulate `$HOME`/`$XDG_CONFIG_HOME` to sandbox a run, which is fragile and pollutes other tools.

## Acceptance criteria

- [x] `bzr --config /tmp/agent.toml ...` reads/writes only that file.
- [x] `BZR_CONFIG` does the same; precedence documented alongside the env table.

## Precedence

`--config` flag > `BZR_CONFIG` env (a full path to the file) > `$XDG_CONFIG_HOME/bzr/config.toml` > platform config dir.

## Implementation notes

- `Config::path()` is the single chokepoint every read/write already routes through (~55 call sites), so resolution happens there — no parameter threading.
- The `--config` flag is applied once in `main` via `Config::set_path_override`, backed by a **resettable** `RwLock<Option<PathBuf>>` (not `OnceLock`) so the precedence chain is unit-testable and tests can clear it.
- Parent directories of a custom path are created `0700` by the existing `ensure_config_dir`.

## Tests

`config_path_resolution_precedence` exercises default → `BZR_CONFIG` → override-beats-env → clear-falls-back → empty-env-ignored (with cleanup so later tests see default resolution). `parse_config_path_flag` covers the clap arg. End-to-end verified manually: flag writes/reads the named file, `BZR_CONFIG` works, and the flag wins over the env var.

## Docs

Global Options + Environment Variables tables and the command-tree global line in `docs/bzr-cli.md`, a note in the README config section, and a CHANGELOG entry.

## Validation

`cargo clippy --locked --features test-helpers -- -D warnings` and `cargo test --features test-helpers` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
