### PR TITLE
feat(bug): add --sort/--order result ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `--sort <FIELD>` / `--order asc|desc` on `bug list`, `bug search`, `bug my`,
+  and `query run` control result ordering (mapped to Bugzilla's `order`), with
+  a `bug_id` tiebreaker for deterministic ties. Absent `--sort`, results now
+  default to a stable `bug_id` order so identical runs are reproducible — note
+  this means `bug search` no longer defaults to relevance ranking; pass `--sort`
+  to choose another order. `query save --sort` persists an order into the saved
+  query; `query run --sort` overrides it. (#303)
 - Global `--config <PATH>` flag and `BZR_CONFIG` environment variable select an
   alternate `config.toml` for reads and writes. Precedence: `--config` >
   `BZR_CONFIG` > `$XDG_CONFIG_HOME/bzr/config.toml` (or the platform config

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -87,12 +87,13 @@ bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-col
 │   ├── list [--product <P>...] [--component <C>...] [--status <S>...] [--assignee <A>...]
 │   │        [--creator <C>...] [--priority <P>...] [--severity <S>...] [--id <ID>...]
 │   │        [--alias <A>] [--summary <S>] [--limit <N>] [--fields <F>] [--exclude-fields <F>]
-│   │        [--created-since <D>] [--changed-since <D>]
+│   │        [--created-since <D>] [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
 │   ├── view <ID> [--fields <F>] [--exclude-fields <F>]
 │   ├── search [<QUERY>] [--from-url <URL>] [--save-as [NAME]] [--limit <N>] [--fields <F>] [--exclude-fields <F>]
+│   │          [--sort <FIELD>] [--order asc|desc]
 │   ├── history <ID> [--since <DATE>]
 │   ├── my [--created] [--cc] [--all] [--status <S>...] [--limit <N>]
-│   │       [--fields <F>] [--exclude-fields <F>]
+│   │       [--fields <F>] [--exclude-fields <F>] [--sort <FIELD>] [--order asc|desc]
 │   ├── create [--template <T>] [--product <P>] [--component <C>] --summary <S>
 │   │          [--version <V>] [--description <D>] [--priority <P>] [--severity <S>]
 │   │          [--assignee <A>] [--op-sys <OS>] [--rep-platform <PLAT>]
@@ -174,12 +175,12 @@ bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-col
 │   ├── save <NAME> (--from-url <URL> | [--product <P>...] [--component <C>...] [--status <S>...]
 │   │               [--assignee <A>...] [--creator <C>...] [--priority <P>...] [--severity <S>...]
 │   │               [--search <Q>]) [--limit <N>] [--fields <F>] [--exclude-fields <F>]
-│   │               [--created-since <D>] [--changed-since <D>]
+│   │               [--created-since <D>] [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
 │   ├── list
 │   ├── show <NAME>
 │   ├── delete <NAME>
 │   └── run <NAME> [--limit <N>] [--fields <F>] [--exclude-fields <F>] [--server <NAME>]
-│                  [--created-since <D>] [--changed-since <D>]
+│                  [--created-since <D>] [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
 └── completion <bash|zsh|fish|powershell>
 ```
 
@@ -227,6 +228,20 @@ Filter flags (`--product`, `--component`, `--status`, `--assignee`, `--creator`,
 | `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
 | `--created-since <DATE>` | No | | Filter to bugs whose `creation_time` is `>= DATE`. See [Date format](#date-format) below. |
 | `--changed-since <DATE>` | No | | Filter to bugs whose `last_change_time` is `>= DATE`. See [Date format](#date-format) below. |
+| `--sort <FIELD>` | No | | Sort results by `FIELD` (e.g. `last_change_time`, `priority`, `bug_id`). Field-name aliases (`id`, `severity`, `status`, ...) are accepted. See [Result ordering](#result-ordering) below. |
+| `--order asc\|desc` | No | `asc` | Sort direction; only meaningful with `--sort`. |
+
+#### Result ordering
+
+`--sort`/`--order` map to Bugzilla's `order` parameter and apply to `bug list`,
+`bug search`, `bug my`, and `query run`. A `bug_id` tiebreaker is always
+appended so ties resolve deterministically. **Absent `--sort`, results default
+to a stable `bug_id` order** so identical runs return rows in the same order —
+this means `bug search` no longer relies on Bugzilla's relevance ranking by
+default; pass `--sort` to choose a different order. For `bug search --from-url`
+and `query run`, an explicit `--sort` overrides any ordering carried by the URL
+or saved query; otherwise the saved/URL order is preserved. `query save --sort`
+persists an order into the saved query.
 
 #### Date format
 

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -1,5 +1,24 @@
 use clap::{Args, Subcommand};
 
+use crate::types::SortDirection;
+
+/// Shared `--sort` / `--order` result ordering, flattened into the bug query
+/// subcommands (`list`, `search`, `my`) and `query run`. Absent `--sort`,
+/// results default to a stable `bug_id` order so identical runs are
+/// reproducible.
+#[derive(Args, Debug, Clone, Default)]
+pub struct SortArgs {
+    /// Sort results by this field (e.g. `last_change_time`, `priority`,
+    /// `bug_id`). Field-name aliases (`id`, `severity`, `status`, ...) are
+    /// accepted. Absent, results are ordered by `bug_id` for determinism.
+    #[arg(long, value_name = "FIELD")]
+    pub sort: Option<String>,
+    /// Sort direction: `asc` (default) or `desc`. Only meaningful with
+    /// `--sort`.
+    #[arg(long, default_value = "asc", value_name = "DIR")]
+    pub order: SortDirection,
+}
+
 /// Shared `--fields` / `--exclude-fields` selection, flattened into the bug
 /// query subcommands (`list`, `view`, `search`, `my`) so the pair is defined
 /// once instead of repeated per variant.
@@ -111,6 +130,8 @@ pub enum BugAction {
         limit: u32,
         #[command(flatten)]
         field_args: FieldArgs,
+        #[command(flatten)]
+        sort_args: SortArgs,
         /// Filter to bugs created at or after this date.
         ///
         /// Accepts `YYYY-MM-DD` (interpreted as 00:00:00 UTC),
@@ -281,6 +302,8 @@ pub enum BugAction {
         limit: Option<u32>,
         #[command(flatten)]
         field_args: FieldArgs,
+        #[command(flatten)]
+        sort_args: SortArgs,
     },
     /// Show the change history for a single bug.
     ///
@@ -474,6 +497,8 @@ pub enum BugAction {
         limit: u32,
         #[command(flatten)]
         field_args: FieldArgs,
+        #[command(flatten)]
+        sort_args: SortArgs,
     },
     /// Clone an existing bug, optionally overriding fields.
     ///

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,7 +13,7 @@ mod template;
 mod user;
 
 pub use attachment::AttachmentAction;
-pub use bug::{BugAction, FieldArgs};
+pub use bug::{BugAction, FieldArgs, SortArgs};
 pub use classification::ClassificationAction;
 pub use comment::CommentAction;
 pub use component::ComponentAction;

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -149,6 +149,8 @@ pub enum QueryAction {
         /// Filter by URL field substring (repeatable for OR; prefix with ! to exclude)
         #[arg(long)]
         url: Vec<String>,
+        #[command(flatten)]
+        sort_args: crate::cli::SortArgs,
     },
     /// List all saved queries.
     ///
@@ -291,5 +293,7 @@ pub enum QueryAction {
         /// Override the saved URL filter.
         #[arg(long)]
         url: Vec<String>,
+        #[command(flatten)]
+        sort_args: crate::cli::SortArgs,
     },
 }

--- a/src/client/bug.rs
+++ b/src/client/bug.rs
@@ -132,6 +132,7 @@ fn append_option_params(
         ("exclude_fields", &params.exclude_fields),
         ("creation_time", &params.creation_time),
         ("last_change_time", &params.last_change_time),
+        ("order", &params.order),
     ];
     for &(key, value) in option_fields {
         if let Some(v) = value {

--- a/src/commands/bug/list.rs
+++ b/src/commands/bug/list.rs
@@ -38,6 +38,7 @@ pub(super) async fn handle(
         resolution,
         qa_contact,
         url,
+        sort_args,
     } = action
     else {
         unreachable!()
@@ -70,6 +71,10 @@ pub(super) async fn handle(
         resolution: resolution.clone(),
         qa_contact: qa_contact.clone(),
         url: url.clone(),
+        order: Some(crate::validation::build_order(
+            sort_args.sort.as_deref(),
+            sort_args.order,
+        )),
         ..Default::default()
     };
     let spec = ColumnSpec::new(fields.as_deref(), exclude_fields.as_deref());

--- a/src/commands/bug/list_tests.rs
+++ b/src/commands/bug/list_tests.rs
@@ -34,6 +34,7 @@ fn empty_list_action() -> BugAction {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     }
 }
 
@@ -139,6 +140,7 @@ async fn bug_list_passes_every_field_through_to_search_params() {
         resolution: vec!["FIXED".into()],
         qa_contact: vec!["qa@test.com".into()],
         url: vec!["github.com/foo".into()],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let result = crate::commands::bug::execute(
         &action,
@@ -203,6 +205,7 @@ async fn bug_list_summary_only_sends_substring_filter() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let result = crate::commands::bug::execute(
         &action,
@@ -600,5 +603,53 @@ async fn bug_list_json_all_unknown_fields_exits_7() {
     assert!(
         mock.received_requests().await.unwrap().is_empty(),
         "validation must run before any network I/O"
+    );
+}
+
+#[tokio::test]
+async fn bug_list_sends_default_bug_id_order() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("order", "bug_id"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "bugs": [] })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = empty_list_action();
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    assert!(
+        result.is_ok(),
+        "default-order list should succeed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn bug_list_sends_explicit_sort_and_order() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("order", "last_change_time DESC, bug_id"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "bugs": [] })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut action = empty_list_action();
+    if let BugAction::List { sort_args, .. } = &mut action {
+        sort_args.sort = Some("last_change_time".to_string());
+        sort_args.order = crate::types::SortDirection::Desc;
+    }
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    assert!(
+        result.is_ok(),
+        "explicit-sort list should succeed: {result:?}"
     );
 }

--- a/src/commands/bug/my.rs
+++ b/src/commands/bug/my.rs
@@ -21,6 +21,7 @@ pub(super) async fn handle(
             fields,
             exclude_fields,
         },
+        sort_args,
     } = action
     else {
         unreachable!()
@@ -39,6 +40,10 @@ pub(super) async fn handle(
         limit: Some(*limit),
         include_fields: canonical_field_list(fields.as_deref()),
         exclude_fields: canonical_field_list(exclude_fields.as_deref()),
+        order: Some(crate::validation::build_order(
+            sort_args.sort.as_deref(),
+            sort_args.order,
+        )),
         ..Default::default()
     };
     let mut searches = Vec::new();

--- a/src/commands/bug/my_tests.rs
+++ b/src/commands/bug/my_tests.rs
@@ -51,6 +51,7 @@ async fn bug_my_returns_assigned_by_default() {
             fields: None,
             exclude_fields: None,
         },
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result =
@@ -92,6 +93,7 @@ async fn bug_my_passes_status_limit_and_field_filters() {
             fields: Some("id,summary".into()),
             exclude_fields: Some("comments".into()),
         },
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io2 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -131,6 +133,7 @@ async fn bug_my_created_only_runs_creator_search_not_assigned() {
             fields: None,
             exclude_fields: None,
         },
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io3 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -169,6 +172,7 @@ async fn bug_my_cc_only_runs_cc_search_not_assigned_or_creator() {
             fields: None,
             exclude_fields: None,
         },
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io4 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -214,6 +218,7 @@ async fn bug_my_all_deduplicates() {
             fields: None,
             exclude_fields: None,
         },
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io5 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(

--- a/src/commands/bug/search.rs
+++ b/src/commands/bug/search.rs
@@ -74,6 +74,7 @@ pub(super) async fn handle(
             fields,
             exclude_fields,
         },
+        sort_args,
     } = action
     else {
         unreachable!()
@@ -89,12 +90,20 @@ pub(super) async fn handle(
         let save_info = resolve_save_info(save_as.as_ref(), parsed.suggested_name, &parsed.query)?;
         let canonical_fields = canonical_field_list(fields.as_deref());
         let canonical_exclude = canonical_field_list(exclude_fields.as_deref());
-        let params = build_params_from_url(
+        let mut params = build_params_from_url(
             parsed.query,
             *limit,
             canonical_fields.as_deref(),
             canonical_exclude.as_deref(),
         );
+        // `--sort` overrides the URL's own ordering; otherwise the parsed URL
+        // order (if any) is preserved verbatim.
+        if sort_args.sort.is_some() {
+            params.order = Some(crate::validation::build_order(
+                sort_args.sort.as_deref(),
+                sort_args.order,
+            ));
+        }
         (client, params, save_info)
     } else {
         let query_str = query.as_deref().ok_or_else(|| {
@@ -108,6 +117,10 @@ pub(super) async fn handle(
             limit: Some(limit.unwrap_or(DEFAULT_SEARCH_LIMIT)),
             include_fields: canonical_field_list(fields.as_deref()),
             exclude_fields: canonical_field_list(exclude_fields.as_deref()),
+            order: Some(crate::validation::build_order(
+                sort_args.sort.as_deref(),
+                sort_args.order,
+            )),
             ..Default::default()
         };
         (client, params, None)

--- a/src/commands/bug/search_tests.rs
+++ b/src/commands/bug/search_tests.rs
@@ -17,6 +17,7 @@ fn from_url_action(url: String, save_as: Option<String>) -> BugAction {
             fields: None,
             exclude_fields: None,
         },
+        sort_args: crate::cli::SortArgs::default(),
     }
 }
 
@@ -187,6 +188,7 @@ async fn handle_search_quicksearch_passes_limit_and_field_filters() {
             fields: Some("id,summary".into()),
             exclude_fields: Some("comments".into()),
         },
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io3 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -338,5 +340,61 @@ async fn handle_search_save_as_no_name_no_known_name_errors() {
     assert!(
         err.contains("no name provided for --save-as"),
         "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn bug_search_quicksearch_sends_default_order() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("order", "bug_id"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "bugs": [] })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = BugAction::Search {
+        query: Some("crash".to_string()),
+        from_url: None,
+        save_as: None,
+        limit: None,
+        field_args: crate::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
+        sort_args: crate::cli::SortArgs::default(),
+    };
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    assert!(result.is_ok(), "quicksearch should succeed: {result:?}");
+}
+
+#[tokio::test]
+async fn bug_search_from_url_sort_overrides_url_order() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("order", "priority DESC, bug_id"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "bugs": [] })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let url = format!("{}/buglist.cgi?product=TestProduct", mock.uri());
+    let mut action = from_url_action(url, None);
+    if let BugAction::Search { sort_args, .. } = &mut action {
+        sort_args.sort = Some("priority".to_string());
+        sort_args.order = crate::types::SortDirection::Desc;
+    }
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    assert!(
+        result.is_ok(),
+        "from-url with --sort should succeed: {result:?}"
     );
 }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -41,6 +41,15 @@ pub async fn execute(
     }
 }
 
+/// The `order` clause to persist for a saved query: `Some` only when `--sort`
+/// is given, so `query run` applies its own stable default otherwise.
+fn explicit_sort_order(sort_args: &crate::cli::SortArgs) -> Option<String> {
+    sort_args
+        .sort
+        .as_ref()
+        .map(|_| crate::validation::build_order(sort_args.sort.as_deref(), sort_args.order))
+}
+
 fn handle_save(action: &QueryAction, format: OutputFormat, w: &mut Writers<'_>) -> Result<()> {
     let QueryAction::Save {
         name,
@@ -66,6 +75,7 @@ fn handle_save(action: &QueryAction, format: OutputFormat, w: &mut Writers<'_>) 
         resolution,
         qa_contact,
         url,
+        sort_args,
     } = action
     else {
         unreachable!()
@@ -80,21 +90,14 @@ fn handle_save(action: &QueryAction, format: OutputFormat, w: &mut Writers<'_>) 
         let config = Config::load()?;
         let parsed = crate::url_parser::parse_bugzilla_url(url_str, &config)?;
         let mut query = parsed.query;
-        if let Some(limit) = limit {
-            query.limit = Some(*limit);
-        }
-        if let Some(f) = fields {
-            query.fields = Some(f.clone());
-        }
-        if let Some(ef) = exclude_fields {
-            query.exclude_fields = Some(ef.clone());
-        }
-        if creation_time.is_some() {
-            query.creation_time = creation_time;
-        }
-        if last_change_time.is_some() {
-            query.last_change_time = last_change_time;
-        }
+        // A flag value overrides the URL-parsed value; otherwise the parsed
+        // value is kept.
+        query.limit = (*limit).or(query.limit);
+        query.fields = fields.clone().or(query.fields);
+        query.exclude_fields = exclude_fields.clone().or(query.exclude_fields);
+        query.creation_time = creation_time.or(query.creation_time);
+        query.last_change_time = last_change_time.or(query.last_change_time);
+        query.order = explicit_sort_order(sort_args);
         query
     } else {
         let kind = if search.is_some() {
@@ -125,6 +128,7 @@ fn handle_save(action: &QueryAction, format: OutputFormat, w: &mut Writers<'_>) 
             resolution: resolution.clone(),
             qa_contact: qa_contact.clone(),
             url: url.clone(),
+            order: explicit_sort_order(sort_args),
             ..SavedQuery::default()
         }
     };
@@ -204,6 +208,7 @@ async fn handle_run(
         resolution,
         qa_contact,
         url,
+        sort_args,
     } = action
     else {
         unreachable!()
@@ -242,6 +247,17 @@ async fn handle_run(
     });
     params.include_fields = canonical_field_list(params.include_fields.as_deref());
     params.exclude_fields = canonical_field_list(params.exclude_fields.as_deref());
+    // Result ordering: an explicit `--sort` overrides the saved order; absent
+    // both, default to a stable `bug_id` so runs are deterministic — unless the
+    // saved query (e.g. from a URL) already carries an `order` raw param.
+    if sort_args.sort.is_some() {
+        params.order = Some(crate::validation::build_order(
+            sort_args.sort.as_deref(),
+            sort_args.order,
+        ));
+    } else if params.order.is_none() && !params.raw_params.iter().any(|(k, _)| k == "order") {
+        params.order = Some(crate::validation::build_order(None, sort_args.order));
+    }
 
     // Source columns from the resolved params (saved-query fields + CLI
     // overrides), not the raw flags, so a stored field selection is honored.

--- a/src/commands/query_tests.rs
+++ b/src/commands/query_tests.rs
@@ -32,6 +32,7 @@ fn save_action(name: &str) -> QueryAction {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     }
 }
 
@@ -61,6 +62,7 @@ fn product_save_action(name: &str, product: &str, limit: u32) -> QueryAction {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     }
 }
 
@@ -89,6 +91,7 @@ fn empty_save_action(name: &str, search: Option<String>) -> QueryAction {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     }
 }
 
@@ -117,6 +120,7 @@ fn url_save_action(name: &str, url: String) -> QueryAction {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     }
 }
 
@@ -137,6 +141,7 @@ fn run_action(name: &str) -> QueryAction {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     }
 }
 
@@ -208,6 +213,7 @@ async fn query_save_persists_every_field() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result = super::execute(&action, None, OutputFormat::Json, None, &mut __io.writers()).await;
@@ -523,6 +529,7 @@ async fn query_run_with_limit_override() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io_a10 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -565,6 +572,7 @@ async fn query_save_existing_entry_reports_updated() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io_a11 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -602,6 +610,7 @@ async fn query_save_existing_entry_reports_updated() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io4 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -704,6 +713,7 @@ async fn query_run_applies_field_overrides() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io_a13 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -742,6 +752,7 @@ async fn query_run_applies_field_overrides() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io_a14 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -887,6 +898,7 @@ async fn query_run_with_server_override() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io_a16 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -965,6 +977,7 @@ async fn query_save_rejects_malformed_created_since() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
 
     let result = super::execute(
@@ -1008,6 +1021,7 @@ async fn query_save_stores_canonical_date_forms() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io8 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -1057,6 +1071,7 @@ async fn query_save_accepts_date_only_query() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io9 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -1107,6 +1122,7 @@ async fn query_run_rejects_malformed_created_since_override() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let result = super::execute(
         &action,
@@ -1149,6 +1165,7 @@ async fn query_save_persists_158_field_filters() {
         resolution: vec!["FIXED".into()],
         qa_contact: vec!["qa@example.com".into()],
         url: vec!["github.com/foo".into()],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io_a18 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -1206,6 +1223,7 @@ async fn query_save_accepts_whiteboard_only_filter() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io_a19 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -1252,6 +1270,7 @@ async fn query_run_overrides_replace_saved_field_filters() {
         resolution: vec!["FIXED".into()],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io_a20 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -1291,6 +1310,7 @@ async fn query_run_overrides_replace_saved_field_filters() {
         resolution: vec!["WONTFIX".into()],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io_a21 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -1333,6 +1353,7 @@ async fn query_run_empty_override_keeps_saved_field_filter() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: crate::cli::SortArgs::default(),
     };
     let mut __io_a22 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -1367,4 +1388,95 @@ async fn query_run_empty_override_keeps_saved_field_filter() {
     .await;
     let _ = __io_a23.out_str().to_string();
     assert!(result.is_ok(), "run failed: {result:?}");
+}
+
+#[tokio::test]
+async fn query_run_sends_default_bug_id_order() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    let save = product_save_action("order-default", "TestProduct", 10);
+    super::execute(
+        &save,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut crate::test_helpers::CapturedIo::new().writers(),
+    )
+    .await
+    .unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("order", "bug_id"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "bugs": [] })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let run = run_action("order-default");
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&run, None, OutputFormat::Json, None, &mut __io.writers()).await;
+    assert!(
+        result.is_ok(),
+        "run with default order should succeed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn query_run_sort_override_takes_precedence() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    let save = product_save_action("order-override", "TestProduct", 10);
+    super::execute(
+        &save,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut crate::test_helpers::CapturedIo::new().writers(),
+    )
+    .await
+    .unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("order", "priority ASC, bug_id"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "bugs": [] })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut run = run_action("order-override");
+    if let QueryAction::Run { sort_args, .. } = &mut run {
+        sort_args.sort = Some("priority".to_string());
+    }
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&run, None, OutputFormat::Json, None, &mut __io.writers()).await;
+    assert!(
+        result.is_ok(),
+        "run with --sort override should succeed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn query_save_persists_explicit_sort() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    let mut save = product_save_action("order-persist", "TestProduct", 10);
+    if let QueryAction::Save { sort_args, .. } = &mut save {
+        sort_args.sort = Some("last_change_time".to_string());
+        sort_args.order = crate::types::SortDirection::Desc;
+    }
+    super::execute(
+        &save,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut crate::test_helpers::CapturedIo::new().writers(),
+    )
+    .await
+    .unwrap();
+
+    let config = crate::config::Config::load().unwrap();
+    let saved = config.queries.get("order-persist").unwrap();
+    assert_eq!(
+        saved.order.as_deref(),
+        Some("last_change_time DESC, bug_id")
+    );
 }

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -281,6 +281,10 @@ pub struct SearchParams {
     /// Filter by URL field substring (repeatable). Negated values
     /// use `notsubstring`.
     pub url: Vec<String>,
+    /// Bugzilla `order` clause (e.g. `last_change_time DESC, bug_id`).
+    /// Built from `--sort`/`--order`; defaults to a stable `bug_id` so
+    /// identical runs return rows in a deterministic order.
+    pub order: Option<String>,
 }
 
 /// Optional per-invocation overrides applied to a `SearchParams`
@@ -866,6 +870,10 @@ pub struct SavedQuery {
     /// Filter by URL field substring (repeatable).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub url: Vec<String>,
+    /// Persisted Bugzilla `order` clause (from `query save --sort/--order`).
+    /// Overridden per-run by `query run --sort`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub order: Option<String>,
 }
 
 impl SavedQuery {
@@ -899,6 +907,7 @@ impl SavedQuery {
             resolution: self.resolution,
             qa_contact: self.qa_contact,
             url: self.url,
+            order: self.order,
             ..Default::default()
         }
     }

--- a/src/types/bug_tests.rs
+++ b/src/types/bug_tests.rs
@@ -182,6 +182,7 @@ fn saved_query_list_roundtrips_json() {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        order: None,
     };
     let json = serde_json::to_string(&query).unwrap();
     let roundtripped: SavedQuery = serde_json::from_str(&json).unwrap();

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -88,6 +88,36 @@ impl std::str::FromStr for OutputFormat {
     }
 }
 
+/// Sort direction for the `--order` flag on listing commands.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SortDirection {
+    #[default]
+    Asc,
+    Desc,
+}
+
+impl SortDirection {
+    /// The Bugzilla `order` keyword for this direction.
+    #[must_use]
+    pub fn keyword(self) -> &'static str {
+        match self {
+            SortDirection::Asc => "ASC",
+            SortDirection::Desc => "DESC",
+        }
+    }
+}
+
+impl std::str::FromStr for SortDirection {
+    type Err = String;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "asc" | "ascending" => Ok(SortDirection::Asc),
+            "desc" | "descending" => Ok(SortDirection::Desc),
+            _ => Err(format!("invalid order '{s}': expected 'asc' or 'desc'")),
+        }
+    }
+}
+
 /// Represents the four valid flag status values in Bugzilla.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlagStatus {

--- a/src/types/common_tests.rs
+++ b/src/types/common_tests.rs
@@ -138,3 +138,25 @@ fn api_mode_from_str() {
     assert_eq!("hybrid".parse::<ApiMode>().unwrap(), ApiMode::Hybrid);
     assert!("grpc".parse::<ApiMode>().is_err());
 }
+
+#[test]
+fn sort_direction_from_str_and_keyword() {
+    assert_eq!("asc".parse::<SortDirection>().unwrap(), SortDirection::Asc);
+    assert_eq!("ASC".parse::<SortDirection>().unwrap(), SortDirection::Asc);
+    assert_eq!(
+        "ascending".parse::<SortDirection>().unwrap(),
+        SortDirection::Asc
+    );
+    assert_eq!(
+        "desc".parse::<SortDirection>().unwrap(),
+        SortDirection::Desc
+    );
+    assert_eq!(
+        "DESCENDING".parse::<SortDirection>().unwrap(),
+        SortDirection::Desc
+    );
+    assert!("sideways".parse::<SortDirection>().is_err());
+    assert_eq!(SortDirection::Asc.keyword(), "ASC");
+    assert_eq!(SortDirection::Desc.keyword(), "DESC");
+    assert_eq!(SortDirection::default(), SortDirection::Asc);
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -15,7 +15,7 @@ pub use bug::{
 pub use comment::{Comment, UpdateCommentTagsParams};
 pub use common::{
     ApiMode, AuthMethod, ExtensionInfo, FlagStatus, FlagUpdate, OutputFormat, ServerExtensions,
-    ServerInfoResponse, ServerVersion,
+    ServerInfoResponse, ServerVersion, SortDirection,
 };
 pub use group::{CreateGroupParams, GroupInfo, GroupMember, UpdateGroupParams};
 pub use product::{

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -10,6 +10,8 @@ pub mod datetime;
 pub use datetime::{parse_date_only, parse_iso8601_or_date};
 
 use crate::error::Result;
+use crate::field_aliases::resolve_field_alias;
+use crate::types::SortDirection;
 
 /// Validate an optional date string for use as a Bugzilla search filter.
 ///
@@ -28,3 +30,30 @@ pub fn parse_optional_date(opt: Option<&str>, flag: &str) -> Result<Option<Strin
 pub fn parse_optional_date_only(opt: Option<&str>, flag: &str) -> Result<Option<String>> {
     opt.map(|s| parse_date_only(s, flag)).transpose()
 }
+
+/// Build the Bugzilla `order` clause from `--sort`/`--order`.
+///
+/// With a sort field, returns `<resolved-field> <DIR>` plus a `bug_id`
+/// tiebreaker (omitted when the field already is `bug_id`) so ties resolve
+/// deterministically. Without a sort field, returns the stable default
+/// `bug_id`, so identical runs return rows in the same order even with no
+/// `--sort`. The field name is normalized through the same alias table as
+/// the filter flags (e.g. `assignee` -> `assigned_to`).
+#[must_use]
+pub fn build_order(sort: Option<&str>, direction: SortDirection) -> String {
+    match sort {
+        Some(field) => {
+            let resolved = resolve_field_alias(field);
+            if resolved == "bug_id" {
+                format!("bug_id {}", direction.keyword())
+            } else {
+                format!("{} {}, bug_id", resolved, direction.keyword())
+            }
+        }
+        None => "bug_id".to_string(),
+    }
+}
+
+#[cfg(test)]
+#[path = "validation_tests.rs"]
+mod tests;

--- a/src/validation/validation_tests.rs
+++ b/src/validation/validation_tests.rs
@@ -1,0 +1,40 @@
+use super::build_order;
+use crate::types::SortDirection;
+
+#[test]
+fn build_order_defaults_to_bug_id_when_no_sort() {
+    assert_eq!(build_order(None, SortDirection::Asc), "bug_id");
+    // Direction is ignored without a sort field; the default is always stable.
+    assert_eq!(build_order(None, SortDirection::Desc), "bug_id");
+}
+
+#[test]
+fn build_order_appends_direction_and_tiebreaker() {
+    assert_eq!(
+        build_order(Some("last_change_time"), SortDirection::Desc),
+        "last_change_time DESC, bug_id"
+    );
+    assert_eq!(
+        build_order(Some("priority"), SortDirection::Asc),
+        "priority ASC, bug_id"
+    );
+}
+
+#[test]
+fn build_order_omits_redundant_tiebreaker_for_bug_id() {
+    assert_eq!(
+        build_order(Some("bug_id"), SortDirection::Desc),
+        "bug_id DESC"
+    );
+}
+
+#[test]
+fn build_order_resolves_field_aliases() {
+    // `severity` is an alias for the API field `bug_severity`.
+    assert_eq!(
+        build_order(Some("severity"), SortDirection::Asc),
+        "bug_severity ASC, bug_id"
+    );
+    // `id` resolves to `bug_id`, which drops the redundant tiebreaker.
+    assert_eq!(build_order(Some("id"), SortDirection::Desc), "bug_id DESC");
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -44,6 +44,7 @@ fn empty_list_action() -> bzr::cli::BugAction {
         resolution: vec![],
         qa_contact: vec![],
         url: vec![],
+        sort_args: bzr::cli::SortArgs::default(),
     }
 }
 
@@ -189,6 +190,7 @@ async fn bug_search_integration() {
             fields: None,
             exclude_fields: None,
         },
+        sort_args: bzr::cli::SortArgs::default(),
     };
     let mut __io4 = bzr::test_helpers::CapturedIo::new();
     let result = bzr::commands::bug::execute(


### PR DESCRIPTION
## Summary

Adds `--sort <FIELD>` / `--order asc|desc` to `bug list`, `bug search`, `bug my`, and `query run` (closes #303), mapped to Bugzilla's `order` parameter. Previously there was no way to control ordering, so agents got non-deterministic results — breaking reproducible runs, snapshot diffs, and "take the top N" heuristics.

## Acceptance criteria

- [x] Listing commands accept a sort key + direction and pass it to the server.
- [x] Absent the flag, ordering is stable/deterministic across identical runs (default `bug_id`, with a `bug_id` tiebreaker always appended).
- [x] Saved queries can persist a sort (`query save --sort`); `query run` can override it (`query run --sort`).

## ⚠️ Behavior change to review

**`bug search` now defaults to `order=bug_id` instead of Bugzilla's quicksearch relevance ranking.** This is required to meet the "deterministic without the flag" criterion *consistently* across all four commands (relevance ties are inherently non-deterministic). It is documented in the CHANGELOG and reference. If you'd prefer `bug search` keep relevance-by-default (and only sort when `--sort` is given), that's a one-line change — flagging it for your call.

## Implementation notes

- New `SortDirection` type and a flattened `SortArgs { sort, order }` clap struct (defined once, flattened into list/search/my and query save/run).
- `validation::build_order(sort, dir)` builds the clause: `<field> <DIR>, bug_id`, or `bug_id` when no `--sort`; field names go through the same alias table as filters.
- `order` added to `SearchParams` (sent via the existing client query builder) and `SavedQuery` (persisted; serde-default so existing configs load).
- `bug search --from-url` / `query run`: an explicit `--sort` overrides; otherwise the URL/saved order is preserved. The run-time `bug_id` default is suppressed when the saved query already carries an `order` raw param (verified: a URL `order=` lands in `raw_params`), avoiding a double `order`.

## Tests

`build_order` unit tests (default, direction+tiebreaker, redundant-tiebreaker omission, alias resolution); `bug list` default + explicit order; `bug search` quicksearch default + from-url `--sort` override; `query run` default + override; `query save` sort persistence.

## Validation

`cargo clippy --locked --features test-helpers -- -D warnings`, `cargo test --features test-helpers`, and the agent-skills drift check pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
