### PR TITLE
feat(bug): add `bug view --web` to open a bug page in the browser (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `bzr bug view <ID> --web` opens the bug's page (`show_bug.cgi?id=<ID>`) on the
+  active server in the default browser, the `gh issue view --web` affordance.
+  Resolves the URL from local config with no network call or authentication, so
+  it works even before credentials are set. When stdout is not a terminal or no
+  display is available (headless / SSH without X), it prints the URL and exits 0
+  instead of opening a browser, which keeps it safe for scripts, pipes, and
+  agents. Multiple IDs open (or print) one page each. (#310)
 - `--sort <FIELD>` / `--order asc|desc` on `bug list`, `bug search`, `bug my`,
   and `query run` control result ordering (mapped to Bugzilla's `order`), with
   a `bug_id` tiebreaker for deterministic ties. Absent `--sort`, results now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
  "dirs",
  "keyring-core",
  "mutants",
+ "open",
  "percent-encoding",
  "proptest",
  "quick-xml",
@@ -1031,6 +1032,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1304,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1383,12 @@ dependencies = [
  "fnv",
  "unicode-width",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
 toml = "1"
 dirs = "6"
+open = "5.3.5"
 tabled = { version = "0.21", default-features = false, features = ["std"] }
 thiserror = "2"
 colored = "3"

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -300,6 +300,7 @@ what is sent over the wire.
 bzr bug view 12345
 bzr bug view 12345 12346 12347
 bzr bug view 12345 my-alias 12347 --permissive
+bzr bug view 12345 --web
 bzr --json bug view 12345
 bzr --json bug view 12345 12346 | jq '.bugs[].summary'
 bzr bug view my-alias --fields id,summary,assigned_to
@@ -308,6 +309,7 @@ bzr bug view my-alias --fields id,summary,assigned_to
 | Option | Required | Description |
 |--------|----------|-------------|
 | `<IDS>...` | Yes | One or more bug IDs or aliases. Aliases and numeric IDs may be mixed. |
+| `--web` | No | Open each bug's web page (`show_bug.cgi?id=<ID>`) on the active server in the default browser instead of printing its record. Resolves the URL from local config — no network call or authentication, so it works before credentials are set. When stdout is not a terminal or no display is available (headless / SSH without X), the URL is printed to stdout and the command exits 0 instead of opening a browser. `--fields` and `--permissive` are ignored with `--web`. |
 | `--permissive` | No | Multi-ID only. Continue past per-bug failures, surfacing them as `Bug #N — UNAVAILABLE` placeholder rows (table) or entries in `failed` (JSON). Exit 0 even if some bugs fail. Has no effect on session-wide failures (transport, auth, security) — those still bail. Setting `--permissive` with a single ID returns input-validation error (exit 7). |
 | `--fields <F>` | No | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which detail rows to show. Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
 | `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those detail rows. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). |

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -231,6 +231,18 @@ pub enum BugAction {
         /// security) — those always bail.
         #[arg(long)]
         permissive: bool,
+        /// Open the bug's web page in the default browser instead of
+        /// printing its record.
+        ///
+        /// Resolves the active server's base URL and opens
+        /// `show_bug.cgi?id=<ID>` for each ID given. No network call
+        /// or authentication is needed. When stdout is not a terminal,
+        /// or there is no display (headless / SSH without X), the URL is
+        /// printed to stdout and the command exits 0 instead of opening
+        /// a browser — which keeps it safe for scripts and pipes.
+        /// `--fields` and `--permissive` are ignored with `--web`.
+        #[arg(long)]
+        web: bool,
         #[command(flatten)]
         field_args: FieldArgs,
     },

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -43,6 +43,13 @@ pub async fn execute(
 ) -> Result<()> {
     update::validate_action(action)?;
 
+    // `--web` resolves the bug's URL from local config and opens (or prints)
+    // it — no auth, no network, no field selection. Short-circuit before any
+    // of the connect/validate machinery below.
+    if let BugAction::View { ids, web: true, .. } = action {
+        return view::handle_web(ids, server, w);
+    }
+
     // Resolve the field selection before any network I/O. A selection that
     // leaves nothing to show exits 7 deterministically — measured against the
     // five-column default in table mode, against the full field universe in

--- a/src/commands/bug/view.rs
+++ b/src/commands/bug/view.rs
@@ -118,7 +118,7 @@ pub(super) fn handle_web(ids: &[String], server: Option<&str>, w: &mut Writers<'
     // Open a browser only with both a terminal stdout and a display; anything
     // else (pipe, redirect, headless) prints the URL instead.
     let interactive = std::io::stdout().is_terminal() && has_display();
-    emit_web(&urls, interactive, w);
+    emit_web(&urls, interactive, |url| open::that(url), w);
     Ok(())
 }
 
@@ -142,21 +142,29 @@ fn bug_web_url(base: &str, id: &str) -> String {
 }
 
 /// Whether a graphical display is available to open a browser. GUI platforms
-/// (macOS, Windows) always qualify; elsewhere a display requires `DISPLAY` or
-/// `WAYLAND_DISPLAY` to be set.
+/// (macOS, Windows) always qualify.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn has_display() -> bool {
-    if cfg!(any(target_os = "macos", target_os = "windows")) {
-        return true;
-    }
+    true
+}
+
+/// Whether a graphical display is available to open a browser. On non-GUI
+/// platforms this requires `DISPLAY` or `WAYLAND_DISPLAY` to be set.
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn has_display() -> bool {
     std::env::var_os("DISPLAY").is_some() || std::env::var_os("WAYLAND_DISPLAY").is_some()
 }
 
-/// Open each URL in the browser when interactive, else print it. A failed
-/// `open` falls back to printing so the URL is never lost.
-fn emit_web(urls: &[String], interactive: bool, w: &mut Writers<'_>) {
+/// Open each URL with `open_fn` when interactive, else print it. A failed open
+/// falls back to printing (with a stderr warning) so the URL is never lost.
+/// `open_fn` is injected so the open path is testable without a real browser.
+fn emit_web<F>(urls: &[String], interactive: bool, open_fn: F, w: &mut Writers<'_>)
+where
+    F: Fn(&str) -> std::io::Result<()>,
+{
     for url in urls {
         if interactive {
-            if let Err(e) = open::that(url) {
+            if let Err(e) = open_fn(url) {
                 let _ = writeln!(w.err, "warning: failed to open browser: {e}");
                 let _ = writeln!(w.out, "{url}");
             }

--- a/src/commands/bug/view.rs
+++ b/src/commands/bug/view.rs
@@ -1,5 +1,10 @@
+use std::io::IsTerminal;
+
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+
 use crate::cli::{BugAction, FieldArgs};
 use crate::client::BugzillaClient;
+use crate::config::Config;
 use crate::error::{BzrError, Result};
 use crate::output::resources::bug::{
     bug_to_json, canonical_field_list, write_bug_detail, write_multi_bug_view, ColumnSpec,
@@ -60,6 +65,7 @@ pub(super) async fn handle(
     let BugAction::View {
         ids,
         permissive,
+        web: _,
         field_args: FieldArgs {
             fields,
             exclude_fields,
@@ -103,6 +109,61 @@ pub(super) async fn handle(
     let spec = ColumnSpec::new(inc, exc);
     write_batch(batch, spec, format, w);
     Ok(())
+}
+
+/// Handle `bug view --web`: resolve each ID's web page URL from local config
+/// and open it in the browser, or print it when running headless / non-TTY.
+pub(super) fn handle_web(ids: &[String], server: Option<&str>, w: &mut Writers<'_>) -> Result<()> {
+    let urls = resolve_bug_urls(ids, server)?;
+    // Open a browser only with both a terminal stdout and a display; anything
+    // else (pipe, redirect, headless) prints the URL instead.
+    let interactive = std::io::stdout().is_terminal() && has_display();
+    emit_web(&urls, interactive, w);
+    Ok(())
+}
+
+/// Build the `show_bug.cgi?id=<ID>` URL for each ID against the active server's
+/// base URL. Pure local config read — no network, no auth. Uses the
+/// unvalidated config so opening a bug page never depends on credentials being
+/// set (here or on any other server entry); only the server's URL is needed.
+fn resolve_bug_urls(ids: &[String], server: Option<&str>) -> Result<Vec<String>> {
+    let config = Config::read_unvalidated()?;
+    let (_name, srv) = config.resolve_server(server)?;
+    Ok(ids.iter().map(|id| bug_web_url(&srv.url, id)).collect())
+}
+
+/// Construct a bug's web page URL. Trailing slashes on `base` are trimmed so
+/// the result has exactly one separator; the ID is percent-encoded so an alias
+/// with reserved characters stays a valid query value.
+fn bug_web_url(base: &str, id: &str) -> String {
+    let base = base.trim_end_matches('/');
+    let encoded = utf8_percent_encode(id, NON_ALPHANUMERIC);
+    format!("{base}/show_bug.cgi?id={encoded}")
+}
+
+/// Whether a graphical display is available to open a browser. GUI platforms
+/// (macOS, Windows) always qualify; elsewhere a display requires `DISPLAY` or
+/// `WAYLAND_DISPLAY` to be set.
+fn has_display() -> bool {
+    if cfg!(any(target_os = "macos", target_os = "windows")) {
+        return true;
+    }
+    std::env::var_os("DISPLAY").is_some() || std::env::var_os("WAYLAND_DISPLAY").is_some()
+}
+
+/// Open each URL in the browser when interactive, else print it. A failed
+/// `open` falls back to printing so the URL is never lost.
+fn emit_web(urls: &[String], interactive: bool, w: &mut Writers<'_>) {
+    for url in urls {
+        if interactive {
+            if let Err(e) = open::that(url) {
+                let _ = writeln!(w.err, "warning: failed to open browser: {e}");
+                let _ = writeln!(w.out, "{url}");
+            }
+        } else {
+            let _ = writeln!(w.out, "{url}");
+        }
+    }
 }
 
 async fn view_single(

--- a/src/commands/bug/view_tests.rs
+++ b/src/commands/bug/view_tests.rs
@@ -11,6 +11,7 @@ fn make_view_action(ids: &[&str], permissive: bool) -> BugAction {
     BugAction::View {
         ids: ids.iter().map(|s| (*s).to_string()).collect(),
         permissive,
+        web: false,
         field_args: crate::cli::FieldArgs {
             fields: None,
             exclude_fields: None,
@@ -760,4 +761,122 @@ async fn view_multi_permissive_api_410_bails() {
         "auth-flavored Api code must bail despite --permissive"
     );
     assert!(!result.unwrap_err().is_bug_get_per_resource());
+}
+
+#[test]
+fn web_url_numeric_id() {
+    assert_eq!(
+        super::bug_web_url("https://bz.example.com", "12345"),
+        "https://bz.example.com/show_bug.cgi?id=12345"
+    );
+}
+
+#[test]
+fn web_url_trims_trailing_slash() {
+    assert_eq!(
+        super::bug_web_url("https://bz.example.com/", "42"),
+        "https://bz.example.com/show_bug.cgi?id=42"
+    );
+}
+
+#[test]
+fn web_url_percent_encodes_alias() {
+    // Reserved characters in an alias must be encoded so the query value
+    // stays well-formed; plain alphanumerics pass through untouched.
+    assert_eq!(
+        super::bug_web_url("https://bz.example.com", "my alias/v2"),
+        "https://bz.example.com/show_bug.cgi?id=my%20alias%2Fv2"
+    );
+}
+
+#[test]
+fn emit_web_non_interactive_prints_every_url() {
+    let urls = vec![
+        "https://bz.example.com/show_bug.cgi?id=1".to_string(),
+        "https://bz.example.com/show_bug.cgi?id=2".to_string(),
+    ];
+    let mut io = crate::test_helpers::CapturedIo::new();
+    super::emit_web(&urls, false, &mut io.writers());
+    let out = io.out_str();
+    assert!(
+        out.contains("show_bug.cgi?id=1"),
+        "missing first url:\n{out}"
+    );
+    assert!(
+        out.contains("show_bug.cgi?id=2"),
+        "missing second url:\n{out}"
+    );
+    // Non-interactive must not touch stderr.
+    assert!(io.err_str().is_empty());
+}
+
+#[tokio::test]
+async fn resolve_bug_urls_uses_configured_server() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    let ids = vec!["42".to_string(), "99".to_string()];
+    let urls = super::resolve_bug_urls(&ids, None).unwrap();
+    assert_eq!(urls.len(), 2);
+    assert!(urls[0].starts_with(&mock.uri()));
+    assert!(urls[0].ends_with("/show_bug.cgi?id=42"));
+    assert!(urls[1].ends_with("/show_bug.cgi?id=99"));
+}
+
+#[tokio::test]
+async fn resolve_bug_urls_works_without_credentials() {
+    // A server with a URL but no api_key/env/keyring fails Config::load()
+    // validation; `--web` only needs the URL, so it must still resolve.
+    let _lock = crate::ENV_LOCK.lock().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config_dir = tmp.path().join("bzr");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("config.toml"),
+        "default_server = \"nocreds\"\n\n[servers.nocreds]\nurl = \"https://bz.example.com\"\n",
+    )
+    .unwrap();
+    // SAFETY: ENV_LOCK serializes env access across tests.
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", tmp.path()) };
+
+    let ids = vec!["7".to_string()];
+    let urls = super::resolve_bug_urls(&ids, None).unwrap();
+    assert_eq!(urls, vec!["https://bz.example.com/show_bug.cgi?id=7"]);
+}
+
+#[tokio::test]
+async fn has_display_respects_display_env() {
+    let _lock = crate::ENV_LOCK.lock().await;
+    let saved_display = std::env::var_os("DISPLAY");
+    let saved_wayland = std::env::var_os("WAYLAND_DISPLAY");
+
+    // SAFETY: ENV_LOCK serializes env access across tests.
+    unsafe {
+        std::env::set_var("DISPLAY", ":0");
+        std::env::remove_var("WAYLAND_DISPLAY");
+    }
+    assert!(super::has_display(), "DISPLAY set should report a display");
+
+    unsafe { std::env::remove_var("DISPLAY") };
+    if cfg!(any(target_os = "macos", target_os = "windows")) {
+        assert!(
+            super::has_display(),
+            "GUI platforms always report a display"
+        );
+    } else {
+        assert!(
+            !super::has_display(),
+            "no DISPLAY/WAYLAND_DISPLAY should report headless"
+        );
+    }
+
+    // SAFETY: restore prior environment under the same lock.
+    unsafe {
+        match saved_display {
+            Some(v) => std::env::set_var("DISPLAY", v),
+            None => std::env::remove_var("DISPLAY"),
+        }
+        match saved_wayland {
+            Some(v) => std::env::set_var("WAYLAND_DISPLAY", v),
+            None => std::env::remove_var("WAYLAND_DISPLAY"),
+        }
+    }
 }

--- a/src/commands/bug/view_tests.rs
+++ b/src/commands/bug/view_tests.rs
@@ -796,7 +796,9 @@ fn emit_web_non_interactive_prints_every_url() {
         "https://bz.example.com/show_bug.cgi?id=2".to_string(),
     ];
     let mut io = crate::test_helpers::CapturedIo::new();
-    super::emit_web(&urls, false, &mut io.writers());
+    // Opener must never be called on the non-interactive path.
+    let opener = |_: &str| -> std::io::Result<()> { panic!("opener called when non-interactive") };
+    super::emit_web(&urls, false, opener, &mut io.writers());
     let out = io.out_str();
     assert!(
         out.contains("show_bug.cgi?id=1"),
@@ -808,6 +810,42 @@ fn emit_web_non_interactive_prints_every_url() {
     );
     // Non-interactive must not touch stderr.
     assert!(io.err_str().is_empty());
+}
+
+#[test]
+fn emit_web_interactive_success_is_silent() {
+    let urls = vec!["https://bz.example.com/show_bug.cgi?id=1".to_string()];
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let opener = |_: &str| -> std::io::Result<()> { Ok(()) };
+    super::emit_web(&urls, true, opener, &mut io.writers());
+    // A successful open prints nothing on either stream.
+    assert!(io.out_str().is_empty(), "stdout:\n{}", io.out_str());
+    assert!(io.err_str().is_empty(), "stderr:\n{}", io.err_str());
+}
+
+#[test]
+fn emit_web_interactive_failure_falls_back_to_print() {
+    let urls = vec!["https://bz.example.com/show_bug.cgi?id=9".to_string()];
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let opener = |_: &str| -> std::io::Result<()> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no browser",
+        ))
+    };
+    super::emit_web(&urls, true, opener, &mut io.writers());
+    // On open failure the URL is still printed (so it is never lost) and a
+    // warning naming the cause goes to stderr.
+    assert!(
+        io.out_str().contains("show_bug.cgi?id=9"),
+        "{}",
+        io.out_str()
+    );
+    assert!(
+        io.err_str().contains("failed to open browser") && io.err_str().contains("no browser"),
+        "{}",
+        io.err_str()
+    );
 }
 
 #[tokio::test]
@@ -879,4 +917,53 @@ async fn has_display_respects_display_env() {
             None => std::env::remove_var("WAYLAND_DISPLAY"),
         }
     }
+}
+
+/// End-to-end through `bug::execute` with `--web`. fd 1 is redirected to a temp
+/// file so `is_terminal()` reports non-interactive, forcing the print path —
+/// no real browser is ever launched, and the URL goes to the captured Writers.
+#[cfg(unix)]
+#[tokio::test]
+async fn execute_web_prints_url_when_fd1_not_a_tty() {
+    use std::os::unix::io::AsRawFd;
+
+    extern "C" {
+        fn dup(fd: std::ffi::c_int) -> std::ffi::c_int;
+        fn dup2(oldfd: std::ffi::c_int, newfd: std::ffi::c_int) -> std::ffi::c_int;
+        fn close(fd: std::ffi::c_int) -> std::ffi::c_int;
+    }
+
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    let action = BugAction::View {
+        ids: vec!["55".to_string()],
+        permissive: false,
+        web: true,
+        field_args: crate::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
+    };
+
+    let redirect = tempfile::NamedTempFile::new().unwrap();
+    // SAFETY: save fd 1, then point it at the temp file so is_terminal() is
+    // false. fd 1 is restored before any assertion or further test runs.
+    let saved = unsafe { dup(1) };
+    assert!(saved >= 0, "dup(1) failed");
+    unsafe { dup2(redirect.as_file().as_raw_fd(), 1) };
+
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Table, None, &mut io.writers())
+            .await;
+
+    // SAFETY: restore fd 1 before reading results / yielding to other tests.
+    unsafe {
+        dup2(saved, 1);
+        close(saved);
+    }
+
+    assert!(result.is_ok(), "{:?}", result.err());
+    let out = io.out_str();
+    assert!(out.starts_with(&mock.uri()), "url targets server:\n{out}");
+    assert!(out.contains("/show_bug.cgi?id=55"), "{out}");
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -146,6 +146,7 @@ async fn bug_view_integration() {
     let action = bzr::cli::BugAction::View {
         ids: vec!["42".to_string()],
         permissive: false,
+        web: false,
         field_args: bzr::cli::FieldArgs {
             fields: None,
             exclude_fields: None,
@@ -776,6 +777,7 @@ async fn api_error_propagates() {
     let action = bzr::cli::BugAction::View {
         ids: vec!["99999".to_string()],
         permissive: false,
+        web: false,
         field_args: bzr::cli::FieldArgs {
             fields: None,
             exclude_fields: None,


### PR DESCRIPTION
## Summary

Adds `bzr bug view <ID> --web`, the `gh issue view --web` affordance: open the bug's page on the active server in the default browser instead of printing its record.

| Issue | Title | Type | Files Changed |
|-------|-------|------|---------------|
| #310 | Open a bug in the browser (`--web`) | feat | `src/cli/bug.rs`, `src/commands/bug/mod.rs`, `src/commands/bug/view.rs`, `Cargo.toml` |

## Behavior

- `bzr bug view 12345 --web` opens `<server>/show_bug.cgi?id=12345` in the default browser.
- URL is resolved from local config with **no network call and no authentication** (uses the unvalidated config), so it works even before credentials are set and is unaffected by an unrelated half-configured server entry.
- **Headless guard:** when stdout is not a terminal, or there is no display (no `DISPLAY`/`WAYLAND_DISPLAY` on non-GUI platforms), the URL is printed to stdout and the command exits 0 instead of opening a browser. This keeps it safe for scripts, pipes, and agents. A failed browser launch also falls back to printing the URL.
- Multiple IDs open (or print) one page each. `--fields` and `--permissive` are ignored with `--web`.

## Implementation notes

- The `--web` branch short-circuits at the top of `bug::execute()` **before** `connect_and_configure` and the field-validation block — no client, no auth/version detection.
- The ID is percent-encoded (`NON_ALPHANUMERIC`) so an alias with reserved characters stays a valid query value; the scheme/host come fixed from config, so there is no URL-injection surface.
- New dependency: `open = "5.3.5"` (and its transitive `is-docker`/`is-wsl`/`pathdiff`).

## Review notes

- An adversarial review flagged that an earlier draft used `Config::load()`, which validates **every** server entry and rejects credential-less ones — breaking `--web` in exactly the recoverable states where it should work. Fixed by switching to `Config::read_unvalidated()`, with a regression test (`resolve_bug_urls_works_without_credentials`).
- The only side-effecting line (`open::that`) is isolated behind an explicit `interactive` parameter, so URL building, the non-interactive print path, and display detection are all unit-tested without ever launching a browser during `cargo test`.

## Test coverage

`bug_web_url` (numeric, trailing-slash trim, alias percent-encoding), `emit_web` non-interactive print, `resolve_bug_urls` (configured server + no-credentials), and `has_display` env detection. `docs/bzr-cli.md` and `CHANGELOG.md` updated.

## Validation

`cargo test --features test-helpers` (1379 lib + 78 integration) and `cargo clippy --locked --features test-helpers -- -D warnings` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
