### PR TITLE
feat(bug): give `bug create` field parity with `bug update` (#301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `bzr bug create` gains field flags shared with `bug update`: `--alias`,
+  `--url`, `--whiteboard`, `--target-milestone`, `--deadline`, `--cc`,
+  `--keywords`, `--groups`, and `--flag`. They are sent in the same
+  `Bug.create` call, so a bug and its metadata are filed in one API round-trip
+  instead of a create-then-update two-step. The list flags accept
+  comma-separated, repeatable values; `--flag` uses Bugzilla flag syntax;
+  `--deadline` takes `YYYY-MM-DD` and rejects malformed input with exit 7. (#301)
 - `bzr bug view <ID> --web` opens the bug's page (`show_bug.cgi?id=<ID>`) on the
   active server in the default browser, the `gh issue view --web` affordance.
   Resolves the URL from local config with no network call or authentication, so

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -97,7 +97,9 @@ bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-col
 │   ├── create [--template <T>] [--product <P>] [--component <C>] --summary <S>
 │   │          [--version <V>] [--description <D>] [--priority <P>] [--severity <S>]
 │   │          [--assignee <A>] [--op-sys <OS>] [--rep-platform <PLAT>]
-│   │          [--blocks <IDs>] [--depends-on <IDs>]
+│   │          [--blocks <IDs>] [--depends-on <IDs>] [--alias <A>] [--url <U>]
+│   │          [--whiteboard <W>] [--target-milestone <T>] [--deadline <DATE>]
+│   │          [--cc <C>...] [--keywords <K>...] [--groups <G>...] [--flag <F>...]
 │   ├── clone <ID> [--summary <S>] [--product <P>] [--component <C>] [--version <V>]
 │   │              [--description <D>] [--priority <P>] [--severity <S>] [--assignee <A>]
 │   │              [--op-sys <OS>] [--rep-platform <PLAT>]
@@ -439,7 +441,18 @@ bzr bug create --template security-bug --summary "XSS in login form"
 | `--rep-platform <PLAT>` | No | | Hardware platform (required by some Bugzilla installations) |
 | `--blocks <IDs>` | No | | Bug IDs this bug blocks (comma-separated) |
 | `--depends-on <IDs>` | No | | Bug IDs this bug depends on (comma-separated) |
+| `--alias <A>` | No | | Set an alias for the new bug |
+| `--url <U>` | No | | Set the URL field |
+| `--whiteboard <W>` | No | | Set the Status Whiteboard |
+| `--target-milestone <T>` | No | | Set the Target Milestone |
+| `--deadline <DATE>` | No | | Set the deadline (`YYYY-MM-DD`); malformed input exits 7 |
+| `--cc <C>` | No | | Add CC entries (comma-separated, repeatable) |
+| `--keywords <K>` | No | | Add keywords (comma-separated, repeatable) |
+| `--groups <G>` | No | | Add the bug to these groups (comma-separated, repeatable) |
+| `--flag <F>` | No | | Set/request a flag using Bugzilla flag syntax (repeatable): `name+`, `name-`, `name?`, `name?(user@example.com)` |
 | `--template <T>` | No | | Name of a saved template to use for default field values |
+
+These field flags give `bzr bug create` parity with `bzr bug update` for the subset Bugzilla's `Bug.create` accepts, so a bug and its metadata are filed in a single API call instead of a create-then-update two-step.
 
 *Required unless a template provides the value.
 **`--summary` is required unless the editor flow is active. The editor flow opens `$EDITOR` (or `vi` fallback) with a templated buffer when stdin is a TTY and no description source is supplied; the first non-empty line above the buffer's `# ------------------------ >8 ------------------------` sentinel divider becomes the summary, the rest becomes the description.

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -19,6 +19,44 @@ pub struct SortArgs {
     pub order: SortDirection,
 }
 
+/// Create-time field flags shared into `bug create`, giving it parity with
+/// `bug update` for the subset Bugzilla's `Bug.create` accepts in one call.
+/// Grouped into one flattened struct so the `Create` variant stays readable
+/// and the set is defined once.
+#[derive(Args, Debug, Clone, Default)]
+pub struct CreateFieldArgs {
+    /// Set an alias for the new bug.
+    #[arg(long)]
+    pub alias: Option<String>,
+    /// Set the URL field.
+    #[arg(long)]
+    pub url: Option<String>,
+    /// Set the Status Whiteboard.
+    #[arg(long)]
+    pub whiteboard: Option<String>,
+    /// Set the Target Milestone.
+    #[arg(long)]
+    pub target_milestone: Option<String>,
+    /// Set the deadline date (`YYYY-MM-DD`).
+    #[arg(long, value_name = "DATE")]
+    pub deadline: Option<String>,
+    /// Add CC entries (comma-separated, repeatable).
+    #[arg(long, value_delimiter = ',')]
+    pub cc: Vec<String>,
+    /// Add keywords (comma-separated, repeatable).
+    #[arg(long, value_delimiter = ',')]
+    pub keywords: Vec<String>,
+    /// Add the new bug to these groups (comma-separated, repeatable).
+    #[arg(long, value_delimiter = ',')]
+    pub groups: Vec<String>,
+    /// Set or request a flag using Bugzilla flag syntax (repeatable).
+    ///
+    /// Accepted forms: `name+` (granted), `name-` (denied), `name?`
+    /// (request), or `name?(user@example.com)` (request a specific user).
+    #[arg(long)]
+    pub flag: Vec<String>,
+}
+
 /// Shared `--fields` / `--exclude-fields` selection, flattened into the bug
 /// query subcommands (`list`, `view`, `search`, `my`) so the pair is defined
 /// once instead of repeated per variant.
@@ -381,10 +419,23 @@ pub enum BugAction {
     ///     # becomes the summary
     ///   bzr bug create --template security-bug --summary "XSS in login"
     ///
+    /// Field flags shared with `bug update` set the new bug's metadata
+    /// in the same `Bug.create` call (no follow-up update): `--alias`,
+    /// `--url`, `--whiteboard`, `--target-milestone`, `--deadline`,
+    /// `--cc`, `--keywords`, `--groups`, and `--flag`. The list flags
+    /// (`--cc`, `--keywords`, `--groups`) accept comma-separated values
+    /// and repeat; `--flag` uses Bugzilla flag syntax (`name+`, `name-`,
+    /// `name?`, `name?(user@example.com)`) and repeats. `--deadline`
+    /// takes a `YYYY-MM-DD` date.
+    ///
+    ///   bzr bug create --product P --component C --summary S \
+    ///     --description D --keywords regression,crash \
+    ///     --cc qa@example.com --flag review? --target-milestone 9.0
+    ///
     /// Exit codes: 0 on success, 4 on Bugzilla API error, 7 on
     /// input validation (missing --summary outside the editor flow,
     /// empty editor buffer, missing or non-UTF-8 --description-file,
-    /// $EDITOR exited non-zero), 9 on auth failure.
+    /// malformed --deadline, $EDITOR exited non-zero), 9 on auth failure.
     ///
     /// See bzr-bug-clone(1) for cloning an existing bug,
     /// bzr-template(1) for managing templates, and bzr-field(1) for
@@ -454,6 +505,8 @@ pub enum BugAction {
         /// Bug IDs that this bug depends on (comma-separated)
         #[arg(long, value_delimiter = ',')]
         depends_on: Vec<u64>,
+        #[command(flatten)]
+        create_fields: CreateFieldArgs,
     },
     /// Show bugs related to the authenticated user.
     ///

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,7 +13,7 @@ mod template;
 mod user;
 
 pub use attachment::AttachmentAction;
-pub use bug::{BugAction, FieldArgs, SortArgs};
+pub use bug::{BugAction, CreateFieldArgs, FieldArgs, SortArgs};
 pub use classification::ClassificationAction;
 pub use comment::CommentAction;
 pub use component::ComponentAction;

--- a/src/commands/bug/clone.rs
+++ b/src/commands/bug/clone.rs
@@ -82,6 +82,7 @@ pub(super) async fn handle(
         } else {
             source.keywords
         },
+        ..Default::default()
     };
 
     let new_id = client.create_bug(&params).await?;

--- a/src/commands/bug/create.rs
+++ b/src/commands/bug/create.rs
@@ -29,21 +29,16 @@ impl MergedFields {
         CreateBugParams {
             product: self.product.clone(),
             component: self.component.clone(),
-            summary: String::new(),
             version: self
                 .version
                 .clone()
                 .unwrap_or_else(|| "unspecified".to_string()),
-            description: None,
             priority: self.priority.clone(),
             severity: self.severity.clone(),
             assigned_to: self.assigned_to.clone(),
             op_sys: self.op_sys.clone(),
             rep_platform: self.rep_platform.clone(),
-            blocks: vec![],
-            depends_on: vec![],
-            cc: vec![],
-            keywords: vec![],
+            ..Default::default()
         }
     }
 }
@@ -244,11 +239,18 @@ pub(super) async fn handle(
         description_file,
         blocks,
         depends_on,
+        create_fields,
         ..
     } = action
     else {
         unreachable!()
     };
+
+    let flags = crate::commands::flags::parse_flags(&create_fields.flag)?;
+    let deadline = crate::validation::parse_optional_date_only(
+        create_fields.deadline.as_deref(),
+        "--deadline",
+    )?;
 
     let resolved_description =
         resolve_description(description.as_deref(), description_file.as_deref())?;
@@ -282,10 +284,17 @@ pub(super) async fn handle(
         assigned_to: merged.assigned_to,
         op_sys: merged.op_sys,
         rep_platform: merged.rep_platform,
+        alias: create_fields.alias.clone(),
+        url: create_fields.url.clone(),
+        whiteboard: create_fields.whiteboard.clone(),
+        target_milestone: create_fields.target_milestone.clone(),
+        deadline,
         blocks: blocks.clone(),
         depends_on: depends_on.clone(),
-        cc: vec![],
-        keywords: vec![],
+        cc: create_fields.cc.clone(),
+        keywords: create_fields.keywords.clone(),
+        groups: create_fields.groups.clone(),
+        flags,
     };
     let id = client.create_bug(&params).await?;
     write_result(

--- a/src/commands/bug/create_tests.rs
+++ b/src/commands/bug/create_tests.rs
@@ -26,6 +26,7 @@ fn create_action() -> BugAction {
         rep_platform: None,
         blocks: vec![],
         depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs::default(),
     }
 }
 
@@ -60,6 +61,107 @@ async fn bug_create_sends_post() {
 }
 
 #[tokio::test]
+async fn bug_create_sends_parity_fields_in_body() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    // Every parity field must appear in the POST body. A request missing any
+    // of these matchers won't match the mock, so the call would 404 and fail.
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .and(body_string_contains("\"alias\":\"a-1\""))
+        .and(body_string_contains(
+            "\"url\":\"https://example.com/repro\"",
+        ))
+        .and(body_string_contains("\"whiteboard\":\"needs-triage\""))
+        .and(body_string_contains("\"target_milestone\":\"M1\""))
+        .and(body_string_contains("\"deadline\":\"2026-12-31\""))
+        .and(body_string_contains("\"cc\":[\"cc@example.com\"]"))
+        .and(body_string_contains("\"keywords\":[\"regression\"]"))
+        .and(body_string_contains("\"groups\":[\"security\"]"))
+        .and(body_string_contains(
+            "\"flags\":[{\"name\":\"review\",\"status\":\"+\"}]",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 123})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = BugAction::Create {
+        template: None,
+        product: Some("TestProduct".into()),
+        component: Some("General".into()),
+        summary: Some("New bug".into()),
+        version: Some("unspecified".into()),
+        description: Some("body".into()),
+        description_file: None,
+        priority: None,
+        severity: None,
+        assignee: None,
+        op_sys: None,
+        rep_platform: None,
+        blocks: vec![],
+        depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs {
+            alias: Some("a-1".into()),
+            url: Some("https://example.com/repro".into()),
+            whiteboard: Some("needs-triage".into()),
+            target_milestone: Some("M1".into()),
+            deadline: Some("2026-12-31".into()),
+            cc: vec!["cc@example.com".into()],
+            keywords: vec!["regression".into()],
+            groups: vec!["security".into()],
+            flag: vec!["review+".into()],
+        },
+    };
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    assert!(
+        result.is_ok(),
+        "create with parity fields failed: {result:?}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    assert_eq!(parsed["id"], 123);
+}
+
+#[tokio::test]
+async fn bug_create_rejects_malformed_deadline() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let action = BugAction::Create {
+        template: None,
+        product: Some("TestProduct".into()),
+        component: Some("General".into()),
+        summary: Some("New bug".into()),
+        version: Some("unspecified".into()),
+        description: Some("body".into()),
+        description_file: None,
+        priority: None,
+        severity: None,
+        assignee: None,
+        op_sys: None,
+        rep_platform: None,
+        blocks: vec![],
+        depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs {
+            deadline: Some("not-a-date".into()),
+            ..Default::default()
+        },
+    };
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    let err = result.unwrap_err();
+    assert!(
+        matches!(&err, BzrError::InputValidation(msg) if msg.contains("--deadline")),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn bug_create_missing_product_returns_input_validation() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
@@ -78,6 +180,7 @@ async fn bug_create_missing_product_returns_input_validation() {
         rep_platform: None,
         blocks: vec![],
         depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs::default(),
     };
     let mut __io2 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -115,6 +218,7 @@ async fn bug_create_missing_component_returns_input_validation() {
         rep_platform: None,
         blocks: vec![],
         depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs::default(),
     };
     let mut __io3 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -152,6 +256,7 @@ async fn bug_create_with_unknown_template_errors() {
         rep_platform: None,
         blocks: vec![],
         depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs::default(),
     };
     let mut __io4 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -227,6 +332,7 @@ async fn bug_create_with_template_fills_missing_fields() {
         rep_platform: None,
         blocks: vec![],
         depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs::default(),
     };
     let mut __io6 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -279,6 +385,7 @@ async fn bug_create_reads_description_from_file() {
         rep_platform: None,
         blocks: vec![],
         depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs::default(),
     };
     let mut __io7 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -313,6 +420,7 @@ async fn bug_create_description_file_missing_returns_input_validation() {
         rep_platform: None,
         blocks: vec![],
         depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs::default(),
     };
     let mut __io8 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -354,6 +462,7 @@ async fn bug_create_description_file_non_utf8_returns_input_validation() {
         rep_platform: None,
         blocks: vec![],
         depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs::default(),
     };
     let mut __io9 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -392,6 +501,7 @@ async fn bug_create_missing_summary_without_editor_flow_is_rejected() {
         rep_platform: None,
         blocks: vec![],
         depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs::default(),
     };
     let mut __io10 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -503,6 +613,13 @@ fn build_editor_template_includes_summary_and_field_reminder() {
         depends_on: vec![],
         cc: vec![],
         keywords: vec![],
+        alias: None,
+        url: None,
+        whiteboard: None,
+        target_milestone: None,
+        deadline: None,
+        groups: vec![],
+        flags: vec![],
     };
     let buf = super::build_editor_template(Some("Pre-filled summary"), None, &params);
     assert!(buf.starts_with("Pre-filled summary\n"));
@@ -531,6 +648,13 @@ fn build_editor_template_includes_template_description_body() {
         depends_on: vec![],
         cc: vec![],
         keywords: vec![],
+        alias: None,
+        url: None,
+        whiteboard: None,
+        target_milestone: None,
+        deadline: None,
+        groups: vec![],
+        flags: vec![],
     };
     let buf = super::build_editor_template(None, Some("## Steps\n\n## Expected"), &params);
     assert!(buf.contains("## Steps"));
@@ -569,6 +693,7 @@ fn editor_action_no_summary_no_description() -> BugAction {
         rep_platform: None,
         blocks: vec![],
         depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs::default(),
     }
 }
 
@@ -740,6 +865,7 @@ async fn bug_create_template_description_does_not_fall_back_outside_editor_flow(
         rep_platform: None,
         blocks: vec![],
         depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs::default(),
     };
     let mut __io14 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -596,7 +596,7 @@ pub const FIELD_MAPPINGS: &[FieldMapping] = &[
     },
 ];
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 #[non_exhaustive]
 pub struct CreateBugParams {
     pub product: String,
@@ -615,6 +615,16 @@ pub struct CreateBugParams {
     pub op_sys: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rep_platform: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub whiteboard: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_milestone: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deadline: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub blocks: Vec<u64>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -623,6 +633,10 @@ pub struct CreateBugParams {
     pub cc: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub keywords: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub groups: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub flags: Vec<FlagUpdate>,
 }
 
 /// Represents an incremental update to a list field (blocks, `depends_on`).

--- a/src/types/bug_tests.rs
+++ b/src/types/bug_tests.rs
@@ -1155,3 +1155,70 @@ fn update_bug_params_serializes_comment_is_private_map() {
         serde_json::Value::Bool(true)
     );
 }
+
+/// Minimal create params (only the required fields) must not emit any of the
+/// optional parity fields, so the server applies its own defaults.
+fn minimal_create_params() -> CreateBugParams {
+    CreateBugParams {
+        product: "Prod".into(),
+        component: "Comp".into(),
+        summary: "Sum".into(),
+        version: "1.0".into(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn create_params_omit_unset_parity_fields() {
+    let json = serde_json::to_value(minimal_create_params()).unwrap();
+    let obj = json.as_object().unwrap();
+    for key in [
+        "alias",
+        "url",
+        "whiteboard",
+        "target_milestone",
+        "deadline",
+        "cc",
+        "keywords",
+        "groups",
+        "flags",
+    ] {
+        assert!(
+            !obj.contains_key(key),
+            "unset field '{key}' must be omitted"
+        );
+    }
+}
+
+#[test]
+fn create_params_serialize_parity_fields() {
+    let params = CreateBugParams {
+        alias: Some("my-alias".into()),
+        url: Some("https://example.com/repro".into()),
+        whiteboard: Some("needs-triage".into()),
+        target_milestone: Some("M1".into()),
+        deadline: Some("2026-12-31".into()),
+        cc: vec!["a@example.com".into(), "b@example.com".into()],
+        keywords: vec!["regression".into()],
+        groups: vec!["security".into()],
+        flags: vec![FlagUpdate {
+            name: "review".into(),
+            status: crate::types::FlagStatus::Grant,
+            requestee: None,
+        }],
+        ..minimal_create_params()
+    };
+    let json = serde_json::to_value(&params).unwrap();
+    assert_eq!(json["alias"], "my-alias");
+    assert_eq!(json["url"], "https://example.com/repro");
+    assert_eq!(json["whiteboard"], "needs-triage");
+    assert_eq!(json["target_milestone"], "M1");
+    assert_eq!(json["deadline"], "2026-12-31");
+    assert_eq!(json["cc"][0], "a@example.com");
+    assert_eq!(json["cc"][1], "b@example.com");
+    assert_eq!(json["keywords"][0], "regression");
+    assert_eq!(json["groups"][0], "security");
+    // Flags serialize as the Bug.create array shape: {name, status}.
+    assert_eq!(json["flags"][0]["name"], "review");
+    assert_eq!(json["flags"][0]["status"], "+");
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -235,6 +235,7 @@ async fn bug_create_integration() {
         rep_platform: None,
         blocks: vec![],
         depends_on: vec![],
+        create_fields: bzr::cli::CreateFieldArgs::default(),
     };
     let mut __io5 = bzr::test_helpers::CapturedIo::new();
     let result = bzr::commands::bug::execute(


### PR DESCRIPTION
## Summary

Gives `bzr bug create` field parity with `bzr bug update` for the subset Bugzilla's `Bug.create` accepts, so a bug and its metadata are filed in a single API call instead of a forced create-then-update two-step (which doubled round-trips and the failure surface for agents).

| Issue | Title | Type | Files Changed |
|-------|-------|------|---------------|
| #301 | bug create field parity with bug update | feat | `src/cli/bug.rs`, `src/commands/bug/create.rs`, `src/types/bug.rs`, `src/commands/bug/clone.rs` |

## New flags on `bug create`

`--alias`, `--url`, `--whiteboard`, `--target-milestone`, `--deadline`, `--cc`, `--keywords`, `--groups`, `--flag`. All nine are documented `Bug.create` parameters in the Bugzilla REST API and are sent in the same create call — no follow-up update needed.

- List flags (`--cc`, `--keywords`, `--groups`) accept comma-separated, repeatable values, serialized as flat arrays (the correct `Bug.create` shape — there's no prior state to add/remove against at create time, unlike `bug update`'s `{add, remove}` deltas).
- `--flag` reuses the shared Bugzilla flag-syntax parser (`name+`, `name-`, `name?`, `name?(user@example.com)`).
- `--deadline` reuses the shared `YYYY-MM-DD` validator and rejects malformed input with exit 7 **before** any network call.

## Implementation notes

- Flags are grouped into a flattened clap `CreateFieldArgs` struct (mirroring the existing `FieldArgs`/`SortArgs` pattern) to keep the `Create` variant readable.
- `CreateBugParams` and `UpdateBugParams` stay separate types: their list-field wire shapes differ (flat arrays vs add/remove deltas), so a shared base would only cover a few scalar fields while entangling two serialization contracts.
- `CreateBugParams` now derives `Default`, collapsing the hand-written field defaults in the editor-preview and clone construction paths.

## Review notes

- Verified against the Bugzilla 5.2 REST docs that all nine fields are valid `Bug.create` parameters, and that the API errors on unknown fields rather than silently dropping them. Permission-gated fields (`--deadline`, `--groups`) may be silently ignored by the server when the caller lacks permission — documented Bugzilla behavior, identical to `bug update`.

## Test coverage

- `CreateBugParams` serialization: parity fields emit correct JSON keys/values; unset fields are omitted (`skip_serializing_if`).
- Command-level: `bug create` with every parity flag set sends them all in the POST body (wiremock body matchers); malformed `--deadline` exits 7 before any request.

## Validation

`cargo test --features test-helpers` (1386 lib + 78 integration) and `cargo clippy --locked --features test-helpers -- -D warnings` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
