### PR TITLE
feat(bug): add resolve/close/reopen/dup convenience verbs (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Convenience verbs over `bzr bug update` for the common state transitions:
+  `bzr bug resolve <ID...> [--as <RESOLUTION>]` (defaults to `FIXED`),
+  `bzr bug close <ID...> [--as <RESOLUTION>]`, `bzr bug reopen <ID...>`, and
+  `bzr bug dup <ID> <TARGET>`. Each is thin sugar that builds the equivalent
+  `Bug.update` and inherits its batch (multi-ID, partial-failure exit 11) and
+  `--comment` / `--comment-file` / `--comment-private` behavior. (#309)
 - `bzr bug create` gains field flags shared with `bug update`: `--alias`,
   `--url`, `--whiteboard`, `--target-milestone`, `--deadline`, `--cc`,
   `--keywords`, `--groups`, and `--flag`. They are sent in the same

--- a/agent-skills/skills/bzr-reference/reference/commands.md
+++ b/agent-skills/skills/bzr-reference/reference/commands.md
@@ -10,6 +10,7 @@ Operate on bugs.
 - `bzr bug create --product Foo --component bar --summary "..." --description "..."`
 - `bzr bug clone 12345`
 - `bzr bug update 12345 --status RESOLVED --resolution FIXED --flag "review+(a@b.com)"`
+- `bzr bug resolve 12345 [--as WONTFIX]` / `close` / `reopen` / `dup 12345 100` (sugar over `update`)
 - `bzr bug history 12345 [--since 2025-01-01]`
 - `bzr bug my [--status \!CLOSED]`
 

--- a/agent-skills/skills/bzr-reference/reference/commands.yml
+++ b/agent-skills/skills/bzr-reference/reference/commands.yml
@@ -1,6 +1,6 @@
 # bzr command manifest — authored against bzr 0.4.4.
 # Format: "<group>: <verb> <verb> ...". Consumed by tests/drift-check.sh.
-bug: list view search create clone update history my
+bug: list view search create clone update history my resolve close reopen dup
 comment: list add tag search-tags
 attachment: list view download upload update
 config: set-server show set-default set-keyring unset-keyring migrate-to-keyring remove-server rename-server

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -104,14 +104,18 @@ bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-col
 │   │              [--description <D>] [--priority <P>] [--severity <S>] [--assignee <A>]
 │   │              [--op-sys <OS>] [--rep-platform <PLAT>]
 │   │              [--no-comment] [--add-depends-on] [--add-blocks] [--no-cc] [--no-keywords]
-│   └── update <ID...> [--status <S>] [--resolution <R>] [--assignee <A>]
-│                       [--priority <P>] [--severity <S>] [--summary <S>]
-│                       [--alias <A>] [--deadline <DATE>] [--estimated-time <HOURS>]
-│                       [--remaining-time <HOURS>] [--work-time <HOURS>]
-│                       [--whiteboard <W>] [--reset-assigned-to] [--reset-qa-contact]
-│                       [--flag <F>...] [--blocks-add <IDs>]
-│                       [--blocks-remove <IDs>] [--depends-on-add <IDs>]
-│                       [--depends-on-remove <IDs>]
+│   ├── update <ID...> [--status <S>] [--resolution <R>] [--assignee <A>]
+│   │                   [--priority <P>] [--severity <S>] [--summary <S>]
+│   │                   [--alias <A>] [--deadline <DATE>] [--estimated-time <HOURS>]
+│   │                   [--remaining-time <HOURS>] [--work-time <HOURS>]
+│   │                   [--whiteboard <W>] [--reset-assigned-to] [--reset-qa-contact]
+│   │                   [--flag <F>...] [--blocks-add <IDs>]
+│   │                   [--blocks-remove <IDs>] [--depends-on-add <IDs>]
+│   │                   [--depends-on-remove <IDs>]
+│   ├── resolve <ID...> [--as <RESOLUTION>] [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
+│   ├── close <ID...> [--as <RESOLUTION>] [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
+│   ├── reopen <ID...> [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
+│   └── dup <ID> <TARGET> [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
 ├── comment
 │   ├── list <BUG_ID> [--since <DATE>]
 │   ├── add <BUG_ID> [--body <TEXT>] [--body-file <PATH>]
@@ -576,6 +580,35 @@ bzr bug update 100 200 300 --status RESOLVED --resolution WONTFIX
 When updating multiple bugs, failures on individual bugs do not abort the batch. A summary is printed showing which bugs succeeded and which failed.
 
 Agent note: before automated status, priority, severity, or resolution changes, validate allowed values with `bzr field list <field>`, for example `bzr field list status` or `bzr field list resolution`.
+
+### `bzr bug resolve` / `close` / `reopen` / `dup`
+
+Convenience verbs — thin sugar over `bzr bug update` for the common state
+transitions, so you don't have to spell out `--status`/`--resolution` each
+time. Each accepts multiple IDs (batch, except `dup`) and the same
+`--comment` / `--comment-file` / `--comment-private` flags as `bug update`,
+posting the comment atomically with the change. Batch behavior (per-bug
+partial-failure reporting, exit code 11) is inherited from `bug update`.
+
+```bash
+bzr bug resolve 12345                       # → update --status RESOLVED --resolution FIXED
+bzr bug resolve 12345 12346 --as WONTFIX    # batch, custom resolution
+bzr bug close 12345 --comment "Shipped"     # → update --status CLOSED (resolution preserved)
+bzr bug close 12345 --as INVALID            # close an open bug with a resolution
+bzr bug reopen 12345                         # → update --status REOPENED
+bzr bug dup 12345 100                        # → update --dupe-of 100
+```
+
+| Verb | Equivalent `update` | Notes |
+|------|---------------------|-------|
+| `resolve <ID...> [--as <R>]` | `--status RESOLVED --resolution <R>` | `--as` defaults to `FIXED` |
+| `close <ID...> [--as <R>]` | `--status CLOSED [--resolution <R>]` | resolution set only when `--as` is given, otherwise the existing one is preserved |
+| `reopen <ID...>` | `--status REOPENED` | Bugzilla clears the resolution automatically |
+| `dup <ID> <TARGET>` | `--dupe-of <TARGET>` | Bugzilla sets RESOLVED/DUPLICATE automatically |
+
+The status strings (`RESOLVED`, `CLOSED`, `REOPENED`) follow the conventional
+Bugzilla workflow; on a server with a customized workflow, an unsupported
+transition fails with the same server error `bug update` would return.
 
 ---
 

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -57,6 +57,28 @@ pub struct CreateFieldArgs {
     pub flag: Vec<String>,
 }
 
+/// Shared comment flags for the convenience verbs (`resolve`, `close`,
+/// `reopen`, `dup`), which post a comment atomically with the state change —
+/// the same `--comment` / `--comment-file` / `--comment-private` set `bug
+/// update` accepts.
+#[derive(Args, Debug, Clone, Default)]
+pub struct CommentArgs {
+    /// Post a comment atomically with the change.
+    ///
+    /// A value of `-` reads the comment from stdin. Mutually exclusive
+    /// with `--comment-file`. Empty / whitespace-only bodies exit 7.
+    #[arg(long, value_name = "BODY", conflicts_with = "comment_file")]
+    pub comment: Option<String>,
+    /// Read the comment body from a UTF-8 file.
+    ///
+    /// A path of `-` reads from stdin. Mutually exclusive with `--comment`.
+    #[arg(long, value_name = "PATH", conflicts_with = "comment")]
+    pub comment_file: Option<std::path::PathBuf>,
+    /// Mark the comment private (requires `--comment` or `--comment-file`).
+    #[arg(long)]
+    pub comment_private: bool,
+}
+
 /// Shared `--fields` / `--exclude-fields` selection, flattened into the bug
 /// query subcommands (`list`, `view`, `search`, `my`) so the pair is defined
 /// once instead of repeated per variant.
@@ -846,5 +868,88 @@ pub enum BugAction {
         /// Repeat the flag to remove multiple URLs.
         #[arg(long)]
         see_also_remove: Vec<String>,
+    },
+    /// Resolve one or more bugs (sets status RESOLVED + a resolution).
+    ///
+    /// Sugar for `bug update <IDs> --status RESOLVED --resolution <AS>`.
+    /// `--as` defaults to `FIXED`; pass another resolution (`WONTFIX`,
+    /// `INVALID`, `WORKSFORME`, `DUPLICATE`, ...) to override. Accepts
+    /// multiple IDs (batch) and the same `--comment` flags as `bug update`.
+    ///
+    /// Examples:
+    ///
+    ///   bzr bug resolve 12345
+    ///   bzr bug resolve 12345 12346 --as WONTFIX
+    ///   bzr bug resolve 12345 --comment "Fixed in 9.1"
+    #[command(verbatim_doc_comment)]
+    Resolve {
+        /// Bug ID(s) to resolve.
+        #[arg(required = true, num_args = 1..)]
+        ids: Vec<u64>,
+        /// Resolution to set (default `FIXED`).
+        #[arg(long = "as", value_name = "RESOLUTION", default_value = "FIXED")]
+        as_resolution: String,
+        #[command(flatten)]
+        comment: CommentArgs,
+    },
+    /// Close one or more bugs (sets status CLOSED).
+    ///
+    /// Sugar for `bug update <IDs> --status CLOSED`. By default the bug's
+    /// existing resolution is preserved (so close an already-resolved bug);
+    /// pass `--as <RESOLUTION>` to set one when closing directly. Accepts
+    /// multiple IDs (batch) and the same `--comment` flags as `bug update`.
+    ///
+    /// Examples:
+    ///
+    ///   bzr bug close 12345
+    ///   bzr bug close 12345 12346 --as WONTFIX --comment "Out of scope"
+    #[command(verbatim_doc_comment)]
+    Close {
+        /// Bug ID(s) to close.
+        #[arg(required = true, num_args = 1..)]
+        ids: Vec<u64>,
+        /// Resolution to set when closing an unresolved bug. Omit to
+        /// preserve any existing resolution.
+        #[arg(long = "as", value_name = "RESOLUTION")]
+        as_resolution: Option<String>,
+        #[command(flatten)]
+        comment: CommentArgs,
+    },
+    /// Reopen one or more bugs (sets status REOPENED).
+    ///
+    /// Sugar for `bug update <IDs> --status REOPENED`. Bugzilla clears the
+    /// resolution automatically on reopen. Accepts multiple IDs (batch) and
+    /// the same `--comment` flags as `bug update`.
+    ///
+    /// Examples:
+    ///
+    ///   bzr bug reopen 12345
+    ///   bzr bug reopen 12345 --comment "Regressed in 9.2"
+    #[command(verbatim_doc_comment)]
+    Reopen {
+        /// Bug ID(s) to reopen.
+        #[arg(required = true, num_args = 1..)]
+        ids: Vec<u64>,
+        #[command(flatten)]
+        comment: CommentArgs,
+    },
+    /// Mark a bug as a duplicate of another bug.
+    ///
+    /// Sugar for `bug update <ID> --dupe-of <TARGET>`. Bugzilla sets the
+    /// status/resolution transition (RESOLVED/DUPLICATE) automatically.
+    /// Supports the same `--comment` flags as `bug update`.
+    ///
+    /// Examples:
+    ///
+    ///   bzr bug dup 12345 100
+    ///   bzr bug dup 12345 100 --comment "Same root cause"
+    #[command(verbatim_doc_comment)]
+    Dup {
+        /// The duplicate bug.
+        id: u64,
+        /// The canonical bug this one duplicates.
+        target: u64,
+        #[command(flatten)]
+        comment: CommentArgs,
     },
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,7 +13,7 @@ mod template;
 mod user;
 
 pub use attachment::AttachmentAction;
-pub use bug::{BugAction, CreateFieldArgs, FieldArgs, SortArgs};
+pub use bug::{BugAction, CommentArgs, CreateFieldArgs, FieldArgs, SortArgs};
 pub use classification::ClassificationAction;
 pub use comment::CommentAction;
 pub use component::ComponentAction;

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -15,6 +15,7 @@ mod list;
 mod my;
 mod search;
 mod update;
+mod verbs;
 mod view;
 
 /// The `--fields` / `--exclude-fields` column spec for the four field-bearing
@@ -96,6 +97,10 @@ pub async fn execute(
         BugAction::Create { .. } => create::handle(&client, action, format, w).await,
         BugAction::Clone { .. } => clone::handle(&client, action, format, w).await,
         BugAction::Update { .. } => update::handle(&client, action, format, w).await,
+        BugAction::Resolve { .. }
+        | BugAction::Close { .. }
+        | BugAction::Reopen { .. }
+        | BugAction::Dup { .. } => verbs::handle(&client, action, format, w).await,
         BugAction::Search { .. } => unreachable!("handled above"),
     }
 }

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -62,7 +62,7 @@ fn string_list_update(
     })
 }
 
-fn resolve_comment(
+pub(super) fn resolve_comment(
     comment: Option<&str>,
     comment_file: Option<&std::path::Path>,
     comment_private: bool,
@@ -291,6 +291,19 @@ pub(super) async fn handle(
     w: &mut Writers<'_>,
 ) -> Result<()> {
     let (ids, params) = build_update_params(action)?;
+    apply(client, ids, params, format, w).await
+}
+
+/// Apply an already-built `UpdateBugParams` to one or more bug IDs, dispatching
+/// to the single- or batch-update path. Shared by `bug update` and the
+/// convenience verbs (`resolve`/`close`/`reopen`/`dup`).
+pub(super) async fn apply(
+    client: &BugzillaClient,
+    ids: Vec<u64>,
+    params: UpdateBugParams,
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) -> Result<()> {
     if ids.len() == 1 {
         update_single(client, ids[0], &params, format, w).await
     } else {

--- a/src/commands/bug/verbs.rs
+++ b/src/commands/bug/verbs.rs
@@ -1,0 +1,83 @@
+//! Convenience verbs (`resolve`, `close`, `reopen`, `dup`) — thin sugar over
+//! `bug update`. Each builds an `UpdateBugParams` for the common state
+//! transition and delegates to the shared `update::apply` path, inheriting its
+//! batch, comment, and partial-failure behavior.
+
+use crate::cli::{BugAction, CommentArgs};
+use crate::client::BugzillaClient;
+use crate::error::Result;
+use crate::output::writers::Writers;
+use crate::types::{CommentUpdate, OutputFormat, UpdateBugParams};
+
+/// Resolve the `CommentArgs` into an optional `CommentUpdate`, reusing the same
+/// stdin/file/private handling as `bug update`.
+fn comment_update(args: &CommentArgs) -> Result<Option<CommentUpdate>> {
+    super::update::resolve_comment(
+        args.comment.as_deref(),
+        args.comment_file.as_deref(),
+        args.comment_private,
+    )
+}
+
+pub(super) async fn handle(
+    client: &BugzillaClient,
+    action: &BugAction,
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) -> Result<()> {
+    let (ids, params) = match action {
+        BugAction::Resolve {
+            ids,
+            as_resolution,
+            comment,
+        } => (
+            ids.clone(),
+            UpdateBugParams {
+                status: Some("RESOLVED".into()),
+                resolution: Some(as_resolution.clone()),
+                comment: comment_update(comment)?,
+                ..Default::default()
+            },
+        ),
+        BugAction::Close {
+            ids,
+            as_resolution,
+            comment,
+        } => (
+            ids.clone(),
+            UpdateBugParams {
+                status: Some("CLOSED".into()),
+                resolution: as_resolution.clone(),
+                comment: comment_update(comment)?,
+                ..Default::default()
+            },
+        ),
+        BugAction::Reopen { ids, comment } => (
+            ids.clone(),
+            UpdateBugParams {
+                status: Some("REOPENED".into()),
+                comment: comment_update(comment)?,
+                ..Default::default()
+            },
+        ),
+        BugAction::Dup {
+            id,
+            target,
+            comment,
+        } => (
+            vec![*id],
+            UpdateBugParams {
+                dupe_of: Some(*target),
+                comment: comment_update(comment)?,
+                ..Default::default()
+            },
+        ),
+        _ => unreachable!("verbs::handle called with non-verb action"),
+    };
+
+    super::update::apply(client, ids, params, format, w).await
+}
+
+#[cfg(test)]
+#[path = "verbs_tests.rs"]
+mod tests;

--- a/src/commands/bug/verbs_tests.rs
+++ b/src/commands/bug/verbs_tests.rs
@@ -1,0 +1,184 @@
+#![expect(clippy::unwrap_used)]
+
+use wiremock::matchers::{body_json, method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+use crate::cli::{BugAction, CommentArgs};
+use crate::test_helpers::setup_test_env;
+use crate::types::OutputFormat;
+
+fn ok_put(id: u64) -> ResponseTemplate {
+    ResponseTemplate::new(200)
+        .set_body_json(serde_json::json!({"bugs": [{"id": id, "changes": {}}]}))
+}
+
+/// Mount a PUT mock on `/rest/bug/{id}` asserting the exact JSON body, then run
+/// `execute` for `action` and assert success.
+async fn run_verb_expecting_body(action: BugAction, id: u64, body: serde_json::Value) {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("PUT"))
+        .and(path(format!("/rest/bug/{id}")))
+        .and(body_json(body))
+        .respond_with(ok_put(id))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    assert!(result.is_ok(), "verb failed: {:?}", result.err());
+}
+
+#[tokio::test]
+async fn resolve_defaults_to_fixed() {
+    let action = BugAction::Resolve {
+        ids: vec![5],
+        as_resolution: "FIXED".into(),
+        comment: CommentArgs::default(),
+    };
+    run_verb_expecting_body(
+        action,
+        5,
+        serde_json::json!({"status": "RESOLVED", "resolution": "FIXED"}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn resolve_with_as_override() {
+    let action = BugAction::Resolve {
+        ids: vec![7],
+        as_resolution: "WONTFIX".into(),
+        comment: CommentArgs::default(),
+    };
+    run_verb_expecting_body(
+        action,
+        7,
+        serde_json::json!({"status": "RESOLVED", "resolution": "WONTFIX"}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn close_without_resolution_preserves_existing() {
+    let action = BugAction::Close {
+        ids: vec![9],
+        as_resolution: None,
+        comment: CommentArgs::default(),
+    };
+    // No resolution key — the server keeps any existing resolution.
+    run_verb_expecting_body(action, 9, serde_json::json!({"status": "CLOSED"})).await;
+}
+
+#[tokio::test]
+async fn close_with_as_sets_resolution() {
+    let action = BugAction::Close {
+        ids: vec![9],
+        as_resolution: Some("WONTFIX".into()),
+        comment: CommentArgs::default(),
+    };
+    run_verb_expecting_body(
+        action,
+        9,
+        serde_json::json!({"status": "CLOSED", "resolution": "WONTFIX"}),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn reopen_sends_reopened_status() {
+    let action = BugAction::Reopen {
+        ids: vec![3],
+        comment: CommentArgs::default(),
+    };
+    run_verb_expecting_body(action, 3, serde_json::json!({"status": "REOPENED"})).await;
+}
+
+#[tokio::test]
+async fn dup_sends_dupe_of() {
+    let action = BugAction::Dup {
+        id: 12,
+        target: 100,
+        comment: CommentArgs::default(),
+    };
+    run_verb_expecting_body(action, 12, serde_json::json!({"dupe_of": 100})).await;
+}
+
+#[tokio::test]
+async fn resolve_posts_comment_atomically() {
+    let action = BugAction::Resolve {
+        ids: vec![5],
+        as_resolution: "FIXED".into(),
+        comment: CommentArgs {
+            comment: Some("done in 9.1".into()),
+            comment_file: None,
+            comment_private: false,
+        },
+    };
+    run_verb_expecting_body(
+        action,
+        5,
+        // is_private is omitted when false (skip_serializing_if).
+        serde_json::json!({
+            "status": "RESOLVED",
+            "resolution": "FIXED",
+            "comment": {"body": "done in 9.1"}
+        }),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn resolve_batch_updates_each_id() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    for id in [1_u64, 2] {
+        Mock::given(method("PUT"))
+            .and(path(format!("/rest/bug/{id}")))
+            .and(body_json(
+                serde_json::json!({"status": "RESOLVED", "resolution": "FIXED"}),
+            ))
+            .respond_with(ok_put(id))
+            .expect(1)
+            .mount(&mock)
+            .await;
+    }
+
+    let action = BugAction::Resolve {
+        ids: vec![1, 2],
+        as_resolution: "FIXED".into(),
+        comment: CommentArgs::default(),
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    assert!(result.is_ok(), "batch resolve failed: {:?}", result.err());
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    // Batch JSON shape from update_batch / BatchResult.
+    assert_eq!(parsed["succeeded"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn close_private_comment_without_body_is_rejected() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    let action = BugAction::Close {
+        ids: vec![5],
+        as_resolution: None,
+        comment: CommentArgs {
+            comment: None,
+            comment_file: None,
+            comment_private: true,
+        },
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    let err = result.unwrap_err();
+    assert!(
+        matches!(&err, crate::error::BzrError::InputValidation(m) if m.contains("--comment-private")),
+        "got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the `gh issue close`/`reopen`-style convenience verbs for the most common Bugzilla state transitions, so they no longer require the verbose `bzr bug update <ID> --status … --resolution …`.

| Issue | Title | Type | Files Changed |
|-------|-------|------|---------------|
| #309 | Convenience verbs (resolve/close/reopen/dup) | feat | `src/cli/bug.rs`, `src/commands/bug/verbs.rs` (new), `src/commands/bug/update.rs`, `src/commands/bug/mod.rs` |

## Verbs

| Verb | Equivalent `update` | Notes |
|------|---------------------|-------|
| `bug resolve <ID...> [--as <R>]` | `--status RESOLVED --resolution <R>` | `--as` defaults to `FIXED` |
| `bug close <ID...> [--as <R>]` | `--status CLOSED [--resolution <R>]` | resolution set only with `--as`; otherwise the existing one is preserved (no silent overwrite) |
| `bug reopen <ID...>` | `--status REOPENED` | Bugzilla clears the resolution automatically |
| `bug dup <ID> <TARGET>` | `--dupe-of <TARGET>` | Bugzilla sets RESOLVED/DUPLICATE automatically |

All accept multiple IDs (batch, except `dup`) and the same `--comment` / `--comment-file` / `--comment-private` flags as `bug update`, posting the comment atomically with the change.

## Implementation notes

- Each verb is **thin sugar**: it builds an `UpdateBugParams` and delegates to a newly-extracted `update::apply` (the single-vs-batch dispatch). This inherits `bug update`'s batch behavior, partial-failure reporting (exit 11), output formatting, and atomic-comment handling — no update logic is duplicated.
- `resolve_comment` is shared via `pub(super)` (both modules are children of `commands::bug`); comment flags are factored into a flattened `CommentArgs` clap struct.
- The comment is resolved **once** before batch dispatch, so a `--comment -` (stdin) read happens once and applies to every ID.

## Review notes

- The status strings (`RESOLVED`/`CLOSED`/`REOPENED`) follow the conventional Bugzilla workflow. On a server with a customized workflow, an unsupported transition fails with the same server error the equivalent `bug update` would return — which is exactly the documented thin-wrapper contract. Called out in `docs/bzr-cli.md`.
- `close` deliberately omits the resolution key unless `--as` is given, so closing an already-resolved bug never overwrites its resolution.

## Test coverage

Each verb's exact PUT body (status/resolution/dupe_of), `--as` override, default FIXED, atomic comment, batch (per-ID PUT + `succeeded` JSON), and the `--comment-private`-without-body rejection. `bug resolve/close/reopen/dup` added to the drift-checked command manifest (drift-check passes).

## Validation

`cargo test --features test-helpers` (1395 lib + 78 integration) and `cargo clippy --locked --features test-helpers -- -D warnings` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
