### PR TITLE
feat(bug): add --count to list/search/my (#317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `--count` on `bzr bug list`, `bzr bug search`, and `bzr bug my` prints only the
+  number of matching bugs — an integer (table) or `{"count": N}` (JSON) — for
+  dashboards, triage gates, and agent branching. It fetches ids only and lifts
+  the row limit (`limit=0`), so the count reflects all matches (bounded by the
+  server's max-results setting) rather than a single page; `bug my` reports the
+  distinct total deduped across the active categories. (#317)
 - Convenience verbs over `bzr bug update` for the common state transitions:
   `bzr bug resolve <ID...> [--as <RESOLUTION>]` (defaults to `FIXED`),
   `bzr bug close <ID...> [--as <RESOLUTION>]`, `bzr bug reopen <ID...>`, and

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -86,13 +86,13 @@ bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-col
 ├── bug
 │   ├── list [--product <P>...] [--component <C>...] [--status <S>...] [--assignee <A>...]
 │   │        [--creator <C>...] [--priority <P>...] [--severity <S>...] [--id <ID>...]
-│   │        [--alias <A>] [--summary <S>] [--limit <N>] [--fields <F>] [--exclude-fields <F>]
+│   │        [--alias <A>] [--summary <S>] [--limit <N>] [--count] [--fields <F>] [--exclude-fields <F>]
 │   │        [--created-since <D>] [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
 │   ├── view <ID> [--fields <F>] [--exclude-fields <F>]
-│   ├── search [<QUERY>] [--from-url <URL>] [--save-as [NAME]] [--limit <N>] [--fields <F>] [--exclude-fields <F>]
+│   ├── search [<QUERY>] [--from-url <URL>] [--save-as [NAME]] [--limit <N>] [--count] [--fields <F>] [--exclude-fields <F>]
 │   │          [--sort <FIELD>] [--order asc|desc]
 │   ├── history <ID> [--since <DATE>]
-│   ├── my [--created] [--cc] [--all] [--status <S>...] [--limit <N>]
+│   ├── my [--created] [--cc] [--all] [--status <S>...] [--limit <N>] [--count]
 │   │       [--fields <F>] [--exclude-fields <F>] [--sort <FIELD>] [--order asc|desc]
 │   ├── create [--template <T>] [--product <P>] [--component <C>] --summary <S>
 │   │          [--version <V>] [--description <D>] [--priority <P>] [--severity <S>]
@@ -231,6 +231,7 @@ Filter flags (`--product`, `--component`, `--status`, `--assignee`, `--creator`,
 | `--alias <A>` | No | | Filter by bug alias |
 | `--summary <S>` | No | | Substring match on the Summary field (matches all bug states) |
 | `--limit <N>` | No | 50 | Max results |
+| `--count` | No | | Print only the count of matching bugs — an integer (table) or `{"count": N}` (JSON). Fetches ids only and lifts the row limit, so the count reflects all matches (bounded by the server's max-results setting). Ignores `--fields`, `--limit`, and `--sort`. |
 | `--fields <F>` | No | | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
 | `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
 | `--created-since <DATE>` | No | | Filter to bugs whose `creation_time` is `>= DATE`. See [Date format](#date-format) below. |
@@ -361,6 +362,7 @@ bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?known_name=m
 | `--from-url <URL>` | No* | | Execute a search from a Bugzilla buglist.cgi URL. Recognized parameters (product, component, status, etc.) are mapped to structured fields; unrecognized parameters (boolean charts, field-change filters) are passed through to the REST API verbatim. |
 | `--save-as [NAME]` | No | | Save this URL query for future reuse. If `NAME` is omitted, uses the URL's `known_name` parameter as the query name. Requires `--from-url`. |
 | `--limit <N>` | No | 50 | Max results. When `--from-url` is used, the URL's own limit parameter takes precedence unless overridden here. |
+| `--count` | No | | Print only the count of matching bugs — an integer (table) or `{"count": N}` (JSON). Counts all matches (bounded by the server's max-results setting). |
 | `--fields <F>` | No | | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
 | `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
 
@@ -403,6 +405,7 @@ bzr bug my --status NEW --status '!RESOLVED'  # mixed positive and negated
 | `--all` | No | | Show all bugs related to me (assigned + created + CC'd) |
 | `--status <S>` | No | | Filter by status (repeatable; `!` prefix to exclude) |
 | `--limit <N>` | No | 50 | Max results per category. With `--all`, each of the three categories (assigned, created, CC'd) is queried separately up to this limit; duplicates across categories are removed. |
+| `--count` | No | | Print only the count of distinct matching bugs (deduped across the active categories) — an integer (table) or `{"count": N}` (JSON). |
 | `--fields <F>` | No | | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
 | `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
 

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -188,6 +188,14 @@ pub enum BugAction {
         /// Max number of results
         #[arg(long, default_value = "50")]
         limit: u32,
+        /// Print only the number of matching bugs, not the rows.
+        ///
+        /// Counts all matches (bounded by the server's max-results setting)
+        /// and prints just the integer (table) or `{"count": N}` (JSON).
+        /// `--limit` and `--sort` are ignored, and `--fields` does not affect
+        /// the count (though an invalid `--fields` value is still rejected).
+        #[arg(long)]
+        count: bool,
         #[command(flatten)]
         field_args: FieldArgs,
         #[command(flatten)]
@@ -372,6 +380,12 @@ pub enum BugAction {
         /// Max number of results (default: 50)
         #[arg(long)]
         limit: Option<u32>,
+        /// Print only the number of matching bugs, not the rows.
+        ///
+        /// Counts all matches (bounded by the server's max-results setting)
+        /// and prints just the integer (table) or `{"count": N}` (JSON).
+        #[arg(long)]
+        count: bool,
         #[command(flatten)]
         field_args: FieldArgs,
         #[command(flatten)]
@@ -582,6 +596,13 @@ pub enum BugAction {
         /// the limit applies to the single active category.
         #[arg(long, default_value = "50")]
         limit: u32,
+        /// Print only the number of matching bugs, not the rows.
+        ///
+        /// Counts the distinct bugs across the active categories (deduped),
+        /// bounded by the server's max-results setting, and prints just the
+        /// integer (table) or `{"count": N}` (JSON).
+        #[arg(long)]
+        count: bool,
         #[command(flatten)]
         field_args: FieldArgs,
         #[command(flatten)]

--- a/src/commands/bug/list.rs
+++ b/src/commands/bug/list.rs
@@ -39,6 +39,7 @@ pub(super) async fn handle(
         qa_contact,
         url,
         sort_args,
+        count,
     } = action
     else {
         unreachable!()
@@ -77,6 +78,14 @@ pub(super) async fn handle(
         )),
         ..Default::default()
     };
+    if *count {
+        let bugs = client
+            .search_bugs(&super::count_search_params(params))
+            .await?;
+        crate::output::result_types::write_count(bugs.len(), format, w.out);
+        return Ok(());
+    }
+
     let spec = ColumnSpec::new(fields.as_deref(), exclude_fields.as_deref());
     let bugs = client.search_bugs(&params).await?;
     write_bugs(&bugs, spec, format, w.out, w.err);

--- a/src/commands/bug/list_tests.rs
+++ b/src/commands/bug/list_tests.rs
@@ -35,6 +35,7 @@ fn empty_list_action() -> BugAction {
         qa_contact: vec![],
         url: vec![],
         sort_args: crate::cli::SortArgs::default(),
+        count: false,
     }
 }
 
@@ -141,6 +142,7 @@ async fn bug_list_passes_every_field_through_to_search_params() {
         qa_contact: vec!["qa@test.com".into()],
         url: vec!["github.com/foo".into()],
         sort_args: crate::cli::SortArgs::default(),
+        count: false,
     };
     let result = crate::commands::bug::execute(
         &action,
@@ -206,6 +208,7 @@ async fn bug_list_summary_only_sends_substring_filter() {
         qa_contact: vec![],
         url: vec![],
         sort_args: crate::cli::SortArgs::default(),
+        count: false,
     };
     let result = crate::commands::bug::execute(
         &action,
@@ -652,4 +655,66 @@ async fn bug_list_sends_explicit_sort_and_order() {
         result.is_ok(),
         "explicit-sort list should succeed: {result:?}"
     );
+}
+
+fn count_list_action() -> BugAction {
+    let mut action = empty_list_action();
+    if let BugAction::List { count, .. } = &mut action {
+        *count = true;
+    }
+    action
+}
+
+#[tokio::test]
+async fn bug_list_count_json_emits_count_object() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    // --count must request id-only fields and lift the limit (limit=0), then
+    // report the number of returned ids.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("include_fields", "id"))
+        .and(query_param("limit", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1}, {"id": 2}, {"id": 3}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
+        &count_list_action(),
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __io.writers(),
+    )
+    .await;
+    assert!(result.is_ok(), "count list failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    assert_eq!(parsed["count"], 3);
+}
+
+#[tokio::test]
+async fn bug_list_count_table_prints_integer_only() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 10}, {"id": 11}]
+        })))
+        .mount(&mock)
+        .await;
+
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
+        &count_list_action(),
+        None,
+        OutputFormat::Table,
+        None,
+        &mut __io.writers(),
+    )
+    .await;
+    assert!(result.is_ok());
+    assert_eq!(__io.out_str().trim(), "2");
 }

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -34,6 +34,18 @@ fn bug_column_spec(action: &BugAction) -> Option<ColumnSpec<'_>> {
     ))
 }
 
+/// Rewrite search params for `--count`: fetch only IDs (smallest payload) and
+/// lift the row limit (`0` = all matches, bounded by the server's max-results)
+/// so the count reflects the full match set, not a page of it.
+pub(super) fn count_search_params(
+    mut params: crate::types::SearchParams,
+) -> crate::types::SearchParams {
+    params.include_fields = Some("id".to_string());
+    params.exclude_fields = None;
+    params.limit = Some(0);
+    params
+}
+
 /// Dispatch bug actions to their respective handlers.
 pub async fn execute(
     action: &BugAction,

--- a/src/commands/bug/my.rs
+++ b/src/commands/bug/my.rs
@@ -22,6 +22,7 @@ pub(super) async fn handle(
             exclude_fields,
         },
         sort_args,
+        count,
     } = action
     else {
         unreachable!()
@@ -35,7 +36,7 @@ pub(super) async fn handle(
     let mut seen_ids = std::collections::HashSet::new();
 
     // Build search params for each enabled filter, varying one field.
-    let base = SearchParams {
+    let mut base = SearchParams {
         status: status.clone(),
         limit: Some(*limit),
         include_fields: canonical_field_list(fields.as_deref()),
@@ -46,6 +47,11 @@ pub(super) async fn handle(
         )),
         ..Default::default()
     };
+    // `--count` needs every distinct match, so fetch IDs only and lift the
+    // per-category limit; the dedup below then yields the true distinct count.
+    if *count {
+        base = super::count_search_params(base);
+    }
     let mut searches = Vec::new();
     if *all || (!created && !cc) {
         let mut p = base.clone();
@@ -65,10 +71,16 @@ pub(super) async fn handle(
 
     for params in &searches {
         for bug in client.search_bugs(params).await? {
-            if seen_ids.insert(bug.id) {
+            // When counting, only the deduped id set matters — don't retain rows.
+            if seen_ids.insert(bug.id) && !*count {
                 all_bugs.push(bug);
             }
         }
+    }
+
+    if *count {
+        crate::output::result_types::write_count(seen_ids.len(), format, w.out);
+        return Ok(());
     }
 
     write_bugs(&all_bugs, spec, format, w.out, w.err);

--- a/src/commands/bug/my_tests.rs
+++ b/src/commands/bug/my_tests.rs
@@ -52,6 +52,7 @@ async fn bug_my_returns_assigned_by_default() {
             exclude_fields: None,
         },
         sort_args: crate::cli::SortArgs::default(),
+        count: false,
     };
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result =
@@ -94,6 +95,7 @@ async fn bug_my_passes_status_limit_and_field_filters() {
             exclude_fields: Some("comments".into()),
         },
         sort_args: crate::cli::SortArgs::default(),
+        count: false,
     };
     let mut __io2 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -134,6 +136,7 @@ async fn bug_my_created_only_runs_creator_search_not_assigned() {
             exclude_fields: None,
         },
         sort_args: crate::cli::SortArgs::default(),
+        count: false,
     };
     let mut __io3 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -173,6 +176,7 @@ async fn bug_my_cc_only_runs_cc_search_not_assigned_or_creator() {
             exclude_fields: None,
         },
         sort_args: crate::cli::SortArgs::default(),
+        count: false,
     };
     let mut __io4 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -219,6 +223,7 @@ async fn bug_my_all_deduplicates() {
             exclude_fields: None,
         },
         sort_args: crate::cli::SortArgs::default(),
+        count: false,
     };
     let mut __io5 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -236,4 +241,44 @@ async fn bug_my_all_deduplicates() {
     let bugs = parsed.as_array().expect("expected JSON array");
     assert_eq!(bugs.len(), 1, "duplicate bug should be deduplicated");
     assert_eq!(bugs[0]["id"], 42);
+}
+
+#[tokio::test]
+async fn bug_my_all_count_reports_distinct_total() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mount_whoami(&mock).await;
+    // All three category searches return the same ids {1,2}; --count must
+    // report the distinct total (2), not the sum (6), and must request
+    // id-only fields with limit=0.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("include_fields", "id"))
+        .and(query_param("limit", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1}, {"id": 2}]
+        })))
+        .mount(&mock)
+        .await;
+
+    let action = BugAction::My {
+        created: false,
+        cc: false,
+        all: true,
+        status: vec![],
+        limit: 50,
+        field_args: crate::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
+        sort_args: crate::cli::SortArgs::default(),
+        count: true,
+    };
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    assert!(result.is_ok(), "my --all --count failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(__io.out_str().trim()).unwrap();
+    // Three searches each return ids {1,2}; deduped distinct count is 2.
+    assert_eq!(parsed["count"], 2);
 }

--- a/src/commands/bug/search.rs
+++ b/src/commands/bug/search.rs
@@ -70,6 +70,7 @@ pub(super) async fn handle(
         from_url,
         save_as,
         limit,
+        count,
         field_args: FieldArgs {
             fields,
             exclude_fields,
@@ -126,8 +127,15 @@ pub(super) async fn handle(
         (client, params, None)
     };
 
-    let bugs = client.search_bugs(&params).await?;
-    write_bugs(&bugs, spec, format, w.out, w.err);
+    if *count {
+        let bugs = client
+            .search_bugs(&super::count_search_params(params))
+            .await?;
+        crate::output::result_types::write_count(bugs.len(), format, w.out);
+    } else {
+        let bugs = client.search_bugs(&params).await?;
+        write_bugs(&bugs, spec, format, w.out, w.err);
+    }
 
     if let Some((name, query)) = save_info {
         let mut is_update = false;

--- a/src/commands/bug/search_tests.rs
+++ b/src/commands/bug/search_tests.rs
@@ -18,6 +18,7 @@ fn from_url_action(url: String, save_as: Option<String>) -> BugAction {
             exclude_fields: None,
         },
         sort_args: crate::cli::SortArgs::default(),
+        count: false,
     }
 }
 
@@ -189,6 +190,7 @@ async fn handle_search_quicksearch_passes_limit_and_field_filters() {
             exclude_fields: Some("comments".into()),
         },
         sort_args: crate::cli::SortArgs::default(),
+        count: false,
     };
     let mut __io3 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -364,6 +366,7 @@ async fn bug_search_quicksearch_sends_default_order() {
             exclude_fields: None,
         },
         sort_args: crate::cli::SortArgs::default(),
+        count: false,
     };
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result =
@@ -397,4 +400,41 @@ async fn bug_search_from_url_sort_overrides_url_order() {
         result.is_ok(),
         "from-url with --sort should succeed: {result:?}"
     );
+}
+
+#[tokio::test]
+async fn handle_search_count_emits_count_object() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    // Quicksearch + --count: requests id-only fields and limit=0, reports count.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("quicksearch", "crash"))
+        .and(query_param("include_fields", "id"))
+        .and(query_param("limit", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = BugAction::Search {
+        query: Some("crash".to_string()),
+        from_url: None,
+        save_as: None,
+        limit: None,
+        field_args: crate::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
+        sort_args: crate::cli::SortArgs::default(),
+        count: true,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    assert!(result.is_ok(), "search --count failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["count"], 4);
 }

--- a/src/output/result_types.rs
+++ b/src/output/result_types.rs
@@ -21,6 +21,27 @@ pub fn write_result<W: Write + ?Sized>(
     }
 }
 
+/// Count-only result for `--count`: serializes as `{"count": N}` under JSON;
+/// the table form prints just the integer.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct CountResult {
+    pub count: usize,
+}
+
+impl CountResult {
+    #[must_use]
+    pub fn new(count: usize) -> Self {
+        Self { count }
+    }
+}
+
+/// Write a count-only result: `{"count": N}` under JSON, a bare integer for
+/// the table form. Shared by the `--count` paths of `bug list`/`search`/`my`.
+pub fn write_count<W: Write + ?Sized>(count: usize, format: OutputFormat, out: &mut W) {
+    write_result(&CountResult::new(count), &count.to_string(), format, out);
+}
+
 // ── Action result types ─────────────────────────────────────────────
 
 /// Resource type for mutation result payloads.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -45,6 +45,7 @@ fn empty_list_action() -> bzr::cli::BugAction {
         qa_contact: vec![],
         url: vec![],
         sort_args: bzr::cli::SortArgs::default(),
+        count: false,
     }
 }
 
@@ -192,6 +193,7 @@ async fn bug_search_integration() {
             exclude_fields: None,
         },
         sort_args: bzr::cli::SortArgs::default(),
+        count: false,
     };
     let mut __io4 = bzr::test_helpers::CapturedIo::new();
     let result = bzr::commands::bug::execute(


### PR DESCRIPTION
## Summary

Adds a count-only mode to the bug listing commands, so you can learn how many bugs match a filter without fetching and rendering rows — for dashboards, triage gates, and agent branching ("if >0 open regressions, do X").

| Issue | Title | Type | Files Changed |
|-------|-------|------|---------------|
| #317 | Count-only mode (`--count`) | feat | `src/cli/bug.rs`, `src/commands/bug/{list,search,my,mod}.rs`, `src/output/result_types.rs` |

## Behavior

`--count` on `bzr bug list`, `bzr bug search`, and `bzr bug my`:
- **JSON:** `{"count": N}`. **Table:** a bare integer.
- Fetches **ids only** (`include_fields=id`) and lifts the row limit (`limit=0`), so the count reflects the full match set, not a 50-row page.
- `bug my` reports the **distinct** total, deduped across the active categories (reusing its existing `seen_ids` set).

```bash
bzr --json bug list --product P --status NEW --count   # {"count": 42}
bzr bug search "regression" --count                     # 17
bzr bug my --all --count                                # distinct total
```

## Implementation notes

- A shared `count_search_params` rewrites the already-built `SearchParams` (id-only fields, `limit=0`); a typed `CountResult` + `write_count` helper guarantee the `{"count": N}` shape and de-duplicate the output across the three handlers.
- Counting is per-handler rather than a single dispatch choke point, because the three build params differently and `my` fans out 2–3 searches and dedups — there's no common "result set" to hook.

## Review notes (known limitation)

Bugzilla's REST API has **no count-only endpoint**, so this counts ids client-side. `limit=0` means "all matches" but Bugzilla bounds that by its server-side `maxallowedresults` setting — so for a filter matching more than that cap, the count is silently bounded by the cap (no truncation signal, since the API doesn't expose the cap value). This is documented on the flag, in `docs/bzr-cli.md`, and in `CHANGELOG.md`. A real truncation signal is the domain of #302 (pagination/truncation), still pending.

## Test coverage

`bug list --count` JSON (asserts `include_fields=id` + `limit=0` are sent → `{"count": 3}`), table (bare integer), `bug my --all --count` distinct-dedup (3 overlapping searches → distinct 2), and `bug search --count`. Whole-file coverage: list 98.8%, my 98.6%, search 93.4%, result_types 100%.

## Validation

`cargo test --features test-helpers` (1403 lib + 78 integration) and `cargo clippy --locked --features test-helpers -- -D warnings` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
