### PR TITLE
feat(docs): drift-check command tree flags against the binary (#306)

### DIFF
--- a/.github/workflows/agent-skills.yml
+++ b/.github/workflows/agent-skills.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "agent-skills/**"
       - "src/**"
+      - "docs/bzr-cli.md"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/agent-skills.yml"
@@ -12,6 +13,7 @@ on:
     paths:
       - "agent-skills/**"
       - "src/**"
+      - "docs/bzr-cli.md"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/agent-skills.yml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- The command tree in `docs/bzr-cli.md` is now drift-checked against the binary
+  in CI. A new `agent-skills/tests/flag-drift-check.sh` (run alongside the
+  existing verb-level `drift-check.sh`) compares every command-specific long
+  flag the binary exposes against that command's block in the tree, both
+  directions, and fails the build on a mismatch. Fixed the existing drift it
+  surfaced — the tree was missing flags such as `bug view --web`/`--permissive`,
+  `bug update --dupe-of`/`--comment`/`--cc-add`/`--keywords-add`/`--groups-add`/
+  `--see-also-add` (and `*-remove`), `bug list`/`query` search filters
+  (`--resolution`, `--version`, `--op-sys`, `--platform`, `--whiteboard`,
+  `--target-milestone`, `--qa-contact`, `--url`), `bug create --description-file`,
+  `comment add --private`, `attachment download --bug`/`--out`/`--out-dir`,
+  `attachment upload --comment`/`--comment-private`, and `config set-keyring`/
+  `migrate-to-keyring --service`/`--account`. (#306)
 - Recorded the decision to keep `bzr` as the command name despite the
   historical collision with GNU Bazaar (retired in 2025; its successor Breezy
   uses `brz`), with rationale in `docs/decisions/0001-bzr-command-name.md` and

--- a/agent-skills/tests/flag-drift-check-test.sh
+++ b/agent-skills/tests/flag-drift-check-test.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+set -eu
+# shellcheck disable=SC1007  # CDPATH= is a per-command env var, not an assignment
+HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck disable=SC1091  # lib.sh path is dynamic; resolved at runtime
+. "$HERE/lib.sh"
+CHECK="$HERE/flag-drift-check.sh"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# Fake bzr: `<group> <verb> --help` prints a clap-style Options: block. The
+# real check extracts long flags only from option-name lines (≤8 leading
+# spaces), so prose mentions of non-flags must be ignored.
+cat >"$WORK/bzr" <<'EOF'
+#!/bin/sh
+# args: <group> <verb> --help
+case "$1 $2" in
+"demo alpha")
+  cat <<H
+Alpha command.
+
+Mentions --notaflag in prose which must be ignored.
+
+Options:
+      --server <SERVER>
+          Global, must be excluded.
+      --foo <FOO>
+          A flag.
+      --bar <BAR>
+          Another flag.
+  -h, --help
+          Print help
+H
+  ;;
+"demo beta")
+  cat <<H
+Options:
+      --server <SERVER>
+          Global.
+      --baz <BAZ>
+          Beta flag.
+H
+  ;;
+"demo gamma")
+  cat <<H
+Options:
+      --server <SERVER>
+          Only globals here -> no command-specific flags.
+  -h, --help
+          Print help
+H
+  ;;
+esac
+EOF
+chmod +x "$WORK/bzr"
+
+printf 'demo: alpha beta gamma\n' >"$WORK/commands.yml"
+
+# A matching doc: tree lists exactly the command-specific flags per command,
+# globals only on the root line.
+matching_doc() {
+  cat >"$WORK/doc.md" <<'EOF'
+# Title
+
+## Command Tree
+
+```
+bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [-v...]
+├── demo
+│   ├── alpha [--foo <X>] [--bar <Y>]
+│   ├── beta [--baz <Z>]
+│   └── gamma <ARG>
+```
+
+## Next Section
+
+Unrelated --whatever text outside the tree must not count.
+EOF
+}
+
+run_check() {
+  BZR_BIN="$WORK/bzr" "$CHECK" "$WORK/commands.yml" "$WORK/doc.md" 2>&1
+}
+
+# 1. Matching tree -> exit 0.
+matching_doc
+out=$(run_check) && rc=0 || rc=$?
+assert_eq "matching tree exits 0" "0" "$rc"
+
+# 2. A flag present in the binary but missing from the tree -> error naming it.
+matching_doc
+# drop --bar from alpha's block
+sed 's/\[--foo <X>\] \[--bar <Y>\]/[--foo <X>]/' "$WORK/doc.md" >"$WORK/doc.md.tmp"
+mv "$WORK/doc.md.tmp" "$WORK/doc.md"
+out=$(run_check) && rc=0 || rc=$?
+assert_eq "missing flag fails" "1" "$rc"
+assert_contains "missing flag named" "$out" "--bar"
+assert_contains "missing flag attributes command" "$out" "alpha"
+
+# 3. A flag in the tree the binary does not have -> error naming it.
+matching_doc
+sed 's/\[--baz <Z>\]/[--baz <Z>] [--ghost <G>]/' "$WORK/doc.md" >"$WORK/doc.md.tmp"
+mv "$WORK/doc.md.tmp" "$WORK/doc.md"
+out=$(run_check) && rc=0 || rc=$?
+assert_eq "stale flag fails" "1" "$rc"
+assert_contains "stale flag named" "$out" "--ghost"
+
+# 4. Prose mention of a non-flag (--notaflag) is ignored.
+matching_doc
+out=$(run_check) && rc=0 || rc=$?
+assert_eq "prose non-flag ignored (still 0)" "0" "$rc"
+assert_not_contains "prose non-flag not reported" "$out" "notaflag"
+
+# 4b. A global flag redundantly listed in a command's block is ignored, not
+# flagged as stale (globals belong on the root line but may be repeated).
+matching_doc
+sed 's/\[--baz <Z>\]/[--baz <Z>] [--server <S>]/' "$WORK/doc.md" >"$WORK/doc.md.tmp"
+mv "$WORK/doc.md.tmp" "$WORK/doc.md"
+out=$(run_check) && rc=0 || rc=$?
+assert_eq "global in command block ignored (still 0)" "0" "$rc"
+assert_not_contains "global in command block not reported" "$out" "--server"
+
+# 5. A required global missing from the tree root -> error.
+matching_doc
+sed 's/\[--no-color\] //' "$WORK/doc.md" >"$WORK/doc.md.tmp"
+mv "$WORK/doc.md.tmp" "$WORK/doc.md"
+out=$(run_check) && rc=0 || rc=$?
+assert_eq "missing root global fails" "1" "$rc"
+assert_contains "missing root global named" "$out" "--no-color"
+
+# 6. BZR_BIN set but unresolvable -> fail closed, names BZR_BIN.
+matching_doc
+out=$(BZR_BIN="$WORK/nope" "$CHECK" "$WORK/commands.yml" "$WORK/doc.md" 2>&1) && rc=0 || rc=$?
+assert_eq "set-but-missing BZR_BIN fails closed" "1" "$rc"
+assert_contains "fail-closed names BZR_BIN" "$out" "BZR_BIN"
+
+# 7. BZR_BIN unset and bzr not on PATH -> legitimate skip, exit 0.
+mkdir -p "$WORK/toolbin"
+for t in dirname grep sed sort comm awk tr cat sh mktemp; do
+  p=$(command -v "$t" 2>/dev/null) && ln -sf "$p" "$WORK/toolbin/$t"
+done
+matching_doc
+out=$(
+  unset BZR_BIN
+  PATH="$WORK/toolbin" "$CHECK" "$WORK/commands.yml" "$WORK/doc.md" 2>&1
+) && rc=0 || rc=$?
+assert_eq "unset BZR_BIN + no PATH bzr skips" "0" "$rc"
+assert_contains "skip notice printed" "$out" "SKIPPED"
+
+report "flag-drift-check-test"

--- a/agent-skills/tests/flag-drift-check.sh
+++ b/agent-skills/tests/flag-drift-check.sh
@@ -1,0 +1,152 @@
+#!/bin/sh
+# Flag-level drift check for the Command Tree in docs/bzr-cli.md.
+#
+# Every command-specific long flag the bzr binary exposes must appear in that
+# command's block of the "## Command Tree" section, and every long flag the
+# tree lists for a command must be a real flag of that command. This catches
+# the tree drifting from the actual CLI surface (a `--flag` added in code but
+# never documented, or a documented flag that was removed/renamed).
+#
+# It complements drift-check.sh (which checks command *verbs* against
+# commands.yml) by checking the *flag* surface, as requested in issue #306.
+#
+# Coverage is bounded by the manifest: only the (group, verb) commands listed in
+# commands.yml are checked. Top-level commands absent from it (e.g. `completion`)
+# are not validated here -- add them to the manifest if they grow flags worth
+# guarding. Only long flags are compared; short-only flags (e.g. `-o`) are out
+# of scope.
+#
+# Usage: flag-drift-check.sh [MANIFEST] [DOC]
+#   MANIFEST defaults to the bzr-reference commands.yml (same file as
+#            drift-check.sh); it enumerates the (group, verb) commands to check.
+#   DOC      defaults to docs/bzr-cli.md.
+# Env: BZR_BIN overrides the bzr binary path.
+#
+# Exit: 1 on any drift, a missing doc, or a fail-closed BZR_BIN. 0 on a clean
+#       match or a legitimate skip (no binary available).
+set -eu
+
+# shellcheck disable=SC1007  # CDPATH= is a per-command env var, not an assignment
+HERE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+MANIFEST="${1:-$HERE/../skills/bzr-reference/reference/commands.yml}"
+DOC="${2:-$HERE/../../docs/bzr-cli.md}"
+BZR="${BZR_BIN:-bzr}"
+fail=0
+
+# Globals the tree's root line is expected to spell out, and that every command
+# inherits. -v/--verbose, --help and --version are auto/standard flags the
+# curated tree abbreviates (`[-v...]`) or omits, so they are not required there.
+ROOT_GLOBALS='--server --output --json --config --no-color --quiet --api'
+# Full inherited set excluded from per-command comparison on both sides (the
+# tree lists them once on its root line, but a command block may still repeat
+# one, e.g. `query run [--server <NAME>]`, and that is not drift). Derived from
+# ROOT_GLOBALS plus clap's auto flags so the shared list has one source of
+# truth. `--version` is deliberately absent: it is a real per-command field flag
+# (`bug create --version`, `bug list --version`, ...), not propagated from the
+# top-level `-V, --version` to subcommands.
+GLOBALS_RE="$(printf '%s' "$ROOT_GLOBALS --verbose --help" | tr ' ' '|')"
+
+# Resolve the binary with the same fail-closed / skip semantics as
+# drift-check.sh so the two checks behave identically under CI and locally.
+if ! command -v "$BZR" >/dev/null 2>&1; then
+  if [ -n "${BZR_BIN:-}" ]; then
+    printf 'flag-drift-check: ERROR BZR_BIN set to "%s" but it is not an executable\n' "$BZR" >&2
+    exit 1
+  fi
+  printf 'flag-drift-check: SKIPPED (no binary): BZR_BIN unset and bzr not on PATH\n'
+  exit 0
+fi
+
+if [ ! -f "$DOC" ]; then
+  printf 'flag-drift-check: ERROR doc not found: %s\n' "$DOC" >&2
+  exit 1
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# Command-specific long flags the binary exposes for `<group> <verb>`. Only
+# option-name lines (≤8 leading spaces then a dash) are scanned, so flags named
+# in the prose help text are ignored; globals are filtered out.
+binary_flags() {
+  "$BZR" "$1" "$2" --help 2>/dev/null |
+    grep -E '^[[:space:]]{1,8}-' |
+    grep -oE -- '--[a-zA-Z][a-zA-Z0-9-]*' |
+    grep -vxE -- "$GLOBALS_RE" |
+    sort -u
+}
+
+# Group names from the manifest (the leading `<group>:` token of each entry);
+# the tree parser uses this set to tell a group node (`├── bug`) from a verb
+# node (`├── list`). Surrounding spaces let the parser match with `" $n "`.
+groups=" $(sed -n 's/^\([A-Za-z][A-Za-z0-9_-]*\):.*/\1/p' "$MANIFEST" | tr '\n' ' ')"
+
+# Flatten the tree into "group<TAB>verb<TAB>--flag" rows (group is "ROOT" for
+# the root line). Group vs verb is decided by name, not indentation, so the
+# parser is robust to the multibyte box-drawing characters and line wrapping.
+TREE="$WORK/tree.tsv"
+awk -v groups="$groups" '
+function emit(g, v, s,   t) {
+  while (match(s, /--[a-zA-Z][a-zA-Z0-9-]*/)) {
+    t = substr(s, RSTART, RLENGTH)
+    print g "\t" v "\t" t
+    s = substr(s, RSTART + RLENGTH)
+  }
+}
+/^## Command Tree/ { intree = 1; next }
+intree && /^## / { intree = 0 }
+intree && /^```/ {
+  if (infence == 0) { infence = 1 } else { infence = 0; intree = 0 }
+  next
+}
+intree && infence {
+  if ($0 ~ /^bzr /) { emit("ROOT", ".", $0); next }
+  if ($0 ~ /──/) {
+    name = $0
+    sub(/^.*── */, "", name)        # strip pipes + connector
+    n = name
+    sub(/[ \t].*/, "", n)           # first token = node name
+    rest = name
+    sub(/^[^ \t]*/, "", rest)       # remainder may carry flags
+    if (index(groups, " " n " ") > 0) { g = n; v = "" }
+    else { v = n; emit(g, v, rest) }
+  } else if (v != "") {
+    emit(g, v, $0)                  # continuation line of the current verb
+  }
+}
+' "$DOC" >"$TREE"
+
+err() {
+  printf 'flag-drift-check: ERROR %s\n' "$1" >&2
+  fail=1
+}
+
+# Per-command comparison, driven by the manifest.
+while IFS= read -r line; do
+  case "$line" in '' | \#*) continue ;; esac
+  group=${line%%:*}
+  verbs=${line#*:}
+  group=$(printf '%s' "$group" | tr -d ' ')
+  [ -n "$group" ] || continue
+  for v in $verbs; do
+    awk -F'\t' -v g="$group" -v vv="$v" '$1==g && $2==vv {print $3}' "$TREE" |
+      grep -vxE -- "$GLOBALS_RE" |
+      sort -u >"$WORK/doc.flags"
+    binary_flags "$group" "$v" >"$WORK/bin.flags"
+    for f in $(comm -23 "$WORK/bin.flags" "$WORK/doc.flags"); do
+      err "command tree is missing $f for \`$group $v\`"
+    done
+    for f in $(comm -13 "$WORK/bin.flags" "$WORK/doc.flags"); do
+      err "command tree lists $f for \`$group $v\` but the binary has no such flag"
+    done
+  done
+done <"$MANIFEST"
+
+# Root globals: every flag the tree promises on its root line must be present.
+awk -F'\t' '$1=="ROOT"{print $3}' "$TREE" | sort -u >"$WORK/root.flags"
+for gl in $ROOT_GLOBALS; do
+  grep -qxF -- "$gl" "$WORK/root.flags" ||
+    err "command tree root line is missing global $gl"
+done
+
+exit "$fail"

--- a/agent-skills/tests/run.sh
+++ b/agent-skills/tests/run.sh
@@ -15,10 +15,12 @@ printf 'run: drift check uses BZR_BIN=%s\n' "${BZR_BIN:-<unset; will try PATH>}"
 # Content checks
 sh "$HERE/validate-skills.sh" || rc=1
 sh "$HERE/drift-check.sh" || rc=1
+sh "$HERE/flag-drift-check.sh" || rc=1
 
 # Self-tests
 run "validate-skills-test.sh"
 run "drift-check-test.sh"
+run "flag-drift-check-test.sh"
 run "installer-test.sh"
 run "installer-ps1-test.sh"
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -86,16 +86,18 @@ bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-col
 ├── bug
 │   ├── list [--product <P>...] [--component <C>...] [--status <S>...] [--assignee <A>...]
 │   │        [--creator <C>...] [--priority <P>...] [--severity <S>...] [--id <ID>...]
-│   │        [--alias <A>] [--summary <S>] [--limit <N>] [--count] [--fields <F>] [--exclude-fields <F>]
+│   │        [--alias <A>] [--summary <S>] [--resolution <R>...] [--version <V>...] [--op-sys <OS>...]
+│   │        [--platform <P>...] [--whiteboard <W>] [--target-milestone <M>...] [--qa-contact <Q>...] [--url <U>]
+│   │        [--limit <N>] [--count] [--fields <F>] [--exclude-fields <F>]
 │   │        [--created-since <D>] [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
-│   ├── view <ID> [--fields <F>] [--exclude-fields <F>]
+│   ├── view <ID> [--fields <F>] [--exclude-fields <F>] [--permissive] [--web]
 │   ├── search [<QUERY>] [--from-url <URL>] [--save-as [NAME]] [--limit <N>] [--count] [--fields <F>] [--exclude-fields <F>]
 │   │          [--sort <FIELD>] [--order asc|desc]
 │   ├── history <ID> [--since <DATE>]
 │   ├── my [--created] [--cc] [--all] [--status <S>...] [--limit <N>] [--count]
 │   │       [--fields <F>] [--exclude-fields <F>] [--sort <FIELD>] [--order asc|desc]
 │   ├── create [--template <T>] [--product <P>] [--component <C>] --summary <S>
-│   │          [--version <V>] [--description <D>] [--priority <P>] [--severity <S>]
+│   │          [--version <V>] [--description <D>] [--description-file <PATH>] [--priority <P>] [--severity <S>]
 │   │          [--assignee <A>] [--op-sys <OS>] [--rep-platform <PLAT>]
 │   │          [--blocks <IDs>] [--depends-on <IDs>] [--alias <A>] [--url <U>]
 │   │          [--whiteboard <W>] [--target-milestone <T>] [--deadline <DATE>]
@@ -104,29 +106,32 @@ bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-col
 │   │              [--description <D>] [--priority <P>] [--severity <S>] [--assignee <A>]
 │   │              [--op-sys <OS>] [--rep-platform <PLAT>]
 │   │              [--no-comment] [--add-depends-on] [--add-blocks] [--no-cc] [--no-keywords]
-│   ├── update <ID...> [--status <S>] [--resolution <R>] [--assignee <A>]
+│   ├── update <ID...> [--status <S>] [--resolution <R>] [--dupe-of <ID>] [--assignee <A>]
 │   │                   [--priority <P>] [--severity <S>] [--summary <S>]
 │   │                   [--alias <A>] [--deadline <DATE>] [--estimated-time <HOURS>]
 │   │                   [--remaining-time <HOURS>] [--work-time <HOURS>]
 │   │                   [--whiteboard <W>] [--reset-assigned-to] [--reset-qa-contact]
 │   │                   [--flag <F>...] [--blocks-add <IDs>]
 │   │                   [--blocks-remove <IDs>] [--depends-on-add <IDs>]
-│   │                   [--depends-on-remove <IDs>]
+│   │                   [--depends-on-remove <IDs>] [--keywords-add <K>] [--keywords-remove <K>]
+│   │                   [--cc-add <C>] [--cc-remove <C>] [--groups-add <G>] [--groups-remove <G>]
+│   │                   [--see-also-add <URL>] [--see-also-remove <URL>]
+│   │                   [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
 │   ├── resolve <ID...> [--as <RESOLUTION>] [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
 │   ├── close <ID...> [--as <RESOLUTION>] [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
 │   ├── reopen <ID...> [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
 │   └── dup <ID> <TARGET> [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
 ├── comment
 │   ├── list <BUG_ID> [--since <DATE>]
-│   ├── add <BUG_ID> [--body <TEXT>] [--body-file <PATH>]
+│   ├── add <BUG_ID> [--body <TEXT>] [--body-file <PATH>] [--private]
 │   ├── tag <COMMENT_ID> [--add <TAG>...] [--remove <TAG>...]
 │   └── search-tags <QUERY>
 ├── attachment
 │   ├── list <BUG_ID>
 │   ├── view <ATTACHMENT_ID>
-│   ├── download <ATTACHMENT_ID> [-o <FILE>]
-│   ├── upload <BUG_ID> <FILE> [--summary <S>] [--content-type <MIME>]
-│   │                          [--private|--no-private] [--patch|--no-patch] [--flag <F>...]
+│   ├── download <ATTACHMENT_ID> [--bug <ID>] [-o|--out <FILE>] [--out-dir <DIR>]
+│   ├── upload <BUG_ID> <FILE> [--summary <S>] [--content-type <MIME>] [--comment <BODY>]
+│   │                          [--comment-private] [--private|--no-private] [--patch|--no-patch] [--flag <F>...]
 │   └── update <ATTACHMENT_ID> [--summary <S>] [--file-name <N>] [--content-type <MIME>]
 │                               [--obsolete|--no-obsolete] [--patch|--no-patch]
 │                               [--private|--no-private] [--flag <F>...]
@@ -164,9 +169,9 @@ bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-col
 ├── config
 │   ├── set-server <NAME> --url <URL> (--api-key <KEY> | --api-key-env <ENV_VAR>) [--email <EMAIL>] [--auth-method <METHOD>]
 │   │                     [--tls-insecure] [--tls-ca-cert <PATH>] [--tls-pin-sha256 <HEX>] [--tls-pin-now] [--tls-pin-clear]
-│   ├── set-keyring <NAME>
+│   ├── set-keyring <NAME> [--service <S>] [--account <A>]
 │   ├── unset-keyring <NAME>
-│   ├── migrate-to-keyring <NAME> [--yes]
+│   ├── migrate-to-keyring <NAME> [--service <S>] [--account <A>] [--yes]
 │   ├── set-default <NAME>
 │   ├── remove-server <NAME>
 │   ├── rename-server <OLD> <NEW>
@@ -181,12 +186,16 @@ bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-col
 ├── query
 │   ├── save <NAME> (--from-url <URL> | [--product <P>...] [--component <C>...] [--status <S>...]
 │   │               [--assignee <A>...] [--creator <C>...] [--priority <P>...] [--severity <S>...]
+│   │               [--resolution <R>...] [--version <V>...] [--op-sys <OS>...] [--platform <P>...]
+│   │               [--whiteboard <W>] [--target-milestone <M>...] [--qa-contact <Q>...] [--url <U>]
 │   │               [--search <Q>]) [--limit <N>] [--fields <F>] [--exclude-fields <F>]
 │   │               [--created-since <D>] [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
 │   ├── list
 │   ├── show <NAME>
 │   ├── delete <NAME>
 │   └── run <NAME> [--limit <N>] [--fields <F>] [--exclude-fields <F>] [--server <NAME>]
+│                  [--resolution <R>...] [--version <V>...] [--op-sys <OS>...] [--platform <P>...]
+│                  [--whiteboard <W>] [--target-milestone <M>...] [--qa-contact <Q>...] [--url <U>]
 │                  [--created-since <D>] [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
 └── completion <bash|zsh|fish|powershell>
 ```


### PR DESCRIPTION
## Summary

Adds a **flag-level** drift check for the command tree in `docs/bzr-cli.md`, fixing #306. It complements the existing verb-level `agent-skills/tests/drift-check.sh` (which checks command *verbs* against `commands.yml`) by checking the *flag* surface, as the issue requested ("mirror the existing pattern … and extend it to the flag surface").

| Issue | Title | Type | Files Changed |
|-------|-------|------|---------------|
| #306 | Auto-generate / drift-check the command tree in docs | docs / tooling | `agent-skills/tests/flag-drift-check.sh` (new), `agent-skills/tests/flag-drift-check-test.sh` (new), `agent-skills/tests/run.sh`, `.github/workflows/agent-skills.yml`, `docs/bzr-cli.md`, `CHANGELOG.md` |

## What it does

`flag-drift-check.sh` runs in CI via `run.sh` (already invoked by the `agent-skills` workflow). For every `(group, verb)` command in `commands.yml` it:

1. Extracts the command-specific long flags the binary exposes, parsed from `bzr <group> <verb> --help` (only option-name lines, so prose mentions like the bare `--blocks` in `bug update`'s description are ignored).
2. Extracts the flags that command's block lists in the `## Command Tree` section of `docs/bzr-cli.md`.
3. Compares both directions with `comm` and **fails** on any mismatch (binary flag missing from the tree, or tree flag the binary doesn't have).

Global flags (`--server`, `--output`, …) are excluded from per-command comparison and checked once against the tree's root line.

### Design notes

- **Parse by name, not indentation.** The tree uses multibyte box-drawing characters (`├──`, `│`), so column math is fragile. The parser instead uses the manifest's group set to distinguish a group node (`├── bug`) from a verb node (`├── list`), which is robust to line-wrapping and the multibyte prefix.
- **`--version` is a real per-command flag.** It is a bug field (`bug create --version`, `bug list --version`, …) and is *not* propagated from the top-level `-V, --version` to subcommands, so it is deliberately not treated as a global.
- **TDD.** A sibling self-test (`flag-drift-check-test.sh`, 16 cases) covers match, missing flag, stale flag, prose-mention exclusion, globals-in-a-command-block, missing root global, and the fail-closed / skip `BZR_BIN` semantics. It mirrors the existing `drift-check-test.sh` and reuses `lib.sh`.

## Drift fixed

The check surfaced 49 genuine drift instances — the tree had fallen behind the binary. Fixed:

- `bug view --web` / `--permissive`
- `bug update --dupe-of` / `--comment` / `--comment-file` / `--comment-private` / `--cc-add` / `--cc-remove` / `--keywords-add` / `--keywords-remove` / `--groups-add` / `--groups-remove` / `--see-also-add` / `--see-also-remove`
- `bug list` and `query save` / `query run` search filters: `--resolution` / `--version` / `--op-sys` / `--platform` / `--whiteboard` / `--target-milestone` / `--qa-contact` / `--url`
- `bug create --description-file`
- `comment add --private`
- `attachment download --bug` / `--out` / `--out-dir`
- `attachment upload --comment` / `--comment-private`
- `config set-keyring` / `config migrate-to-keyring --service` / `--account`

Added `docs/bzr-cli.md` to the `agent-skills` workflow `paths` (push + PR) so doc-only edits that introduce drift also trigger the check.

## Review notes

- **Scope / "fails the build".** This runs in the `agent-skills` workflow, which is **not** one of the required merge checks (consistent with the existing `drift-check.sh`, which the issue asked me to mirror). Drift shows as a red `agent-skills` check but doesn't hard-block merge. Promoting `agent-skills` to a required check is a reasonable follow-up if you want a hard gate.
- **Coverage is manifest-bounded.** Only `(group, verb)` commands in `commands.yml` are checked; top-level commands absent from it (e.g. `completion`, which has no command-specific long flags today) are not validated. This is documented in the script header.
- **Possible future enhancement (not in this PR):** generate the command tree directly from clap so there's nothing to hand-maintain. #306 explicitly scoped to the drift-check approach, so this stays a note rather than added scope.

## Validation

- `sh agent-skills/tests/run.sh` (with `BZR_BIN` set) passes: all self-tests green, both content drift checks clean, `shellcheck` + `shfmt` clean.
- `cargo fmt --check` + `cargo clippy` pass via the pre-commit hook (no Rust changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
