### PR TITLE
feat(client): configurable timeout and transient retry (#311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Global `--timeout <SECS>` (and `BZR_TIMEOUT`) overrides the per-request
+  timeout (default 30s) for slow or distant servers; the 10s connect timeout is
+  unchanged. Global `--retry <N>` (default 0, max 10) retries transient failures
+  with exponential backoff that honors a `Retry-After` header. To avoid
+  duplicate writes, 429 and connect failures are retried for any operation while
+  5xx responses and read timeouts are retried only for safe reads (GET/HEAD),
+  never for writes (create, update, comment). Retries are off by default;
+  exhausted retries surface the usual network error (exit code 5). (#311)
 - `--count` on `bzr bug list`, `bzr bug search`, and `bzr bug my` prints only the
   number of matching bugs — an integer (table) or `{"count": N}` (JSON) — for
   dashboards, triage gates, and agent branching. It fetches ids only and lifts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ sha2 = "0.10"
 webpki-roots = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-tokio = { version = "1", features = ["macros", "rt", "sync"] }
+tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 toml = "1"
 dirs = "6"
 open = "5.3.5"

--- a/agent-skills/tests/flag-drift-check-test.sh
+++ b/agent-skills/tests/flag-drift-check-test.sh
@@ -65,7 +65,7 @@ matching_doc() {
 ## Command Tree
 
 ```
-bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [-v...]
+bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [-v...]
 ├── demo
 │   ├── alpha [--foo <X>] [--bar <Y>]
 │   ├── beta [--baz <Z>]

--- a/agent-skills/tests/flag-drift-check.sh
+++ b/agent-skills/tests/flag-drift-check.sh
@@ -36,7 +36,7 @@ fail=0
 # Globals the tree's root line is expected to spell out, and that every command
 # inherits. -v/--verbose, --help and --version are auto/standard flags the
 # curated tree abbreviates (`[-v...]`) or omits, so they are not required there.
-ROOT_GLOBALS='--server --output --json --config --no-color --quiet --api'
+ROOT_GLOBALS='--server --output --json --config --no-color --quiet --api --timeout --retry'
 # Full inherited set excluded from per-command comparison on both sides (the
 # tree lists them once on its root line, but a command block may still repeat
 # one, e.g. `query run [--server <NAME>]`, and that is not drift). Derived from

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -41,6 +41,8 @@ For installation and quick start, see [README.md](../README.md).
 | `--no-color` | Disable colored output. Color is also suppressed automatically when stdout is not a TTY. |
 | `--quiet` | Suppress stdout and tracing logs (exit code confirms success) |
 | `--api <MODE>` | Override API transport: `rest`, `xmlrpc`, or `hybrid`. Auto-detected from server version if not set. |
+| `--timeout <SECS>` | Per-request timeout in seconds (default 30). Takes precedence over `BZR_TIMEOUT`. The 10s connect timeout is unaffected. |
+| `--retry <N>` | Retry transient failures up to N times with exponential backoff honoring `Retry-After`. 429 and connect failures are retried for any operation; 5xx and read timeouts only for safe reads (GET/HEAD), never for writes (create, update, comment) where a replay could duplicate the effect. Default 0 (disabled); max 10. Exhausted retries exit 5. |
 | `-v, --verbose` | Increase log verbosity (`-v`=info, `-vv`=debug, `-vvv`=trace; `RUST_LOG` overrides) |
 | `-h, --help` | Print help |
 | `-V, --version` | Print version |
@@ -53,6 +55,7 @@ Agent note: at an interactive TTY, `bzr` defaults to table output. For agent wor
 |----------|-------------|
 | `BZR_OUTPUT` | Default output format (`table` or `json`). Overridden by `--output` or `--json`. |
 | `BZR_CONFIG` | Full path to an alternate `config.toml`. Overrides the default config directory; overridden by `--config`. |
+| `BZR_TIMEOUT` | Per-request timeout in seconds. Overridden by `--timeout`; invalid values are ignored with a warning. |
 | `NO_COLOR` | Disable colored output (any value). Supported natively by the `colored` crate. |
 | `CLICOLOR` | Set to `0` to disable colored output (standard convention respected by the `colored` crate). |
 | `CLICOLOR_FORCE` | Set to `1` to force colored output even when stdout is not a TTY. |
@@ -82,7 +85,7 @@ Agent note: at an interactive TTY, `bzr` defaults to table output. For agent wor
 ## Command Tree
 
 ```
-bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [-v...]
+bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [-v...]
 ├── bug
 │   ├── list [--product <P>...] [--component <C>...] [--status <S>...] [--assignee <A>...]
 │   │        [--creator <C>...] [--priority <P>...] [--severity <S>...] [--id <ID>...]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -137,6 +137,25 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub api: Option<ApiMode>,
 
+    /// Per-request timeout in seconds (default: 30).
+    ///
+    /// Overrides the built-in request timeout for slow or distant servers.
+    /// Takes precedence over the `BZR_TIMEOUT` environment variable. The
+    /// connect timeout (10s) is unaffected. Must be at least 1.
+    #[arg(long, value_name = "SECS", global = true, value_parser = clap::value_parser!(u64).range(1..))]
+    pub timeout: Option<u64>,
+
+    /// Retry transient failures up to N times (default: 0, disabled).
+    ///
+    /// Uses exponential backoff that honors a `Retry-After` header. 429 and
+    /// connect failures (request provably not processed) are retried for any
+    /// operation; 5xx responses and read timeouts are retried only for safe
+    /// reads (GET/HEAD), never for writes (create, update, comment) where a
+    /// replay could duplicate the effect. Off by default; bounded to at most
+    /// 10. Exhausted retries surface the usual network error (exit code 5).
+    #[arg(long, value_name = "N", global = true, value_parser = clap::value_parser!(u32).range(0..=10))]
+    pub retry: Option<u32>,
+
     /// Set log verbosity (default: warnings only, -v=info, -vv=debug, -vvv=trace; `RUST_LOG` overrides)
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]
     pub verbose: u8,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -56,6 +56,9 @@ pub struct BugzillaClient {
     pub(super) xmlrpc: Option<XmlRpcClient>,
     /// Email hint for Bugzilla 5.0 compatibility (whoami fallback via user lookup).
     email_hint: Option<String>,
+    /// Transient-retry budget (429 / 5xx / timeout). Captured from the global
+    /// `--retry` setting at construction; 0 disables retries.
+    retry_max: u32,
 }
 
 /// Configuration needed to construct a [`BugzillaClient`].
@@ -190,7 +193,16 @@ impl BugzillaClient {
             api_mode,
             xmlrpc,
             email_hint: email_hint.map(String::from),
+            retry_max: crate::http::retry_max(),
         })
+    }
+
+    /// Override the transient-retry budget. Used by tests to exercise the
+    /// retry path without mutating the process-wide `--retry` global (which
+    /// would race other tests).
+    #[cfg(test)]
+    pub(crate) fn set_retry_max(&mut self, n: u32) {
+        self.retry_max = n;
     }
 
     pub(super) fn url(&self, path: &str) -> String {
@@ -285,7 +297,83 @@ impl BugzillaClient {
         }
     }
 
+    /// Send a request, applying transient-failure retries (429 / 5xx / connect
+    /// timeout) with exponential backoff when `--retry` is enabled. Each attempt
+    /// also performs the 401 alternate-auth fallback (see [`Self::send_raw`]).
+    /// The status of the final attempt is checked normally, so exhausted retries
+    /// surface the usual `HttpStatus`/`Http` error (exit code 5).
     pub(super) async fn send(&self, builder: RequestBuilder) -> Result<reqwest::Response> {
+        // A write must not be replayed after a 5xx or read timeout: the server
+        // may have already applied it, so a retry would duplicate the effect.
+        // We gate on `is_safe()` (GET/HEAD), not `is_idempotent()`, because
+        // bzr's PUT `Bug.update` is not effect-idempotent — `--work-time` is
+        // additive and `--comment` posts atomically, so a replayed PUT could
+        // double-count work or duplicate a comment. 429s and connect failures
+        // are provably un-processed and stay retryable for any method; an
+        // undeterminable method is treated as unsafe.
+        let safe = builder
+            .try_clone()
+            .and_then(|b| b.build().ok())
+            .is_some_and(|r| r.method().is_safe());
+        let mut attempt: u32 = 0;
+        loop {
+            // Clone for a possible retry; a non-cloneable body (streaming) can't
+            // be replayed, so send it once without retry.
+            let Some(this) = builder.try_clone() else {
+                return self
+                    .check_response_status(self.send_raw(builder).await?)
+                    .await;
+            };
+            match self.send_raw(this).await {
+                Ok(resp)
+                    if attempt < self.retry_max
+                        && crate::http::should_retry_status(resp.status().as_u16(), safe) =>
+                {
+                    let status = resp.status().as_u16();
+                    let retry_after = resp
+                        .headers()
+                        .get(reqwest::header::RETRY_AFTER)
+                        .and_then(|v| v.to_str().ok())
+                        .and_then(crate::http::parse_retry_after);
+                    Self::sleep_before_retry(attempt, retry_after, &format!("HTTP {status}")).await;
+                    attempt += 1;
+                }
+                Ok(resp) => return self.check_response_status(resp).await,
+                Err(e) if attempt < self.retry_max && Self::is_transient(&e, safe) => {
+                    Self::sleep_before_retry(attempt, None, &e.to_string()).await;
+                    attempt += 1;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// Whether an error is a transient transport failure worth retrying for a
+    /// request with the given safety (GET/HEAD).
+    fn is_transient(err: &BzrError, safe: bool) -> bool {
+        matches!(err, BzrError::Http(e) if crate::http::should_retry_transport(e, safe))
+    }
+
+    /// Sleep for the backoff interval before the next retry, logging the reason.
+    async fn sleep_before_retry(
+        attempt: u32,
+        retry_after: Option<std::time::Duration>,
+        reason: &str,
+    ) {
+        let delay = crate::http::backoff_delay(attempt, retry_after);
+        tracing::warn!(
+            attempt = attempt + 1,
+            delay_ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+            reason,
+            "transient failure; retrying after backoff"
+        );
+        tokio::time::sleep(delay).await;
+    }
+
+    /// One request attempt: send, log, and perform the 401 alternate-auth
+    /// fallback. Returns the raw response without status-checking so the caller
+    /// ([`Self::send`]) can decide whether a retryable status warrants a retry.
+    async fn send_raw(&self, builder: RequestBuilder) -> Result<reqwest::Response> {
         let retry_builder = builder.try_clone();
         let resp = builder.send().await?;
         tracing::debug!(
@@ -298,7 +386,7 @@ impl BugzillaClient {
                 return Ok(retried);
             }
         }
-        self.check_response_status(resp).await
+        Ok(resp)
     }
 
     /// On 401, retry the request with the alternate auth method (header ↔ query param).

--- a/src/client/mod_tests.rs
+++ b/src/client/mod_tests.rs
@@ -633,3 +633,147 @@ async fn parse_json_redacts_api_key_in_body_preview() {
         "redaction marker should be present: {msg}"
     );
 }
+
+// ── Transient retry (#311) ──────────────────────────────────────────
+
+fn bug_ok_body() -> serde_json::Value {
+    serde_json::json!({ "bugs": [{ "id": 1, "summary": "ok", "status": "NEW" }] })
+}
+
+#[tokio::test]
+async fn retry_recovers_after_transient_503() {
+    let mock = MockServer::start().await;
+    // First attempt 503, then a healthy 200. Higher priority (lower number)
+    // and up_to_n_times(1) makes the 503 serve exactly once.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("busy"))
+        .up_to_n_times(1)
+        .with_priority(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(bug_ok_body()))
+        .with_priority(2)
+        .mount(&mock)
+        .await;
+
+    let mut client = test_client(&mock.uri());
+    client.set_retry_max(1);
+    let bug = client.get_bug("1", None, None).await.unwrap();
+    assert_eq!(bug.id, 1);
+}
+
+#[tokio::test]
+async fn retry_recovers_after_429_with_retry_after() {
+    let mock = MockServer::start().await;
+    // Retry-After: 0 keeps the test fast while still exercising header parsing.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("Retry-After", "0")
+                .set_body_string("slow down"),
+        )
+        .up_to_n_times(1)
+        .with_priority(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(bug_ok_body()))
+        .with_priority(2)
+        .mount(&mock)
+        .await;
+
+    let mut client = test_client(&mock.uri());
+    client.set_retry_max(1);
+    assert_eq!(client.get_bug("1", None, None).await.unwrap().id, 1);
+}
+
+#[tokio::test]
+async fn retry_exhausted_surfaces_http_error() {
+    let mock = MockServer::start().await;
+    // Always 500; with retry_max=1 the endpoint is hit exactly twice
+    // (initial + one retry) and the final error is returned.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+        .expect(2)
+        .mount(&mock)
+        .await;
+
+    let mut client = test_client(&mock.uri());
+    client.set_retry_max(1);
+    let err = client.get_bug("1", None, None).await.unwrap_err();
+    assert_eq!(err.exit_code(), 5, "exhausted retries keep HTTP exit code");
+}
+
+#[tokio::test]
+async fn no_retry_on_client_error_404() {
+    let mock = MockServer::start().await;
+    // 404 is a caller error: it must be hit exactly once even with a budget.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("missing"))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut client = test_client(&mock.uri());
+    client.set_retry_max(3);
+    assert!(client.get_bug("1", None, None).await.is_err());
+}
+
+#[tokio::test]
+async fn no_retry_on_post_5xx_mutation() {
+    let mock = MockServer::start().await;
+    // A POST Bug.create returning 503 must NOT be retried even with a budget:
+    // the create may already have been applied, so a replay could duplicate it.
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("busy"))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut client = test_client(&mock.uri());
+    client.set_retry_max(3);
+    let params = crate::types::CreateBugParams::default();
+    assert!(client.create_bug(&params).await.is_err());
+}
+
+#[tokio::test]
+async fn no_retry_on_put_update_5xx() {
+    let mock = MockServer::start().await;
+    // PUT Bug.update is HTTP-idempotent but not effect-idempotent in bzr
+    // (`--work-time` accumulates, `--comment` posts atomically), so a 5xx must
+    // not be retried: the endpoint is hit exactly once despite the budget.
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("busy"))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut client = test_client(&mock.uri());
+    client.set_retry_max(3);
+    let params = crate::types::UpdateBugParams::default();
+    assert!(client.update_bug(1, &params).await.is_err());
+}
+
+#[tokio::test]
+async fn no_retry_when_budget_zero() {
+    let mock = MockServer::start().await;
+    // Default budget is 0: a 503 is not retried (hit exactly once).
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("busy"))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    assert!(client.get_bug("1", None, None).await.is_err());
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,9 +1,112 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::RwLock;
 use std::time::Duration;
 
 /// Kept short (10s) to fail fast on unreachable servers.
 pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
-/// Per-request ceiling (30s) — covers large attachment downloads.
+/// Per-request ceiling (30s) — covers large attachment downloads. Overridable
+/// per invocation via `--timeout` / `BZR_TIMEOUT` (see [`request_timeout`]).
 pub(crate) const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Process-wide request-timeout override, set once from `--timeout` /
+/// `BZR_TIMEOUT` before any client is built. `None` keeps [`REQUEST_TIMEOUT`].
+static REQUEST_TIMEOUT_OVERRIDE: RwLock<Option<Duration>> = RwLock::new(None);
+/// Process-wide retry budget for transient (429 / 5xx / timeout) failures, set
+/// from `--retry`. 0 (the default) disables retries.
+static RETRY_MAX: AtomicU32 = AtomicU32::new(0);
+
+/// Base unit for exponential backoff between transient retries.
+const RETRY_BACKOFF_BASE: Duration = Duration::from_millis(500);
+/// Upper bound on any single backoff sleep, including a server `Retry-After`.
+const RETRY_BACKOFF_CAP: Duration = Duration::from_secs(30);
+
+/// Install the request-timeout override (seconds). Called once at startup,
+/// before any [`crate::client::BugzillaClient`] is constructed.
+pub fn set_request_timeout_secs(secs: Option<u64>) {
+    let dur = secs.map(Duration::from_secs);
+    if let Ok(mut guard) = REQUEST_TIMEOUT_OVERRIDE.write() {
+        *guard = dur;
+    }
+}
+
+/// The effective per-request timeout: the override if set, else the default.
+pub(crate) fn request_timeout() -> Duration {
+    REQUEST_TIMEOUT_OVERRIDE
+        .read()
+        .ok()
+        .and_then(|g| *g)
+        .unwrap_or(REQUEST_TIMEOUT)
+}
+
+/// Install the transient-retry budget. Called once at startup.
+pub fn set_retry_max(n: u32) {
+    RETRY_MAX.store(n, Ordering::Relaxed);
+}
+
+/// The configured transient-retry budget (0 = retries disabled).
+pub(crate) fn retry_max() -> u32 {
+    RETRY_MAX.load(Ordering::Relaxed)
+}
+
+/// Resolve the request-timeout override from the `--timeout` flag and the
+/// `BZR_TIMEOUT` environment value. The flag wins (already validated `>= 1` by
+/// clap); otherwise the env value is accepted only when a positive integer. An
+/// invalid env value yields `None` (the caller keeps the default and may warn).
+pub fn resolve_timeout_secs(flag: Option<u64>, env: Option<&str>) -> Option<u64> {
+    if let Some(secs) = flag {
+        return Some(secs);
+    }
+    env.and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&s| s >= 1)
+}
+
+/// Whether an HTTP status is transient in principle: 429 (rate limited) or any
+/// 5xx (server error). Other 4xx are caller errors. This does not consider
+/// idempotency — see [`should_retry_status`].
+pub(crate) fn is_retryable_status(status: u16) -> bool {
+    status == 429 || (500..600).contains(&status)
+}
+
+/// Whether a response status should actually be retried, given whether the
+/// request is safe (no side effects — GET/HEAD). 429 means the request was
+/// rate-limited before processing, so it is always retryable; a 5xx may have
+/// been applied server-side before the error surfaced, so it is retried only
+/// for safe requests — retrying a write (POST `Bug.create`, PUT `Bug.update`
+/// with `--work-time`/`--comment`) could duplicate the effect.
+pub(crate) fn should_retry_status(status: u16, safe: bool) -> bool {
+    status == 429 || (safe && is_retryable_status(status))
+}
+
+/// Whether a transport-level error should be retried, given whether the request
+/// is safe (GET/HEAD). A connect failure means the server never received the
+/// request, so it is always retryable; a read timeout may have been processed
+/// before the timeout fired, so it is retried only for safe requests.
+pub(crate) fn should_retry_transport(err: &reqwest::Error, safe: bool) -> bool {
+    err.is_connect() || (safe && err.is_timeout())
+}
+
+/// Parse a `Retry-After` header value. Only the delta-seconds form (a bare
+/// integer) is supported; the HTTP-date form is rare for `Retry-After` and is
+/// treated as unknown (the caller falls back to exponential backoff) rather
+/// than pulling in a date-parsing dependency for it.
+pub(crate) fn parse_retry_after(value: &str) -> Option<Duration> {
+    value.trim().parse::<u64>().ok().map(Duration::from_secs)
+}
+
+/// Backoff before retry `attempt` (0-based): `RETRY_BACKOFF_BASE * 2^attempt`,
+/// capped at [`RETRY_BACKOFF_CAP`]. A server `Retry-After` is honored when it is
+/// longer than the exponential base (and is itself capped), so the client never
+/// waits less than the server asked nor more than the cap.
+pub(crate) fn backoff_delay(attempt: u32, retry_after: Option<Duration>) -> Duration {
+    let factor = 1u32 << attempt.min(5);
+    let base = RETRY_BACKOFF_BASE
+        .saturating_mul(factor)
+        .min(RETRY_BACKOFF_CAP);
+    match retry_after {
+        Some(ra) => ra.min(RETRY_BACKOFF_CAP).max(base),
+        None => base,
+    }
+}
 /// Cap applied to opportunistic XML-RPC retries triggered when a primary
 /// REST request succeeded with no rows. The full `REQUEST_TIMEOUT` is too
 /// generous here: REST already returned an answer, and a slow XML-RPC

--- a/src/http_tests.rs
+++ b/src/http_tests.rs
@@ -189,3 +189,91 @@ fn redact_api_key_preserves_subsequent_query_params() {
         "other params should be preserved: {result}"
     );
 }
+
+// ── Timeout + retry helpers (#311) ──────────────────────────────────
+
+#[test]
+fn is_retryable_status_covers_429_and_5xx_only() {
+    assert!(is_retryable_status(429));
+    assert!(is_retryable_status(500));
+    assert!(is_retryable_status(503));
+    assert!(is_retryable_status(599));
+    assert!(!is_retryable_status(200));
+    assert!(!is_retryable_status(400));
+    assert!(!is_retryable_status(401));
+    assert!(!is_retryable_status(404));
+    assert!(!is_retryable_status(418));
+}
+
+#[test]
+fn should_retry_status_gates_5xx_on_safety() {
+    // 429 is always retryable (rate-limited, not processed).
+    assert!(should_retry_status(429, false));
+    assert!(should_retry_status(429, true));
+    // 5xx only for safe (GET/HEAD) requests; a write 500 may have been applied.
+    assert!(should_retry_status(503, true));
+    assert!(!should_retry_status(503, false));
+    assert!(should_retry_status(500, true));
+    assert!(!should_retry_status(500, false));
+    // Non-transient statuses are never retried regardless of safety.
+    assert!(!should_retry_status(404, true));
+    assert!(!should_retry_status(200, true));
+}
+
+#[test]
+fn backoff_delay_grows_exponentially_and_caps() {
+    let d0 = backoff_delay(0, None);
+    let d1 = backoff_delay(1, None);
+    let d2 = backoff_delay(2, None);
+    assert!(d1 > d0, "attempt 1 should wait longer than attempt 0");
+    assert!(d2 > d1, "attempt 2 should wait longer than attempt 1");
+    // Far-out attempts are capped, never unbounded.
+    assert!(backoff_delay(20, None) <= std::time::Duration::from_secs(30));
+}
+
+#[test]
+fn backoff_delay_honors_retry_after_when_longer() {
+    // A long server Retry-After overrides the short exponential base.
+    let ra = std::time::Duration::from_secs(10);
+    assert_eq!(backoff_delay(0, Some(ra)), ra);
+    // But a Retry-After is still capped.
+    let huge = std::time::Duration::from_secs(9999);
+    assert!(backoff_delay(0, Some(huge)) <= std::time::Duration::from_secs(30));
+    // A tiny Retry-After never shortens the exponential base.
+    let tiny = std::time::Duration::from_millis(1);
+    assert!(backoff_delay(3, Some(tiny)) >= backoff_delay(3, None));
+}
+
+#[test]
+fn parse_retry_after_reads_delta_seconds() {
+    assert_eq!(
+        parse_retry_after("5"),
+        Some(std::time::Duration::from_secs(5))
+    );
+    assert_eq!(
+        parse_retry_after("  12 "),
+        Some(std::time::Duration::from_secs(12))
+    );
+}
+
+#[test]
+fn parse_retry_after_rejects_non_integer() {
+    // HTTP-date form is unsupported (no date dep); falls back to backoff.
+    assert_eq!(parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT"), None);
+    assert_eq!(parse_retry_after("soon"), None);
+    assert_eq!(parse_retry_after(""), None);
+}
+
+#[test]
+fn resolve_timeout_secs_prefers_flag_then_env() {
+    assert_eq!(resolve_timeout_secs(Some(15), Some("99")), Some(15));
+    assert_eq!(resolve_timeout_secs(None, Some("99")), Some(99));
+    assert_eq!(resolve_timeout_secs(None, None), None);
+}
+
+#[test]
+fn resolve_timeout_secs_ignores_invalid_env() {
+    assert_eq!(resolve_timeout_secs(None, Some("0")), None);
+    assert_eq!(resolve_timeout_secs(None, Some("-3")), None);
+    assert_eq!(resolve_timeout_secs(None, Some("abc")), None);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ pub async fn dispatch(
     format: types::OutputFormat,
     w: &mut output::writers::Writers<'_>,
 ) -> error::Result<()> {
+    apply_network_tuning(cli);
+
     let api = cli.api;
     let server = cli.server.as_deref();
 
@@ -93,6 +95,33 @@ pub async fn dispatch(
         }
         cli::Commands::Completion { shell } => commands::completion::execute(*shell, w),
     }
+}
+
+/// Install process-wide network tuning from the global flags before any client
+/// is built: the request timeout (`--timeout`, falling back to `BZR_TIMEOUT`)
+/// and the transient-retry budget (`--retry`). An invalid `BZR_TIMEOUT` is
+/// ignored with a warning so the built-in default stands.
+///
+/// This mutates process-global state, so `dispatch` is not safe to call
+/// concurrently from one process with differing `--timeout`/`--retry` values
+/// (the CLI runs a single dispatch per process, so this is not a concern in
+/// practice; tests exercise per-client retry overrides instead).
+fn apply_network_tuning(cli: &cli::Cli) {
+    let env_timeout = std::env::var("BZR_TIMEOUT").ok();
+    if cli.timeout.is_none() {
+        if let Some(raw) = &env_timeout {
+            if http::resolve_timeout_secs(None, Some(raw)).is_none() {
+                tracing::warn!(
+                    "ignoring invalid BZR_TIMEOUT={raw:?} (expected a positive integer)"
+                );
+            }
+        }
+    }
+    http::set_request_timeout_secs(http::resolve_timeout_secs(
+        cli.timeout,
+        env_timeout.as_deref(),
+    ));
+    http::set_retry_max(cli.retry.unwrap_or(0));
 }
 
 /// Shared mutex for tests that modify the process-global `XDG_CONFIG_HOME` env var.

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -38,6 +38,8 @@ fn base_cli(command: Commands) -> Cli {
         no_color: false,
         quiet: false,
         api: None,
+        timeout: None,
+        retry: None,
         verbose: 0,
         command,
     }

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -101,7 +101,7 @@ fn same_host_redirect_policy() -> reqwest::redirect::Policy {
 pub fn build_tls_client(config: &TlsConfig) -> crate::error::Result<reqwest::Client> {
     let builder = reqwest::Client::builder()
         .connect_timeout(crate::http::CONNECT_TIMEOUT)
-        .timeout(crate::http::REQUEST_TIMEOUT)
+        .timeout(crate::http::request_timeout())
         .redirect(same_host_redirect_policy());
     apply_tls_verification(builder, config)?
         .build()
@@ -119,7 +119,7 @@ pub fn build_tls_client(config: &TlsConfig) -> crate::error::Result<reqwest::Cli
 pub(crate) fn build_probe_client(config: &TlsConfig) -> crate::error::Result<reqwest::Client> {
     let builder = reqwest::Client::builder()
         .connect_timeout(crate::http::CONNECT_TIMEOUT)
-        .timeout(crate::http::REQUEST_TIMEOUT)
+        .timeout(crate::http::request_timeout())
         .redirect(reqwest::redirect::Policy::none());
     apply_tls_verification(builder, config)?
         .build()


### PR DESCRIPTION
## Summary

Adds two global flags for tuning network behavior against slow or busy Bugzilla servers, fixing #311.

| Issue | Title | Type | Key files |
|-------|-------|------|-----------|
| #311 | Configurable timeout + retry/backoff | feat | `src/http.rs`, `src/client/mod.rs`, `src/cli/mod.rs`, `src/lib.rs`, `src/tls/mod.rs` |

- **`--timeout <SECS>`** (and **`BZR_TIMEOUT`**) overrides the per-request timeout (default 30s) for slow or distant servers. The flag wins over the env var; the 10s connect timeout is unchanged; an invalid `BZR_TIMEOUT` is ignored with a warning. Validated `>= 1` by clap.
- **`--retry <N>`** (default 0, max 10) retries transient failures with exponential backoff (500ms × 2ⁿ, capped 30s) that honors a `Retry-After` header.

## Retry safety (no duplicate writes)

The retry decision is gated on request safety so an enabled `--retry` can never duplicate a write:

| Failure | Safe read (GET/HEAD) | Write (POST/PUT) |
|---------|----------------------|------------------|
| 429 (rate-limited, not processed) | retry | **retry** |
| connect error (never reached server) | retry | **retry** |
| 5xx response | retry | **no retry** |
| read timeout | retry | **no retry** |

5xx/read-timeouts are ambiguous — the server may have applied the write before the error surfaced — so they are retried only for safe methods. Note this uses `Method::is_safe()` (GET/HEAD), **not** `is_idempotent()`: bzr's `Bug.update` is a PUT but is *not* effect-idempotent (`--work-time` accumulates, `--comment` posts atomically), so a replayed PUT could double-count work or duplicate a comment. Exhausted retries surface the usual network error (exit code 5).

## Implementation notes

- The retry loop wraps the single `BugzillaClient::send()` chokepoint, so every REST call is covered and each attempt still gets the existing 401 alternate-auth fallback (`send_raw`).
- Timeout is a process-global read by the client builder at construction; the retry budget is captured per-client at construction. Tests override retry per-client (`#[cfg(test)] set_retry_max`) to avoid racing the process-global. `dispatch`'s `apply_network_tuning` documents that it mutates process-global state (safe for the single-dispatch-per-process CLI).
- Pure, fully-tested helpers in `http.rs`: `resolve_timeout_secs`, `should_retry_status`, `should_retry_transport`, `parse_retry_after` (delta-seconds; HTTP-date falls back to backoff, no new date dep), `backoff_delay`.
- Adds the `tokio` `time` feature for backoff sleeps (no new crate; `Cargo.lock` unchanged).
- Updates the command-tree root globals (`docs/bzr-cli.md`) and the flag-drift check's `ROOT_GLOBALS` for the two new globals; both drift checks stay green.

## Test coverage

- `http.rs` unit tests: status classification, idempotency/safety gating, backoff growth + cap + `Retry-After` honoring, `Retry-After` parsing, timeout resolution + invalid-env handling.
- `client` wiremock tests: GET 503→200 retried; 429+`Retry-After`→200 retried; exhausted retries return exit-5 error; **POST 503 not retried**; **PUT update 503 not retried**; 404 not retried; zero budget not retried.

## Review notes

- `--retry` covers the **REST** transport only; XML-RPC fallback calls (`xmlrpc/client.rs`) issue their own request and are not auto-retried (no duplication risk — same behavior as before).
- Reviewed adversarially over three rounds; the write-replay hazard was found and closed (POST then PUT). Two non-blocking follow-up ideas surfaced and were deliberately left out of scope: threading tuning through `BugzillaClientConfig` instead of process-globals, and passing the method down from the typed helpers instead of rebuilding the request to read it.

## Validation

`cargo test` (1418 lib + 78 integration + 22 bin), `cargo clippy --locked --features test-helpers -- -D warnings`, `cargo fmt --check`, and the `agent-skills` drift checks all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
