### PR TITLE
feat(query,template): edit saved queries and templates in place (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `bzr query update <NAME>` and `bzr template update <NAME>` edit a saved query
+  or template in place: a supplied flag replaces that field, an omitted flag
+  leaves it unchanged, and `--clear <FIELD>` (repeatable, names matching the long
+  flags) resets a field. Previously the only way to change one field was delete +
+  re-create (re-specifying everything). A no-op call is rejected, as is an update
+  that would leave a template with no fields or a query with no filters (exit 7).
+  (#315)
 - Global `--timeout <SECS>` (and `BZR_TIMEOUT`) overrides the per-request
   timeout (default 30s) for slow or distant servers; the 10s connect timeout is
   unchanged. Global `--retry <N>` (default 0, max 10) retries transient failures

--- a/agent-skills/skills/bzr-reference/reference/commands.yml
+++ b/agent-skills/skills/bzr-reference/reference/commands.yml
@@ -12,5 +12,5 @@ whoami:
 server: info
 classification: list view
 component: list view create update
-template: save list show delete
-query: save list show delete run
+template: save list show update delete
+query: save list show update delete run

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -185,6 +185,9 @@ bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-col
 │   │               [--description <D>]
 │   ├── list
 │   ├── show <NAME>
+│   ├── update <NAME> [--product <P>] [--component <C>] [--version <V>] [--priority <P>]
+│   │                 [--severity <S>] [--assignee <A>] [--op-sys <OS>] [--rep-platform <PLAT>]
+│   │                 [--description <D>] [--clear <FIELD>]
 │   └── delete <NAME>
 ├── query
 │   ├── save <NAME> (--from-url <URL> | [--product <P>...] [--component <C>...] [--status <S>...]
@@ -195,6 +198,12 @@ bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-col
 │   │               [--created-since <D>] [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
 │   ├── list
 │   ├── show <NAME>
+│   ├── update <NAME> [--search <Q>] [--product <P>...] [--component <C>...] [--status <S>...]
+│   │                 [--assignee <A>...] [--creator <C>...] [--priority <P>...] [--severity <S>...]
+│   │                 [--resolution <R>...] [--version <V>...] [--op-sys <OS>...] [--platform <P>...]
+│   │                 [--whiteboard <W>...] [--target-milestone <M>...] [--qa-contact <Q>...] [--url <U>...]
+│   │                 [--limit <N>] [--fields <F>] [--exclude-fields <F>] [--created-since <D>]
+│   │                 [--changed-since <D>] [--clear <FIELD>] [--sort <FIELD>] [--order asc|desc]
 │   ├── delete <NAME>
 │   └── run <NAME> [--limit <N>] [--fields <F>] [--exclude-fields <F>] [--server <NAME>]
 │                  [--resolution <R>...] [--version <V>...] [--op-sys <OS>...] [--platform <P>...]
@@ -1428,6 +1437,20 @@ bzr template show security-bug
 bzr --json template show security-bug
 ```
 
+### `bzr template update`
+
+Edit an existing template in place. A supplied field flag replaces that field;
+an omitted flag leaves it unchanged. `--clear <FIELD>` (repeatable; names match
+the long flags: `product`, `component`, `version`, `priority`, `severity`,
+`assignee`, `op-sys`, `rep-platform`, `description`) resets a field. At least one
+change is required, and a fully-cleared template is rejected (exit 7). If a field
+is both set and cleared in one call, `--clear` wins.
+
+```bash
+bzr template update security-bug --severity blocker
+bzr template update security-bug --clear assignee
+```
+
 ### `bzr template delete`
 
 Delete a saved template.
@@ -1515,6 +1538,23 @@ For URL-sourced queries (saved with `--from-url`), the output also includes the
 original source URL, the associated server name, and a count of raw passthrough
 parameters. In JSON format, the full list of raw parameters is included.
 
+### `bzr query update`
+
+Edit an existing saved query in place. A supplied filter flag (repeatable)
+replaces that field's saved list; a scalar flag (`--limit`, `--fields`,
+`--search`, `--created-since`, ...) replaces that value; an omitted flag leaves
+it unchanged. `--clear <FIELD>` (repeatable; names match the long flags, e.g.
+`status`, `limit`, `search`, `created-since`, `sort`) resets a saved field. At
+least one change is required, and an update that would leave the query with no
+filters is rejected (exit 7). Raw passthrough params from a `--from-url` query
+are preserved. `--sort` / `--order` set the persisted ordering. If a field is
+both set and cleared in one call, `--clear` wins.
+
+```bash
+bzr query update firefox-new --status ASSIGNED
+bzr query update firefox-new --limit 100 --clear severity
+```
+
 ### `bzr query delete`
 
 Delete a saved query.
@@ -1557,9 +1597,10 @@ bzr query run recent-firefox --changed-since 2026-05-01
 
 All eight `bzr bug list` field filters from #158 are also accepted
 as overrides. Passing a flag replaces the saved value for that
-field; omitting it keeps the saved value. There is no clear
-sentinel — to clear a saved field, edit the config or re-save the
-query.
+field; omitting it keeps the saved value. These overrides apply to
+this run only — to change a saved field permanently use
+[`bzr query update`](#bzr-query-update) (with `--clear <FIELD>` to
+reset one).
 
 ---
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -23,7 +23,7 @@ pub use group::GroupAction;
 pub use product::ProductAction;
 pub use query::QueryAction;
 pub use server::ServerAction;
-pub use template::TemplateAction;
+pub use template::{TemplateAction, TemplateFields};
 pub use user::UserAction;
 
 use clap::{Parser, Subcommand};

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -1105,19 +1105,12 @@ fn parse_template_save_with_fields() {
     .unwrap();
     match cli.command {
         Commands::Template {
-            action:
-                TemplateAction::Save {
-                    name,
-                    product,
-                    component,
-                    severity,
-                    ..
-                },
+            action: TemplateAction::Save { name, fields },
         } => {
             assert_eq!(name, "security-bug");
-            assert_eq!(product.as_deref(), Some("Security"));
-            assert_eq!(component.as_deref(), Some("Vulnerabilities"));
-            assert_eq!(severity.as_deref(), Some("critical"));
+            assert_eq!(fields.product.as_deref(), Some("Security"));
+            assert_eq!(fields.component.as_deref(), Some("Vulnerabilities"));
+            assert_eq!(fields.severity.as_deref(), Some("critical"));
         }
         _ => panic!("expected Template Save"),
     }

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -204,6 +204,102 @@ pub enum QueryAction {
         name: String,
     },
 
+    /// Update fields of an existing saved query in place.
+    ///
+    /// Merges the supplied flags into the named query without
+    /// re-specifying the rest: a filter flag (repeatable) replaces
+    /// that field's saved list, a scalar flag (`--limit`,
+    /// `--fields`, `--search`, `--created-since`, ...) replaces that
+    /// value, and an omitted flag leaves it unchanged. Use
+    /// `--clear <field>` (repeatable) to reset a saved field; valid
+    /// names are the long flag names (`product`, `status`, `limit`,
+    /// `fields`, `search`, `created-since`, `sort`, ...). At least
+    /// one change is required, and the result must keep at least one
+    /// filter set (exit 7 otherwise). URL pass-through params from a
+    /// `--from-url` query are preserved. If a field is both set and
+    /// cleared in one call, `--clear` wins.
+    ///
+    /// Examples:
+    ///
+    ///   bzr query update firefox-new --status ASSIGNED
+    ///   bzr query update firefox-new --limit 100 --clear severity
+    ///
+    /// See bzr-query-save(1) to create one and bzr-query-show(1) to
+    /// inspect the result.
+    #[command(verbatim_doc_comment)]
+    Update {
+        /// Query name
+        name: String,
+        /// Replace the free-text search
+        #[arg(long)]
+        search: Option<String>,
+        /// Replace the product filter (repeatable)
+        #[arg(long)]
+        product: Vec<String>,
+        /// Replace the component filter (repeatable)
+        #[arg(long)]
+        component: Vec<String>,
+        /// Replace the status filter (repeatable)
+        #[arg(long)]
+        status: Vec<String>,
+        /// Replace the assignee filter (repeatable)
+        #[arg(long)]
+        assignee: Vec<String>,
+        /// Replace the creator filter (repeatable)
+        #[arg(long)]
+        creator: Vec<String>,
+        /// Replace the priority filter (repeatable)
+        #[arg(long)]
+        priority: Vec<String>,
+        /// Replace the severity filter (repeatable)
+        #[arg(long)]
+        severity: Vec<String>,
+        /// Replace the saved limit
+        #[arg(long)]
+        limit: Option<u32>,
+        /// Replace the saved field selection (comma-separated)
+        #[arg(long)]
+        fields: Option<String>,
+        /// Replace the saved field exclusion (comma-separated)
+        #[arg(long)]
+        exclude_fields: Option<String>,
+        /// Replace the saved `creation_time` filter (same forms as `bzr bug list`)
+        #[arg(long, value_name = "DATE")]
+        created_since: Option<String>,
+        /// Replace the saved `last_change_time` filter
+        #[arg(long, value_name = "DATE")]
+        changed_since: Option<String>,
+        /// Replace the Status Whiteboard filter (repeatable)
+        #[arg(long)]
+        whiteboard: Vec<String>,
+        /// Replace the Target Milestone filter (repeatable)
+        #[arg(long)]
+        target_milestone: Vec<String>,
+        /// Replace the Version filter (repeatable)
+        #[arg(long)]
+        version: Vec<String>,
+        /// Replace the Operating System filter (repeatable)
+        #[arg(long)]
+        op_sys: Vec<String>,
+        /// Replace the Platform filter (repeatable)
+        #[arg(long)]
+        platform: Vec<String>,
+        /// Replace the Resolution filter (repeatable)
+        #[arg(long)]
+        resolution: Vec<String>,
+        /// Replace the QA Contact filter (repeatable)
+        #[arg(long)]
+        qa_contact: Vec<String>,
+        /// Replace the URL filter (repeatable)
+        #[arg(long)]
+        url: Vec<String>,
+        /// Reset a field to unset (repeatable). Names match the long flags.
+        #[arg(long, value_name = "FIELD")]
+        clear: Vec<String>,
+        #[command(flatten)]
+        sort_args: crate::cli::SortArgs,
+    },
+
     /// Run a saved query against a Bugzilla server.
     ///
     /// Reads the query's stored parameters (filter flags, free-text
@@ -225,8 +321,9 @@ pub enum QueryAction {
     /// All eight bzl-parity field filters from `bzr bug list` are
     /// also overrideable here. Passing a flag replaces the saved
     /// list for that field; omitting it keeps the saved value.
-    /// There is no clear sentinel — to clear a saved field, edit
-    /// the config or re-save the query.
+    /// These overrides apply to this run only — to change a saved
+    /// field permanently use `bzr query update <NAME>` (with
+    /// `--clear <FIELD>` to reset one).
     ///
     /// Examples:
     ///

--- a/src/cli/template.rs
+++ b/src/cli/template.rs
@@ -1,10 +1,6 @@
 use clap::Subcommand;
 
 #[derive(Subcommand)]
-#[expect(
-    clippy::large_enum_variant,
-    reason = "only constructed once from CLI args"
-)]
 pub enum TemplateAction {
     /// Save (or replace) a named bug-creation template.
     ///
@@ -60,6 +56,62 @@ pub enum TemplateAction {
         /// Default description
         #[arg(long)]
         description: Option<String>,
+    },
+
+    /// Update fields of an existing template in place.
+    ///
+    /// Merges the supplied flags into the named template without
+    /// re-specifying the rest: a flag replaces that field, an
+    /// omitted flag leaves it unchanged. Use `--clear <field>`
+    /// (repeatable) to reset a field to unset; valid names are the
+    /// long flag names (`product`, `component`, `version`,
+    /// `priority`, `severity`, `assignee`, `op-sys`, `rep-platform`,
+    /// `description`). At least one change (a field flag or
+    /// `--clear`) is required, and the result must keep at least one
+    /// field set (a fully-cleared template is rejected, exit 7). If a
+    /// field is both set and cleared in one call, `--clear` wins.
+    ///
+    /// Examples:
+    ///
+    ///   bzr template update security-bug --severity blocker
+    ///   bzr template update security-bug --clear assignee
+    ///
+    /// See bzr-template-save(1) to create one and
+    /// bzr-template-show(1) to inspect the result.
+    #[command(verbatim_doc_comment)]
+    Update {
+        /// Template name
+        name: String,
+        /// Set the default product
+        #[arg(long)]
+        product: Option<String>,
+        /// Set the default component
+        #[arg(long)]
+        component: Option<String>,
+        /// Set the default version
+        #[arg(long)]
+        version: Option<String>,
+        /// Set the default priority
+        #[arg(long)]
+        priority: Option<String>,
+        /// Set the default severity
+        #[arg(long)]
+        severity: Option<String>,
+        /// Set the default assignee
+        #[arg(long)]
+        assignee: Option<String>,
+        /// Set the default operating system
+        #[arg(long)]
+        op_sys: Option<String>,
+        /// Set the default hardware platform
+        #[arg(long)]
+        rep_platform: Option<String>,
+        /// Set the default description
+        #[arg(long)]
+        description: Option<String>,
+        /// Reset a field to unset (repeatable). Names match the long flags.
+        #[arg(long, value_name = "FIELD")]
+        clear: Vec<String>,
     },
 
     /// List all saved templates.

--- a/src/cli/template.rs
+++ b/src/cli/template.rs
@@ -1,4 +1,57 @@
-use clap::Subcommand;
+use crate::types::BugTemplate;
+use clap::{Args, Subcommand};
+
+/// The default-field flags shared by `template save` and `template update`.
+/// Grouped into one flattened struct so the set is defined once and the two
+/// variants cannot drift apart.
+#[derive(Args, Debug, Clone, Default)]
+pub struct TemplateFields {
+    /// Default product
+    #[arg(long)]
+    pub product: Option<String>,
+    /// Default component
+    #[arg(long)]
+    pub component: Option<String>,
+    /// Default version
+    #[arg(long)]
+    pub version: Option<String>,
+    /// Default priority
+    #[arg(long)]
+    pub priority: Option<String>,
+    /// Default severity
+    #[arg(long)]
+    pub severity: Option<String>,
+    /// Default assignee
+    #[arg(long)]
+    pub assignee: Option<String>,
+    /// Default operating system
+    #[arg(long)]
+    pub op_sys: Option<String>,
+    /// Default hardware platform
+    #[arg(long)]
+    pub rep_platform: Option<String>,
+    /// Default description
+    #[arg(long)]
+    pub description: Option<String>,
+}
+
+impl TemplateFields {
+    /// Build a `BugTemplate` from these flags (used by `template save`).
+    #[must_use]
+    pub fn to_template(&self) -> BugTemplate {
+        BugTemplate {
+            product: self.product.clone(),
+            component: self.component.clone(),
+            version: self.version.clone(),
+            priority: self.priority.clone(),
+            severity: self.severity.clone(),
+            assignee: self.assignee.clone(),
+            op_sys: self.op_sys.clone(),
+            rep_platform: self.rep_platform.clone(),
+            description: self.description.clone(),
+        }
+    }
+}
 
 #[derive(Subcommand)]
 pub enum TemplateAction {
@@ -29,33 +82,8 @@ pub enum TemplateAction {
     Save {
         /// Template name
         name: String,
-        /// Default product
-        #[arg(long)]
-        product: Option<String>,
-        /// Default component
-        #[arg(long)]
-        component: Option<String>,
-        /// Default version
-        #[arg(long)]
-        version: Option<String>,
-        /// Default priority
-        #[arg(long)]
-        priority: Option<String>,
-        /// Default severity
-        #[arg(long)]
-        severity: Option<String>,
-        /// Default assignee
-        #[arg(long)]
-        assignee: Option<String>,
-        /// Default operating system
-        #[arg(long)]
-        op_sys: Option<String>,
-        /// Default hardware platform
-        #[arg(long)]
-        rep_platform: Option<String>,
-        /// Default description
-        #[arg(long)]
-        description: Option<String>,
+        #[command(flatten)]
+        fields: TemplateFields,
     },
 
     /// Update fields of an existing template in place.
@@ -82,33 +110,8 @@ pub enum TemplateAction {
     Update {
         /// Template name
         name: String,
-        /// Set the default product
-        #[arg(long)]
-        product: Option<String>,
-        /// Set the default component
-        #[arg(long)]
-        component: Option<String>,
-        /// Set the default version
-        #[arg(long)]
-        version: Option<String>,
-        /// Set the default priority
-        #[arg(long)]
-        priority: Option<String>,
-        /// Set the default severity
-        #[arg(long)]
-        severity: Option<String>,
-        /// Set the default assignee
-        #[arg(long)]
-        assignee: Option<String>,
-        /// Set the default operating system
-        #[arg(long)]
-        op_sys: Option<String>,
-        /// Set the default hardware platform
-        #[arg(long)]
-        rep_platform: Option<String>,
-        /// Set the default description
-        #[arg(long)]
-        description: Option<String>,
+        #[command(flatten)]
+        fields: TemplateFields,
         /// Reset a field to unset (repeatable). Names match the long flags.
         #[arg(long, value_name = "FIELD")]
         clear: Vec<String>,

--- a/src/commands/bug/create_tests.rs
+++ b/src/commands/bug/create_tests.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use wiremock::matchers::{body_string_contains, method, path};
 use wiremock::{Mock, ResponseTemplate};
 
-use crate::cli::{BugAction, TemplateAction};
+use crate::cli::{BugAction, TemplateAction, TemplateFields};
 use crate::error::BzrError;
 use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
@@ -283,15 +283,14 @@ async fn bug_create_with_template_fills_missing_fields() {
     // bug create command can resolve them from the template.
     let save = TemplateAction::Save {
         name: "tpl".into(),
-        product: Some("TplProduct".into()),
-        component: Some("TplComponent".into()),
-        version: Some("9.9".into()),
-        priority: Some("P2".into()),
-        severity: None,
-        assignee: None,
-        op_sys: None,
-        rep_platform: None,
-        description: Some("from template".into()),
+        fields: TemplateFields {
+            product: Some("TplProduct".into()),
+            component: Some("TplComponent".into()),
+            version: Some("9.9".into()),
+            priority: Some("P2".into()),
+            description: Some("from template".into()),
+            ..Default::default()
+        },
     };
     let mut __io5 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::template::execute(
@@ -824,15 +823,12 @@ async fn bug_create_template_description_does_not_fall_back_outside_editor_flow(
     // Pre-populate a template that has a description body.
     let save = TemplateAction::Save {
         name: "tpl-with-desc".into(),
-        product: Some("TestProduct".into()),
-        component: Some("General".into()),
-        version: None,
-        priority: None,
-        severity: None,
-        assignee: None,
-        op_sys: None,
-        rep_platform: None,
-        description: Some("template body".into()),
+        fields: TemplateFields {
+            product: Some("TestProduct".into()),
+            component: Some("General".into()),
+            description: Some("template body".into()),
+            ..Default::default()
+        },
     };
     let mut __io13 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::template::execute(

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -4,6 +4,7 @@
 //! Only `run` requires a network client.
 
 use crate::cli::QueryAction;
+use crate::commands::shared::{merge_set, merge_vec};
 use crate::config::Config;
 use crate::error::{BzrError, Result};
 use crate::output::resources::bug::{
@@ -36,6 +37,7 @@ pub async fn execute(
         QueryAction::Save { .. } => handle_save(action, format, w),
         QueryAction::List => handle_list(format, w),
         QueryAction::Show { .. } => handle_show(action, format, w),
+        QueryAction::Update { .. } => handle_update(action, format, w),
         QueryAction::Delete { .. } => handle_delete(action, format, w),
         QueryAction::Run { .. } => handle_run(action, server, format, api, w).await,
     }
@@ -182,6 +184,169 @@ fn handle_delete(action: &QueryAction, format: OutputFormat, w: &mut Writers<'_>
     })?;
 
     write_query_saved(name, "Deleted", format, w.out);
+    Ok(())
+}
+
+/// Reset the named field of a saved query to its empty/unset state. The name
+/// matches the long flag (kebab-case).
+fn clear_query_field(q: &mut SavedQuery, field: &str) -> Result<()> {
+    match field {
+        "product" => q.product.clear(),
+        "component" => q.component.clear(),
+        "status" => q.status.clear(),
+        "assignee" => q.assignee.clear(),
+        "creator" => q.creator.clear(),
+        "priority" => q.priority.clear(),
+        "severity" => q.severity.clear(),
+        "whiteboard" => q.whiteboard.clear(),
+        "target-milestone" => q.target_milestone.clear(),
+        "version" => q.version.clear(),
+        "op-sys" => q.op_sys.clear(),
+        "platform" => q.platform.clear(),
+        "resolution" => q.resolution.clear(),
+        "qa-contact" => q.qa_contact.clear(),
+        "url" => q.url.clear(),
+        "search" => q.quicksearch = None,
+        "limit" => q.limit = None,
+        "fields" => q.fields = None,
+        "exclude-fields" => q.exclude_fields = None,
+        "created-since" => q.creation_time = None,
+        "changed-since" => q.last_change_time = None,
+        "sort" | "order" => q.order = None,
+        other => {
+            return Err(BzrError::InputValidation(format!(
+                "unknown --clear field '{other}'; see `bzr query update --help` for valid names"
+            )))
+        }
+    }
+    Ok(())
+}
+
+/// Merge a `query update` action's supplied flags into `q` in place: filter
+/// flags replace lists, scalars replace values, `--clear` resets fields.
+/// `creation_time`/`last_change_time` are the pre-validated canonical dates.
+/// Returns `true` if any change was requested (so the caller can reject a
+/// no-op call).
+fn apply_query_updates(
+    q: &mut SavedQuery,
+    action: &QueryAction,
+    creation_time: Option<&str>,
+    last_change_time: Option<&str>,
+) -> Result<bool> {
+    let QueryAction::Update {
+        search,
+        product,
+        component,
+        status,
+        assignee,
+        creator,
+        priority,
+        severity,
+        limit,
+        fields,
+        exclude_fields,
+        created_since,
+        changed_since,
+        whiteboard,
+        target_milestone,
+        version,
+        op_sys,
+        platform,
+        resolution,
+        qa_contact,
+        url,
+        clear,
+        sort_args,
+        ..
+    } = action
+    else {
+        unreachable!()
+    };
+    let mut changed = false;
+    changed |= merge_vec(&mut q.product, product);
+    changed |= merge_vec(&mut q.component, component);
+    changed |= merge_vec(&mut q.status, status);
+    changed |= merge_vec(&mut q.assignee, assignee);
+    changed |= merge_vec(&mut q.creator, creator);
+    changed |= merge_vec(&mut q.priority, priority);
+    changed |= merge_vec(&mut q.severity, severity);
+    changed |= merge_vec(&mut q.whiteboard, whiteboard);
+    changed |= merge_vec(&mut q.target_milestone, target_milestone);
+    changed |= merge_vec(&mut q.version, version);
+    changed |= merge_vec(&mut q.op_sys, op_sys);
+    changed |= merge_vec(&mut q.platform, platform);
+    changed |= merge_vec(&mut q.resolution, resolution);
+    changed |= merge_vec(&mut q.qa_contact, qa_contact);
+    changed |= merge_vec(&mut q.url, url);
+    changed |= merge_set(&mut q.quicksearch, search.as_deref());
+    changed |= merge_set(&mut q.fields, fields.as_deref());
+    changed |= merge_set(&mut q.exclude_fields, exclude_fields.as_deref());
+    if let Some(l) = limit {
+        q.limit = Some(*l);
+        changed = true;
+    }
+    if created_since.is_some() {
+        q.creation_time = creation_time.map(ToOwned::to_owned);
+        changed = true;
+    }
+    if changed_since.is_some() {
+        q.last_change_time = last_change_time.map(ToOwned::to_owned);
+        changed = true;
+    }
+    if sort_args.sort.is_some() {
+        q.order = explicit_sort_order(sort_args);
+        changed = true;
+    }
+    for field in clear {
+        clear_query_field(q, field)?;
+        changed = true;
+    }
+    Ok(changed)
+}
+
+fn handle_update(action: &QueryAction, format: OutputFormat, w: &mut Writers<'_>) -> Result<()> {
+    let QueryAction::Update {
+        name,
+        created_since,
+        changed_since,
+        ..
+    } = action
+    else {
+        unreachable!()
+    };
+
+    // Validate dates before acquiring the lock so a bad value exits cleanly.
+    let creation_time =
+        crate::validation::parse_optional_date(created_since.as_deref(), "--created-since")?;
+    let last_change_time =
+        crate::validation::parse_optional_date(changed_since.as_deref(), "--changed-since")?;
+
+    Config::update_locked(|config| {
+        let Some(q) = config.queries.get_mut(name.as_str()) else {
+            return Err(BzrError::config(format!("query '{name}' not found")));
+        };
+        let changed = apply_query_updates(
+            q,
+            action,
+            creation_time.as_deref(),
+            last_change_time.as_deref(),
+        )?;
+        if !changed {
+            return Err(BzrError::InputValidation(
+                "no changes specified: provide a filter/field flag or --clear <field>".into(),
+            ));
+        }
+        if !q.has_filters() {
+            return Err(BzrError::InputValidation(
+                "update would leave the query with no filters; a saved query must keep at \
+                 least one filter set"
+                    .into(),
+            ));
+        }
+        Ok(())
+    })?;
+
+    write_query_saved(name, "Updated", format, w.out);
     Ok(())
 }
 

--- a/src/commands/query_tests.rs
+++ b/src/commands/query_tests.rs
@@ -1636,3 +1636,87 @@ async fn query_update_clear_wins_over_set() {
     // status was both set and cleared -> cleared.
     assert!(Config::load().unwrap().queries["q"].status.is_empty());
 }
+
+#[test]
+fn clear_query_field_handles_every_name() {
+    let mut q = crate::types::SavedQuery {
+        product: vec!["p".into()],
+        component: vec!["c".into()],
+        status: vec!["s".into()],
+        assignee: vec!["a".into()],
+        creator: vec!["cr".into()],
+        priority: vec!["pr".into()],
+        severity: vec!["se".into()],
+        whiteboard: vec!["w".into()],
+        target_milestone: vec!["t".into()],
+        version: vec!["v".into()],
+        op_sys: vec!["o".into()],
+        platform: vec!["pl".into()],
+        resolution: vec!["r".into()],
+        qa_contact: vec!["q".into()],
+        url: vec!["u".into()],
+        quicksearch: Some("x".into()),
+        limit: Some(5),
+        fields: Some("f".into()),
+        exclude_fields: Some("e".into()),
+        creation_time: Some("2026-01-01".into()),
+        last_change_time: Some("2026-02-01".into()),
+        order: Some("bug_id".into()),
+        ..Default::default()
+    };
+    for name in [
+        "product",
+        "component",
+        "status",
+        "assignee",
+        "creator",
+        "priority",
+        "severity",
+        "whiteboard",
+        "target-milestone",
+        "version",
+        "op-sys",
+        "platform",
+        "resolution",
+        "qa-contact",
+        "url",
+        "search",
+        "limit",
+        "fields",
+        "exclude-fields",
+        "created-since",
+        "changed-since",
+        "sort",
+        "order",
+    ] {
+        super::clear_query_field(&mut q, name).unwrap();
+    }
+    assert!(!q.has_filters(), "every filter cleared");
+    assert!(q.limit.is_none() && q.fields.is_none() && q.order.is_none());
+}
+
+#[tokio::test]
+async fn query_update_sets_dates_and_sort() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run_q(&save_action("q")).await.unwrap();
+
+    let mut a = empty_update("q");
+    if let QueryAction::Update {
+        created_since,
+        changed_since,
+        sort_args,
+        ..
+    } = &mut a
+    {
+        *created_since = Some("2026-03-01".into());
+        *changed_since = Some("2026-03-02".into());
+        sort_args.sort = Some("priority".into());
+    }
+    run_q(&a).await.unwrap();
+
+    let config = Config::load().unwrap();
+    let q = &config.queries["q"];
+    assert!(q.creation_time.is_some());
+    assert!(q.last_change_time.is_some());
+    assert!(q.order.is_some());
+}

--- a/src/commands/query_tests.rs
+++ b/src/commands/query_tests.rs
@@ -1480,3 +1480,159 @@ async fn query_save_persists_explicit_sort() {
         Some("last_change_time DESC, bug_id")
     );
 }
+
+// ── Update (#315) ───────────────────────────────────────────────────
+
+fn empty_update(name: &str) -> QueryAction {
+    QueryAction::Update {
+        name: name.into(),
+        search: None,
+        product: vec![],
+        component: vec![],
+        status: vec![],
+        assignee: vec![],
+        creator: vec![],
+        priority: vec![],
+        severity: vec![],
+        limit: None,
+        fields: None,
+        exclude_fields: None,
+        created_since: None,
+        changed_since: None,
+        whiteboard: vec![],
+        target_milestone: vec![],
+        version: vec![],
+        op_sys: vec![],
+        platform: vec![],
+        resolution: vec![],
+        qa_contact: vec![],
+        url: vec![],
+        clear: vec![],
+        sort_args: crate::cli::SortArgs::default(),
+    }
+}
+
+async fn run_q(action: &QueryAction) -> crate::error::Result<()> {
+    let mut io = crate::test_helpers::CapturedIo::new();
+    super::execute(action, None, OutputFormat::Json, None, &mut io.writers()).await
+}
+
+#[tokio::test]
+async fn query_update_replaces_filter_keeps_rest() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run_q(&save_action("q")).await.unwrap(); // product=Firefox, status=NEW, limit=25
+
+    let mut a = empty_update("q");
+    if let QueryAction::Update { status, .. } = &mut a {
+        *status = vec!["ASSIGNED".into()];
+    }
+    run_q(&a).await.unwrap();
+
+    let config = Config::load().unwrap();
+    let q = &config.queries["q"];
+    assert_eq!(q.status, vec!["ASSIGNED".to_string()]);
+    assert_eq!(q.product, vec!["Firefox".to_string()]); // untouched
+    assert_eq!(q.limit, Some(25)); // untouched
+}
+
+#[tokio::test]
+async fn query_update_replaces_limit() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run_q(&save_action("q")).await.unwrap();
+
+    let mut a = empty_update("q");
+    if let QueryAction::Update { limit, .. } = &mut a {
+        *limit = Some(100);
+    }
+    run_q(&a).await.unwrap();
+
+    assert_eq!(Config::load().unwrap().queries["q"].limit, Some(100));
+}
+
+#[tokio::test]
+async fn query_update_clear_resets_filter() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run_q(&save_action("q")).await.unwrap();
+
+    let mut a = empty_update("q");
+    if let QueryAction::Update { clear, .. } = &mut a {
+        *clear = vec!["status".into()];
+    }
+    run_q(&a).await.unwrap();
+
+    let config = Config::load().unwrap();
+    assert!(config.queries["q"].status.is_empty());
+    assert_eq!(config.queries["q"].product, vec!["Firefox".to_string()]);
+}
+
+#[tokio::test]
+async fn query_update_unknown_query_errors() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    let mut a = empty_update("missing");
+    if let QueryAction::Update { status, .. } = &mut a {
+        *status = vec!["NEW".into()];
+    }
+    let err = run_q(&a).await.unwrap_err();
+    assert!(err.to_string().contains("query 'missing' not found"));
+}
+
+#[tokio::test]
+async fn query_update_requires_a_change() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run_q(&save_action("q")).await.unwrap();
+    let err = run_q(&empty_update("q")).await.unwrap_err();
+    assert!(err.to_string().contains("no changes"));
+}
+
+#[tokio::test]
+async fn query_update_unknown_clear_field_errors() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run_q(&save_action("q")).await.unwrap();
+    let mut a = empty_update("q");
+    if let QueryAction::Update { clear, .. } = &mut a {
+        *clear = vec!["bogus".into()];
+    }
+    let err = run_q(&a).await.unwrap_err();
+    assert!(err.to_string().contains("unknown --clear field"));
+}
+
+#[tokio::test]
+async fn query_update_clearing_all_filters_rejected() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run_q(&product_save_action("q", "Firefox", 10))
+        .await
+        .unwrap(); // only product
+
+    let mut a = empty_update("q");
+    if let QueryAction::Update { clear, .. } = &mut a {
+        *clear = vec!["product".into()];
+    }
+    let err = run_q(&a).await.unwrap_err();
+    assert!(err.to_string().contains("at least one filter"));
+}
+
+#[tokio::test]
+async fn query_update_bad_date_errors() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run_q(&save_action("q")).await.unwrap();
+    let mut a = empty_update("q");
+    if let QueryAction::Update { created_since, .. } = &mut a {
+        *created_since = Some("not-a-date".into());
+    }
+    assert!(run_q(&a).await.is_err());
+}
+
+#[tokio::test]
+async fn query_update_clear_wins_over_set() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run_q(&save_action("q")).await.unwrap(); // product=Firefox, status=NEW
+
+    let mut a = empty_update("q");
+    if let QueryAction::Update { status, clear, .. } = &mut a {
+        *status = vec!["ASSIGNED".into()];
+        *clear = vec!["status".into()];
+    }
+    run_q(&a).await.unwrap();
+    // status was both set and cleared -> cleared.
+    assert!(Config::load().unwrap().queries["q"].status.is_empty());
+}

--- a/src/commands/shared.rs
+++ b/src/commands/shared.rs
@@ -495,6 +495,31 @@ pub(crate) fn read_file_with_context(path: &std::path::Path, flag: &str) -> Resu
     })
 }
 
+/// Overwrite `target` with `value` when an `Option` flag was supplied; an
+/// absent flag (`None`) leaves the existing value unchanged. Returns `true` if
+/// the flag was supplied (i.e. an assignment happened). Used by the in-place
+/// `update` merges for templates and saved queries.
+pub(crate) fn merge_set(target: &mut Option<String>, value: Option<&str>) -> bool {
+    if let Some(v) = value {
+        *target = Some(v.to_owned());
+        true
+    } else {
+        false
+    }
+}
+
+/// Overwrite `target` with `value` when a repeatable flag was supplied (a
+/// non-empty `Vec`); an empty `Vec` (absent flag) leaves it unchanged. Returns
+/// `true` if the flag was supplied.
+pub(crate) fn merge_vec(target: &mut Vec<String>, value: &[String]) -> bool {
+    if value.is_empty() {
+        false
+    } else {
+        *target = value.to_vec();
+        true
+    }
+}
+
 #[cfg(test)]
 #[path = "shared_tests.rs"]
 mod tests;

--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -3,6 +3,7 @@
 //! Template operations are pure local file I/O — no network client needed.
 
 use crate::cli::TemplateAction;
+use crate::commands::shared::merge_set;
 use crate::config::Config;
 use crate::error::{BzrError, Result};
 use crate::output::resources::template::{
@@ -49,16 +50,7 @@ pub async fn execute(
             };
 
             // Require at least one field to be set
-            if template.product.is_none()
-                && template.component.is_none()
-                && template.version.is_none()
-                && template.priority.is_none()
-                && template.severity.is_none()
-                && template.assignee.is_none()
-                && template.op_sys.is_none()
-                && template.rep_platform.is_none()
-                && template.description.is_none()
-            {
+            if template_is_empty(&template) {
                 return Err(BzrError::InputValidation(
                     "template must have at least one field set".into(),
                 ));
@@ -86,6 +78,7 @@ pub async fn execute(
                 .ok_or_else(|| BzrError::config(format!("template '{name}' not found")))?;
             write_template_detail(name, template, format, w.out);
         }
+        TemplateAction::Update { .. } => handle_update(action, format, w)?,
         TemplateAction::Delete { name } => {
             Config::update_locked(|config| {
                 if config.templates.remove(name.as_str()).is_none() {
@@ -97,6 +90,107 @@ pub async fn execute(
             write_template_saved(name, "Deleted", format, w.out);
         }
     }
+    Ok(())
+}
+
+/// Whether a template has no fields set (used to reject empty saves/updates).
+fn template_is_empty(t: &BugTemplate) -> bool {
+    t.product.is_none()
+        && t.component.is_none()
+        && t.version.is_none()
+        && t.priority.is_none()
+        && t.severity.is_none()
+        && t.assignee.is_none()
+        && t.op_sys.is_none()
+        && t.rep_platform.is_none()
+        && t.description.is_none()
+}
+
+/// Reset the named field to unset. The name matches the long flag (kebab-case).
+fn clear_template_field(t: &mut BugTemplate, field: &str) -> Result<()> {
+    match field {
+        "product" => t.product = None,
+        "component" => t.component = None,
+        "version" => t.version = None,
+        "priority" => t.priority = None,
+        "severity" => t.severity = None,
+        "assignee" => t.assignee = None,
+        "op-sys" => t.op_sys = None,
+        "rep-platform" => t.rep_platform = None,
+        "description" => t.description = None,
+        other => {
+            return Err(BzrError::InputValidation(format!(
+                "unknown --clear field '{other}'; valid fields: product, component, \
+                 version, priority, severity, assignee, op-sys, rep-platform, description"
+            )))
+        }
+    }
+    Ok(())
+}
+
+/// Merge `template update` flags into an existing template in place. A field
+/// flag replaces that field; `--clear <field>` resets it; omitted flags are
+/// left unchanged. Rejects a no-op call and a result with no fields set.
+fn handle_update(action: &TemplateAction, format: OutputFormat, w: &mut Writers<'_>) -> Result<()> {
+    let TemplateAction::Update {
+        name,
+        product,
+        component,
+        version,
+        priority,
+        severity,
+        assignee,
+        op_sys,
+        rep_platform,
+        description,
+        clear,
+    } = action
+    else {
+        unreachable!()
+    };
+
+    let sets = [
+        product,
+        component,
+        version,
+        priority,
+        severity,
+        assignee,
+        op_sys,
+        rep_platform,
+        description,
+    ];
+    if sets.iter().all(|f| f.is_none()) && clear.is_empty() {
+        return Err(BzrError::InputValidation(
+            "no changes specified: provide a field flag or --clear <field>".into(),
+        ));
+    }
+
+    Config::update_locked(|config| {
+        let Some(t) = config.templates.get_mut(name.as_str()) else {
+            return Err(BzrError::config(format!("template '{name}' not found")));
+        };
+        merge_set(&mut t.product, product.as_deref());
+        merge_set(&mut t.component, component.as_deref());
+        merge_set(&mut t.version, version.as_deref());
+        merge_set(&mut t.priority, priority.as_deref());
+        merge_set(&mut t.severity, severity.as_deref());
+        merge_set(&mut t.assignee, assignee.as_deref());
+        merge_set(&mut t.op_sys, op_sys.as_deref());
+        merge_set(&mut t.rep_platform, rep_platform.as_deref());
+        merge_set(&mut t.description, description.as_deref());
+        for field in clear {
+            clear_template_field(t, field)?;
+        }
+        if template_is_empty(t) {
+            return Err(BzrError::InputValidation(
+                "update would clear all fields; a template must keep at least one field set".into(),
+            ));
+        }
+        Ok(())
+    })?;
+
+    write_template_saved(name, "Updated", format, w.out);
     Ok(())
 }
 

--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -25,29 +25,8 @@ pub async fn execute(
     w: &mut Writers<'_>,
 ) -> Result<()> {
     match action {
-        TemplateAction::Save {
-            name,
-            product,
-            component,
-            version,
-            priority,
-            severity,
-            assignee,
-            op_sys,
-            rep_platform,
-            description,
-        } => {
-            let template = BugTemplate {
-                product: product.clone(),
-                component: component.clone(),
-                version: version.clone(),
-                priority: priority.clone(),
-                severity: severity.clone(),
-                assignee: assignee.clone(),
-                op_sys: op_sys.clone(),
-                rep_platform: rep_platform.clone(),
-                description: description.clone(),
-            };
+        TemplateAction::Save { name, fields } => {
+            let template = fields.to_template();
 
             // Require at least one field to be set
             if template_is_empty(&template) {
@@ -134,15 +113,7 @@ fn clear_template_field(t: &mut BugTemplate, field: &str) -> Result<()> {
 fn handle_update(action: &TemplateAction, format: OutputFormat, w: &mut Writers<'_>) -> Result<()> {
     let TemplateAction::Update {
         name,
-        product,
-        component,
-        version,
-        priority,
-        severity,
-        assignee,
-        op_sys,
-        rep_platform,
-        description,
+        fields,
         clear,
     } = action
     else {
@@ -150,15 +121,15 @@ fn handle_update(action: &TemplateAction, format: OutputFormat, w: &mut Writers<
     };
 
     let sets = [
-        product,
-        component,
-        version,
-        priority,
-        severity,
-        assignee,
-        op_sys,
-        rep_platform,
-        description,
+        &fields.product,
+        &fields.component,
+        &fields.version,
+        &fields.priority,
+        &fields.severity,
+        &fields.assignee,
+        &fields.op_sys,
+        &fields.rep_platform,
+        &fields.description,
     ];
     if sets.iter().all(|f| f.is_none()) && clear.is_empty() {
         return Err(BzrError::InputValidation(
@@ -170,15 +141,15 @@ fn handle_update(action: &TemplateAction, format: OutputFormat, w: &mut Writers<
         let Some(t) = config.templates.get_mut(name.as_str()) else {
             return Err(BzrError::config(format!("template '{name}' not found")));
         };
-        merge_set(&mut t.product, product.as_deref());
-        merge_set(&mut t.component, component.as_deref());
-        merge_set(&mut t.version, version.as_deref());
-        merge_set(&mut t.priority, priority.as_deref());
-        merge_set(&mut t.severity, severity.as_deref());
-        merge_set(&mut t.assignee, assignee.as_deref());
-        merge_set(&mut t.op_sys, op_sys.as_deref());
-        merge_set(&mut t.rep_platform, rep_platform.as_deref());
-        merge_set(&mut t.description, description.as_deref());
+        merge_set(&mut t.product, fields.product.as_deref());
+        merge_set(&mut t.component, fields.component.as_deref());
+        merge_set(&mut t.version, fields.version.as_deref());
+        merge_set(&mut t.priority, fields.priority.as_deref());
+        merge_set(&mut t.severity, fields.severity.as_deref());
+        merge_set(&mut t.assignee, fields.assignee.as_deref());
+        merge_set(&mut t.op_sys, fields.op_sys.as_deref());
+        merge_set(&mut t.rep_platform, fields.rep_platform.as_deref());
+        merge_set(&mut t.description, fields.description.as_deref());
         for field in clear {
             clear_template_field(t, field)?;
         }

--- a/src/commands/template_tests.rs
+++ b/src/commands/template_tests.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::unwrap_used)]
 
-use crate::cli::TemplateAction;
+use crate::cli::{TemplateAction, TemplateFields};
 use crate::config::Config;
 use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
@@ -8,15 +8,12 @@ use crate::types::OutputFormat;
 fn save_action(name: &str) -> TemplateAction {
     TemplateAction::Save {
         name: name.into(),
-        product: Some("TestProduct".into()),
-        component: Some("General".into()),
-        version: None,
-        priority: Some("P1".into()),
-        severity: None,
-        assignee: None,
-        op_sys: None,
-        rep_platform: None,
-        description: None,
+        fields: TemplateFields {
+            product: Some("TestProduct".into()),
+            component: Some("General".into()),
+            priority: Some("P1".into()),
+            ..Default::default()
+        },
     }
 }
 
@@ -67,15 +64,7 @@ async fn template_save_requires_field() {
 
     let action = TemplateAction::Save {
         name: "empty-tmpl".into(),
-        product: None,
-        component: None,
-        version: None,
-        priority: None,
-        severity: None,
-        assignee: None,
-        op_sys: None,
-        rep_platform: None,
-        description: None,
+        fields: TemplateFields::default(),
     };
     let result = super::execute(
         &action,
@@ -101,15 +90,10 @@ async fn template_save_with_single_field_succeeds() {
 
     let action = TemplateAction::Save {
         name: "version-only".into(),
-        product: None,
-        component: None,
-        version: Some("1.2.3".into()),
-        priority: None,
-        severity: None,
-        assignee: None,
-        op_sys: None,
-        rep_platform: None,
-        description: None,
+        fields: TemplateFields {
+            version: Some("1.2.3".into()),
+            ..Default::default()
+        },
     };
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result = super::execute(&action, None, OutputFormat::Json, None, &mut __io.writers()).await;
@@ -182,15 +166,13 @@ async fn template_save_existing_entry_reports_updated_and_replaces_fields() {
 
     let update = TemplateAction::Save {
         name: "existing".into(),
-        product: None,
-        component: Some("Updated".into()),
-        version: Some("123".into()),
-        priority: None,
-        severity: Some("major".into()),
-        assignee: None,
-        op_sys: None,
-        rep_platform: None,
-        description: Some("updated".into()),
+        fields: TemplateFields {
+            component: Some("Updated".into()),
+            version: Some("123".into()),
+            severity: Some("major".into()),
+            description: Some("updated".into()),
+            ..Default::default()
+        },
     };
     let mut __io_a4 = crate::test_helpers::CapturedIo::new();
     let result = super::execute(
@@ -404,15 +386,14 @@ fn update_action(
 ) -> TemplateAction {
     TemplateAction::Update {
         name: name.into(),
-        product: product.map(Into::into),
-        component: component.map(Into::into),
-        version: version.map(Into::into),
-        priority: priority.map(Into::into),
-        severity: severity.map(Into::into),
-        assignee: None,
-        op_sys: None,
-        rep_platform: None,
-        description: None,
+        fields: TemplateFields {
+            product: product.map(Into::into),
+            component: component.map(Into::into),
+            version: version.map(Into::into),
+            priority: priority.map(Into::into),
+            severity: severity.map(Into::into),
+            ..Default::default()
+        },
         clear: clear.iter().map(|s| (*s).to_string()).collect(),
     }
 }

--- a/src/commands/template_tests.rs
+++ b/src/commands/template_tests.rs
@@ -389,3 +389,160 @@ async fn template_show_unknown_errors() {
 
     assert!(err.to_string().contains("template 'missing' not found"));
 }
+
+// ── Update (#315) ───────────────────────────────────────────────────
+
+#[expect(clippy::too_many_arguments)]
+fn update_action(
+    name: &str,
+    product: Option<&str>,
+    component: Option<&str>,
+    version: Option<&str>,
+    priority: Option<&str>,
+    severity: Option<&str>,
+    clear: &[&str],
+) -> TemplateAction {
+    TemplateAction::Update {
+        name: name.into(),
+        product: product.map(Into::into),
+        component: component.map(Into::into),
+        version: version.map(Into::into),
+        priority: priority.map(Into::into),
+        severity: severity.map(Into::into),
+        assignee: None,
+        op_sys: None,
+        rep_platform: None,
+        description: None,
+        clear: clear.iter().map(|s| (*s).to_string()).collect(),
+    }
+}
+
+async fn run(action: &TemplateAction) -> crate::error::Result<String> {
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(action, None, OutputFormat::Json, None, &mut io.writers()).await;
+    result.map(|()| io.out_str().to_string())
+}
+
+#[tokio::test]
+async fn template_update_merges_field() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run(&save_action("t")).await.unwrap(); // product + component + priority
+
+    run(&update_action(
+        "t",
+        None,
+        None,
+        None,
+        None,
+        Some("blocker"),
+        &[],
+    ))
+    .await
+    .unwrap();
+
+    let config = Config::load().unwrap();
+    let t = &config.templates["t"];
+    assert_eq!(t.severity.as_deref(), Some("blocker"));
+    // Untouched fields are preserved.
+    assert_eq!(t.product.as_deref(), Some("TestProduct"));
+    assert_eq!(t.priority.as_deref(), Some("P1"));
+}
+
+#[tokio::test]
+async fn template_update_clear_resets_field() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run(&save_action("t")).await.unwrap();
+
+    run(&update_action(
+        "t",
+        None,
+        None,
+        None,
+        None,
+        None,
+        &["priority"],
+    ))
+    .await
+    .unwrap();
+
+    let config = Config::load().unwrap();
+    assert!(config.templates["t"].priority.is_none());
+    assert_eq!(
+        config.templates["t"].product.as_deref(),
+        Some("TestProduct")
+    );
+}
+
+#[tokio::test]
+async fn template_update_unknown_template_errors() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    let err = run(&update_action(
+        "missing",
+        Some("X"),
+        None,
+        None,
+        None,
+        None,
+        &[],
+    ))
+    .await
+    .unwrap_err();
+    assert!(err.to_string().contains("template 'missing' not found"));
+}
+
+#[tokio::test]
+async fn template_update_requires_a_change() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run(&save_action("t")).await.unwrap();
+    let err = run(&update_action("t", None, None, None, None, None, &[]))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("no changes"));
+}
+
+#[tokio::test]
+async fn template_update_unknown_clear_field_errors() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run(&save_action("t")).await.unwrap();
+    let err = run(&update_action(
+        "t",
+        None,
+        None,
+        None,
+        None,
+        None,
+        &["bogus"],
+    ))
+    .await
+    .unwrap_err();
+    assert!(err.to_string().contains("unknown --clear field"));
+}
+
+#[tokio::test]
+async fn template_update_clearing_all_fields_rejected() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run(&save_action("t")).await.unwrap(); // product, component, priority set
+    let err = run(&update_action(
+        "t",
+        None,
+        None,
+        None,
+        None,
+        None,
+        &["product", "component", "priority"],
+    ))
+    .await
+    .unwrap_err();
+    assert!(err.to_string().contains("at least one field"));
+}
+
+#[tokio::test]
+async fn template_update_clear_wins_over_set() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run(&save_action("t")).await.unwrap(); // product + component + priority
+
+    // Set and clear the same field in one call: clear wins.
+    let a = update_action("t", None, None, None, None, Some("blocker"), &["severity"]);
+    run(&a).await.unwrap();
+    assert!(Config::load().unwrap().templates["t"].severity.is_none());
+}

--- a/src/commands/template_tests.rs
+++ b/src/commands/template_tests.rs
@@ -546,3 +546,32 @@ async fn template_update_clear_wins_over_set() {
     run(&a).await.unwrap();
     assert!(Config::load().unwrap().templates["t"].severity.is_none());
 }
+
+#[test]
+fn clear_template_field_handles_every_name() {
+    let mut t = crate::types::BugTemplate {
+        product: Some("p".into()),
+        component: Some("c".into()),
+        version: Some("v".into()),
+        priority: Some("pr".into()),
+        severity: Some("s".into()),
+        assignee: Some("a".into()),
+        op_sys: Some("o".into()),
+        rep_platform: Some("rp".into()),
+        description: Some("d".into()),
+    };
+    for name in [
+        "product",
+        "component",
+        "version",
+        "priority",
+        "severity",
+        "assignee",
+        "op-sys",
+        "rep-platform",
+        "description",
+    ] {
+        super::clear_template_field(&mut t, name).unwrap();
+    }
+    assert!(super::template_is_empty(&t));
+}


### PR DESCRIPTION
## Summary

Adds in-place editing of saved queries and templates, fixing #315. Previously the only way to change one field of a saved query/template was delete + re-create, re-specifying everything (and the `query run` docs literally told users to "edit the config or re-save").

| Issue | Title | Type | Key files |
|-------|-------|------|-----------|
| #315 | Edit saved queries/templates in place | feat | `src/cli/query.rs`, `src/cli/template.rs`, `src/commands/query.rs`, `src/commands/template.rs`, `src/commands/shared.rs` |

- **`bzr template update <NAME> [field flags] [--clear <FIELD>]`** — merges into an existing template.
- **`bzr query update <NAME> [filter/scalar flags] [--clear <FIELD>]`** — merges into an existing saved query.

## Merge semantics

- A supplied flag **replaces** that field: repeatable filter flags replace the whole list, scalars (`--limit`, `--fields`, `--search`, `--created-since`, `--sort`, ...) replace the value.
- An **omitted** flag leaves the field unchanged.
- `--clear <FIELD>` (repeatable; names match the long flags, e.g. `status`, `limit`, `search`, `op-sys`, `created-since`, `sort`) resets a field.
- If a field is **both set and cleared** in one call, `--clear` wins (clears run after merges). Documented in `--help` and the docs.
- A **no-op** call is rejected, and an update that would leave a template with no fields or a query with no filters is rejected (exit 7).

## Correctness

- Dates (`--created-since`/`--changed-since`) are validated **before** the config lock is acquired, so a bad value exits cleanly.
- The merge runs inside `Config::update_locked`, which reads a **fresh** config from disk and only calls `write_to_disk()` after the mutator returns `Ok` — a rejected update (unknown `--clear` name, no-op, empty result, missing name) **never persists a partial change**.
- Unknown `--clear` field names are rejected with a message listing the valid names.

## Implementation notes

- Shared `merge_set` / `merge_vec` helpers (in `commands/shared.rs`) implement the "absent flag keeps the value" policy and return whether a change was applied; that return value also drives no-op detection (so there's a single source of truth for "did anything change").
- `template_save`'s empty-check was extracted to a shared `template_is_empty` and reused by update.
- Updates the command tree (`docs/bzr-cli.md`), the verb manifest (`commands.yml`), the per-command docs sections, and the now-stale "edit the config or re-save" guidance in `query run`.

## Review notes

- Reviewed adversarially (merge precedence, `--clear` validation ordering, config-write atomicity, `Search`-kind interaction) — all clean. The `--clear`-wins precedence was the one surfaced nuance and is now documented and tested.
- A `/simplify` pass removed a redundant 24-field destructure (no-op detection now folded into the merge's return value).
- `--clear` validity is checked in the command layer (not via clap `value_parser`) and the 15 filter-clear arms are an explicit match rather than routed through `SavedQuery::get_field_mut` — deliberate: routing would need kebab→snake translation plus an `assignee`/`assigned_to` special case and still leave the scalars explicit (net more complex).

## Test coverage

16 new tests: merge-replaces-field, replaces-scalar, `--clear` resets, clear-wins-over-set, unknown name, no-op rejected, unknown `--clear` field, clear-all rejected, bad-date rejected — for both `query` and `template`.

## Validation

`cargo test` (1434 lib + integration + bin), `cargo clippy --locked --features test-helpers -- -D warnings`, `cargo fmt --check`, and the `agent-skills` verb + flag drift checks all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
