### PR TITLE
feat(bug): add global --dry-run to preview mutations (#308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Global `--dry-run` flag for bug mutations. Previews `bug create`, `update`,
+  `clone`, `resolve`, `close`, `reopen`, and `dup` without writing: it resolves
+  and validates the request, then prints the would-be payload and affected bug
+  IDs as `{"resource":"bug","action":"dry-run","ids":[...],"changes":{...}}`
+  instead of calling the write API, exiting 0 on a valid request. Useful as a
+  safety net for humans and a pre-flight validation step for agents before an
+  irreversible batch `update`. `clone` still reads the source bug to build the
+  preview. Using `--dry-run` on any non-mutation command exits 7. (#308)
+
 ### Changed
 
 - **Breaking:** attachment boolean flags now use a uniform `--x` / `--no-x`

--- a/agent-skills/tests/flag-drift-check-test.sh
+++ b/agent-skills/tests/flag-drift-check-test.sh
@@ -65,7 +65,7 @@ matching_doc() {
 ## Command Tree
 
 ```
-bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [-v...]
+bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [--dry-run] [-v...]
 ├── demo
 │   ├── alpha [--foo <X>] [--bar <Y>]
 │   ├── beta [--baz <Z>]

--- a/agent-skills/tests/flag-drift-check.sh
+++ b/agent-skills/tests/flag-drift-check.sh
@@ -36,7 +36,7 @@ fail=0
 # Globals the tree's root line is expected to spell out, and that every command
 # inherits. -v/--verbose, --help and --version are auto/standard flags the
 # curated tree abbreviates (`[-v...]`) or omits, so they are not required there.
-ROOT_GLOBALS='--server --output --json --config --no-color --quiet --api --timeout --retry'
+ROOT_GLOBALS='--server --output --json --config --no-color --quiet --api --timeout --retry --dry-run'
 # Full inherited set excluded from per-command comparison on both sides (the
 # tree lists them once on its root line, but a command block may still repeat
 # one, e.g. `query run [--server <NAME>]`, and that is not drift). Derived from

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -43,6 +43,7 @@ For installation and quick start, see [README.md](../README.md).
 | `--api <MODE>` | Override API transport: `rest`, `xmlrpc`, or `hybrid`. Auto-detected from server version if not set. |
 | `--timeout <SECS>` | Per-request timeout in seconds (default 30). Takes precedence over `BZR_TIMEOUT`. The 10s connect timeout is unaffected. |
 | `--retry <N>` | Retry transient failures up to N times with exponential backoff honoring `Retry-After`. 429 and connect failures are retried for any operation; 5xx and read timeouts only for safe reads (GET/HEAD), never for writes (create, update, comment) where a replay could duplicate the effect. Default 0 (disabled); max 10. Exhausted retries exit 5. |
+| `--dry-run` | Preview a bug mutation without writing. Resolves and validates the request, then prints the would-be payload and affected bug IDs as `{"resource":"bug","action":"dry-run","ids":[...],"changes":{...}}` instead of calling the write API. Exits 0 on a valid request. Only valid for `bug create`, `update`, `clone`, `resolve`, `close`, `reopen`, and `dup`; on any other command it exits 7. `clone` still reads the source bug to build the preview. |
 | `-v, --verbose` | Increase log verbosity (`-v`=info, `-vv`=debug, `-vvv`=trace; `RUST_LOG` overrides) |
 | `-h, --help` | Print help |
 | `-V, --version` | Print version |
@@ -85,7 +86,7 @@ Agent note: at an interactive TTY, `bzr` defaults to table output. For agent wor
 ## Command Tree
 
 ```
-bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [-v...]
+bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [--dry-run] [-v...]
 ├── bug
 │   ├── list [--product <P>...] [--component <C>...] [--status <S>...] [--assignee <A>...]
 │   │        [--creator <C>...] [--priority <P>...] [--severity <S>...] [--id <ID>...]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -73,6 +73,10 @@ use crate::types::{ApiMode, OutputFormat};
     clippy::doc_markdown,
     reason = "doc examples are literal shell commands; wrapping URLs in <> or identifiers in backticks would degrade copy-paste UX"
 )]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "independent global on/off CLI switches (--json, --no-color, --quiet, --dry-run); a state machine does not model unrelated flags"
+)]
 pub struct Cli {
     /// Server name from config (uses default if not set).
     #[arg(long, global = true)]
@@ -155,6 +159,16 @@ pub struct Cli {
     /// 10. Exhausted retries surface the usual network error (exit code 5).
     #[arg(long, value_name = "N", global = true, value_parser = clap::value_parser!(u32).range(0..=10))]
     pub retry: Option<u32>,
+
+    /// Preview a bug mutation without writing (no API call).
+    ///
+    /// Resolves and validates the request, then prints the would-be payload
+    /// and affected bug IDs with `"action":"dry-run"` instead of calling the
+    /// write API. Exits 0 on a valid request. Only valid for the bug
+    /// mutations (`create`, `update`, `clone`, `resolve`, `close`, `reopen`,
+    /// `dup`); used on any other command it exits 7.
+    #[arg(long, global = true)]
+    pub dry_run: bool,
 
     /// Set log verbosity (default: warnings only, -v=info, -vv=debug, -vvv=trace; `RUST_LOG` overrides)
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]

--- a/src/commands/bug/clone.rs
+++ b/src/commands/bug/clone.rs
@@ -1,7 +1,7 @@
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
-use crate::output::result_types::{write_result, ActionResult, ResourceKind};
+use crate::output::result_types::{write_result, ActionResult, DryRunResult, ResourceKind};
 use crate::output::writers::Writers;
 use crate::types::{CreateBugParams, OutputFormat};
 
@@ -85,6 +85,11 @@ pub(super) async fn handle(
         ..Default::default()
     };
 
+    if crate::commands::dry_run::enabled() {
+        write_clone_dry_run(source.id, &params, format, w);
+        return Ok(());
+    }
+
     let new_id = client.create_bug(&params).await?;
 
     // The bug was created successfully — that is the clone operation. The
@@ -113,6 +118,23 @@ pub(super) async fn handle(
         w.out,
     );
     Ok(())
+}
+
+/// Emit the would-be clone payload without writing, marked `"action":"dry-run"`.
+/// The clone creates a new bug, so `ids` is empty; `changes` carries the
+/// resolved `CreateBugParams` (built from the fetched source bug).
+fn write_clone_dry_run(
+    source_id: u64,
+    params: &CreateBugParams,
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) {
+    write_result(
+        &DryRunResult::new(ResourceKind::Bug, &[], params),
+        &format!("Dry run: would clone bug #{source_id} (no bug created)"),
+        format,
+        w.out,
+    );
 }
 
 #[cfg(test)]

--- a/src/commands/bug/clone_tests.rs
+++ b/src/commands/bug/clone_tests.rs
@@ -284,3 +284,76 @@ async fn bug_clone_no_comment_skips_comment() {
     let _output = __io2.out_str().to_string();
     assert!(result.is_ok(), "bug clone --no-comment failed: {result:?}");
 }
+
+#[tokio::test]
+async fn bug_clone_dry_run_reads_source_but_creates_nothing() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    crate::commands::dry_run::set(true);
+
+    // Source fetch (GET) is allowed in a dry run; it builds the would-be payload.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{
+                "id": 100,
+                "summary": "Original bug",
+                "status": "NEW",
+                "product": "TestProduct",
+                "component": "General",
+                "version": "2.0",
+                "cc": [],
+                "keywords": []
+            }]
+        })))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/100/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": { "100": { "comments": [{
+                "id": 1, "count": 0, "text": "Original description",
+                "creator": "dev@test.com", "creation_time": "2025-01-01T00:00:00Z"
+            }] } }
+        })))
+        .mount(&mock)
+        .await;
+    // No write may happen: any create POST fails the test on drop.
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 999})))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let action = BugAction::Clone {
+        id: "100".to_string(),
+        summary: None,
+        product: None,
+        component: None,
+        version: None,
+        description: None,
+        priority: None,
+        severity: None,
+        assignee: None,
+        op_sys: None,
+        rep_platform: None,
+        no_comment: false,
+        add_depends_on: false,
+        add_blocks: false,
+        no_cc: false,
+        no_keywords: false,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    let output = io.out_str().to_string();
+    crate::commands::dry_run::set(false);
+
+    assert!(result.is_ok(), "dry-run clone failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["ids"], serde_json::json!([]));
+    assert_eq!(parsed["changes"]["product"], "TestProduct");
+    assert_eq!(parsed["changes"]["summary"], "Original bug");
+}

--- a/src/commands/bug/create.rs
+++ b/src/commands/bug/create.rs
@@ -4,7 +4,7 @@ use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::commands::editor;
 use crate::error::Result;
-use crate::output::result_types::{write_result, ActionResult, ResourceKind};
+use crate::output::result_types::{write_result, ActionResult, DryRunResult, ResourceKind};
 use crate::output::writers::Writers;
 use crate::types::{CreateBugParams, OutputFormat};
 
@@ -296,6 +296,11 @@ pub(super) async fn handle(
         groups: create_fields.groups.clone(),
         flags,
     };
+    if crate::commands::dry_run::enabled() {
+        write_create_dry_run(&params, format, w);
+        return Ok(());
+    }
+
     let id = client.create_bug(&params).await?;
     write_result(
         &ActionResult::created(id, ResourceKind::Bug),
@@ -304,6 +309,21 @@ pub(super) async fn handle(
         w.out,
     );
     Ok(())
+}
+
+/// Emit the would-be create payload without writing, marked `"action":"dry-run"`.
+/// No bug exists yet, so `ids` is empty; `changes` carries the resolved
+/// `CreateBugParams`.
+fn write_create_dry_run(params: &CreateBugParams, format: OutputFormat, w: &mut Writers<'_>) {
+    write_result(
+        &DryRunResult::new(ResourceKind::Bug, &[], params),
+        &format!(
+            "Dry run: would create a bug in {}/{} (no bug created)",
+            params.product, params.component
+        ),
+        format,
+        w.out,
+    );
 }
 
 #[cfg(test)]

--- a/src/commands/bug/create_tests.rs
+++ b/src/commands/bug/create_tests.rs
@@ -61,6 +61,41 @@ async fn bug_create_sends_post() {
 }
 
 #[tokio::test]
+async fn bug_create_dry_run_makes_no_write_and_marks_payload() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    // A create POST must never fire under --dry-run. The connect-time TLS
+    // probe is a HEAD, so it won't match this mock.
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 1})))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    crate::commands::dry_run::set(true);
+
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
+        &create_action(),
+        None,
+        OutputFormat::Json,
+        None,
+        &mut io.writers(),
+    )
+    .await;
+    let output = io.out_str().to_string();
+    crate::commands::dry_run::set(false);
+
+    assert!(result.is_ok(), "dry-run create failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["resource"], "bug");
+    assert_eq!(parsed["ids"], serde_json::json!([]));
+    assert_eq!(parsed["changes"]["product"], "TestProduct");
+    assert_eq!(parsed["changes"]["component"], "General");
+    assert_eq!(parsed["changes"]["summary"], "New bug");
+}
+
+#[tokio::test]
 async fn bug_create_sends_parity_fields_in_body() {
     let (_lock, mock, _tmp) = setup_test_env().await;
 

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -46,6 +46,22 @@ pub(super) fn count_search_params(
     params
 }
 
+/// Whether a bug action is a mutation that supports `--dry-run` (the create-,
+/// update-, and clone-shaped writes). Read actions and `--web` are excluded.
+#[must_use]
+pub fn is_dry_runnable(action: &BugAction) -> bool {
+    matches!(
+        action,
+        BugAction::Create { .. }
+            | BugAction::Update { .. }
+            | BugAction::Clone { .. }
+            | BugAction::Resolve { .. }
+            | BugAction::Close { .. }
+            | BugAction::Reopen { .. }
+            | BugAction::Dup { .. }
+    )
+}
+
 /// Dispatch bug actions to their respective handlers.
 pub async fn execute(
     action: &BugAction,

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -2,7 +2,7 @@ use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::error::Result;
 use crate::output::result_types::{
-    write_result, ActionResult, BatchFailure, BatchResult, ResourceKind,
+    write_result, ActionResult, BatchFailure, BatchResult, DryRunResult, ResourceKind,
 };
 use crate::output::writers::Writers;
 use crate::types::{IdListUpdate, OutputFormat, StringListUpdate, UpdateBugParams};
@@ -294,9 +294,32 @@ pub(super) async fn handle(
     apply(client, ids, params, format, w).await
 }
 
+/// Emit the would-be update without writing: the affected IDs and the payload
+/// that would be sent, marked `"action":"dry-run"`. Shared by `bug update` and
+/// the convenience verbs.
+fn write_update_dry_run(
+    ids: &[u64],
+    params: &UpdateBugParams,
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) {
+    let ids_str: Vec<String> = ids.iter().map(|id| format!("#{id}")).collect();
+    let suffix = comment_suffix(params.comment.is_some());
+    write_result(
+        &DryRunResult::new(ResourceKind::Bug, ids, params),
+        &format!(
+            "Dry run: would update bug(s) {}{suffix} (no changes made)",
+            ids_str.join(", ")
+        ),
+        format,
+        w.out,
+    );
+}
+
 /// Apply an already-built `UpdateBugParams` to one or more bug IDs, dispatching
 /// to the single- or batch-update path. Shared by `bug update` and the
-/// convenience verbs (`resolve`/`close`/`reopen`/`dup`).
+/// convenience verbs (`resolve`/`close`/`reopen`/`dup`). Under `--dry-run`,
+/// previews the change without calling the write API.
 pub(super) async fn apply(
     client: &BugzillaClient,
     ids: Vec<u64>,
@@ -304,6 +327,10 @@ pub(super) async fn apply(
     format: OutputFormat,
     w: &mut Writers<'_>,
 ) -> Result<()> {
+    if crate::commands::dry_run::enabled() {
+        write_update_dry_run(&ids, &params, format, w);
+        return Ok(());
+    }
     if ids.len() == 1 {
         update_single(client, ids[0], &params, format, w).await
     } else {

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -795,3 +795,98 @@ fn build_update_params_rejects_update_with_no_fields() {
         "expected an at-least-one-field validation error, got {err:?}"
     );
 }
+
+// ── Dry run (#308) ──────────────────────────────────────────────────
+
+/// Mount a method-only PUT mock that must never fire — proves a dry run
+/// performs no write. The connect-time TLS probe is a HEAD, so it won't match.
+async fn forbid_put(mock: &wiremock::MockServer) {
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(mock)
+        .await;
+}
+
+#[tokio::test]
+async fn bug_update_dry_run_makes_no_write_and_marks_payload() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    forbid_put(&mock).await;
+    crate::commands::dry_run::set(true);
+
+    let action = make_update_action(vec![42]);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    let output = io.out_str().to_string();
+    crate::commands::dry_run::set(false);
+
+    assert!(result.is_ok(), "dry-run update failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["resource"], "bug");
+    assert_eq!(parsed["ids"], serde_json::json!([42]));
+    assert_eq!(parsed["changes"]["status"], "RESOLVED");
+    assert_eq!(parsed["changes"]["resolution"], "FIXED");
+}
+
+#[tokio::test]
+async fn bug_update_dry_run_batch_lists_all_ids() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    forbid_put(&mock).await;
+    crate::commands::dry_run::set(true);
+
+    let action = make_update_action(vec![1, 2, 3]);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    let output = io.out_str().to_string();
+    crate::commands::dry_run::set(false);
+
+    assert!(result.is_ok());
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["ids"], serde_json::json!([1, 2, 3]));
+}
+
+#[tokio::test]
+async fn bug_update_dry_run_table_prints_human_preview() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    forbid_put(&mock).await;
+    crate::commands::dry_run::set(true);
+
+    let action = make_update_action(vec![7, 8]);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Table, None, &mut io.writers())
+            .await;
+    let output = io.out_str().to_string();
+    crate::commands::dry_run::set(false);
+
+    assert!(result.is_ok(), "dry-run update (table) failed: {result:?}");
+    assert!(
+        output.contains("Dry run") && output.contains("#7") && output.contains("#8"),
+        "expected a human preview naming both bugs, got: {output:?}"
+    );
+}
+
+#[tokio::test]
+async fn bug_update_dry_run_still_validates_empty_update() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    forbid_put(&mock).await;
+    crate::commands::dry_run::set(true);
+
+    let action = make_empty_update_action(vec![42]);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    crate::commands::dry_run::set(false);
+
+    assert!(matches!(
+        result,
+        Err(crate::error::BzrError::InputValidation(_))
+    ));
+}

--- a/src/commands/bug/verbs_tests.rs
+++ b/src/commands/bug/verbs_tests.rs
@@ -32,6 +32,37 @@ async fn run_verb_expecting_body(action: BugAction, id: u64, body: serde_json::V
 }
 
 #[tokio::test]
+async fn resolve_dry_run_makes_no_write() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    // A verb PUT must never fire under --dry-run; the connect probe is a HEAD.
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    crate::commands::dry_run::set(true);
+
+    let action = BugAction::Resolve {
+        ids: vec![5],
+        as_resolution: "FIXED".into(),
+        comment: CommentArgs::default(),
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    let output = io.out_str().to_string();
+    crate::commands::dry_run::set(false);
+
+    assert!(result.is_ok(), "dry-run resolve failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["ids"], serde_json::json!([5]));
+    assert_eq!(parsed["changes"]["status"], "RESOLVED");
+    assert_eq!(parsed["changes"]["resolution"], "FIXED");
+}
+
+#[tokio::test]
 async fn resolve_defaults_to_fixed() {
     let action = BugAction::Resolve {
         ids: vec![5],

--- a/src/commands/dry_run.rs
+++ b/src/commands/dry_run.rs
@@ -1,0 +1,35 @@
+//! Process-global `--dry-run` switch.
+//!
+//! `--dry-run` is a global CLI flag. Like the network-tuning globals (see
+//! `lib::apply_network_tuning`), it is installed once per process by
+//! `dispatch` and read by the bug mutation handlers, which short-circuit
+//! before any write API call and emit a `"action":"dry-run"` payload instead.
+//!
+//! Using a process-global avoids threading a `dry_run` bool through every
+//! command handler signature (and every test call site). The CLI runs a
+//! single dispatch per process, so the shared state is not a concurrency
+//! concern in practice; tests reset it to `false` via `setup_test_env`.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Install the dry-run state from the global `--dry-run` flag.
+///
+/// Production calls this once, from `dispatch`. Test-side callers must hold
+/// `ENV_LOCK` (as `setup_test_env` does) so they serialize with the mutation
+/// tests; otherwise a parallel test could observe a foreign value.
+pub fn set(enabled: bool) {
+    ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+/// Whether the current invocation is a dry run (no writes).
+///
+/// Test-side callers that toggle this via [`set`] must hold `ENV_LOCK` so they
+/// serialize with the mutation tests (which reset it through `setup_test_env`);
+/// otherwise a parallel test could observe a foreign value. Behavior is covered
+/// end-to-end by the dispatch and per-handler dry-run tests.
+#[must_use]
+pub fn enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod comment;
 pub mod completion;
 pub mod component;
 pub mod config;
+pub mod dry_run;
 mod editor;
 pub mod field;
 pub mod flags;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@ pub async fn dispatch(
     w: &mut output::writers::Writers<'_>,
 ) -> error::Result<()> {
     apply_network_tuning(cli);
+    ensure_dry_run_supported(cli)?;
+    commands::dry_run::set(cli.dry_run);
 
     let api = cli.api;
     let server = cli.server.as_deref();
@@ -122,6 +124,27 @@ fn apply_network_tuning(cli: &cli::Cli) {
         env_timeout.as_deref(),
     ));
     http::set_retry_max(cli.retry.unwrap_or(0));
+}
+
+/// Reject `--dry-run` on commands that don't honor it.
+///
+/// `--dry-run` is a global flag (so it can appear after any subcommand), but
+/// only the bug mutations preview without writing. Allowing it elsewhere would
+/// silently ignore it — e.g. `bzr comment add --dry-run` would still post the
+/// comment. Fail fast (exit 7) instead of writing when a preview was asked for.
+fn ensure_dry_run_supported(cli: &cli::Cli) -> error::Result<()> {
+    if !cli.dry_run {
+        return Ok(());
+    }
+    if let cli::Commands::Bug { action } = &cli.command {
+        if commands::bug::is_dry_runnable(action) {
+            return Ok(());
+        }
+    }
+    Err(error::BzrError::InputValidation(
+        "--dry-run is only supported for bug create, update, clone, resolve, close, reopen, and dup"
+            .into(),
+    ))
 }
 
 /// Shared mutex for tests that modify the process-global `XDG_CONFIG_HOME` env var.

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -56,3 +56,53 @@ async fn dispatch_routes_local_query_commands() {
     assert_eq!(parsed["name"], "firefox-new");
     assert_eq!(parsed["action"], "saved");
 }
+
+#[tokio::test]
+async fn dispatch_rejects_dry_run_on_unsupported_command() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    // --dry-run on a non-mutation command is rejected before any network I/O,
+    // so a silently-ignored preview can never turn into a real write.
+    let cli = cli::Cli::try_parse_from(["bzr", "--server", "test", "--dry-run", "whoami"]).unwrap();
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = dispatch(&cli, OutputFormat::Json, &mut io.writers()).await;
+
+    assert!(matches!(
+        result,
+        Err(error::BzrError::InputValidation(ref msg)) if msg.contains("--dry-run")
+    ));
+    // The reject must not leak dry-run state into a later command.
+    assert!(!commands::dry_run::enabled());
+}
+
+#[tokio::test]
+async fn dispatch_allows_dry_run_on_bug_update() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let cli = cli::Cli::try_parse_from([
+        "bzr",
+        "--server",
+        "test",
+        "--json",
+        "--dry-run",
+        "bug",
+        "update",
+        "5",
+        "--status",
+        "RESOLVED",
+    ])
+    .unwrap();
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = dispatch(&cli, OutputFormat::Json, &mut io.writers()).await;
+    let output = io.out_str().to_string();
+
+    assert!(result.is_ok(), "dry-run dispatch failed: {result:?}");
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["ids"], serde_json::json!([5]));
+}

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -40,6 +40,7 @@ fn base_cli(command: Commands) -> Cli {
         api: None,
         timeout: None,
         retry: None,
+        dry_run: false,
         verbose: 0,
         command,
     }

--- a/src/output/result_types.rs
+++ b/src/output/result_types.rs
@@ -80,6 +80,8 @@ pub enum ActionKind {
     Renamed,
     #[serde(rename = "downloaded")]
     Downloaded,
+    #[serde(rename = "dry-run")]
+    DryRun,
 }
 
 /// Typed result payload for relationship mutations (e.g. group membership).
@@ -383,6 +385,37 @@ impl ActionResult {
             name: Some(name.into()),
             resource,
             action: ActionKind::Updated,
+        }
+    }
+}
+
+/// Typed result payload for a `--dry-run` mutation preview.
+///
+/// Serializes the normal mutation marker (`resource`, `action: "dry-run"`)
+/// plus the affected existing bug `ids` (empty for `create`/`clone`, which
+/// produce a new bug) and the `changes` payload that *would* be sent to the
+/// write API. `changes` is generic over the request type so `create`
+/// (`CreateBugParams`) and `update` (`UpdateBugParams`) can share one shape
+/// without an intermediate `serde_json::Value`.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct DryRunResult<'a, P: Serialize> {
+    pub resource: ResourceKind,
+    pub action: ActionKind,
+    pub ids: &'a [u64],
+    pub changes: &'a P,
+}
+
+impl<'a, P: Serialize> DryRunResult<'a, P> {
+    /// Build a dry-run preview for `resource`, listing the existing bug `ids`
+    /// that would be affected (empty for create-shaped operations) and the
+    /// would-be request `changes`.
+    pub fn new(resource: ResourceKind, ids: &'a [u64], changes: &'a P) -> Self {
+        Self {
+            resource,
+            action: ActionKind::DryRun,
+            ids,
+            changes,
         }
     }
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -15,6 +15,9 @@ pub async fn setup_test_env() -> (
     tempfile::TempDir,
 ) {
     let lock = super::ENV_LOCK.lock().await;
+    // Reset process-global dry-run state to the test baseline so a prior
+    // dry-run test cannot leak `--dry-run` into one that expects real writes.
+    super::commands::dry_run::set(false);
     let mock = wiremock::MockServer::start().await;
     let tmp = tempfile::TempDir::new().unwrap();
     setup_config(&tmp, &mock.uri());


### PR DESCRIPTION
## Summary

Adds a global `--dry-run` flag that previews a bug mutation without writing, fixing #308. For humans it's a safety net before an irreversible batch `update`; for agents it's a pre-flight validation step before committing to a write.

| Issue | Title | Type | Key files |
|-------|-------|------|-----------|
| #308 | `--dry-run` on mutations | feat | `src/cli/mod.rs`, `src/commands/dry_run.rs`, `src/commands/bug/{create,update,clone,mod}.rs`, `src/lib.rs`, `src/output/result_types.rs` |

## Behavior

- `bzr bug update 100 200 300 --status RESOLVED --dry-run` resolves and validates the request, then prints the would-be payload and affected IDs **instead of** calling the write API:

  ```json
  {"resource":"bug","action":"dry-run","ids":[100,200,300],"changes":{"status":"RESOLVED"}}
  ```

  Table mode prints a human line (`Dry run: would update bug(s) #100, #200, #300 (no changes made)`).
- Covers `bug create`, `update`, `clone`, and the convenience verbs (`resolve`/`close`/`reopen`/`dup`). `create`/`clone` have no existing bug, so `ids` is empty and `changes` carries the resolved `CreateBugParams`.
- Exits 0 on a valid request. Validation still runs first, so an empty `update` exits 7 whether or not `--dry-run` is set.
- `clone` still reads the source bug (a GET) to build the preview — a preview without it would be meaningless.

## Write-safety

- Each handler short-circuits **before** its write call: `create`/`clone` before `client.create_bug` (and clone before the follow-up "Cloned from" comment), `update`/verbs before `client.update_bug` via the shared `apply`. No code path writes under `--dry-run`.
- A dispatch guard rejects `--dry-run` on any non-mutation command (exit 7), so a silently-ignored preview can't become a real write (e.g. `comment add --dry-run` errors rather than posting). The guard runs **before** the global is set, so a rejected invocation never leaves dry-run state behind.

## Implementation notes

- `--dry-run` is a global flag installed once per process by `dispatch`, the same mechanism the codebase already uses for the `--timeout`/`--retry` network-tuning globals (`apply_network_tuning`). This avoids threading a `dry_run` bool through `bug::execute` (243 call sites) or every `BugAction` variant (66 construction/destructure sites).
- `DryRunResult<'a, P: Serialize>` borrows the affected `ids` and the request `changes` by reference, so `create` (`CreateBugParams`) and `update` (`UpdateBugParams`) share one shape with no intermediate `serde_json::Value`.
- `setup_test_env` resets the process-global to `false` under `ENV_LOCK`, so a dry-run test cannot leak `--dry-run` into a write-expecting test.

## Review notes

- Reviewed adversarially (`/challenge`, twice): the first pass confirmed write-safety and the guard, and flagged a test-only contamination risk (an unsynchronized unit test toggling the global in parallel with mutation tests) — fixed by removing that test and documenting the `ENV_LOCK` invariant on `dry_run::set`/`enabled`. Second pass: approve.
- A `/simplify` pass collapsed three near-identical dry-run writer helpers onto the existing `write_result` format-dispatch facade (the same idiom the real mutation paths use).
- New global flag, so the command tree (`docs/bzr-cli.md`), the Global Options table, `CHANGELOG.md`, and the flag-drift `ROOT_GLOBALS` + self-test root line are all updated.

## Test coverage

9 new tests: per-handler no-write previews (`create`/`update`/`clone`/`resolve`) asserting the write mock never fires and the `action":"dry-run"` payload shape; batch-lists-all-ids; dry-run still validates an empty update; a Table-mode human-preview test; and two dispatch-level tests (guard rejects `--dry-run` on `whoami`; allows it end-to-end on `bug update`).

## Validation

`cargo test` (1446 lib + 22 + 78 integration), `cargo clippy --locked --features test-helpers -- -D warnings`, `cargo fmt --check`, and the `agent-skills` drift + flag-drift checks all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
