### PR TITLE
feat(bug): confirm large batch mutations, add -y/--yes (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Confirmation gate for large batch bug mutations, with a global `-y`/`--yes`
+  bypass. A `bug update`/`resolve`/`close`/`reopen` targeting more than 10 bugs
+  now prompts for confirmation at an interactive terminal before writing, so a
+  mistyped ID list cannot mass-mutate bugs unnoticed. Non-interactive runs
+  (piped stdin, agents) auto-bypass and are never blocked; `--yes` skips the
+  prompt explicitly. (#313)
 - Global `--dry-run` flag for bug mutations. Previews `bug create`, `update`,
   `clone`, `resolve`, `close`, `reopen`, and `dup` without writing: it resolves
   and validates the request, then prints the would-be payload and affected bug

--- a/agent-skills/tests/flag-drift-check-test.sh
+++ b/agent-skills/tests/flag-drift-check-test.sh
@@ -65,7 +65,7 @@ matching_doc() {
 ## Command Tree
 
 ```
-bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [--dry-run] [-v...]
+bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [--dry-run] [--yes] [-v...]
 ├── demo
 │   ├── alpha [--foo <X>] [--bar <Y>]
 │   ├── beta [--baz <Z>]

--- a/agent-skills/tests/flag-drift-check.sh
+++ b/agent-skills/tests/flag-drift-check.sh
@@ -36,7 +36,7 @@ fail=0
 # Globals the tree's root line is expected to spell out, and that every command
 # inherits. -v/--verbose, --help and --version are auto/standard flags the
 # curated tree abbreviates (`[-v...]`) or omits, so they are not required there.
-ROOT_GLOBALS='--server --output --json --config --no-color --quiet --api --timeout --retry --dry-run'
+ROOT_GLOBALS='--server --output --json --config --no-color --quiet --api --timeout --retry --dry-run --yes'
 # Full inherited set excluded from per-command comparison on both sides (the
 # tree lists them once on its root line, but a command block may still repeat
 # one, e.g. `query run [--server <NAME>]`, and that is not drift). Derived from

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -44,6 +44,7 @@ For installation and quick start, see [README.md](../README.md).
 | `--timeout <SECS>` | Per-request timeout in seconds (default 30). Takes precedence over `BZR_TIMEOUT`. The 10s connect timeout is unaffected. |
 | `--retry <N>` | Retry transient failures up to N times with exponential backoff honoring `Retry-After`. 429 and connect failures are retried for any operation; 5xx and read timeouts only for safe reads (GET/HEAD), never for writes (create, update, comment) where a replay could duplicate the effect. Default 0 (disabled); max 10. Exhausted retries exit 5. |
 | `--dry-run` | Preview a bug mutation without writing. Resolves and validates the request, then prints the would-be payload and affected bug IDs as `{"resource":"bug","action":"dry-run","ids":[...],"changes":{...}}` instead of calling the write API. Exits 0 on a valid request. Only valid for `bug create`, `update`, `clone`, `resolve`, `close`, `reopen`, and `dup`; on any other command it exits 7. `clone` still reads the source bug to build the preview. |
+| `-y, --yes` | Skip the confirmation prompt for a large batch mutation. A `bug update`/`resolve`/`close`/`reopen` targeting more than 10 bugs prompts for confirmation at an interactive terminal; `--yes` bypasses it. Non-interactive runs (piped stdin, agents) never prompt, so this is only needed in an interactive session. |
 | `-v, --verbose` | Increase log verbosity (`-v`=info, `-vv`=debug, `-vvv`=trace; `RUST_LOG` overrides) |
 | `-h, --help` | Print help |
 | `-V, --version` | Print version |
@@ -86,7 +87,7 @@ Agent note: at an interactive TTY, `bzr` defaults to table output. For agent wor
 ## Command Tree
 
 ```
-bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [--dry-run] [-v...]
+bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [--dry-run] [--yes] [-v...]
 ├── bug
 │   ├── list [--product <P>...] [--component <C>...] [--status <S>...] [--assignee <A>...]
 │   │        [--creator <C>...] [--priority <P>...] [--severity <S>...] [--id <ID>...]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -170,6 +170,15 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub dry_run: bool,
 
+    /// Skip confirmation prompts for large batch mutations.
+    ///
+    /// A `bug update` (or `resolve`/`close`/`reopen`) targeting more than 10
+    /// bugs prompts for confirmation at an interactive terminal; `--yes`
+    /// bypasses that prompt. Non-interactive runs (piped stdin, agents) never
+    /// prompt, so this flag is only needed to override an interactive session.
+    #[arg(short = 'y', long, global = true)]
+    pub yes: bool,
+
     /// Set log verbosity (default: warnings only, -v=info, -vv=debug, -vvv=trace; `RUST_LOG` overrides)
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]
     pub verbose: u8,

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -151,6 +151,17 @@ fn parse_global_server_flag() {
 }
 
 #[test]
+fn parse_global_yes_flag_short_and_long() {
+    let short = Cli::try_parse_from(["bzr", "-y", "bug", "update", "5", "--status", "X"]).unwrap();
+    assert!(short.yes);
+    let long =
+        Cli::try_parse_from(["bzr", "--yes", "bug", "update", "5", "--status", "X"]).unwrap();
+    assert!(long.yes);
+    let absent = Cli::try_parse_from(["bzr", "bug", "list"]).unwrap();
+    assert!(!absent.yes);
+}
+
+#[test]
 fn parse_config_set_server() {
     let cli = Cli::try_parse_from([
         "bzr",

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -331,11 +331,29 @@ pub(super) async fn apply(
         write_update_dry_run(&ids, &params, format, w);
         return Ok(());
     }
+    if !confirm_batch(ids.len(), w)? {
+        let _ = writeln!(w.err, "Aborted; no changes made.");
+        return Ok(());
+    }
     if ids.len() == 1 {
         update_single(client, ids[0], &params, format, w).await
     } else {
         update_batch(client, &ids, &params, format, w).await
     }
+}
+
+/// Prompt for confirmation before a large batch mutation, wiring the real
+/// stdin/TTY into the testable [`crate::commands::confirm`] primitives. The
+/// `should_prompt` gate is checked first, so stdin is locked only when a prompt
+/// is actually shown. Returns whether to proceed.
+fn confirm_batch(count: usize, w: &mut Writers<'_>) -> Result<bool> {
+    use std::io::IsTerminal;
+    let is_tty = std::io::stdin().is_terminal();
+    if !crate::commands::confirm::should_prompt(count, crate::commands::confirm::yes(), is_tty) {
+        return Ok(true);
+    }
+    let stdin = std::io::stdin();
+    crate::commands::confirm::read_yes_no(&mut stdin.lock(), w.err, count)
 }
 
 #[cfg(test)]

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -796,6 +796,31 @@ fn build_update_params_rejects_update_with_no_fields() {
     );
 }
 
+// ── Batch confirmation (#313) ───────────────────────────────────────
+
+#[tokio::test]
+async fn bug_update_large_batch_auto_proceeds_when_not_a_tty() {
+    // Test stdin is not a TTY, so a >threshold batch must run without blocking
+    // on a confirmation prompt — agents and pipes are never gated.
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    let ids: Vec<u64> = (1..=11).collect();
+    for &id in &ids {
+        mock_put_bug_ok(&mock, id).await;
+    }
+
+    let action = make_update_action(ids.clone());
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    let output = io.out_str().to_string();
+
+    assert!(result.is_ok(), "large batch should proceed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+    assert_eq!(parsed["action"], "updated");
+    assert_eq!(parsed["succeeded"].as_array().unwrap().len(), 11);
+}
+
 // ── Dry run (#308) ──────────────────────────────────────────────────
 
 /// Mount a method-only PUT mock that must never fire — proves a dry run

--- a/src/commands/confirm.rs
+++ b/src/commands/confirm.rs
@@ -1,0 +1,80 @@
+//! Interactive confirmation gate for large batch mutations.
+//!
+//! A mistyped ID list or wrong filter can mass-mutate bugs irreversibly, so a
+//! batch larger than [`BATCH_THRESHOLD`] prompts for confirmation at an
+//! interactive TTY. `--yes`/`-y` bypasses the prompt, and non-interactive runs
+//! (piped stdin, agents) auto-bypass so they are never blocked.
+//!
+//! `--yes` is a global flag installed once per process by `dispatch` (the same
+//! pattern as `--dry-run` and the network-tuning globals), so it does not need
+//! threading through every handler signature. See [`crate::commands::dry_run`].
+
+use std::io::{BufRead, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::error::Result;
+
+/// Batches strictly larger than this prompt for confirmation at a TTY.
+pub const BATCH_THRESHOLD: usize = 10;
+
+static ASSUME_YES: AtomicBool = AtomicBool::new(false);
+
+/// Install the assume-yes state from the global `--yes` flag.
+///
+/// Production calls this once, from `dispatch`. Test-side callers must hold
+/// `ENV_LOCK` (as `setup_test_env` does) so they serialize with the mutation
+/// tests; otherwise a parallel test could observe a foreign value.
+pub fn set_yes(assume_yes: bool) {
+    ASSUME_YES.store(assume_yes, Ordering::Relaxed);
+}
+
+/// Whether `--yes` was given (skip all confirmation prompts).
+#[must_use]
+pub fn yes() -> bool {
+    ASSUME_YES.load(Ordering::Relaxed)
+}
+
+/// Whether a batch of `count` items needs an interactive confirmation prompt.
+/// A prompt is needed only above the threshold, when `--yes` was not given, and
+/// only at an interactive TTY — so piped/non-interactive runs never block.
+#[must_use]
+pub fn should_prompt(count: usize, assume_yes: bool, is_tty: bool) -> bool {
+    count > BATCH_THRESHOLD && !assume_yes && is_tty
+}
+
+/// Render the prompt to `w` and read a yes/no answer from `reader`. Anything
+/// other than `y`/`yes` (case-insensitive, trimmed) is a no — the safe default,
+/// so a bare Enter declines.
+///
+/// An immediate EOF (no line at all) is **not** a silent decline: it means no
+/// answer could be read — typically because stdin was already consumed by a
+/// `--comment -` / `--comment-file -` body on the same command. That returns an
+/// error naming `--yes`, so the user gets an actionable message instead of a
+/// confusing "aborted" with no input typed.
+pub fn read_yes_no<R: BufRead, W: Write + ?Sized>(
+    reader: &mut R,
+    w: &mut W,
+    count: usize,
+) -> Result<bool> {
+    let _ = write!(
+        w,
+        "About to modify {count} bugs; this cannot be undone. Continue? [y/N] "
+    );
+    let _ = w.flush();
+    let mut line = String::new();
+    if reader.read_line(&mut line)? == 0 {
+        return Err(crate::error::BzrError::InputValidation(format!(
+            "could not read a confirmation answer from stdin (it may have been \
+             consumed by --comment - / --comment-file -); re-run with --yes to \
+             confirm modifying {count} bugs"
+        )));
+    }
+    Ok(matches!(
+        line.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+#[cfg(test)]
+#[path = "confirm_tests.rs"]
+mod tests;

--- a/src/commands/confirm_tests.rs
+++ b/src/commands/confirm_tests.rs
@@ -1,0 +1,56 @@
+use std::io::Cursor;
+
+use super::{read_yes_no, should_prompt, BATCH_THRESHOLD};
+
+#[test]
+fn should_prompt_only_above_threshold_at_interactive_tty() {
+    // At or below threshold: never prompt, regardless of TTY.
+    assert!(!should_prompt(BATCH_THRESHOLD, false, true));
+    // Above threshold at a TTY without --yes: prompt.
+    assert!(should_prompt(BATCH_THRESHOLD + 1, false, true));
+    // --yes bypasses.
+    assert!(!should_prompt(BATCH_THRESHOLD + 1, true, true));
+    // Non-TTY (piped/agent) bypasses.
+    assert!(!should_prompt(BATCH_THRESHOLD + 1, false, false));
+}
+
+#[test]
+fn read_yes_no_accepts_y_and_yes_case_insensitively() {
+    for answer in ["y\n", "Y\n", "yes\n", "YES\n", "  yes \n"] {
+        let mut reader = Cursor::new(answer.as_bytes().to_vec());
+        let mut w = Vec::new();
+        assert!(
+            read_yes_no(&mut reader, &mut w, 12).unwrap(),
+            "{answer:?} should be a yes"
+        );
+        assert!(String::from_utf8(w)
+            .unwrap()
+            .contains("About to modify 12 bugs"));
+    }
+}
+
+#[test]
+fn read_yes_no_treats_a_typed_non_yes_as_no() {
+    // A line was typed but it isn't yes: decline (safe default), not an error.
+    for answer in ["n\n", "no\n", "\n", "maybe\n"] {
+        let mut reader = Cursor::new(answer.as_bytes().to_vec());
+        let mut w = Vec::new();
+        assert!(
+            !read_yes_no(&mut reader, &mut w, 5).unwrap(),
+            "{answer:?} should be a no (safe default)"
+        );
+    }
+}
+
+#[test]
+fn read_yes_no_errors_on_eof_with_yes_hint() {
+    // No line at all (stdin already consumed, e.g. by --comment -) is not a
+    // silent decline: surface an actionable error naming --yes.
+    let mut reader = Cursor::new(Vec::new());
+    let mut w = Vec::new();
+    let err = read_yes_no(&mut reader, &mut w, 12).unwrap_err();
+    assert!(
+        matches!(&err, crate::error::BzrError::InputValidation(m) if m.contains("--yes")),
+        "EOF should error with a --yes hint, got {err:?}"
+    );
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod comment;
 pub mod completion;
 pub mod component;
 pub mod config;
+pub mod confirm;
 pub mod dry_run;
 mod editor;
 pub mod field;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub async fn dispatch(
     apply_network_tuning(cli);
     ensure_dry_run_supported(cli)?;
     commands::dry_run::set(cli.dry_run);
+    commands::confirm::set_yes(cli.yes);
 
     let api = cli.api;
     let server = cli.server.as_deref();

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -41,6 +41,7 @@ fn base_cli(command: Commands) -> Cli {
         timeout: None,
         retry: None,
         dry_run: false,
+        yes: false,
         verbose: 0,
         command,
     }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -15,9 +15,11 @@ pub async fn setup_test_env() -> (
     tempfile::TempDir,
 ) {
     let lock = super::ENV_LOCK.lock().await;
-    // Reset process-global dry-run state to the test baseline so a prior
-    // dry-run test cannot leak `--dry-run` into one that expects real writes.
+    // Reset process-global mutation switches to the test baseline so a prior
+    // test cannot leak `--dry-run`/`--yes` into one that expects real writes
+    // or an interactive prompt.
     super::commands::dry_run::set(false);
+    super::commands::confirm::set_yes(false);
     let mock = wiremock::MockServer::start().await;
     let tmp = tempfile::TempDir::new().unwrap();
     setup_config(&tmp, &mock.uri());


### PR DESCRIPTION
## Summary

Adds a confirmation gate for large batch bug mutations, with a global `-y`/`--yes` bypass, fixing #313. A mistyped ID list or wrong filter can mass-mutate bugs irreversibly; this prompts before doing so at an interactive terminal, while leaving agents and pipes unaffected.

| Issue | Title | Type | Key files |
|-------|-------|------|-----------|
| #313 | Confirmation / `--yes` for large batch mutations | feat | `src/commands/confirm.rs`, `src/commands/bug/update.rs`, `src/cli/mod.rs`, `src/lib.rs` |

## Behavior

- A `bug update`/`resolve`/`close`/`reopen` targeting **more than 10 bugs** at an interactive TTY prompts: `About to modify N bugs; this cannot be undone. Continue? [y/N]`. Only `y`/`yes` proceeds; anything else aborts with `Aborted; no changes made.` (exit 0, no write).
- `-y`/`--yes` skips the prompt.
- Non-interactive runs (piped stdin, agents) **auto-bypass** — they never block. This is the documented design so agent workflows are unaffected.
- The threshold (10) is documented in the Global Options table.

## Write-safety / correctness

- The gate lives in the shared `update::apply`, so every multi-ID mutation routes through it (`bug update` and the `resolve`/`close`/`reopen` verbs; `dup`/`create`/`clone` are single-target and never prompt). No batch write path bypasses it.
- Safe direction on every branch: `y` proceeds; a typed non-yes declines (exit 0, no write); a read error propagates (no write).
- **`--comment -` interaction:** a stdin-sourced comment is resolved before the gate, so the prompt read would hit EOF. Rather than silently declining, that returns a clear error naming `--yes` (exit 7) — the user gets an actionable message instead of an unexplained abort. The common piped case is already covered by the non-TTY auto-bypass.

## Implementation notes

- `--yes` is a global flag installed once per process by `dispatch` (same pattern as `--dry-run`/the network-tuning globals), so it isn't threaded through every handler signature. `setup_test_env` resets it under `ENV_LOCK`.
- `confirm.rs` exposes pure, unit-tested primitives: `should_prompt(count, assume_yes, is_tty)` and `read_yes_no(reader, w, count)` (the answer stream and TTY state are injected, so both the proceed and decline/EOF paths are testable). The thin `confirm_batch` wrapper wires the real stdin/TTY and checks `should_prompt` first, so stdin is locked only when a prompt is actually shown.

## Review notes

- Reviewed adversarially (`/challenge`, twice): the first pass confirmed the gate routes all batch paths and the safe direction holds, and flagged the `--comment -`/stdin-exhaustion edge — fixed by making EOF an actionable `--yes` error rather than a silent decline. Second pass: approve.
- A `/simplify` pass removed a single-use `confirm()` wrapper and reordered `confirm_batch` so stdin is locked only when prompting.
- New global flag, so the command tree (`docs/bzr-cli.md`), Global Options table, `CHANGELOG.md`, and the flag-drift `ROOT_GLOBALS` + self-test root line are all updated.

## Test coverage

8 new tests: `should_prompt` truth table (threshold/`--yes`/TTY); `read_yes_no` accepts `y`/`yes` case-insensitively, treats a typed non-yes as a decline, and errors on EOF with a `--yes` hint; a large (>10) batch auto-proceeds at non-TTY (the agent path); and `-y`/`--yes` short/long parsing.

## Validation

`cargo test` (1452 lib + 22 + 78 integration), `cargo clippy --locked --features test-helpers -- -D warnings`, `cargo fmt --check`, and the `agent-skills` drift + flag-drift checks all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
