### PR TITLE
feat(cli): add inline --server-url for stateless invocations (closes #314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Inline / ad-hoc server via global `--server-url`, `--server-api-key-env`, and
+  optional `--server-email`. Defines an ephemeral server for a single
+  invocation, so a one-off query or a fully stateless agent run can target a
+  Bugzilla instance that was never written to any config file — nothing is read
+  from or written to `config.toml`. The API key is sourced from the named
+  environment variable (never a literal flag, keeping the secret out of the
+  process argument list). `--server-url` requires `--server-api-key-env` and
+  conflicts with `--server`; it pairs with `--config` for sandboxed runs. (#314)
 - `bug update --expect-unchanged-since <TIMESTAMP>` optimistic-concurrency guard.
   Pass the `last_change_time` from a preceding `bug view`; before writing, bzr
   re-reads each target bug and refuses the update (exit 14, a new distinct

--- a/agent-skills/tests/flag-drift-check-test.sh
+++ b/agent-skills/tests/flag-drift-check-test.sh
@@ -65,7 +65,7 @@ matching_doc() {
 ## Command Tree
 
 ```
-bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [--dry-run] [--yes] [-v...]
+bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--server-email <EMAIL>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [--dry-run] [--yes] [-v...]
 ├── demo
 │   ├── alpha [--foo <X>] [--bar <Y>]
 │   ├── beta [--baz <Z>]

--- a/agent-skills/tests/flag-drift-check.sh
+++ b/agent-skills/tests/flag-drift-check.sh
@@ -36,7 +36,7 @@ fail=0
 # Globals the tree's root line is expected to spell out, and that every command
 # inherits. -v/--verbose, --help and --version are auto/standard flags the
 # curated tree abbreviates (`[-v...]`) or omits, so they are not required there.
-ROOT_GLOBALS='--server --output --json --config --no-color --quiet --api --timeout --retry --dry-run --yes'
+ROOT_GLOBALS='--server --server-url --server-api-key-env --server-email --output --json --config --no-color --quiet --api --timeout --retry --dry-run --yes'
 # Full inherited set excluded from per-command comparison on both sides (the
 # tree lists them once on its root line, but a command block may still repeat
 # one, e.g. `query run [--server <NAME>]`, and that is not drift). Derived from

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -35,6 +35,9 @@ For installation and quick start, see [README.md](../README.md).
 | Option | Description |
 |--------|-------------|
 | `--server <NAME>` | Use a specific server from config instead of the default |
+| `--server-url <URL>` | Connect to an ad-hoc server by URL, without using config. Defines an ephemeral server for this one invocation: nothing is read from or written to the config file. Requires `--server-api-key-env`; conflicts with `--server`. Pairs with `--config` for sandboxed throwaway runs. |
+| `--server-api-key-env <ENV>` | Environment variable holding the API key for `--server-url`. The key is read from this variable, never passed as a literal flag, so the secret stays out of the process argument list. Only meaningful with `--server-url`. |
+| `--server-email <EMAIL>` | Login email for `--server-url`, for the Bugzilla 5.0 whoami fallback. Optional; only meaningful with `--server-url`. |
 | `--output <FORMAT>` | Output format: `table` or `json`. Defaults to table at a TTY; auto-selects json when stdout is not a TTY. |
 | `--json` | Shorthand for `--output json` |
 | `--config <PATH>` | Use an alternate `config.toml` for reads and writes. Takes precedence over `BZR_CONFIG`; both override the default config directory. |
@@ -88,7 +91,7 @@ Agent note: at an interactive TTY, `bzr` defaults to table output. For agent wor
 ## Command Tree
 
 ```
-bzr [--server <NAME>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [--dry-run] [--yes] [-v...]
+bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--server-email <EMAIL>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [--dry-run] [--yes] [-v...]
 ├── bug
 │   ├── list [--product <P>...] [--component <C>...] [--status <S>...] [--assignee <A>...]
 │   │        [--creator <C>...] [--priority <P>...] [--severity <S>...] [--id <ID>...]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -82,6 +82,41 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub server: Option<String>,
 
+    /// Connect to an ad-hoc server by URL, without using config.
+    ///
+    /// Defines an ephemeral server for this one invocation: nothing is read
+    /// from or written to the config file, so a fully stateless run needs no
+    /// `config set-server` first. Requires `--server-api-key-env`; conflicts
+    /// with `--server` (a named server and an inline one are mutually
+    /// exclusive). Pairs with `--config` for sandboxed throwaway runs.
+    ///
+    ///   bzr --server-url https://bz.example.com \
+    ///     --server-api-key-env BZR_KEY bug view 123
+    #[arg(
+        long,
+        value_name = "URL",
+        global = true,
+        conflicts_with = "server",
+        requires = "server_api_key_env",
+        verbatim_doc_comment
+    )]
+    pub server_url: Option<String>,
+
+    /// Environment variable holding the API key for `--server-url`.
+    ///
+    /// The key is read from this variable, never passed as a literal flag, so
+    /// the secret stays out of the process argument list. Only meaningful with
+    /// `--server-url`.
+    #[arg(long, value_name = "ENV", global = true, requires = "server_url")]
+    pub server_api_key_env: Option<String>,
+
+    /// Login email for `--server-url` (older-Bugzilla whoami fallback).
+    ///
+    /// Optional. Mirrors the per-server `email` config field; needed only for
+    /// the Bugzilla 5.0 whoami fallback. Only meaningful with `--server-url`.
+    #[arg(long, value_name = "EMAIL", global = true, requires = "server_url")]
+    pub server_email: Option<String>,
+
     /// Output format: `table` (default at a TTY) or `json`.
     ///
     /// When stdout is piped, the default flips to `json` unless this

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -179,6 +179,68 @@ fn parse_update_expect_unchanged_since() {
 }
 
 #[test]
+fn parse_inline_server_flags() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "--server-url",
+        "https://bz.example.com",
+        "--server-api-key-env",
+        "BZR_KEY",
+        "--server-email",
+        "dev@example.com",
+        "bug",
+        "view",
+        "42",
+    ])
+    .unwrap();
+    assert_eq!(cli.server_url.as_deref(), Some("https://bz.example.com"));
+    assert_eq!(cli.server_api_key_env.as_deref(), Some("BZR_KEY"));
+    assert_eq!(cli.server_email.as_deref(), Some("dev@example.com"));
+}
+
+#[test]
+fn inline_server_url_requires_api_key_env() {
+    // --server-url alone is rejected: a credential source is mandatory.
+    let result = Cli::try_parse_from([
+        "bzr",
+        "--server-url",
+        "https://bz.example.com",
+        "bug",
+        "view",
+        "42",
+    ]);
+    assert!(result.is_err(), "--server-url without env key must fail");
+}
+
+#[test]
+fn inline_server_conflicts_with_named_server() {
+    // A named (config) server and an inline one are mutually exclusive.
+    let result = Cli::try_parse_from([
+        "bzr",
+        "--server",
+        "prod",
+        "--server-url",
+        "https://bz.example.com",
+        "--server-api-key-env",
+        "BZR_KEY",
+        "bug",
+        "view",
+        "42",
+    ]);
+    assert!(result.is_err(), "--server and --server-url must conflict");
+}
+
+#[test]
+fn inline_server_email_requires_url() {
+    // --server-email is meaningless without --server-url.
+    let result = Cli::try_parse_from(["bzr", "--server-email", "dev@example.com", "bug", "list"]);
+    assert!(
+        result.is_err(),
+        "--server-email without --server-url must fail"
+    );
+}
+
+#[test]
 fn parse_global_yes_flag_short_and_long() {
     let short = Cli::try_parse_from(["bzr", "-y", "bug", "update", "5", "--status", "X"]).unwrap();
     assert!(short.yes);

--- a/src/commands/inline_server.rs
+++ b/src/commands/inline_server.rs
@@ -1,0 +1,50 @@
+//! Ad-hoc / inline server support for stateless invocations.
+//!
+//! The global `--server-url` / `--server-api-key-env` / `--server-email` flags
+//! let a single command run against a Bugzilla instance that was never written
+//! to any config file. The parsed definition is stashed here as process-global
+//! state (set once in `dispatch`, before any client is built) and read by
+//! [`crate::commands::shared::connect_and_configure`], mirroring the pattern
+//! used for `--dry-run` and `--yes`.
+//!
+//! Test callers that set this must hold `ENV_LOCK` and reset it to `None`
+//! before releasing the lock, so the inline definition cannot leak into a
+//! sibling test that expects config-based resolution.
+
+use std::sync::RwLock;
+
+/// Synthetic server name for an inline server. Parenthesized so it can never
+/// collide with a real (TOML-table) config server name; shown in error
+/// messages and any TLS prompt.
+pub const INLINE_SERVER_NAME: &str = "(inline)";
+
+/// An ad-hoc server defined entirely on the command line, with its API key
+/// sourced from an environment variable (never a literal flag, to keep the
+/// secret out of `argv`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InlineServer {
+    pub url: String,
+    pub api_key_env: String,
+    pub email: Option<String>,
+}
+
+static INLINE: RwLock<Option<InlineServer>> = RwLock::new(None);
+
+/// Install (or clear) the inline server definition. Called once from
+/// `dispatch` after argument parsing; `None` clears it.
+pub fn set(inline: Option<InlineServer>) {
+    if let Ok(mut guard) = INLINE.write() {
+        *guard = inline;
+    }
+}
+
+/// The inline server definition for this invocation, if `--server-url` was
+/// given. Returns an owned clone so callers don't hold the lock.
+#[must_use]
+pub fn get() -> Option<InlineServer> {
+    INLINE.read().ok().and_then(|guard| guard.clone())
+}
+
+#[cfg(test)]
+#[path = "inline_server_tests.rs"]
+mod tests;

--- a/src/commands/inline_server_tests.rs
+++ b/src/commands/inline_server_tests.rs
@@ -1,0 +1,27 @@
+use super::{get, set, InlineServer, INLINE_SERVER_NAME};
+use crate::ENV_LOCK;
+
+#[tokio::test]
+async fn set_then_get_round_trips() {
+    let _lock = ENV_LOCK.lock().await;
+    set(None);
+    assert_eq!(get(), None);
+
+    let inline = InlineServer {
+        url: "https://bugzilla.example.com".into(),
+        api_key_env: "BZR_KEY".into(),
+        email: Some("dev@example.com".into()),
+    };
+    set(Some(inline.clone()));
+    assert_eq!(get(), Some(inline));
+
+    set(None);
+    assert_eq!(get(), None, "clearing restores the no-inline state");
+}
+
+#[test]
+fn inline_name_is_parenthesized() {
+    // The synthetic name must not be a legal TOML table key, so it can never
+    // shadow a real configured server.
+    assert!(INLINE_SERVER_NAME.starts_with('('));
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,6 +11,7 @@ mod editor;
 pub mod field;
 pub mod flags;
 pub mod group;
+pub mod inline_server;
 pub mod product;
 pub mod query;
 pub mod server;

--- a/src/commands/shared.rs
+++ b/src/commands/shared.rs
@@ -1,6 +1,6 @@
 use crate::client::BugzillaClient;
 use crate::client::DetectedServerSettings;
-use crate::config::Config;
+use crate::config::{Config, ServerConfig};
 use crate::error::{BzrError, Result};
 use crate::tls::TlsConfig;
 use crate::types::{ApiMode, AuthMethod};
@@ -96,11 +96,40 @@ struct ConnectContext {
     api_key: String,
     email: Option<String>,
     api_override: Option<ApiMode>,
+    /// Whether detected settings (and TOFU pins) may be written back to the
+    /// config file. `false` for an inline `--server-url` server, which has no
+    /// config entry and must leave the filesystem untouched.
+    persist: bool,
 }
 
 impl ConnectContext {
     fn email_hint(&self) -> Option<&str> {
         self.email.as_deref()
+    }
+
+    /// Persist detected settings to config, unless this is an ephemeral
+    /// (inline) server — in which case it is a no-op so a stateless invocation
+    /// writes nothing to disk.
+    fn persist_settings(
+        &self,
+        settings: &DetectedServerSettings,
+        persist_auth: bool,
+    ) -> Result<()> {
+        if self.persist {
+            persist_detected_settings(&self.server_name, settings, persist_auth)?;
+        }
+        Ok(())
+    }
+
+    /// Apply `mutator` to the config under the lock, unless this is an ephemeral
+    /// (inline) server. Routes the TOFU/rotation pin writes through the same
+    /// `persist` gate as [`Self::persist_settings`], so "ephemeral ⇒ no config
+    /// writes" is a single invariant rather than a flag checked at each site.
+    fn persist_locked(&self, mutator: impl FnOnce(&mut Config) -> Result<()>) -> Result<()> {
+        if self.persist {
+            Config::update_locked(mutator)?;
+        }
+        Ok(())
     }
 
     fn hostname(&self) -> String {
@@ -143,11 +172,14 @@ async fn handle_tofu(ctx: &ConnectContext) -> Result<BugzillaClient> {
             // "always" — persist pin to config under the lock. `issuer_der` is
             // Option<String>; clone the values the closure needs before it (the
             // bare `fingerprint`/`issuer_der` are still used to build TlsConfig below).
+            // An inline server has no config entry to pin against, so "always"
+            // degrades to a session-only trust (`persist_locked` no-ops; the
+            // TlsConfig below still applies for the rest of this invocation).
             let fingerprint_c = fingerprint.clone();
             let issuer_c = issuer.clone();
             let issuer_der_c = issuer_der.clone();
             let server_name = ctx.server_name.clone();
-            Config::update_locked(move |config| {
+            ctx.persist_locked(move |config| {
                 if let Some(srv) = config.servers.get_mut(&server_name) {
                     srv.tls_pin_sha256 = Some(fingerprint_c);
                     srv.tls_pin_issuer = Some(issuer_c);
@@ -227,7 +259,7 @@ async fn handle_pin_rotation(
     let new_fp = new_fingerprint.to_owned();
     let new_iss = new_issuer.to_owned();
     let server_name = ctx.server_name.clone();
-    Config::update_locked(move |config| {
+    ctx.persist_locked(move |config| {
         if let Some(srv) = config.servers.get_mut(&server_name) {
             srv.tls_pin_sha256 = Some(new_fp);
             srv.tls_pin_issuer = Some(new_iss);
@@ -254,7 +286,7 @@ async fn detect_and_build_client(
     let settings =
         crate::client::detect_server_settings(&ctx.url, &ctx.api_key, ctx.email_hint(), tls_config)
             .await?;
-    persist_detected_settings(&ctx.server_name, &settings, true)?;
+    ctx.persist_settings(&settings, true)?;
     let api_mode = ctx.api_override.unwrap_or(settings.api_mode);
     ctx.build_client(settings.auth_method, api_mode, tls_config)
 }
@@ -332,6 +364,64 @@ enum DetectOrClient {
     Client(BugzillaClient),
 }
 
+/// A resolved connection target: the [`ConnectContext`] plus the TLS config and
+/// any cached auth/mode. Produced from either an inline `--server-url`
+/// definition or a named config server.
+struct ConnectTarget {
+    ctx: ConnectContext,
+    tls_config: TlsConfig,
+    cached_auth: Option<AuthMethod>,
+    cached_mode: Option<ApiMode>,
+}
+
+/// Resolve the connection target. When an inline server is set (global
+/// `--server-url`), builds an ephemeral, never-persisted target and skips the
+/// config file entirely — so a fully stateless invocation needs no config.
+/// Otherwise loads config and resolves the named (or default) server.
+fn resolve_connect_target(
+    server: Option<&str>,
+    api_override: Option<ApiMode>,
+) -> Result<ConnectTarget> {
+    if let Some(inline) = crate::commands::inline_server::get() {
+        let name = crate::commands::inline_server::INLINE_SERVER_NAME;
+        let srv = ServerConfig::from_url_with_env_key(inline.url, inline.api_key_env, inline.email);
+        srv.validate(name)?;
+        let tls_config = srv.tls_config(name);
+        let ctx = ConnectContext {
+            server_name: name.to_string(),
+            url: srv.url.clone(),
+            api_key: srv.resolve_api_key(name)?,
+            email: srv.email.clone(),
+            api_override,
+            persist: false,
+        };
+        return Ok(ConnectTarget {
+            ctx,
+            tls_config,
+            cached_auth: None,
+            cached_mode: None,
+        });
+    }
+
+    let config = Config::load()?;
+    let (server_name, srv) = config.resolve_server(server)?;
+    let tls_config = srv.tls_config(server_name);
+    let ctx = ConnectContext {
+        server_name: server_name.to_string(),
+        url: srv.url.clone(),
+        api_key: srv.resolve_api_key(server_name)?,
+        email: srv.email.clone(),
+        api_override,
+        persist: true,
+    };
+    Ok(ConnectTarget {
+        ctx,
+        tls_config,
+        cached_auth: srv.auth_method,
+        cached_mode: srv.api_mode,
+    })
+}
+
 /// Connect to a Bugzilla server with auto-configuration.
 ///
 /// On first connection to a server, detects auth method and API mode, then
@@ -346,16 +436,12 @@ pub async fn connect_and_configure(
     server: Option<&str>,
     api_override: Option<ApiMode>,
 ) -> Result<BugzillaClient> {
-    let config = Config::load()?;
-    let (server_name, srv) = config.resolve_server(server)?;
-    let tls_config = srv.tls_config(server_name);
-    let ctx = ConnectContext {
-        server_name: server_name.to_string(),
-        url: srv.url.clone(),
-        api_key: srv.resolve_api_key(server_name)?,
-        email: srv.email.clone(),
-        api_override,
-    };
+    let ConnectTarget {
+        ctx,
+        tls_config,
+        cached_auth,
+        cached_mode,
+    } = resolve_connect_target(server, api_override)?;
 
     if tls_config.insecure {
         tracing::warn!(
@@ -365,7 +451,9 @@ pub async fn connect_and_configure(
     }
 
     // Three cases: fully cached, partially cached (auth only), or uncached.
-    let (auth, resolved_mode) = match (srv.auth_method, srv.api_mode) {
+    // An inline server is always uncached (no config entry), so it takes the
+    // detect path and persists nothing.
+    let (auth, resolved_mode) = match (cached_auth, cached_mode) {
         (Some(method), Some(mode)) => {
             // Even with full cache, surface TLS errors at connect-time so
             // TOFU and pin-rotation prompts can fire. Skipped only when
@@ -392,7 +480,7 @@ pub async fn connect_and_configure(
             match detect_with_tofu_fallback(&ctx, &tls_config).await? {
                 DetectOrClient::Client(client) => return Ok(client),
                 DetectOrClient::Settings(settings) => {
-                    persist_detected_settings(&ctx.server_name, &settings, false)?;
+                    ctx.persist_settings(&settings, false)?;
                     (method, settings.api_mode)
                 }
             }
@@ -400,7 +488,7 @@ pub async fn connect_and_configure(
         _ => match detect_with_tofu_fallback(&ctx, &tls_config).await? {
             DetectOrClient::Client(client) => return Ok(client),
             DetectOrClient::Settings(settings) => {
-                persist_detected_settings(&ctx.server_name, &settings, true)?;
+                ctx.persist_settings(&settings, true)?;
                 (settings.auth_method, settings.api_mode)
             }
         },

--- a/src/commands/shared_tests.rs
+++ b/src/commands/shared_tests.rs
@@ -19,6 +19,7 @@ fn connect_context(
         api_key: "test-key".to_string(),
         email: None,
         api_override,
+        persist: true,
     }
 }
 
@@ -211,6 +212,74 @@ api_mode = "rest"
 
     let result = super::connect_and_configure(None, None).await;
     assert!(result.is_ok(), "env-backed config should succeed");
+}
+
+/// #314 acceptance: a complete connect against an inline `--server-url` server
+/// works with NO config file present, and writes none to disk.
+#[tokio::test]
+async fn inline_server_connects_without_config_and_persists_nothing() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock = MockServer::start().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    // Point XDG at an empty dir — there is NO bzr/config.toml here.
+    // SAFETY: tests are serialized via ENV_LOCK.
+    unsafe {
+        std::env::set_var("XDG_CONFIG_HOME", tmp.path());
+        std::env::set_var("BZR_INLINE_TEST_KEY", "inline-secret");
+    }
+    mount_detection_mocks(&mock).await;
+
+    crate::commands::inline_server::set(Some(crate::commands::inline_server::InlineServer {
+        url: mock.uri(),
+        api_key_env: "BZR_INLINE_TEST_KEY".into(),
+        email: None,
+    }));
+    let result = super::connect_and_configure(None, None).await;
+    // Reset before any assertion can unwind, so the inline definition never
+    // leaks into a sibling test that expects config-based resolution.
+    crate::commands::inline_server::set(None);
+
+    assert!(
+        result.is_ok(),
+        "inline server should connect with no config file: {:?}",
+        result.err()
+    );
+    assert!(
+        !tmp.path().join("bzr").join("config.toml").exists(),
+        "an inline connect must not create or write the config file"
+    );
+}
+
+/// An inline server whose API-key env var is unset fails with a clear config
+/// error naming the variable — not a panic or a silent empty key.
+#[tokio::test]
+async fn inline_server_missing_env_var_is_clean_error() {
+    let _lock = ENV_LOCK.lock().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    // SAFETY: tests are serialized via ENV_LOCK.
+    unsafe {
+        std::env::set_var("XDG_CONFIG_HOME", tmp.path());
+        std::env::remove_var("BZR_INLINE_ABSENT_KEY");
+    }
+
+    crate::commands::inline_server::set(Some(crate::commands::inline_server::InlineServer {
+        url: "https://bugzilla.example.com".into(),
+        api_key_env: "BZR_INLINE_ABSENT_KEY".into(),
+        email: None,
+    }));
+    let result = super::connect_and_configure(None, None).await;
+    crate::commands::inline_server::set(None);
+
+    match result {
+        Err(BzrError::Config(msg)) => {
+            assert!(
+                msg.contains("BZR_INLINE_ABSENT_KEY"),
+                "error should name the missing env var: {msg}"
+            );
+        }
+        Err(other) => panic!("expected a Config error for the unset env var, got {other:?}"),
+        Ok(_) => panic!("expected an error for the unset env var, got a client"),
+    }
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ pub struct Config {
     pub queries: HashMap<String, SavedQuery>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ServerConfig {
     pub url: String,
@@ -119,6 +119,21 @@ impl CredentialSourceKind {
 }
 
 impl ServerConfig {
+    /// Build an ephemeral server backed by an environment-variable credential,
+    /// for the inline `--server-url` flow. The result is never written to disk:
+    /// auth method and API mode are left unset (detected per-invocation) and TLS
+    /// uses the default OS trust store. Construction cannot fail; an unset or
+    /// empty env var surfaces later from [`Self::resolve_api_key`].
+    #[must_use]
+    pub fn from_url_with_env_key(url: String, api_key_env: String, email: Option<String>) -> Self {
+        ServerConfig {
+            url,
+            api_key_env: Some(api_key_env),
+            email,
+            ..Self::default()
+        }
+    }
+
     pub fn tls_config(&self, server_name: &str) -> crate::tls::TlsConfig {
         crate::tls::TlsConfig {
             insecure: self.tls_insecure,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub async fn dispatch(
     ensure_dry_run_supported(cli)?;
     commands::dry_run::set(cli.dry_run);
     commands::confirm::set_yes(cli.yes);
+    commands::inline_server::set(resolve_inline_server(cli));
 
     let api = cli.api;
     let server = cli.server.as_deref();
@@ -125,6 +126,22 @@ fn apply_network_tuning(cli: &cli::Cli) {
         env_timeout.as_deref(),
     ));
     http::set_retry_max(cli.retry.unwrap_or(0));
+}
+
+/// Build the inline server definition from the global `--server-url` flags, or
+/// `None` when no inline server was requested. Returns `Some` only when both
+/// the URL and its API-key env var are present; clap's `requires` guarantees
+/// they come as a pair, but this is robust if a `Cli` is constructed directly
+/// (as integration tests do).
+fn resolve_inline_server(cli: &cli::Cli) -> Option<commands::inline_server::InlineServer> {
+    cli.server_url
+        .as_ref()
+        .zip(cli.server_api_key_env.as_ref())
+        .map(|(url, api_key_env)| commands::inline_server::InlineServer {
+            url: url.clone(),
+            api_key_env: api_key_env.clone(),
+            email: cli.server_email.clone(),
+        })
 }
 
 /// Reject `--dry-run` on commands that don't honor it.

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -32,6 +32,9 @@ fn with_bzr_output<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
 fn base_cli(command: Commands) -> Cli {
     Cli {
         server: None,
+        server_url: None,
+        server_api_key_env: None,
+        server_email: None,
         output: None,
         json: false,
         config: None,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -20,6 +20,7 @@ pub async fn setup_test_env() -> (
     // or an interactive prompt.
     super::commands::dry_run::set(false);
     super::commands::confirm::set_yes(false);
+    super::commands::inline_server::set(None);
     let mock = wiremock::MockServer::start().await;
     let tmp = tempfile::TempDir::new().unwrap();
     setup_config(&tmp, &mock.uri());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2142,6 +2142,64 @@ async fn e2e_whoami_via_cli_args() {
     assert_eq!(parsed["name"], "admin@example.com");
 }
 
+/// #314 end-to-end: `bug view` against an inline `--server-url` server with no
+/// config file on disk, driven through the real CLI parse + dispatch path.
+#[tokio::test]
+async fn e2e_inline_server_bug_view_without_config() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock = wiremock::MockServer::start().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    // Empty XDG dir — no bzr/config.toml exists.
+    // SAFETY: tests are serialized via ENV_LOCK.
+    unsafe {
+        std::env::set_var("XDG_CONFIG_HOME", tmp.path());
+        std::env::set_var("BZR_E2E_INLINE_KEY", "secret");
+    }
+
+    // Auth + version detection for the uncached inline server.
+    Mock::given(method("GET"))
+        .and(path("/rest/whoami"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 1})))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/version"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"version": "5.1.2"})),
+        )
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 42, "summary": "Inline view", "status": "NEW"}]
+        })))
+        .mount(&mock)
+        .await;
+
+    let (result, output) = dispatch_cli_with_output(&[
+        "bzr",
+        "--server-url",
+        &mock.uri(),
+        "--server-api-key-env",
+        "BZR_E2E_INLINE_KEY",
+        "--json",
+        "bug",
+        "view",
+        "42",
+    ])
+    .await;
+
+    assert!(result.is_ok(), "inline e2e bug view: {result:?}");
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
+    assert_eq!(parsed["id"], 42);
+    assert_eq!(parsed["summary"], "Inline view");
+    assert!(
+        !tmp.path().join("bzr").join("config.toml").exists(),
+        "inline invocation must not write the config file"
+    );
+}
+
 #[tokio::test]
 async fn e2e_config_show_via_cli_args() {
     let (_lock, _mock, _tmp) = setup_test_env().await;


### PR DESCRIPTION
## Summary

Adds an inline / ad-hoc server, fixing #314: a one-off query or a fully stateless agent run can target a Bugzilla instance that was never written to any config file. No `config set-server` first, and no config residue afterward.

| Issue | Title | Type | Key files |
|-------|-------|------|-----------|
| #314 | Ad-hoc / inline server without `config set-server` | feat | `src/cli/mod.rs`, `src/commands/inline_server.rs`, `src/commands/shared.rs`, `src/config.rs`, `src/lib.rs` |

## Behavior

- `bzr --server-url https://bz.example.com --server-api-key-env BZR_KEY bug view 123` connects to an ad-hoc server with **no config file read or written**.
- The API key is sourced from the named environment variable — never a literal flag — so the secret stays out of `argv`/`ps`.
- `--server-url` **requires** `--server-api-key-env` and **conflicts with** `--server` (a named server and an inline one are mutually exclusive). `--server-email` is optional (Bugzilla 5.0 whoami fallback).
- **Acceptance criterion met:** a complete read/write operation runs against a server never written to any config file (covered by a unit test asserting `config.toml` is never created, and an end-to-end `bug view` test through real arg-parsing + dispatch).

## Design notes

- **Why not `--url`/`--api-key-env`/`--email`?** clap propagates `global = true` args into *every* subcommand, and `config set-server` already defines those long names — the duplicate panics at construction. The inline flags are therefore `--server-*`.
- **Resolution seam.** A new `resolve_connect_target` bifurcates "build an ephemeral target" vs "load config and resolve named server" into one `ConnectTarget`; everything after the seam (auth/version detection, client build) is shared. The inline branch returns `cached_auth/mode: None`, so it naturally takes the detect path.
- **Never persist.** A `persist` flag on `ConnectContext` gates every config-write site through `persist_settings` / `persist_locked`, so "ephemeral ⇒ no config writes" is a single invariant — covering detected-settings, the TOFU "always" pin, and the pin-rotation write. The inline branch also returns before any `Config::load`, so a stateless run touches no file.
- **Process-global pattern.** The inline definition is stashed in a small `inline_server` module (set once in `dispatch`, read at the connect choke-point, reset in `setup_test_env`), mirroring `--dry-run`/`--yes`.

## Review notes

- Reviewed adversarially (`/challenge`): persist-gating is complete (no write path escapes the gate; the inline branch never loads config), no secret reaches disk, and resolution precedence is unambiguous. Noted non-blocking limitations: no inline TLS-trust flags (out of issue scope — a self-signed inline server still hits the interactive TOFU prompt), and no URL well-formedness check (matches existing named-server behavior, not a regression).
- `/simplify` applied: derived `Default` on `ServerConfig` (constructor is now 3 fields + `..Self::default()`), `resolve_inline_server` via `.zip().map()`, and centralized the pin-write persist gate into `ConnectContext::persist_locked`.
- New globals, so `docs/bzr-cli.md` (globals table + tree root line), the `agent-skills` flag-drift `ROOT_GLOBALS`/synthetic root line, and `CHANGELOG.md` are updated.

## Test coverage

- `inline_server` set/get round-trip and synthetic-name invariant.
- `connect_and_configure` against an inline server with no config file present, asserting nothing is written; plus the unset-env-var clean-error path.
- End-to-end `bug view` against an inline server through `Cli::try_parse_from` + `dispatch`, asserting no config file is created.
- CLI parse matrix: all three flags parse; `--server-url` requires the env key; conflicts with `--server`; `--server-email` requires `--server-url`.

## Validation

`cargo test` (1471 lib + 22 + 2 + 79 integration), `cargo clippy --locked --features test-helpers -- -D warnings`, `cargo fmt --check`, and the `agent-skills` flag-drift drift + self-test all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
