### PR TITLE
feat(bug): add create --from-json structured input (closes #307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `bug create --from-json <PATH|->` structured input. Files one or more bugs
+  from a JSON object (one bug) or array (one bug per element, with the
+  partial-failure model and exit 11), so an agent that already models a bug as
+  an object can submit it directly instead of flattening it into shell flags.
+  Keys match the create flag names; unknown keys are rejected (exit 7) so a typo
+  fails fast, and undesigned `cf_*` custom-field writes (#283) stay out of this
+  path. Explicit CLI flags override the corresponding JSON field, applied to
+  every array element. Mutually exclusive with `--template`; bypasses the
+  `$EDITOR` flow. `bug update` and other resources are tracked as follow-up.
+  (#307)
+
 - Inline / ad-hoc server via global `--server-url`, `--server-api-key-env`, and
   optional `--server-email`. Defines an ephemeral server for a single
   invocation, so a one-off query or a fully stateless agent run can target a

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -105,7 +105,7 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │   ├── history <ID> [--since <DATE>]
 │   ├── my [--created] [--cc] [--all] [--status <S>...] [--limit <N>] [--count]
 │   │       [--fields <F>] [--exclude-fields <F>] [--sort <FIELD>] [--order asc|desc]
-│   ├── create [--template <T>] [--product <P>] [--component <C>] --summary <S>
+│   ├── create [--from-json <PATH>] [--template <T>] [--product <P>] [--component <C>] --summary <S>
 │   │          [--version <V>] [--description <D>] [--description-file <PATH>] [--priority <P>] [--severity <S>]
 │   │          [--assignee <A>] [--op-sys <OS>] [--rep-platform <PLAT>]
 │   │          [--blocks <IDs>] [--depends-on <IDs>] [--alias <A>] [--url <U>]
@@ -460,10 +460,18 @@ echo "long-form description" | bzr bug create \
 bzr bug create --product Fedora --component kernel
 
 bzr bug create --template security-bug --summary "XSS in login form"
+
+# File a bug from a structured JSON object on stdin
+printf '%s' '{"product":"Fedora","component":"kernel","summary":"S"}' \
+  | bzr bug create --from-json -
+
+# Batch-create from a JSON array (one bug per element)
+bzr bug create --from-json bugs.json
 ```
 
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
+| `--from-json <PATH>` | No | | Create one or more bugs from a JSON object or array (`-` reads stdin). See [Structured input](#structured-input---from-json) below. Mutually exclusive with `--template`. |
 | `--product <P>` | Yes* | | Product name |
 | `--component <C>` | Yes* | | Component name |
 | `--summary <S>` | Yes** | | One-line summary |
@@ -513,10 +521,31 @@ A value of `-` for `--description` or `--description-file` reads the description
 | 0 | Success |
 | 2 | Conflicting flags (e.g. `--description` and `--description-file` both set) |
 | 4 | Bugzilla API error (e.g. server requires `--op-sys` and it wasn't provided) |
-| 7 | Input validation: missing `--summary` outside the editor flow; missing or unreadable `--description-file`; empty stdin without an explicit description; empty editor buffer; `$EDITOR` exited non-zero |
+| 7 | Input validation: missing `--summary` outside the editor flow; missing or unreadable `--description-file`; empty stdin without an explicit description; empty editor buffer; `$EDITOR` exited non-zero; malformed `--from-json` (bad JSON, unknown key, wrong shape, or missing required field) |
 | 9 | Authentication failure |
+| 11 | Partial failure: one or more elements of a `--from-json` array failed to create |
 
 Agent note: agent workflows should pass `--description` (or `--description-file`) explicitly and supply `--summary`. The `$EDITOR` flow only fires when stdin is a TTY, which is rare in headless / CI invocations.
+
+#### Structured input (`--from-json`)
+
+`--from-json <PATH>` files bugs from a structured JSON document instead of discrete flags; `-` reads the document from stdin. This is the inverse of the `--json` *output* story: an agent that already models a bug as an object can submit it directly without flattening it into shell flags.
+
+- A top-level **object** files one bug and returns the usual `{"resource":"bug","action":"created","id":N}` result.
+- A top-level **array** files one bug per element and returns a partial-failure result `{"resource":"bug","action":"created","created":[...],"failed":[{"index":N,"error":"..."}]}`. If any element fails, the command exits **11** (`BatchPartialFailure`); all input is validated before any bug is created, so a malformed element never half-creates a batch.
+
+Accepted keys match the create flag names: `product`, `component`, `summary`, `version`, `description`, `priority`, `severity`, `assignee`, `op_sys`, `rep_platform`, `alias`, `url`, `whiteboard`, `target_milestone`, `deadline`, `blocks`, `depends_on`, `cc`, `keywords`, `groups`, `flags` (an array of flag-syntax strings). **Unknown keys are rejected** (exit 7) rather than silently ignored, so a typo fails fast. `product`, `component`, and `summary` are required (in the JSON or via a CLI flag).
+
+**Precedence:** an explicit CLI flag overrides the corresponding JSON field, applied uniformly to every element of an array — e.g. `--product Fedora --from-json bugs.json` forces `product` on all entries. `--from-json` is mutually exclusive with `--template` and bypasses the `$EDITOR` flow.
+
+`bug update` and the other resource commands do not yet accept `--from-json`; that is tracked as follow-up work.
+
+```bash
+printf '%s' '{"product":"Fedora","component":"kernel","summary":"S"}' \
+  | bzr bug create --from-json -
+
+bzr bug create --from-json bugs.json --json | jq '.created'
+```
 
 ### `bzr bug clone`
 

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -479,6 +479,22 @@ pub enum BugAction {
     /// values.
     #[command(verbatim_doc_comment)]
     Create {
+        /// Create one or more bugs from a JSON object or array.
+        ///
+        /// A value of `-` reads the JSON from stdin; otherwise it is a
+        /// file path. A single object files one bug; an array files one
+        /// bug per element and returns a partial-failure result (exit 11
+        /// if any element fails). Keys match the create flag names
+        /// (`product`, `component`, `summary`, `version`, `description`,
+        /// `priority`, `severity`, `assignee`, `op_sys`, `rep_platform`,
+        /// `alias`, `url`, `whiteboard`, `target_milestone`, `deadline`,
+        /// `blocks`, `depends_on`, `cc`, `keywords`, `groups`, `flags`);
+        /// unknown keys are rejected. Explicit CLI flags override the
+        /// corresponding JSON field (applied to every element of an
+        /// array). Mutually exclusive with `--template`; bypasses the
+        /// `$EDITOR` flow.
+        #[arg(long, value_name = "PATH", conflicts_with = "template")]
+        from_json: Option<String>,
         /// Use a saved template for default field values.
         ///
         /// References a named template from `bzr template list`.

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -241,6 +241,35 @@ fn inline_server_email_requires_url() {
 }
 
 #[test]
+fn parse_bug_create_from_json_stdin() {
+    let cli = Cli::try_parse_from(["bzr", "bug", "create", "--from-json", "-"]).unwrap();
+    let Commands::Bug {
+        action: BugAction::Create { from_json, .. },
+    } = cli.command
+    else {
+        panic!("expected bug create");
+    };
+    assert_eq!(from_json.as_deref(), Some("-"));
+}
+
+#[test]
+fn bug_create_from_json_conflicts_with_template() {
+    let result = Cli::try_parse_from([
+        "bzr",
+        "bug",
+        "create",
+        "--from-json",
+        "bugs.json",
+        "--template",
+        "sec",
+    ]);
+    assert!(
+        result.is_err(),
+        "--from-json and --template must be mutually exclusive"
+    );
+}
+
+#[test]
 fn parse_global_yes_flag_short_and_long() {
     let short = Cli::try_parse_from(["bzr", "-y", "bug", "update", "5", "--status", "X"]).unwrap();
     assert!(short.yes);

--- a/src/commands/bug/create.rs
+++ b/src/commands/bug/create.rs
@@ -1,10 +1,15 @@
 use std::io::IsTerminal;
 
+use serde::Deserialize;
+
 use crate::cli::BugAction;
 use crate::client::BugzillaClient;
 use crate::commands::editor;
+use crate::commands::shared::{merge_set, merge_vec};
 use crate::error::Result;
-use crate::output::result_types::{write_result, ActionResult, DryRunResult, ResourceKind};
+use crate::output::result_types::{
+    write_result, ActionResult, BatchCreateResult, CreateFailure, DryRunResult, ResourceKind,
+};
 use crate::output::writers::Writers;
 use crate::types::{CreateBugParams, OutputFormat};
 
@@ -226,6 +231,335 @@ fn merge_fields(
     })
 }
 
+/// One bug's worth of structured input for `bug create --from-json`. Keys match
+/// the create flag names; `deny_unknown_fields` rejects typos and keeps
+/// undesigned `cf_*` custom-field writes (issue #283) out of this path. All
+/// fields are optional here — required-field and date validation happen in
+/// [`Self::into_params`] so the error messages can name the offending field.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct JsonCreateBug {
+    product: Option<String>,
+    component: Option<String>,
+    summary: Option<String>,
+    version: Option<String>,
+    description: Option<String>,
+    priority: Option<String>,
+    severity: Option<String>,
+    assignee: Option<String>,
+    op_sys: Option<String>,
+    rep_platform: Option<String>,
+    alias: Option<String>,
+    url: Option<String>,
+    whiteboard: Option<String>,
+    target_milestone: Option<String>,
+    deadline: Option<String>,
+    #[serde(default)]
+    blocks: Vec<u64>,
+    #[serde(default)]
+    depends_on: Vec<u64>,
+    #[serde(default)]
+    cc: Vec<String>,
+    #[serde(default)]
+    keywords: Vec<String>,
+    #[serde(default)]
+    groups: Vec<String>,
+    #[serde(default)]
+    flags: Vec<String>,
+}
+
+impl JsonCreateBug {
+    /// Validate the merged fields and build the API params. `product`,
+    /// `component`, and `summary` are required; `version` defaults to
+    /// `"unspecified"`; `flags` and `deadline` are parsed/validated.
+    fn into_params(self) -> Result<CreateBugParams> {
+        let required = |value: Option<String>, field: &str| {
+            value.ok_or_else(|| {
+                crate::error::BzrError::InputValidation(format!(
+                    "--from-json: '{field}' is required (set it in the JSON or via --{field})"
+                ))
+            })
+        };
+        let flags = crate::commands::flags::parse_flags(&self.flags)?;
+        let deadline =
+            crate::validation::parse_optional_date_only(self.deadline.as_deref(), "deadline")?;
+        Ok(CreateBugParams {
+            product: required(self.product, "product")?,
+            component: required(self.component, "component")?,
+            summary: required(self.summary, "summary")?,
+            version: self.version.unwrap_or_else(|| "unspecified".to_string()),
+            description: self.description,
+            priority: self.priority,
+            severity: self.severity,
+            assigned_to: self.assignee,
+            op_sys: self.op_sys,
+            rep_platform: self.rep_platform,
+            alias: self.alias,
+            url: self.url,
+            whiteboard: self.whiteboard,
+            target_milestone: self.target_milestone,
+            deadline,
+            blocks: self.blocks,
+            depends_on: self.depends_on,
+            cc: self.cc,
+            keywords: self.keywords,
+            groups: self.groups,
+            flags,
+        })
+    }
+}
+
+/// Read the `--from-json` argument: `-` is stdin, anything else a file path.
+fn read_from_json(arg: &str) -> Result<String> {
+    if arg == "-" {
+        crate::commands::shared::read_stdin_to_string()
+    } else {
+        crate::commands::shared::read_file_with_context(std::path::Path::new(arg), "--from-json")
+    }
+}
+
+/// Structured `--from-json` input, preserving the top-level shape so the
+/// output shape follows the *input* (a 1-element array is still a batch), not
+/// the element count.
+#[derive(Debug)]
+enum JsonInput {
+    /// A top-level object: one bug, single-result output. Boxed because a
+    /// `JsonCreateBug` is far larger than the `Many` vec handle.
+    One(Box<JsonCreateBug>),
+    /// A top-level array: one bug per element, partial-failure output.
+    Many(Vec<JsonCreateBug>),
+}
+
+/// Parse the raw `--from-json` text. A top-level object is one bug; a top-level
+/// array is one bug per element (even when it holds one). Any other shape, or
+/// malformed JSON, is a clean input error naming the offending position.
+fn parse_json_bugs(raw: &str) -> Result<JsonInput> {
+    let value: serde_json::Value = serde_json::from_str(raw).map_err(|e| {
+        crate::error::BzrError::InputValidation(format!("--from-json: invalid JSON: {e}"))
+    })?;
+    match value {
+        serde_json::Value::Array(items) => {
+            let entries = items
+                .into_iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    serde_json::from_value(v).map_err(|e| {
+                        crate::error::BzrError::InputValidation(format!(
+                            "--from-json item {i}: {e}"
+                        ))
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(JsonInput::Many(entries))
+        }
+        serde_json::Value::Object(_) => {
+            let one = serde_json::from_value(value).map_err(|e| {
+                crate::error::BzrError::InputValidation(format!("--from-json: {e}"))
+            })?;
+            Ok(JsonInput::One(Box::new(one)))
+        }
+        _ => Err(crate::error::BzrError::InputValidation(
+            "--from-json expects a JSON object or an array of objects".into(),
+        )),
+    }
+}
+
+/// Resolve an explicit `--description`/`--description-file` for the JSON path.
+/// Unlike the interactive create flow, this does NOT auto-read stdin — only an
+/// explicitly-supplied value overrides the JSON `description`.
+fn explicit_description(
+    description: Option<&str>,
+    description_file: Option<&std::path::Path>,
+) -> Result<Option<String>> {
+    crate::commands::shared::materialize_body_source(
+        crate::commands::shared::classify_body_source(
+            description,
+            description_file,
+            "--description",
+            "--description-file",
+        )?,
+        "--description-file",
+    )
+}
+
+/// Overlay explicit CLI flags onto a JSON entry: a CLI value (a `Some` scalar
+/// or a non-empty repeatable) wins over the JSON field, applied uniformly to
+/// every element of an array.
+fn overlay_cli(mut json: JsonCreateBug, action: &BugAction) -> Result<JsonCreateBug> {
+    let BugAction::Create {
+        product,
+        component,
+        summary,
+        version,
+        description,
+        description_file,
+        priority,
+        severity,
+        assignee,
+        op_sys,
+        rep_platform,
+        blocks,
+        depends_on,
+        create_fields,
+        ..
+    } = action
+    else {
+        unreachable!()
+    };
+    // `merge_set`/`merge_vec` overwrite the target when the CLI flag was
+    // supplied (a `Some` scalar / non-empty repeatable), else leave the JSON
+    // value — exactly the "CLI wins" precedence.
+    merge_set(&mut json.product, product.as_deref());
+    merge_set(&mut json.component, component.as_deref());
+    merge_set(&mut json.summary, summary.as_deref());
+    merge_set(&mut json.version, version.as_deref());
+    merge_set(&mut json.priority, priority.as_deref());
+    merge_set(&mut json.severity, severity.as_deref());
+    merge_set(&mut json.assignee, assignee.as_deref());
+    merge_set(&mut json.op_sys, op_sys.as_deref());
+    merge_set(&mut json.rep_platform, rep_platform.as_deref());
+    merge_set(&mut json.alias, create_fields.alias.as_deref());
+    merge_set(&mut json.url, create_fields.url.as_deref());
+    merge_set(&mut json.whiteboard, create_fields.whiteboard.as_deref());
+    merge_set(
+        &mut json.target_milestone,
+        create_fields.target_milestone.as_deref(),
+    );
+    merge_set(&mut json.deadline, create_fields.deadline.as_deref());
+    if let Some(desc) = explicit_description(description.as_deref(), description_file.as_deref())? {
+        json.description = Some(desc);
+    }
+    merge_vec(&mut json.cc, &create_fields.cc);
+    merge_vec(&mut json.keywords, &create_fields.keywords);
+    merge_vec(&mut json.groups, &create_fields.groups);
+    merge_vec(&mut json.flags, &create_fields.flag);
+    // `blocks`/`depends_on` are `Vec<u64>`; `merge_vec` is `Vec<String>`-typed,
+    // so keep the equivalent guard inline.
+    if !blocks.is_empty() {
+        json.blocks.clone_from(blocks);
+    }
+    if !depends_on.is_empty() {
+        json.depends_on.clone_from(depends_on);
+    }
+    Ok(json)
+}
+
+/// Emit a batch-create result: a partial-failure object under `--json`, or a
+/// created-IDs line plus per-item failures on stderr in table mode.
+fn write_batch_create(result: &BatchCreateResult, format: OutputFormat, w: &mut Writers<'_>) {
+    match format {
+        OutputFormat::Json => write_result(result, "", format, w.out),
+        OutputFormat::Table => {
+            if !result.created.is_empty() {
+                let ids: Vec<String> = result.created.iter().map(|id| format!("#{id}")).collect();
+                let _ = writeln!(w.out, "Created bugs: {}", ids.join(", "));
+            }
+            for f in &result.failed {
+                let _ = writeln!(
+                    w.err,
+                    "Failed to create bug (item {}): {}",
+                    f.index, f.error
+                );
+            }
+        }
+    }
+}
+
+/// Build one bug from a structured JSON object or array, the `--from-json`
+/// path. All entries are validated before any write, so malformed input never
+/// half-creates a batch; per-element server failures use the partial-failure
+/// model (exit 11).
+async fn handle_from_json(
+    client: &BugzillaClient,
+    action: &BugAction,
+    arg: &str,
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) -> Result<()> {
+    let raw = read_from_json(arg)?;
+    match parse_json_bugs(&raw)? {
+        JsonInput::One(entry) => {
+            let params = overlay_cli(*entry, action)?.into_params()?;
+            create_and_report(client, &params, format, w).await
+        }
+        JsonInput::Many(entries) => {
+            if entries.is_empty() {
+                return Err(crate::error::BzrError::InputValidation(
+                    "--from-json: empty array, nothing to create".into(),
+                ));
+            }
+            let mut params_list = Vec::with_capacity(entries.len());
+            for entry in entries {
+                params_list.push(overlay_cli(entry, action)?.into_params()?);
+            }
+            create_batch_from_json(client, &params_list, format, w).await
+        }
+    }
+}
+
+/// Create one bug and report it (or preview under `--dry-run`). Shared by the
+/// flag/editor path and the `--from-json` single-object path.
+async fn create_and_report(
+    client: &BugzillaClient,
+    params: &CreateBugParams,
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) -> Result<()> {
+    if crate::commands::dry_run::enabled() {
+        write_create_dry_run(params, format, w);
+        return Ok(());
+    }
+    let id = client.create_bug(params).await?;
+    write_result(
+        &ActionResult::created(id, ResourceKind::Bug),
+        &format!("Created bug #{id}"),
+        format,
+        w.out,
+    );
+    Ok(())
+}
+
+/// Create a batch of bugs (top-level JSON array). The array shape always yields
+/// the partial-failure result — even for a single element — so an agent's
+/// output handling does not depend on the element count. Exits 11 if any
+/// element fails.
+async fn create_batch_from_json(
+    client: &BugzillaClient,
+    params_list: &[CreateBugParams],
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) -> Result<()> {
+    if crate::commands::dry_run::enabled() {
+        // One coherent object for the whole batch (N pretty-printed objects
+        // would not be valid JSON); `changes` carries the array of params.
+        write_result(
+            &DryRunResult::new(ResourceKind::Bug, &[], &params_list),
+            &format!(
+                "Dry run: would create {} bug(s) (no bugs created)",
+                params_list.len()
+            ),
+            format,
+            w.out,
+        );
+        return Ok(());
+    }
+    let mut created = Vec::new();
+    let mut failed = Vec::new();
+    for (index, params) in params_list.iter().enumerate() {
+        match client.create_bug(params).await {
+            Ok(id) => created.push(id),
+            Err(e) => failed.push(CreateFailure {
+                index,
+                error: e.to_string(),
+            }),
+        }
+    }
+    let succeeded = created.len();
+    let failures = failed.len();
+    write_batch_create(&BatchCreateResult::new(created, failed), format, w);
+    super::update::ensure_batch_complete(succeeded, failures)
+}
+
 pub(super) async fn handle(
     client: &BugzillaClient,
     action: &BugAction,
@@ -233,6 +567,7 @@ pub(super) async fn handle(
     w: &mut Writers<'_>,
 ) -> Result<()> {
     let BugAction::Create {
+        from_json,
         template: template_name,
         summary,
         description,
@@ -245,6 +580,10 @@ pub(super) async fn handle(
     else {
         unreachable!()
     };
+
+    if let Some(arg) = from_json {
+        return handle_from_json(client, action, arg, format, w).await;
+    }
 
     let flags = crate::commands::flags::parse_flags(&create_fields.flag)?;
     let deadline = crate::validation::parse_optional_date_only(
@@ -296,19 +635,7 @@ pub(super) async fn handle(
         groups: create_fields.groups.clone(),
         flags,
     };
-    if crate::commands::dry_run::enabled() {
-        write_create_dry_run(&params, format, w);
-        return Ok(());
-    }
-
-    let id = client.create_bug(&params).await?;
-    write_result(
-        &ActionResult::created(id, ResourceKind::Bug),
-        &format!("Created bug #{id}"),
-        format,
-        w.out,
-    );
-    Ok(())
+    create_and_report(client, &params, format, w).await
 }
 
 /// Emit the would-be create payload without writing, marked `"action":"dry-run"`.

--- a/src/commands/bug/create_tests.rs
+++ b/src/commands/bug/create_tests.rs
@@ -12,6 +12,7 @@ use crate::types::OutputFormat;
 
 fn create_action() -> BugAction {
     BugAction::Create {
+        from_json: None,
         template: None,
         product: Some("TestProduct".into()),
         component: Some("General".into()),
@@ -122,6 +123,7 @@ async fn bug_create_sends_parity_fields_in_body() {
         .await;
 
     let action = BugAction::Create {
+        from_json: None,
         template: None,
         product: Some("TestProduct".into()),
         component: Some("General".into()),
@@ -166,6 +168,7 @@ async fn bug_create_rejects_malformed_deadline() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = BugAction::Create {
+        from_json: None,
         template: None,
         product: Some("TestProduct".into()),
         component: Some("General".into()),
@@ -201,6 +204,7 @@ async fn bug_create_missing_product_returns_input_validation() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = BugAction::Create {
+        from_json: None,
         template: None,
         product: None,
         component: Some("General".into()),
@@ -239,6 +243,7 @@ async fn bug_create_missing_component_returns_input_validation() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = BugAction::Create {
+        from_json: None,
         template: None,
         product: Some("TestProduct".into()),
         component: None,
@@ -277,6 +282,7 @@ async fn bug_create_with_unknown_template_errors() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = BugAction::Create {
+        from_json: None,
         template: Some("does-not-exist".into()),
         product: Some("TestProduct".into()),
         component: Some("General".into()),
@@ -352,6 +358,7 @@ async fn bug_create_with_template_fills_missing_fields() {
         .await;
 
     let action = BugAction::Create {
+        from_json: None,
         template: Some("tpl".into()),
         product: None,
         component: None,
@@ -405,6 +412,7 @@ async fn bug_create_reads_description_from_file() {
         .await;
 
     let action = BugAction::Create {
+        from_json: None,
         template: None,
         product: Some("TestProduct".into()),
         component: Some("General".into()),
@@ -440,6 +448,7 @@ async fn bug_create_description_file_missing_returns_input_validation() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = BugAction::Create {
+        from_json: None,
         template: None,
         product: Some("TestProduct".into()),
         component: Some("General".into()),
@@ -482,6 +491,7 @@ async fn bug_create_description_file_non_utf8_returns_input_validation() {
     std::fs::write(&bad_path, [0xff_u8, 0xfe_u8, 0xfd_u8]).unwrap();
 
     let action = BugAction::Create {
+        from_json: None,
         template: None,
         product: Some("TestProduct".into()),
         component: Some("General".into()),
@@ -521,6 +531,7 @@ async fn bug_create_missing_summary_without_editor_flow_is_rejected() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
 
     let action = BugAction::Create {
+        from_json: None,
         template: None,
         product: Some("TestProduct".into()),
         component: Some("General".into()),
@@ -713,6 +724,7 @@ fn install_fake_editor() -> std::path::PathBuf {
 
 fn editor_action_no_summary_no_description() -> BugAction {
     BugAction::Create {
+        from_json: None,
         template: None,
         product: Some("TestProduct".into()),
         component: Some("General".into()),
@@ -882,6 +894,7 @@ async fn bug_create_template_description_does_not_fall_back_outside_editor_flow(
     // be used as a fallback. The empty-stdin branch fires first and
     // returns InputValidation.
     let action = BugAction::Create {
+        from_json: None,
         template: Some("tpl-with-desc".into()),
         product: None,
         component: None,
@@ -926,4 +939,287 @@ fn resolve_description_conflict_errors() {
         }
         other => panic!("expected InputValidation, got {other:?}"),
     }
+}
+
+// ── Structured input: bug create --from-json (#307) ──────────────────
+
+/// Build a `from_json` create action: `from_json` set, every CLI field at its
+/// default so the JSON is the sole field source unless a test overrides one.
+fn from_json_action(path: &str) -> BugAction {
+    BugAction::Create {
+        from_json: Some(path.to_string()),
+        template: None,
+        product: None,
+        component: None,
+        summary: None,
+        version: None,
+        description: None,
+        description_file: None,
+        priority: None,
+        severity: None,
+        assignee: None,
+        op_sys: None,
+        rep_platform: None,
+        blocks: vec![],
+        depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs::default(),
+    }
+}
+
+/// Write `json` to a file under `tmp` and return its path, so tests exercise
+/// the `--from-json <PATH>` branch without driving stdin.
+fn write_json_file(tmp: &tempfile::TempDir, json: &str) -> String {
+    let path = tmp.path().join("input.json");
+    std::fs::write(&path, json).unwrap();
+    path.to_string_lossy().into_owned()
+}
+
+#[tokio::test]
+async fn from_json_single_object_files_a_bug() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .and(body_string_contains("\"product\":\"P\""))
+        .and(body_string_contains("\"summary\":\"S\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 7})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let json = r#"{"product":"P","component":"C","summary":"S"}"#;
+    let action = from_json_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+
+    assert!(
+        result.is_ok(),
+        "single object should file a bug: {result:?}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["action"], "created");
+    assert_eq!(parsed["id"], 7);
+}
+
+#[tokio::test]
+async fn from_json_array_batch_creates_one_per_element() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 11})))
+        .expect(2)
+        .mount(&mock)
+        .await;
+
+    let json = r#"[{"product":"P","component":"C","summary":"one"},
+                   {"product":"P","component":"C","summary":"two"}]"#;
+    let action = from_json_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+
+    assert!(result.is_ok(), "array should batch-create: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["action"], "created");
+    assert_eq!(parsed["created"], serde_json::json!([11, 11]));
+    assert_eq!(parsed["failed"], serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn from_json_array_partial_failure_exits_11() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    // First create succeeds (id 11); the component endpoint for the second is a
+    // 400 with a Bugzilla error body, so it fails.
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .and(body_string_contains("\"summary\":\"ok\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 11})))
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .and(body_string_contains("\"summary\":\"bad\""))
+        .respond_with(ResponseTemplate::new(400).set_body_json(
+            serde_json::json!({"error": true, "code": 51, "message": "Invalid component"}),
+        ))
+        .mount(&mock)
+        .await;
+
+    let json = r#"[{"product":"P","component":"C","summary":"ok"},
+                   {"product":"P","component":"Bad","summary":"bad"}]"#;
+    let action = from_json_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+
+    let err = result.unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            BzrError::BatchPartialFailure {
+                succeeded: 1,
+                failed: 1
+            }
+        ),
+        "expected partial failure 1/1, got {err:?}"
+    );
+    assert_eq!(err.exit_code(), 11);
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["created"], serde_json::json!([11]));
+    assert_eq!(parsed["failed"][0]["index"], 1);
+}
+
+#[tokio::test]
+async fn from_json_cli_flag_overrides_json_field() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    // The JSON says product "FromJson"; --product "FromCli" must win.
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .and(body_string_contains("\"product\":\"FromCli\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 5})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let json = r#"{"product":"FromJson","component":"C","summary":"S"}"#;
+    let mut action = from_json_action(&write_json_file(&tmp, json));
+    if let BugAction::Create { product, .. } = &mut action {
+        *product = Some("FromCli".into());
+    }
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    assert!(
+        result.is_ok(),
+        "CLI override should win and create: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn from_json_rejects_unknown_field() {
+    let (_lock, _mock, tmp) = setup_test_env().await;
+    let json = r#"{"product":"P","component":"C","summary":"S","bogus":1}"#;
+    let action = from_json_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let err =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await
+            .unwrap_err();
+    match err {
+        BzrError::InputValidation(msg) => assert!(
+            msg.contains("bogus") || msg.contains("unknown field"),
+            "should name the unknown field: {msg}"
+        ),
+        other => panic!("expected InputValidation, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn from_json_missing_required_field_errors() {
+    let (_lock, _mock, tmp) = setup_test_env().await;
+    // No summary in JSON and none on the CLI.
+    let json = r#"{"product":"P","component":"C"}"#;
+    let action = from_json_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let err =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await
+            .unwrap_err();
+    match err {
+        BzrError::InputValidation(msg) => assert!(msg.contains("summary"), "names field: {msg}"),
+        other => panic!("expected InputValidation, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_json_bugs_rejects_non_object_scalar() {
+    let err = super::parse_json_bugs("42").unwrap_err();
+    assert!(matches!(err, BzrError::InputValidation(_)));
+}
+
+#[test]
+fn parse_json_bugs_rejects_malformed_json() {
+    let err = super::parse_json_bugs("{not json").unwrap_err();
+    match err {
+        BzrError::InputValidation(msg) => assert!(msg.contains("invalid JSON"), "{msg}"),
+        other => panic!("expected InputValidation, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_json_bugs_object_and_array_shapes() {
+    assert!(matches!(
+        super::parse_json_bugs(r#"{"product":"P"}"#).unwrap(),
+        super::JsonInput::One(_)
+    ));
+    match super::parse_json_bugs(r#"[{"product":"P"},{"product":"Q"}]"#).unwrap() {
+        super::JsonInput::Many(v) => assert_eq!(v.len(), 2),
+        super::JsonInput::One(_) => panic!("array should parse as Many"),
+    }
+    // A 1-element array stays Many, so output shape follows input shape.
+    assert!(matches!(
+        super::parse_json_bugs(r#"[{"product":"P"}]"#).unwrap(),
+        super::JsonInput::Many(_)
+    ));
+}
+
+#[tokio::test]
+async fn from_json_single_element_array_returns_batch_shape() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 8})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    // A top-level array of ONE must still yield the partial-failure shape
+    // (`created`/`failed`), not the single-object `{id}` shape.
+    let json = r#"[{"product":"P","component":"C","summary":"S"}]"#;
+    let action = from_json_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+
+    assert!(result.is_ok(), "1-element array should create: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["created"], serde_json::json!([8]));
+    assert_eq!(parsed["failed"], serde_json::json!([]));
+    assert!(
+        parsed.get("id").is_none(),
+        "array input must not use the single-object shape"
+    );
+}
+
+#[tokio::test]
+async fn from_json_batch_dry_run_emits_single_object_and_no_write() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    // No POST must fire under --dry-run.
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let json = r#"[{"product":"P","component":"C","summary":"one"},
+                   {"product":"P","component":"C","summary":"two"}]"#;
+    let action = from_json_action(&write_json_file(&tmp, json));
+    crate::commands::dry_run::set(true);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    crate::commands::dry_run::set(false);
+
+    assert!(result.is_ok(), "batch dry-run should succeed: {result:?}");
+    // The whole batch is ONE valid JSON object whose changes is the array.
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["changes"].as_array().unwrap().len(), 2);
 }

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -254,7 +254,10 @@ fn write_batch_result(
     }
 }
 
-fn ensure_batch_complete(succeeded: usize, failed: usize) -> Result<()> {
+/// The shared exit-11 gate for batch mutations: returns `BatchPartialFailure`
+/// (exit 11) when any element failed, else `Ok(())`. Used by batch `bug update`
+/// and batch `bug create --from-json`.
+pub(super) fn ensure_batch_complete(succeeded: usize, failed: usize) -> Result<()> {
     if failed > 0 {
         Err(crate::error::BzrError::BatchPartialFailure { succeeded, failed })
     } else {

--- a/src/output/result_types.rs
+++ b/src/output/result_types.rs
@@ -307,6 +307,41 @@ impl BatchResult {
     }
 }
 
+/// Result of an array (batch) `bug create --from-json`: the IDs of the bugs
+/// that were created plus a per-item failure list. Reuses the partial-failure
+/// model of batch `bug update`/`bug view`, but the shape differs because a
+/// failed *create* has no bug ID — failures carry the **input index** instead,
+/// and successes are **new** IDs the server assigned.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct BatchCreateResult {
+    pub resource: ResourceKind,
+    pub action: ActionKind,
+    pub created: Vec<u64>,
+    pub failed: Vec<CreateFailure>,
+}
+
+/// A single failure in a batch create, identified by its 0-based position in
+/// the input array.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct CreateFailure {
+    pub index: usize,
+    pub error: String,
+}
+
+impl BatchCreateResult {
+    #[must_use]
+    pub fn new(created: Vec<u64>, failed: Vec<CreateFailure>) -> Self {
+        Self {
+            resource: ResourceKind::Bug,
+            action: ActionKind::Created,
+            created,
+            failed,
+        }
+    }
+}
+
 /// Typed result payload for multi-ID `bzr bug view` JSON output.
 ///
 /// The wrapped shape is used for **every** multi-ID invocation, with or

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -223,6 +223,7 @@ async fn bug_create_integration() {
         .await;
 
     let action = bzr::cli::BugAction::Create {
+        from_json: None,
         template: None,
         product: Some("TestProduct".to_string()),
         component: Some("General".to_string()),


### PR DESCRIPTION
## Summary

Adds structured JSON input to `bug create`, fixing #307: an agent that already models a bug as an object can submit it directly instead of flattening it into shell flags. This is the inverse of the `--json` *output* story.

| Issue | Title | Type | Key files |
|-------|-------|------|-----------|
| #307 | Structured input for create (`--from-json` / stdin object) | feat | `src/cli/bug.rs`, `src/commands/bug/create.rs`, `src/output/result_types.rs` |

## Behavior

- `printf '%s' '{"product":"P","component":"C","summary":"S"}' | bzr bug create --from-json -` files one bug and returns `{"action":"created","id":N}`.
- A top-level **array** files one bug per element and returns the partial-failure result `{"action":"created","created":[...],"failed":[{"index":N,"error":"..."}]}`; exit **11** if any element fails. All entries are validated before any write, so a malformed element never half-creates a batch.
- Accepted keys match the create flag names; **unknown keys are rejected** (exit 7) so a typo fails fast, and undesigned `cf_*` custom-field writes (#283) stay out of this path.
- Explicit CLI flags override the corresponding JSON field, applied to every array element. `--from-json` is mutually exclusive with `--template` and bypasses the `$EDITOR` flow.

## Design notes

- **Decoupled wire type.** A separate `JsonCreateBug` deserialize struct (not the API type `CreateBugParams`) lets `#[serde(deny_unknown_fields)]` apply to the input boundary only, controls required/default semantics with field-named errors, and fences off `cf_*` writes (#283).
- **Output shape follows input shape, not count.** `parse_json_bugs` returns `JsonInput::One` for a top-level object and `JsonInput::Many` for *any* array — so a 1-element array still returns the batch shape, which an agent that always submits arrays can rely on. (This was the fix from the first `/challenge` pass.)
- **Reuse.** The CLI-over-JSON merge uses the existing `merge_set`/`merge_vec` helpers; the exit-11 gate reuses `ensure_batch_complete` (promoted from `bug update`); the single-create path is shared with the flag/editor path via `create_and_report`.

## Scope

Implements `bug create --from-json`, which meets the issue's acceptance criteria. `bug update` and the other resource commands (the issue's "ideally also" tier) are noted as follow-up in the docs and CHANGELOG — the shape-preserving parser and partial-failure plumbing are the reusable parts for those.

## Review notes

- Reviewed adversarially (`/challenge`, twice): the first pass caught that a 1-element array collapsed to the single-object output shape (fixed via the `JsonInput` enum); the second pass confirmed output shape, exit-11 accounting, and field mapping are correct. A `/simplify` pass replaced hand-rolled merges with the shared helpers and de-duplicated the single-create tail and the exit-11 gate.
- New per-command flag and a new exit path, so the `bug create` command tree, flag table, exit-codes table, a `Structured input` doc subsection (`docs/bzr-cli.md`), and `CHANGELOG.md` are updated.

## Test coverage

13 new tests: single object files a bug; array batch-creates one per element; array partial failure exits 11 with correct `index`; 1-element array returns the batch shape; CLI flag overrides JSON; unknown field rejected; missing required field errors; malformed/scalar JSON rejected; object/array/1-element shape parsing; batch dry-run emits one coherent object and writes nothing; `--from-json -` parses; conflicts with `--template`.

## Validation

`cargo test` (1484 lib + 22 + 2 + 79 integration), `cargo clippy --locked --features test-helpers -- -D warnings`, `cargo fmt --check`, and the `agent-skills` flag-drift drift + self-test all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
