### PR TITLE
feat(bug): pagination (--offset/--paginate) + truncation signal (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Pagination for the search-backed commands (`bug list`, `bug search`, `bug my`,
+  `query run`): `--offset <N>` skips leading matches for manual paging, and
+  `--paginate` loops internally past `--limit` to retrieve every match (the path
+  for "process all matching bugs" workflows). Because Bugzilla's search API
+  returns no total, truncation is detected by over-fetching one row past
+  `--limit`: a truncated table window prints a "more available" footer, and the
+  JSON window writes the same note to stderr (the stdout array shape is
+  unchanged). `--offset`/`--paginate` are mutually exclusive and cannot be
+  combined with `--count` (exit 7). (#302)
+
 - `bug create --from-json <PATH|->` structured input. Files one or more bugs
   from a JSON object (one bug) or array (one bug per element, with the
   partial-failure model and exit 11), so an agent that already models a bug as

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -97,13 +97,13 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │   │        [--creator <C>...] [--priority <P>...] [--severity <S>...] [--id <ID>...]
 │   │        [--alias <A>] [--summary <S>] [--resolution <R>...] [--version <V>...] [--op-sys <OS>...]
 │   │        [--platform <P>...] [--whiteboard <W>] [--target-milestone <M>...] [--qa-contact <Q>...] [--url <U>]
-│   │        [--limit <N>] [--count] [--fields <F>] [--exclude-fields <F>]
+│   │        [--limit <N>] [--offset <N>] [--paginate] [--count] [--fields <F>] [--exclude-fields <F>]
 │   │        [--created-since <D>] [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
 │   ├── view <ID> [--fields <F>] [--exclude-fields <F>] [--permissive] [--web]
-│   ├── search [<QUERY>] [--from-url <URL>] [--save-as [NAME]] [--limit <N>] [--count] [--fields <F>] [--exclude-fields <F>]
+│   ├── search [<QUERY>] [--from-url <URL>] [--save-as [NAME]] [--limit <N>] [--offset <N>] [--paginate] [--count] [--fields <F>] [--exclude-fields <F>]
 │   │          [--sort <FIELD>] [--order asc|desc]
 │   ├── history <ID> [--since <DATE>]
-│   ├── my [--created] [--cc] [--all] [--status <S>...] [--limit <N>] [--count]
+│   ├── my [--created] [--cc] [--all] [--status <S>...] [--limit <N>] [--offset <N>] [--paginate] [--count]
 │   │       [--fields <F>] [--exclude-fields <F>] [--sort <FIELD>] [--order asc|desc]
 │   ├── create [--from-json <PATH>] [--template <T>] [--product <P>] [--component <C>] --summary <S>
 │   │          [--version <V>] [--description <D>] [--description-file <PATH>] [--priority <P>] [--severity <S>]
@@ -212,7 +212,7 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │   │                 [--limit <N>] [--fields <F>] [--exclude-fields <F>] [--created-since <D>]
 │   │                 [--changed-since <D>] [--clear <FIELD>] [--sort <FIELD>] [--order asc|desc]
 │   ├── delete <NAME>
-│   └── run <NAME> [--limit <N>] [--fields <F>] [--exclude-fields <F>] [--server <NAME>]
+│   └── run <NAME> [--limit <N>] [--offset <N>] [--paginate] [--fields <F>] [--exclude-fields <F>] [--server <NAME>]
 │                  [--resolution <R>...] [--version <V>...] [--op-sys <OS>...] [--platform <P>...]
 │                  [--whiteboard <W>] [--target-milestone <M>...] [--qa-contact <Q>...] [--url <U>]
 │                  [--created-since <D>] [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
@@ -259,6 +259,8 @@ Filter flags (`--product`, `--component`, `--status`, `--assignee`, `--creator`,
 | `--alias <A>` | No | | Filter by bug alias |
 | `--summary <S>` | No | | Substring match on the Summary field (matches all bug states) |
 | `--limit <N>` | No | 50 | Max results |
+| `--offset <N>` | No | | Skip the first N matches (manual paging past `--limit`). Mutually exclusive with `--paginate`; cannot be combined with `--count`. |
+| `--paginate` | No | | Retrieve every matching page, looping internally past `--limit` (which becomes the per-request page size). For "process all matching bugs" workflows. Cannot be combined with `--count`. |
 | `--count` | No | | Print only the count of matching bugs — an integer (table) or `{"count": N}` (JSON). Fetches ids only and lifts the row limit, so the count reflects all matches (bounded by the server's max-results setting). Ignores `--fields`, `--limit`, and `--sort`. |
 | `--fields <F>` | No | | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
 | `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
@@ -278,6 +280,40 @@ default; pass `--sort` to choose a different order. For `bug search --from-url`
 and `query run`, an explicit `--sort` overrides any ordering carried by the URL
 or saved query; otherwise the saved/URL order is preserved. `query save --sort`
 persists an order into the saved query.
+
+#### Pagination and truncation
+
+`--limit` caps a single result window. `--offset <N>` and `--paginate` apply to
+`bug list`, `bug search`, `bug my`, and `query run` and let you go past it:
+
+- **`--offset <N>`** skips the first `N` matches, so a window beyond the first
+  `--limit` is retrievable. Page through a large set by repeating with
+  increasing offsets; a short or empty page means there are no more matches.
+- **`--paginate`** loops internally — `--limit` becomes the per-request page
+  size — fetching pages until the server returns a short page, then emits the
+  full result set. This is the path for "process all matching bugs" workflows.
+  (For `bug my`, each of the assigned/created/CC categories is paged
+  independently and the union is de-duplicated.)
+
+The two are mutually exclusive, and neither may be combined with `--count`
+(which already reports the full total) — doing so exits 7.
+
+**Truncation signal.** Bugzilla's search API returns no total-match count, so
+bzr detects "more results exist" by over-fetching one row past `--limit`. When a
+window is truncated:
+
+The over-fetch detects truncation by `--limit`. It cannot detect truncation by
+the server's own `max-results` cap (the same limitation noted for `--count`): if
+`--limit` exceeds `max-results`, the server may withhold matches without a
+signal. When a window is truncated:
+
+- **Table** output appends a footer: `Showing first N result(s); more
+  available — use --paginate for all, or --offset N for the next page.`
+- **JSON** output keeps stdout a clean array and writes the same note to
+  **stderr**, so a deterministic, in-band JSON truncation flag is not added to
+  the default array shape. For programmatic truncation detection, either use
+  `--paginate` (which returns everything) or page with `--offset` until a page
+  returns fewer than `--limit` rows.
 
 #### Date format
 
@@ -390,6 +426,8 @@ bzr bug search --from-url "https://bugzilla.example.com/buglist.cgi?known_name=m
 | `--from-url <URL>` | No* | | Execute a search from a Bugzilla buglist.cgi URL. Recognized parameters (product, component, status, etc.) are mapped to structured fields; unrecognized parameters (boolean charts, field-change filters) are passed through to the REST API verbatim. |
 | `--save-as [NAME]` | No | | Save this URL query for future reuse. If `NAME` is omitted, uses the URL's `known_name` parameter as the query name. Requires `--from-url`. |
 | `--limit <N>` | No | 50 | Max results. When `--from-url` is used, the URL's own limit parameter takes precedence unless overridden here. |
+| `--offset <N>` | No | | Skip the first N matches (manual paging past `--limit`). Mutually exclusive with `--paginate`; cannot be combined with `--count`. |
+| `--paginate` | No | | Retrieve every matching page, looping internally past `--limit`. Cannot be combined with `--count`. |
 | `--count` | No | | Print only the count of matching bugs — an integer (table) or `{"count": N}` (JSON). Counts all matches (bounded by the server's max-results setting). |
 | `--fields <F>` | No | | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
 | `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
@@ -433,6 +471,8 @@ bzr bug my --status NEW --status '!RESOLVED'  # mixed positive and negated
 | `--all` | No | | Show all bugs related to me (assigned + created + CC'd) |
 | `--status <S>` | No | | Filter by status (repeatable; `!` prefix to exclude) |
 | `--limit <N>` | No | 50 | Max results per category. With `--all`, each of the three categories (assigned, created, CC'd) is queried separately up to this limit; duplicates across categories are removed. |
+| `--offset <N>` | No | | Skip the first N matches in each category. Mutually exclusive with `--paginate`; cannot be combined with `--count`. |
+| `--paginate` | No | | Retrieve every matching page of each category, looping internally past `--limit`, then de-duplicate. Cannot be combined with `--count`. |
 | `--count` | No | | Print only the count of distinct matching bugs (deduped across the active categories) — an integer (table) or `{"count": N}` (JSON). |
 | `--fields <F>` | No | | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). A selection that resolves to no known fields is rejected with exit code 7 rather than emitting an empty object. |
 | `--exclude-fields <F>` | No | | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). Excluding every field is rejected with exit code 7 rather than emitting `{}`. |
@@ -1626,6 +1666,8 @@ bzr query run recent-firefox --changed-since 2026-05-01
 |--------|----------|-------------|
 | `<NAME>` | Yes | Query name |
 | `--limit <N>` | No | Override the saved limit |
+| `--offset <N>` | No | Skip the first N matches (manual paging past `--limit`). Mutually exclusive with `--paginate`. |
+| `--paginate` | No | Retrieve every matching page, looping internally past `--limit`. |
 | `--fields <F>` | No | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
 | `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). |
 | `--server <NAME>` | No | Override the server to run the query against. Takes precedence over the server stored in the saved query. The global `--server` flag takes precedence over this flag. |

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -19,6 +19,28 @@ pub struct SortArgs {
     pub order: SortDirection,
 }
 
+/// Shared `--offset` / `--paginate` paging flags, flattened into the
+/// search-backed bug commands (`list`, `search`, `my`) and `query run`.
+/// Bugzilla returns no total, so `--paginate` (loop all pages) is the path to
+/// full retrieval and `--offset` walks windows manually.
+#[derive(Args, Debug, Clone, Default)]
+pub struct PageArgs {
+    /// Skip the first N matching bugs (manual paging past `--limit`).
+    ///
+    /// Page through a large result set by repeating with increasing offsets;
+    /// an empty/short page means there are no more matches. Mutually exclusive
+    /// with `--paginate`.
+    #[arg(long, value_name = "N", conflicts_with = "paginate")]
+    pub offset: Option<u32>,
+    /// Retrieve every matching page, looping internally past `--limit`.
+    ///
+    /// `--limit` becomes the per-request page size; bzr fetches pages until the
+    /// server returns a short page, then emits the full result set. Use this
+    /// for "process all matching bugs" workflows.
+    #[arg(long)]
+    pub paginate: bool,
+}
+
 /// Create-time field flags shared into `bug create`, giving it parity with
 /// `bug update` for the subset Bugzilla's `Bug.create` accepts in one call.
 /// Grouped into one flattened struct so the `Create` variant stays readable
@@ -200,6 +222,8 @@ pub enum BugAction {
         field_args: FieldArgs,
         #[command(flatten)]
         sort_args: SortArgs,
+        #[command(flatten)]
+        page_args: PageArgs,
         /// Filter to bugs created at or after this date.
         ///
         /// Accepts `YYYY-MM-DD` (interpreted as 00:00:00 UTC),
@@ -390,6 +414,8 @@ pub enum BugAction {
         field_args: FieldArgs,
         #[command(flatten)]
         sort_args: SortArgs,
+        #[command(flatten)]
+        page_args: PageArgs,
     },
     /// Show the change history for a single bug.
     ///
@@ -623,6 +649,8 @@ pub enum BugAction {
         field_args: FieldArgs,
         #[command(flatten)]
         sort_args: SortArgs,
+        #[command(flatten)]
+        page_args: PageArgs,
     },
     /// Clone an existing bug, optionally overriding fields.
     ///

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,7 +13,7 @@ mod template;
 mod user;
 
 pub use attachment::AttachmentAction;
-pub use bug::{BugAction, CommentArgs, CreateFieldArgs, FieldArgs, SortArgs};
+pub use bug::{BugAction, CommentArgs, CreateFieldArgs, FieldArgs, PageArgs, SortArgs};
 pub use classification::ClassificationAction;
 pub use comment::CommentAction;
 pub use component::ComponentAction;

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -270,6 +270,29 @@ fn bug_create_from_json_conflicts_with_template() {
 }
 
 #[test]
+fn parse_bug_list_offset_and_paginate() {
+    let cli =
+        Cli::try_parse_from(["bzr", "bug", "list", "--limit", "10", "--offset", "20"]).unwrap();
+    let Commands::Bug {
+        action: BugAction::List { page_args, .. },
+    } = cli.command
+    else {
+        panic!("expected bug list");
+    };
+    assert_eq!(page_args.offset, Some(20));
+    assert!(!page_args.paginate);
+}
+
+#[test]
+fn bug_list_offset_conflicts_with_paginate() {
+    let result = Cli::try_parse_from(["bzr", "bug", "list", "--offset", "20", "--paginate"]);
+    assert!(
+        result.is_err(),
+        "--offset and --paginate must be mutually exclusive"
+    );
+}
+
+#[test]
 fn parse_global_yes_flag_short_and_long() {
     let short = Cli::try_parse_from(["bzr", "-y", "bug", "update", "5", "--status", "X"]).unwrap();
     assert!(short.yes);

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -392,5 +392,7 @@ pub enum QueryAction {
         url: Vec<String>,
         #[command(flatten)]
         sort_args: crate::cli::SortArgs,
+        #[command(flatten)]
+        page_args: crate::cli::PageArgs,
     },
 }

--- a/src/client/bug.rs
+++ b/src/client/bug.rs
@@ -142,6 +142,9 @@ fn append_option_params(
     if let Some(limit) = params.limit {
         builder = builder.query(&[("limit", limit)]);
     }
+    if let Some(offset) = params.offset {
+        builder = builder.query(&[("offset", offset)]);
+    }
     builder
 }
 

--- a/src/commands/bug/list.rs
+++ b/src/commands/bug/list.rs
@@ -39,11 +39,14 @@ pub(super) async fn handle(
         qa_contact,
         url,
         sort_args,
+        page_args: crate::cli::PageArgs { offset, paginate },
         count,
     } = action
     else {
         unreachable!()
     };
+
+    super::ensure_no_paging_with_count(*count, *offset, *paginate)?;
 
     let creation_time = parse_optional_date(created_since.as_deref(), "--created-since")?;
     let last_change_time = parse_optional_date(changed_since.as_deref(), "--changed-since")?;
@@ -60,6 +63,7 @@ pub(super) async fn handle(
         alias: alias.clone(),
         summary: summary.clone(),
         limit: Some(*limit),
+        offset: *offset,
         include_fields: canonical_field_list(fields.as_deref()),
         exclude_fields: canonical_field_list(exclude_fields.as_deref()),
         creation_time,
@@ -87,8 +91,9 @@ pub(super) async fn handle(
     }
 
     let spec = ColumnSpec::new(fields.as_deref(), exclude_fields.as_deref());
-    let bugs = client.search_bugs(&params).await?;
-    write_bugs(&bugs, spec, format, w.out, w.err);
+    let page = crate::commands::paging::fetch_page(client, &params, *paginate).await?;
+    write_bugs(&page.bugs, spec, format, w.out, w.err);
+    crate::commands::paging::write_truncation_note(&page, params.limit, *offset, format, w);
     Ok(())
 }
 

--- a/src/commands/bug/list_tests.rs
+++ b/src/commands/bug/list_tests.rs
@@ -9,6 +9,7 @@ use crate::types::OutputFormat;
 
 fn empty_list_action() -> BugAction {
     BugAction::List {
+        page_args: crate::cli::PageArgs::default(),
         product: vec![],
         component: vec![],
         status: vec![],
@@ -97,7 +98,7 @@ async fn bug_list_passes_every_field_through_to_search_params() {
         .and(query_param("id", "42"))
         .and(query_param("alias", "my-alias"))
         .and(query_param("summary", "kernel panic"))
-        .and(query_param("limit", "5"))
+        .and(query_param("limit", "6"))
         .and(query_param("include_fields", "id,summary"))
         .and(query_param("exclude_fields", "comments"))
         .and(query_param("creation_time", "2026-04-01T00:00:00Z"))
@@ -116,6 +117,7 @@ async fn bug_list_passes_every_field_through_to_search_params() {
         .await;
 
     let action = BugAction::List {
+        page_args: crate::cli::PageArgs::default(),
         product: vec!["Firefox".into()],
         component: vec!["General".into()],
         status: vec!["NEW".into()],
@@ -182,6 +184,7 @@ async fn bug_list_summary_only_sends_substring_filter() {
         .await;
 
     let action = BugAction::List {
+        page_args: crate::cli::PageArgs::default(),
         product: vec![],
         component: vec![],
         status: vec![],
@@ -356,6 +359,7 @@ async fn bug_list_mixed_positive_notequals_notsubstring() {
 
     let mut action = empty_list_action();
     if let BugAction::List {
+        page_args: _,
         product,
         resolution,
         whiteboard,
@@ -717,4 +721,78 @@ async fn bug_list_count_table_prints_integer_only() {
     .await;
     assert!(result.is_ok());
     assert_eq!(__io.out_str().trim(), "2");
+}
+
+// ── Pagination (#302) ────────────────────────────────────────────────
+
+fn list_action_paged(limit: u32, offset: Option<u32>, paginate: bool) -> BugAction {
+    let mut action = empty_list_action();
+    if let BugAction::List {
+        limit: l,
+        page_args,
+        ..
+    } = &mut action
+    {
+        *l = limit;
+        *page_args = crate::cli::PageArgs { offset, paginate };
+    }
+    action
+}
+
+#[tokio::test]
+async fn list_offset_reaches_server_and_truncation_footer_prints() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    // limit 2 + offset 10 → over-fetch sends limit=3 & offset=10; 3 returned ⇒
+    // truncated, footer printed, surplus row trimmed.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("limit", "3"))
+        .and(query_param("offset", "10"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1}, {"id": 2}, {"id": 3}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = crate::commands::bug::execute(
+        &list_action_paged(2, Some(10), false),
+        None,
+        OutputFormat::Table,
+        None,
+        &mut io.writers(),
+    )
+    .await;
+
+    assert!(result.is_ok(), "{result:?}");
+    assert!(
+        io.out_str().contains("more available"),
+        "expected truncation footer, got: {}",
+        io.out_str()
+    );
+    assert!(io.out_str().contains("--offset 12"), "next offset = 10 + 2");
+}
+
+#[tokio::test]
+async fn list_count_with_offset_is_rejected() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    let mut action = empty_list_action();
+    if let BugAction::List {
+        count, page_args, ..
+    } = &mut action
+    {
+        *count = true;
+        *page_args = crate::cli::PageArgs {
+            offset: Some(5),
+            paginate: false,
+        };
+    }
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let err =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await
+            .unwrap_err();
+    assert!(matches!(err, crate::error::BzrError::InputValidation(_)));
+    assert_eq!(err.exit_code(), 7);
 }

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -46,6 +46,22 @@ pub(super) fn count_search_params(
     params
 }
 
+/// Reject `--offset`/`--paginate` combined with `--count`. `--count` reports
+/// the full match total, so windowing or page-looping it is contradictory;
+/// fail fast (exit 7) rather than silently ignore the paging flags.
+pub(super) fn ensure_no_paging_with_count(
+    count: bool,
+    offset: Option<u32>,
+    paginate: bool,
+) -> Result<()> {
+    if count && (offset.is_some() || paginate) {
+        return Err(crate::error::BzrError::InputValidation(
+            "--count cannot be combined with --offset or --paginate".into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Whether a bug action is a mutation that supports `--dry-run` (the create-,
 /// update-, and clone-shaped writes). Read actions and `--web` are excluded.
 #[must_use]

--- a/src/commands/bug/my.rs
+++ b/src/commands/bug/my.rs
@@ -22,11 +22,14 @@ pub(super) async fn handle(
             exclude_fields,
         },
         sort_args,
+        page_args: crate::cli::PageArgs { offset, paginate },
         count,
     } = action
     else {
         unreachable!()
     };
+
+    super::ensure_no_paging_with_count(*count, *offset, *paginate)?;
 
     let spec = ColumnSpec::new(fields.as_deref(), exclude_fields.as_deref());
 
@@ -39,6 +42,7 @@ pub(super) async fn handle(
     let mut base = SearchParams {
         status: status.clone(),
         limit: Some(*limit),
+        offset: *offset,
         include_fields: canonical_field_list(fields.as_deref()),
         exclude_fields: canonical_field_list(exclude_fields.as_deref()),
         order: Some(crate::validation::build_order(
@@ -69,8 +73,14 @@ pub(super) async fn handle(
         searches.push(p);
     }
 
+    // Page each category independently (a single global offset can't span the
+    // overlapping assigned/created/cc sets); the result is the deduped union.
+    // `truncated` means at least one category had more rows than `--limit`.
+    let mut truncated = false;
     for params in &searches {
-        for bug in client.search_bugs(params).await? {
+        let page = crate::commands::paging::fetch_page(client, params, *paginate).await?;
+        truncated |= page.truncated;
+        for bug in page.bugs {
             // When counting, only the deduped id set matters — don't retain rows.
             if seen_ids.insert(bug.id) && !*count {
                 all_bugs.push(bug);
@@ -84,6 +94,11 @@ pub(super) async fn handle(
     }
 
     write_bugs(&all_bugs, spec, format, w.out, w.err);
+    let page = crate::commands::paging::Page {
+        bugs: all_bugs,
+        truncated,
+    };
+    crate::commands::paging::write_truncation_note(&page, Some(*limit), *offset, format, w);
     Ok(())
 }
 

--- a/src/commands/bug/my_tests.rs
+++ b/src/commands/bug/my_tests.rs
@@ -42,6 +42,7 @@ async fn bug_my_returns_assigned_by_default() {
         .await;
 
     let action = BugAction::My {
+        page_args: crate::cli::PageArgs::default(),
         created: false,
         cc: false,
         all: false,
@@ -75,7 +76,7 @@ async fn bug_my_passes_status_limit_and_field_filters() {
     Mock::given(method("GET"))
         .and(path("/rest/bug"))
         .and(query_param("status", "NEW"))
-        .and(query_param("limit", "7"))
+        .and(query_param("limit", "8"))
         .and(query_param("include_fields", "id,summary"))
         .and(query_param("exclude_fields", "comments"))
         .and(query_param("assigned_to", "dev@test.com"))
@@ -85,6 +86,7 @@ async fn bug_my_passes_status_limit_and_field_filters() {
         .await;
 
     let action = BugAction::My {
+        page_args: crate::cli::PageArgs::default(),
         created: false,
         cc: false,
         all: false,
@@ -126,6 +128,7 @@ async fn bug_my_created_only_runs_creator_search_not_assigned() {
         .await;
 
     let action = BugAction::My {
+        page_args: crate::cli::PageArgs::default(),
         created: true,
         cc: false,
         all: false,
@@ -166,6 +169,7 @@ async fn bug_my_cc_only_runs_cc_search_not_assigned_or_creator() {
         .await;
 
     let action = BugAction::My {
+        page_args: crate::cli::PageArgs::default(),
         created: false,
         cc: true,
         all: false,
@@ -213,6 +217,7 @@ async fn bug_my_all_deduplicates() {
         .await;
 
     let action = BugAction::My {
+        page_args: crate::cli::PageArgs::default(),
         created: false,
         cc: false,
         all: true,
@@ -261,6 +266,7 @@ async fn bug_my_all_count_reports_distinct_total() {
         .await;
 
     let action = BugAction::My {
+        page_args: crate::cli::PageArgs::default(),
         created: false,
         cc: false,
         all: true,

--- a/src/commands/bug/search.rs
+++ b/src/commands/bug/search.rs
@@ -76,14 +76,17 @@ pub(super) async fn handle(
             exclude_fields,
         },
         sort_args,
+        page_args: crate::cli::PageArgs { offset, paginate },
     } = action
     else {
         unreachable!()
     };
 
+    super::ensure_no_paging_with_count(*count, *offset, *paginate)?;
+
     let spec = ColumnSpec::new(fields.as_deref(), exclude_fields.as_deref());
 
-    let (client, params, save_info) = if let Some(url_str) = from_url {
+    let (client, mut params, save_info) = if let Some(url_str) = from_url {
         let config = crate::config::Config::load()?;
         let parsed = crate::url_parser::parse_bugzilla_url(url_str, &config)?;
         let effective_server = server.or(parsed.query.server.as_deref());
@@ -126,6 +129,7 @@ pub(super) async fn handle(
         };
         (client, params, None)
     };
+    crate::commands::paging::resolve_offset(&mut params, *offset);
 
     if *count {
         let bugs = client
@@ -133,8 +137,9 @@ pub(super) async fn handle(
             .await?;
         crate::output::result_types::write_count(bugs.len(), format, w.out);
     } else {
-        let bugs = client.search_bugs(&params).await?;
-        write_bugs(&bugs, spec, format, w.out, w.err);
+        let page = crate::commands::paging::fetch_page(&client, &params, *paginate).await?;
+        write_bugs(&page.bugs, spec, format, w.out, w.err);
+        crate::commands::paging::write_truncation_note(&page, params.limit, *offset, format, w);
     }
 
     if let Some((name, query)) = save_info {

--- a/src/commands/bug/search_tests.rs
+++ b/src/commands/bug/search_tests.rs
@@ -9,6 +9,7 @@ use crate::types::OutputFormat;
 
 fn from_url_action(url: String, save_as: Option<String>) -> BugAction {
     BugAction::Search {
+        page_args: crate::cli::PageArgs::default(),
         query: None,
         from_url: Some(url),
         save_as,
@@ -136,7 +137,7 @@ async fn handle_search_from_url_preserves_url_limit_when_cli_unset() {
     Mock::given(method("GET"))
         .and(path("/rest/bug"))
         .and(query_param("product", "TestProduct"))
-        .and(query_param("limit", "10"))
+        .and(query_param("limit", "11"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
         .expect(1)
         .mount(&mock)
@@ -172,7 +173,7 @@ async fn handle_search_quicksearch_passes_limit_and_field_filters() {
     Mock::given(method("GET"))
         .and(path("/rest/bug"))
         .and(query_param("quicksearch", "crash"))
-        .and(query_param("limit", "5"))
+        .and(query_param("limit", "6"))
         .and(query_param("include_fields", "id,summary"))
         .and(query_param("exclude_fields", "comments"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
@@ -181,6 +182,7 @@ async fn handle_search_quicksearch_passes_limit_and_field_filters() {
         .await;
 
     let action = BugAction::Search {
+        page_args: crate::cli::PageArgs::default(),
         query: Some("crash".into()),
         from_url: None,
         save_as: None,
@@ -357,6 +359,7 @@ async fn bug_search_quicksearch_sends_default_order() {
         .await;
 
     let action = BugAction::Search {
+        page_args: crate::cli::PageArgs::default(),
         query: Some("crash".to_string()),
         from_url: None,
         save_as: None,
@@ -419,6 +422,7 @@ async fn handle_search_count_emits_count_object() {
         .await;
 
     let action = BugAction::Search {
+        page_args: crate::cli::PageArgs::default(),
         query: Some("crash".to_string()),
         from_url: None,
         save_as: None,
@@ -437,4 +441,89 @@ async fn handle_search_count_emits_count_object() {
     assert!(result.is_ok(), "search --count failed: {result:?}");
     let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
     assert_eq!(parsed["count"], 4);
+}
+
+#[tokio::test]
+async fn from_url_offset_in_url_is_overridden_by_cli_offset_not_duplicated() {
+    // A URL carrying its own offset=10 plus an explicit --offset 5 must send a
+    // single offset=5 (CLI wins), never two conflicting offset params.
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+        .mount(&mock)
+        .await;
+
+    let url = format!("{}/buglist.cgi?product=P&offset=10", mock.uri());
+    let mut action = from_url_action(url, None);
+    if let BugAction::Search {
+        page_args, limit, ..
+    } = &mut action
+    {
+        *limit = Some(20);
+        *page_args = crate::cli::PageArgs {
+            offset: Some(5),
+            paginate: false,
+        };
+    }
+
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    assert!(result.is_ok(), "{result:?}");
+
+    let requests = mock.received_requests().await.unwrap();
+    let req = requests
+        .iter()
+        .find(|r| r.url.path() == "/rest/bug")
+        .expect("a GET to /rest/bug");
+    let offsets: Vec<String> = req
+        .url
+        .query_pairs()
+        .filter(|(k, _)| k == "offset")
+        .map(|(_, v)| v.into_owned())
+        .collect();
+    assert_eq!(offsets.len(), 1, "exactly one offset param: {offsets:?}");
+    assert_eq!(offsets[0], "5", "the CLI offset wins over the URL's");
+}
+
+#[tokio::test]
+async fn from_url_offset_with_paginate_sends_single_offset_per_page() {
+    // `--from-url …&offset=10 --paginate` must not leave the URL's offset in
+    // raw_params: every page request carries exactly one (loop-managed) offset.
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    // Page size 2: a short first page (1 bug) stops the loop after one request.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1}]
+        })))
+        .mount(&mock)
+        .await;
+
+    let url = format!("{}/buglist.cgi?product=P&offset=10", mock.uri());
+    let mut action = from_url_action(url, None);
+    if let BugAction::Search {
+        page_args, limit, ..
+    } = &mut action
+    {
+        *limit = Some(2);
+        *page_args = crate::cli::PageArgs {
+            offset: None,
+            paginate: true,
+        };
+    }
+
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    assert!(result.is_ok(), "{result:?}");
+
+    let requests = mock.received_requests().await.unwrap();
+    for req in requests.iter().filter(|r| r.url.path() == "/rest/bug") {
+        let n = req.url.query_pairs().filter(|(k, _)| k == "offset").count();
+        assert_eq!(n, 1, "each paginate request must send exactly one offset");
+    }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod field;
 pub mod flags;
 pub mod group;
 pub mod inline_server;
+pub(crate) mod paging;
 pub mod product;
 pub mod query;
 pub mod server;

--- a/src/commands/paging.rs
+++ b/src/commands/paging.rs
@@ -1,0 +1,146 @@
+//! Shared result paging for the search-backed bug commands (`list`, `search`,
+//! `my`) and `query run`.
+//!
+//! Bugzilla's `Bug.search` returns no total-match count, so truncation cannot
+//! be read from the response. Two mechanisms cover the gap:
+//!
+//! - **`--offset <N>`** skips leading matches, so a window past the first
+//!   `--limit` is retrievable.
+//! - **`--paginate`** loops `offset += limit` until a short page and returns
+//!   every match — the full-retrieval path for "process all matching bugs".
+//!
+//! Without `--paginate`, [`fetch_page`] over-fetches one extra row (`limit+1`):
+//! if the server returns more than `limit`, at least one more match exists, so
+//! `truncated` is set deterministically and the surplus row trimmed away.
+
+use crate::client::BugzillaClient;
+use crate::error::Result;
+use crate::output::writers::Writers;
+use crate::types::{Bug, OutputFormat, SearchParams};
+
+/// Backstop on the `--paginate` loop: a server that ignored `offset` would
+/// otherwise return a full page forever. Far above any real result set.
+const MAX_PAGES: u32 = 10_000;
+
+/// Resolve the effective `offset` for a search. A `--from-url` (or a saved
+/// query imported from one) may carry its own `offset=` as an unrecognized
+/// param living in `raw_params`; fold it into the struct field — the single
+/// source of truth the client appends and the `--paginate` loop steps — strip
+/// the raw copy so a request never sends two conflicting `offset` params, then
+/// let an explicit CLI `--offset` override. Mirrors how a URL's `limit` is
+/// folded into the structured field.
+pub(crate) fn resolve_offset(params: &mut SearchParams, cli_offset: Option<u32>) {
+    let url_offset = params
+        .raw_params
+        .iter()
+        .find(|(k, _)| k == "offset")
+        .and_then(|(_, v)| v.parse::<u32>().ok());
+    params.raw_params.retain(|(k, _)| k != "offset");
+    params.offset = cli_offset.or(url_offset);
+}
+
+/// A page of results plus whether more matches exist beyond it.
+pub(crate) struct Page {
+    pub bugs: Vec<Bug>,
+    pub truncated: bool,
+}
+
+/// Fetch results honoring `--offset`/`--paginate`. With `paginate`, returns
+/// every match (never truncated). Otherwise returns one window, with
+/// `truncated` set when the server had more rows than `limit`.
+pub(crate) async fn fetch_page(
+    client: &BugzillaClient,
+    params: &SearchParams,
+    paginate: bool,
+) -> Result<Page> {
+    if paginate {
+        let bugs = fetch_all_pages(client, params).await?;
+        return Ok(Page {
+            bugs,
+            truncated: false,
+        });
+    }
+    // Over-fetch one row past the limit to detect "more available" without a
+    // server total. A zero/absent limit means "no window", so nothing to flag.
+    let Some(limit) = params.limit.filter(|l| *l > 0) else {
+        let bugs = client.search_bugs(params).await?;
+        return Ok(Page {
+            bugs,
+            truncated: false,
+        });
+    };
+    let mut probe = params.clone();
+    probe.limit = Some(limit.saturating_add(1));
+    let mut bugs = client.search_bugs(&probe).await?;
+    let truncated = bugs.len() as u64 > u64::from(limit);
+    bugs.truncate(limit as usize);
+    Ok(Page { bugs, truncated })
+}
+
+/// Loop `offset += limit` until a page shorter than `limit` (the last page) and
+/// return the accumulated matches. A zero/absent limit means the single
+/// unbounded request already returns everything (bounded by the server max).
+async fn fetch_all_pages(client: &BugzillaClient, params: &SearchParams) -> Result<Vec<Bug>> {
+    let Some(page_size) = params.limit.filter(|l| *l > 0) else {
+        return client.search_bugs(params).await;
+    };
+    let mut offset = params.offset.unwrap_or(0);
+    let mut all = Vec::new();
+    let mut reached_last_page = false;
+    for _ in 0..MAX_PAGES {
+        let mut p = params.clone();
+        p.offset = Some(offset);
+        let batch = client.search_bugs(&p).await?;
+        let received = batch.len();
+        all.extend(batch);
+        if received < page_size as usize {
+            reached_last_page = true;
+            break;
+        }
+        offset = offset.saturating_add(page_size);
+    }
+    if !reached_last_page {
+        // Hit the safety cap without a short page — almost always a server that
+        // ignores `offset`. Surface it rather than silently returning a
+        // possibly-incomplete (and duplicate-laden) set.
+        tracing::warn!(
+            "--paginate stopped at the {MAX_PAGES}-page safety cap; \
+             results may be incomplete (the server may be ignoring offset)"
+        );
+    }
+    Ok(all)
+}
+
+/// Emit a truncation footer when a window was truncated: a visible footer line
+/// on stdout for table output, or a note on stderr for JSON (so stdout stays a
+/// clean, parseable document). No-op when nothing was truncated.
+pub(crate) fn write_truncation_note(
+    page: &Page,
+    limit: Option<u32>,
+    offset: Option<u32>,
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) {
+    if !page.truncated {
+        return;
+    }
+    let Some(limit) = limit else { return };
+    let next = offset.unwrap_or(0).saturating_add(limit);
+    let msg = format!(
+        "Showing first {} result(s); more available — use --paginate for all, \
+         or --offset {next} for the next page.",
+        page.bugs.len()
+    );
+    match format {
+        OutputFormat::Table => {
+            let _ = writeln!(w.out, "{msg}");
+        }
+        OutputFormat::Json => {
+            let _ = writeln!(w.err, "{msg}");
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "paging_tests.rs"]
+mod tests;

--- a/src/commands/paging_tests.rs
+++ b/src/commands/paging_tests.rs
@@ -1,0 +1,147 @@
+#![expect(clippy::unwrap_used)]
+
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use super::{fetch_page, write_truncation_note, Page};
+use crate::client::test_helpers::test_client;
+use crate::types::{Bug, OutputFormat, SearchParams};
+
+/// A `Page` of `n` placeholder bugs marked truncated/not for note tests.
+fn page_of(n: usize, truncated: bool) -> Page {
+    let bugs: Vec<Bug> = (1..=n as u64)
+        .map(|id| serde_json::from_value(serde_json::json!({"id": id})).unwrap())
+        .collect();
+    Page { bugs, truncated }
+}
+
+/// A `{"bugs":[...]}` body with `n` bugs (ids 1..=n).
+fn bugs_body(n: u64) -> serde_json::Value {
+    let bugs: Vec<serde_json::Value> = (1..=n).map(|id| serde_json::json!({"id": id})).collect();
+    serde_json::json!({ "bugs": bugs })
+}
+
+fn params_with_limit(limit: u32) -> SearchParams {
+    SearchParams {
+        limit: Some(limit),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn fetch_page_flags_truncation_via_over_fetch() {
+    let mock = MockServer::start().await;
+    // limit 2 → over-fetch requests limit=3; server returns 3 → truncated.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("limit", "3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(bugs_body(3)))
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let page = fetch_page(&client, &params_with_limit(2), false)
+        .await
+        .unwrap();
+
+    assert!(
+        page.truncated,
+        "3 returned for a limit of 2 means more exist"
+    );
+    assert_eq!(
+        page.bugs.len(),
+        2,
+        "the over-fetched surplus row is trimmed"
+    );
+}
+
+#[tokio::test]
+async fn fetch_page_no_truncation_when_under_limit() {
+    let mock = MockServer::start().await;
+    // limit 5 → over-fetch requests limit=6; server returns 3 (< 6).
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("limit", "6"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(bugs_body(3)))
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let page = fetch_page(&client, &params_with_limit(5), false)
+        .await
+        .unwrap();
+
+    assert!(!page.truncated);
+    assert_eq!(page.bugs.len(), 3);
+}
+
+#[tokio::test]
+async fn fetch_page_paginate_loops_until_short_page() {
+    let mock = MockServer::start().await;
+    // Page size 2: offset 0 → 2 bugs, offset 2 → 2 bugs, offset 4 → 1 (short, stop).
+    for (off, n) in [("0", 2u64), ("2", 2), ("4", 1)] {
+        Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .and(query_param("offset", off))
+            .respond_with(ResponseTemplate::new(200).set_body_json(bugs_body(n)))
+            .mount(&mock)
+            .await;
+    }
+
+    let client = test_client(&mock.uri());
+    let page = fetch_page(&client, &params_with_limit(2), true)
+        .await
+        .unwrap();
+
+    assert!(!page.truncated, "paginate retrieves everything");
+    assert_eq!(page.bugs.len(), 5, "2 + 2 + 1 across three pages");
+}
+
+#[test]
+fn truncation_note_table_goes_to_stdout() {
+    let mut io = crate::test_helpers::CapturedIo::new();
+    write_truncation_note(
+        &page_of(50, true),
+        Some(50),
+        None,
+        OutputFormat::Table,
+        &mut io.writers(),
+    );
+    assert!(io.out_str().contains("Showing first 50"));
+    assert!(io.out_str().contains("--paginate"));
+    assert!(io.out_str().contains("--offset 50"));
+    assert!(io.err_str().is_empty());
+}
+
+#[test]
+fn truncation_note_json_goes_to_stderr() {
+    // Under JSON, the note must not pollute the parseable stdout document.
+    let mut io = crate::test_helpers::CapturedIo::new();
+    write_truncation_note(
+        &page_of(25, true),
+        Some(25),
+        Some(50),
+        OutputFormat::Json,
+        &mut io.writers(),
+    );
+    assert!(io.out_str().is_empty(), "stdout stays clean JSON");
+    assert!(io.err_str().contains("Showing first 25"));
+    assert!(
+        io.err_str().contains("--offset 75"),
+        "next offset = 50 + 25"
+    );
+}
+
+#[test]
+fn truncation_note_noop_when_not_truncated() {
+    let mut io = crate::test_helpers::CapturedIo::new();
+    write_truncation_note(
+        &page_of(50, false),
+        Some(50),
+        None,
+        OutputFormat::Table,
+        &mut io.writers(),
+    );
+    assert!(io.out_str().is_empty());
+    assert!(io.err_str().is_empty());
+}

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -374,6 +374,7 @@ async fn handle_run(
         qa_contact,
         url,
         sort_args,
+        page_args: crate::cli::PageArgs { offset, paginate },
     } = action
     else {
         unreachable!()
@@ -412,6 +413,9 @@ async fn handle_run(
     });
     params.include_fields = canonical_field_list(params.include_fields.as_deref());
     params.exclude_fields = canonical_field_list(params.exclude_fields.as_deref());
+    // Fold any saved-query/URL `offset` into the struct field and let `--offset`
+    // override, so a saved-from-URL query never sends two `offset` params.
+    crate::commands::paging::resolve_offset(&mut params, *offset);
     // Result ordering: an explicit `--sort` overrides the saved order; absent
     // both, default to a stable `bug_id` so runs are deterministic — unless the
     // saved query (e.g. from a URL) already carries an `order` raw param.
@@ -439,8 +443,9 @@ async fn handle_run(
     }
 
     let client = super::shared::connect_and_configure(effective_server, api).await?;
-    let bugs = client.search_bugs(&params).await?;
-    write_bugs(&bugs, spec, format, w.out, w.err);
+    let page = crate::commands::paging::fetch_page(&client, &params, *paginate).await?;
+    write_bugs(&page.bugs, spec, format, w.out, w.err);
+    crate::commands::paging::write_truncation_note(&page, params.limit, *offset, format, w);
     Ok(())
 }
 

--- a/src/commands/query_tests.rs
+++ b/src/commands/query_tests.rs
@@ -126,6 +126,7 @@ fn url_save_action(name: &str, url: String) -> QueryAction {
 
 fn run_action(name: &str) -> QueryAction {
     QueryAction::Run {
+        page_args: crate::cli::PageArgs::default(),
         name: name.into(),
         limit: None,
         fields: None,
@@ -507,13 +508,14 @@ async fn query_run_with_limit_override() {
 
     Mock::given(method("GET"))
         .and(path("/rest/bug"))
-        .and(query_param("limit", "5"))
+        .and(query_param("limit", "6"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
         .expect(1)
         .mount(&mock)
         .await;
 
     let run_action = QueryAction::Run {
+        page_args: crate::cli::PageArgs::default(),
         name: "override-test".into(),
         limit: Some(5),
         fields: None,
@@ -737,6 +739,7 @@ async fn query_run_applies_field_overrides() {
         .await;
 
     let run_action = QueryAction::Run {
+        page_args: crate::cli::PageArgs::default(),
         name: "fields-test".into(),
         limit: None,
         fields: Some("id,summary".into()),
@@ -883,6 +886,7 @@ async fn query_run_with_server_override() {
 
     // Run with --server override pointing to the mock server ("test")
     let run_action = QueryAction::Run {
+        page_args: crate::cli::PageArgs::default(),
         name: "server-test".into(),
         limit: None,
         fields: None,
@@ -1107,6 +1111,7 @@ async fn query_run_rejects_malformed_created_since_override() {
     .unwrap();
 
     let action = QueryAction::Run {
+        page_args: crate::cli::PageArgs::default(),
         name: "recent".into(),
         limit: None,
         fields: None,
@@ -1295,6 +1300,7 @@ async fn query_run_overrides_replace_saved_field_filters() {
         .await;
 
     let run_action = QueryAction::Run {
+        page_args: crate::cli::PageArgs::default(),
         name: "field-override-test".into(),
         limit: None,
         fields: None,

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -244,6 +244,9 @@ pub struct SearchParams {
     /// Bug IDs to search for.
     pub id: Vec<u64>,
     pub limit: Option<u32>,
+    /// Number of leading matches to skip (Bugzilla `offset`). Combined with
+    /// `limit` for manual paging; `None` means offset 0.
+    pub offset: Option<u32>,
     pub summary: Option<String>,
     pub quicksearch: Option<String>,
     pub include_fields: Option<String>,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19,6 +19,7 @@ use wiremock::{Mock, ResponseTemplate};
 /// fields they care about.
 fn empty_list_action() -> bzr::cli::BugAction {
     bzr::cli::BugAction::List {
+        page_args: bzr::cli::PageArgs::default(),
         product: vec![],
         component: vec![],
         status: vec![],
@@ -103,6 +104,7 @@ async fn bug_list_changed_since_canonicalizes_bare_date_on_wire() {
 
     let mut action = empty_list_action();
     if let bzr::cli::BugAction::List {
+        page_args: _,
         product,
         changed_since,
         ..
@@ -184,6 +186,7 @@ async fn bug_search_integration() {
         .await;
 
     let action = bzr::cli::BugAction::Search {
+        page_args: bzr::cli::PageArgs::default(),
         query: Some("crash".to_string()),
         from_url: None,
         save_as: None,
@@ -2536,6 +2539,7 @@ async fn bug_list_issue_158_mixed_positive_and_negation_reaches_wire() {
 
     let mut action = empty_list_action();
     if let bzr::cli::BugAction::List {
+        page_args: _,
         product,
         whiteboard,
         resolution,


### PR DESCRIPTION
## Summary

Closes #302. Bugzilla's `Bug.search` returns no total-match count, so a client can't tell whether a result set was cut off by `--limit`. This adds pagination controls and a truncation signal to the search-backed bug commands (`list`, `search`, `my`) and `query run`.

| Issue | Title | Type | Key files |
|-------|-------|------|-----------|
| #302 | Pagination + truncation signal | feat | `src/commands/paging.rs`, `src/cli/bug.rs`, `src/client/bug.rs`, `src/types/bug.rs` |

## What changed

- **`--offset <N>`** — skips leading matches, so windows past the first `--limit` are retrievable.
- **`--paginate`** — loops `offset += limit` until a short page and returns every match (the full-retrieval path). Conflicts with `--offset`.
- **Truncation detection** — without `--paginate`, `fetch_page` over-fetches one extra row (`limit+1`). If the server returns more than `limit`, at least one more match exists, so `truncated` is set deterministically and the surplus row trimmed. This detects `--limit` truncation, not the server's own max-results cap.
- **Truncation note** — a footer line on stdout for table output; a note on stderr for JSON (so stdout stays a clean, parseable document). Points at `--paginate` / `--offset <next>`.

## Implementation notes

- New `src/commands/paging.rs` holds the shared paging logic (`fetch_page`, `fetch_all_pages`, `resolve_offset`, `write_truncation_note`, `Page`), used by all four commands.
- `resolve_offset` folds a URL-carried `offset=` (from `--from-url` or a saved query) into the structured `SearchParams.offset` field and strips the raw copy, so a request never sends two conflicting `offset` params. An explicit CLI `--offset` wins over the URL's.
- `--offset`/`--paginate` are rejected with `--count` (exit 7) — a count has no window to page.
- `bug my` pages each category (assigned/created/cc) independently and returns the deduped union; `truncated` means at least one category had more rows than `--limit`.
- The `--paginate` loop is bounded by a `MAX_PAGES` (10,000) safety cap that emits a `tracing::warn!` when hit, rather than silently returning a possibly-incomplete set (the signature of a server ignoring `offset`).

## Review notes

- The over-fetch changes the `limit` query param sent on a normal (non-paginate) search from `N` to `N+1`; existing request-assertion tests were updated accordingly.
- Two new `search_tests` cases assert that a URL offset + CLI `--offset` sends exactly one `offset` param (CLI value wins), and that `--from-url --paginate` sends a single offset per page.

## Validation

`cargo test --features test-helpers` (1496 + integration green), `cargo clippy --features test-helpers -- -D warnings` clean, `cargo fmt --check` clean, flag-drift check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
