### PR TITLE
feat: ndjson output + bzr schema published JSON Schemas (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- NDJSON output via `--output ndjson` (or `BZR_OUTPUT=ndjson`): list/array
+  results print one compact JSON value per line and single objects print as one
+  compact line — the streaming shape for agents and `jq -c`. An empty list emits
+  no lines; the `bug list`/`search` truncation note goes to stderr so stdout
+  stays one clean record per line. Existing `table`/`json` shapes are unchanged.
+  (#305)
+
+- `bzr schema [NAME]` publishes checked-in JSON Schemas (draft 2020-12) for the
+  `--format json` output of each command family — the read-resource objects
+  (`bug`, `comment`, `attachment`, `product`, `component`, `classification`,
+  `user`, `group`, `field-value`) and the mutation/result envelopes
+  (`action-result`, `batch-result`, `batch-create-result`, `multi-bug-view`,
+  `tag-result`, `membership-result`, `count-result`, `download-result`,
+  `upload-result`, `config-result`, `search-result`, `dry-run-result`). Agents
+  can validate output against a contract instead of branching over the per-
+  command shape differences. Local command (no network); run without a name to
+  list the schemas. A drift test validates each schema against the real
+  serialized output so the published contract stays honest. (#305)
+
 - Pagination for the search-backed commands (`bug list`, `bug search`, `bug my`,
   `query run`): `--offset <N>` skips leading matches for manual paging, and
   `--paginate` loops internally past `--limit` to retrieve every match (the path

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -24,6 +24,7 @@ For installation and quick start, see [README.md](../README.md).
 - [template](#bzr-template----bug-template-management)
 - [query](#bzr-query----saved-query-management)
 - [completion](#bzr-completion----shell-completion)
+- [schema](#bzr-schema----published-json-schemas)
 - [Flag Syntax](#flag-syntax)
 - [JSON Output](#json-output)
 - [Configuration File Format](#configuration-file-format)
@@ -38,7 +39,7 @@ For installation and quick start, see [README.md](../README.md).
 | `--server-url <URL>` | Connect to an ad-hoc server by URL, without using config. Defines an ephemeral server for this one invocation: nothing is read from or written to the config file. Requires `--server-api-key-env`; conflicts with `--server`. Pairs with `--config` for sandboxed throwaway runs. |
 | `--server-api-key-env <ENV>` | Environment variable holding the API key for `--server-url`. The key is read from this variable, never passed as a literal flag, so the secret stays out of the process argument list. Only meaningful with `--server-url`. |
 | `--server-email <EMAIL>` | Login email for `--server-url`, for the Bugzilla 5.0 whoami fallback. Optional; only meaningful with `--server-url`. |
-| `--output <FORMAT>` | Output format: `table` or `json`. Defaults to table at a TTY; auto-selects json when stdout is not a TTY. |
+| `--output <FORMAT>` | Output format: `table`, `json`, or `ndjson`. Defaults to table at a TTY; auto-selects json when stdout is not a TTY. `ndjson` emits newline-delimited JSON — one compact value per line for list results (a single object or result envelope prints as one compact line) — for streaming into agents and `jq -c`. |
 | `--json` | Shorthand for `--output json` |
 | `--config <PATH>` | Use an alternate `config.toml` for reads and writes. Takes precedence over `BZR_CONFIG`; both override the default config directory. |
 | `--no-color` | Disable colored output. Color is also suppressed automatically when stdout is not a TTY. |
@@ -58,7 +59,7 @@ Agent note: at an interactive TTY, `bzr` defaults to table output. For agent wor
 
 | Variable | Description |
 |----------|-------------|
-| `BZR_OUTPUT` | Default output format (`table` or `json`). Overridden by `--output` or `--json`. |
+| `BZR_OUTPUT` | Default output format (`table`, `json`, or `ndjson`). Overridden by `--output` or `--json`. |
 | `BZR_CONFIG` | Full path to an alternate `config.toml`. Overrides the default config directory; overridden by `--config`. |
 | `BZR_TIMEOUT` | Per-request timeout in seconds. Overridden by `--timeout`; invalid values are ignored with a warning. |
 | `NO_COLOR` | Disable colored output (any value). Supported natively by the `colored` crate. |
@@ -91,7 +92,7 @@ Agent note: at an interactive TTY, `bzr` defaults to table output. For agent wor
 ## Command Tree
 
 ```
-bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--server-email <EMAIL>] [--output table|json] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [--dry-run] [--yes] [-v...]
+bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--server-email <EMAIL>] [--output table|json|ndjson] [--json] [--config <PATH>] [--no-color] [--quiet] [--api rest|xmlrpc|hybrid] [--timeout <SECS>] [--retry <N>] [--dry-run] [--yes] [-v...]
 ├── bug
 │   ├── list [--product <P>...] [--component <C>...] [--status <S>...] [--assignee <A>...]
 │   │        [--creator <C>...] [--priority <P>...] [--severity <S>...] [--id <ID>...]
@@ -216,7 +217,8 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │                  [--resolution <R>...] [--version <V>...] [--op-sys <OS>...] [--platform <P>...]
 │                  [--whiteboard <W>] [--target-milestone <M>...] [--qa-contact <Q>...] [--url <U>]
 │                  [--created-since <D>] [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
-└── completion <bash|zsh|fish|powershell>
+├── completion <bash|zsh|fish|powershell>
+└── schema [NAME]
 ```
 
 ---
@@ -1715,6 +1717,44 @@ installed and sourced by your shell startup. For zsh, the file name must be
 
 ---
 
+## `bzr schema` -- Published JSON Schemas
+
+Print a JSON Schema (draft 2020-12) describing the `--format json` output of a
+command family. The schemas are checked into `schemas/` and embedded in the
+binary, so a consumer can validate `bzr` output against a contract instead of
+branching over the per-command shape differences. This command is local: it
+makes no network calls and needs no configured server.
+
+```
+bzr schema [NAME]
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `[NAME]` | No | Schema to print. Omit to list the available schema names. |
+
+Run without a name to list the available schemas; pass one to print it:
+
+```bash
+bzr schema                      # list schema names
+bzr schema bug                  # the bug object (bug view / list elements)
+bzr schema batch-result | jq .  # the batch `bug update` envelope
+```
+
+Listing honors `--output`: a name-per-line table at a TTY, a JSON array under
+`--json`, one JSON string per line under `--ndjson`. Printing a named schema
+emits the schema document verbatim. An unknown name exits 7 with the list of
+valid names.
+
+Available schemas: `bug`, `comment`, `attachment`, `product`, `component`,
+`classification`, `user`, `group`, `field-value` (read shapes); and the
+mutation/result envelopes `action-result`, `batch-result`,
+`batch-create-result`, `multi-bug-view`, `tag-result`, `membership-result`,
+`count-result`, `download-result`, `upload-result`, `config-result`,
+`search-result`, `dry-run-result`.
+
+---
+
 ## Flag Syntax
 
 Flags use the pattern `name[status](requestee)`:
@@ -1799,6 +1839,34 @@ Server config mutations key on `name` and carry `config_file`; `rename-server` a
 ```
 
 All mutation responses include `resource` and `action` fields. Most include `id` for the created/updated resource. Note: `comment tag` responses use `comment_id`, not `id`. Membership responses (`group_membership`) have no `id` field. Template responses use `name` instead of `id`. Server config responses (`remove-server`/`rename-server`) key on `name` (and `previous_name` for renames) with no `id`.
+
+### NDJSON output
+
+`--output ndjson` (or `BZR_OUTPUT=ndjson`) emits newline-delimited JSON: each
+element of a list/array result is printed as one compact value on its own line,
+and single objects print as one compact line. This is the streaming shape for
+agents and `jq -c`, and avoids buffering a whole pretty-printed array:
+
+```bash
+# One bug object per line
+bzr --output ndjson bug search "memory leak" | jq -c '{id, summary}'
+
+# Stream a large result set line-by-line
+bzr --output ndjson bug list --product Fedora --limit 500 | while read -r line; do
+  echo "$line" | jq -r '.id'
+done
+```
+
+An empty list emits no lines. The truncation note for a capped `bug
+list`/`search` (see [Pagination and truncation](#pagination-and-truncation))
+goes to stderr under `ndjson`, keeping stdout one clean record per line.
+
+### Published schemas
+
+`bzr schema` prints checked-in JSON Schemas (draft 2020-12) describing the
+`--format json` shape of each command family, so an agent can validate output
+against a contract instead of branching per command. See
+[`bzr schema`](#bzr-schema----published-json-schemas).
 
 ### Error output
 

--- a/docs/superpowers/specs/2026-06-19-json-envelope-ndjson-design.md
+++ b/docs/superpowers/specs/2026-06-19-json-envelope-ndjson-design.md
@@ -1,0 +1,76 @@
+# #305 — Consistent / documented JSON envelope (+ NDJSON)
+
+Status: in progress (branch `feat/json-envelope-ndjson-305`)
+
+## Problem
+
+JSON output shapes differ across command families (bare arrays for lists,
+`{bugs, failed}` for multi `bug view`, `{resource, action, …}` for mutations,
+`comment_id` for `comment tag`, name-keyed maps for templates/queries). These
+exceptions are documented in prose but agents still pay for them in per-command
+branching, and there is no machine-readable schema to validate against. There is
+also no streaming-friendly output for large result sets.
+
+## Acceptance criteria (from the issue)
+
+1. An agent can rely on a published schema per command.
+2. NDJSON is available for large/streamed result sets.
+3. Current default shapes stay stable (or change only behind an opt-in).
+
+## Decisions
+
+### NDJSON (criterion 2)
+
+Add a third `OutputFormat` variant, `Ndjson`, selectable via `--output ndjson`
+and `BZR_OUTPUT=ndjson`. Semantics:
+
+- **Array outputs** (`bug list`/`search`/`my`, `comment list`, `attachment
+  list`, `product list`, `user`, `classification list`, `component list`, field
+  values, batch `succeeded`/`failed` sets): one compact JSON value per line.
+- **Single objects / envelopes**: the value as a single compact line (still
+  valid NDJSON — one object, one line).
+
+Implementation altitude: a single `write_json_family(value, format, out)` helper
+in `output/formatting.rs` centralizes pretty-vs-NDJSON. `write_formatted` (used
+by most list writers via `write_table_or_empty`) routes through it, so the
+majority of list commands get NDJSON for free. The ~14 bespoke `match format`
+sites change their `OutputFormat::Json =>` arm to
+`OutputFormat::Json | OutputFormat::Ndjson => write_json_family(…, format, …)`.
+`--json` remains shorthand for `--output json` (pretty), unchanged.
+
+### Published schema (criterion 1)
+
+`Bug` JSON is **dynamic**: its hand-written `Serialize` (`src/types/bug.rs`)
+flattens server-specific custom fields to the top level, and `--fields`
+selection projects the key set at render time. A derive-based generator
+(`schemars`) would describe the Rust struct (a nested `custom_fields` map), not
+the real wire shape — so derived schemas would be wrong for the one resource the
+issue cares most about.
+
+Therefore: a checked-in `schemas/` directory of authored JSON Schema (draft
+2020-12) files, one per output shape, embedded in the binary via `include_str!`
+and surfaced by a local (no-network) `bzr schema` command:
+
+- `bzr schema` — list available schema names.
+- `bzr schema <name>` — print that schema.
+
+This adds **zero runtime dependencies**, keeps full fidelity for the dynamic bug
+object (built-in properties + `additionalProperties: true` for custom fields,
+with a description noting `--fields` projection), and the schema files are
+themselves agent-consumable artifacts in the repo.
+
+Drift guard: a test (test-only `jsonschema` dev-dependency) validates a
+representative serialized sample for each shape against its schema, so a struct
+change that breaks a schema fails CI.
+
+### Stable defaults (criterion 3)
+
+No unified envelope is added. Bare arrays stay bare; existing object shapes are
+unchanged. NDJSON and `schema` are purely additive. The optional `{data, meta}`
+envelope from the issue is intentionally **not** implemented (speculative,
+no current consumer) — the schema command + NDJSON cover the stated agent need.
+
+## Out of scope
+
+- `{data, meta}` unified envelope behind a flag (no current consumer).
+- Reshaping batch envelopes for NDJSON (kept as documented).

--- a/schemas/action-result.json
+++ b/schemas/action-result.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/action-result.json",
+  "title": "ActionResult",
+  "description": "Standard mutation result for create/update on a single resource.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "name": {
+      "type": "string"
+    },
+    "resource": {
+      "type": "string",
+      "enum": ["bug", "attachment", "comment", "user", "group", "product", "component", "server"]
+    },
+    "action": {
+      "type": "string",
+      "enum": ["created", "updated", "added", "removed", "renamed", "downloaded", "dry-run"]
+    }
+  },
+  "required": [
+    "resource",
+    "action"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/attachment.json
+++ b/schemas/attachment.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/attachment.json",
+  "title": "Attachment",
+  "description": "A bug attachment as emitted in `--format json` output.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "bug_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "file_name": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "content_type": {
+      "type": "string"
+    },
+    "creator": {
+      "type": ["string", "null"]
+    },
+    "creation_time": {
+      "type": ["string", "null"]
+    },
+    "last_change_time": {
+      "type": ["string", "null"]
+    },
+    "size": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "is_obsolete": {
+      "type": "boolean"
+    },
+    "is_private": {
+      "type": "boolean"
+    },
+    "is_patch": {
+      "type": "boolean"
+    },
+    "data": {
+      "type": ["string", "null"]
+    }
+  },
+  "required": [
+    "id",
+    "bug_id",
+    "file_name",
+    "summary",
+    "content_type",
+    "creator",
+    "creation_time",
+    "last_change_time",
+    "size",
+    "is_obsolete",
+    "is_private",
+    "is_patch"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/batch-create-result.json
+++ b/schemas/batch-create-result.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/batch-create-result.json",
+  "title": "BatchCreateResult",
+  "description": "Result of an array `bug create --from-json`.",
+  "type": "object",
+  "properties": {
+    "resource": {
+      "type": "string",
+      "enum": ["bug", "attachment", "comment", "user", "group", "product", "component", "server"]
+    },
+    "action": {
+      "type": "string",
+      "enum": ["created", "updated", "added", "removed", "renamed", "downloaded", "dry-run"]
+    },
+    "created": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "failed": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "index",
+          "error"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "resource",
+    "action",
+    "created",
+    "failed"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/batch-result.json
+++ b/schemas/batch-result.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/batch-result.json",
+  "title": "BatchResult",
+  "description": "Result of a batch `bug update`.",
+  "type": "object",
+  "properties": {
+    "resource": {
+      "type": "string",
+      "enum": ["bug", "attachment", "comment", "user", "group", "product", "component", "server"]
+    },
+    "action": {
+      "type": "string",
+      "enum": ["created", "updated", "added", "removed", "renamed", "downloaded", "dry-run"]
+    },
+    "succeeded": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "failed": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "error"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "resource",
+    "action",
+    "succeeded",
+    "failed"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/bug.json
+++ b/schemas/bug.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/bug.json",
+  "title": "Bug",
+  "description": "The object emitted by `bug view` (single) and each element of the `bug list`/`bug search`/`bug my` arrays. Server-specific custom fields are flattened in as additional top-level properties. The `--fields`/`--exclude-fields` options may project the property set, so any built-in property may be absent; for that reason `required` is empty even though the built-ins are always present absent projection.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "summary": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "resolution": {
+      "type": ["string", "null"]
+    },
+    "dupe_of": {
+      "type": ["integer", "null"],
+      "minimum": 0
+    },
+    "deadline": {
+      "type": ["string", "null"]
+    },
+    "product": {
+      "type": ["string", "null"]
+    },
+    "component": {
+      "type": ["string", "null"]
+    },
+    "version": {
+      "type": ["string", "null"]
+    },
+    "assigned_to": {
+      "type": ["string", "null"]
+    },
+    "priority": {
+      "type": ["string", "null"]
+    },
+    "severity": {
+      "type": ["string", "null"]
+    },
+    "creation_time": {
+      "type": ["string", "null"]
+    },
+    "last_change_time": {
+      "type": ["string", "null"]
+    },
+    "creator": {
+      "type": ["string", "null"]
+    },
+    "url": {
+      "type": ["string", "null"]
+    },
+    "whiteboard": {
+      "type": ["string", "null"]
+    },
+    "keywords": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "blocks": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "depends_on": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "cc": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "op_sys": {
+      "type": ["string", "null"]
+    },
+    "rep_platform": {
+      "type": ["string", "null"]
+    }
+  },
+  "required": [],
+  "additionalProperties": true
+}

--- a/schemas/classification.json
+++ b/schemas/classification.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/classification.json",
+  "title": "Classification",
+  "description": "A Bugzilla classification as emitted in `--format json` output.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "sort_key": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "products": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "description",
+    "sort_key",
+    "products"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/comment.json
+++ b/schemas/comment.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/comment.json",
+  "title": "Comment",
+  "description": "A bug comment as emitted in `--format json` output.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "bug_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "text": {
+      "type": "string"
+    },
+    "creator": {
+      "type": ["string", "null"]
+    },
+    "creation_time": {
+      "type": ["string", "null"]
+    },
+    "count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "is_private": {
+      "type": "boolean"
+    },
+    "attachment_id": {
+      "type": ["integer", "null"],
+      "minimum": 0
+    }
+  },
+  "required": [
+    "id",
+    "bug_id",
+    "text",
+    "creator",
+    "creation_time",
+    "count",
+    "is_private",
+    "attachment_id"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/component.json
+++ b/schemas/component.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/component.json",
+  "title": "Component",
+  "description": "A product component as emitted in `--format json` output.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "is_active": {
+      "type": "boolean"
+    },
+    "default_assignee": {
+      "type": ["string", "null"]
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "description",
+    "is_active",
+    "default_assignee"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/config-result.json
+++ b/schemas/config-result.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/config-result.json",
+  "title": "ConfigResult",
+  "description": "Result of `config set-server`/`set-default`/`rename-server`/`remove-server`.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "config_file": {
+      "type": "string"
+    },
+    "resource": {
+      "type": "string",
+      "enum": ["bug", "attachment", "comment", "user", "group", "product", "component", "server"]
+    },
+    "action": {
+      "type": "string",
+      "enum": ["created", "updated", "added", "removed", "renamed", "downloaded", "dry-run"]
+    },
+    "previous_name": {
+      "type": ["string", "null"]
+    },
+    "url": {
+      "type": ["string", "null"]
+    },
+    "is_default": {
+      "type": ["boolean", "null"]
+    }
+  },
+  "required": [
+    "name",
+    "config_file",
+    "resource",
+    "action"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/count-result.json
+++ b/schemas/count-result.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/count-result.json",
+  "title": "CountResult",
+  "description": "Result reporting a count of matching items.",
+  "type": "object",
+  "properties": {
+    "count": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "count"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/download-result.json
+++ b/schemas/download-result.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/download-result.json",
+  "title": "DownloadResult",
+  "description": "Result of downloading an attachment to disk.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "file": {
+      "type": "string"
+    },
+    "size": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "resource": {
+      "type": "string",
+      "enum": ["bug", "attachment", "comment", "user", "group", "product", "component", "server"]
+    },
+    "action": {
+      "type": "string",
+      "enum": ["created", "updated", "added", "removed", "renamed", "downloaded", "dry-run"]
+    }
+  },
+  "required": [
+    "id",
+    "file",
+    "size",
+    "resource",
+    "action"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/dry-run-result.json
+++ b/schemas/dry-run-result.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/dry-run-result.json",
+  "title": "DryRunResult",
+  "description": "Preview emitted by `--dry-run` mutations.",
+  "type": "object",
+  "properties": {
+    "resource": {
+      "type": "string",
+      "enum": ["bug", "attachment", "comment", "user", "group", "product", "component", "server"]
+    },
+    "action": {
+      "type": "string",
+      "enum": ["created", "updated", "added", "removed", "renamed", "downloaded", "dry-run"]
+    },
+    "ids": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "changes": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "resource",
+    "action",
+    "ids",
+    "changes"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/field-value.json
+++ b/schemas/field-value.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/field-value.json",
+  "title": "FieldValue",
+  "description": "An allowable value for a Bugzilla field as emitted in `--format json` output.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "sort_key": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "is_active": {
+      "type": "boolean"
+    },
+    "can_change_to": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  "required": [
+    "name",
+    "sort_key",
+    "is_active"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/group.json
+++ b/schemas/group.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/group.json",
+  "title": "Group",
+  "description": "A Bugzilla group (`GroupInfo`) as emitted in `--format json` output.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "is_active": {
+      "type": "boolean"
+    },
+    "membership": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "name": {
+            "type": "string"
+          },
+          "real_name": {
+            "type": ["string", "null"]
+          },
+          "email": {
+            "type": ["string", "null"]
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "real_name",
+          "email"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "description",
+    "is_active",
+    "membership"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/membership-result.json
+++ b/schemas/membership-result.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/membership-result.json",
+  "title": "MembershipResult",
+  "description": "Result of `group add-user`/`remove-user`.",
+  "type": "object",
+  "properties": {
+    "user": {
+      "type": "string"
+    },
+    "group": {
+      "type": "string"
+    },
+    "resource": {
+      "type": "string",
+      "enum": ["bug", "attachment", "comment", "user", "group", "product", "component", "server"]
+    },
+    "action": {
+      "type": "string",
+      "enum": ["created", "updated", "added", "removed", "renamed", "downloaded", "dry-run"]
+    }
+  },
+  "required": [
+    "user",
+    "group",
+    "resource",
+    "action"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/multi-bug-view.json
+++ b/schemas/multi-bug-view.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/multi-bug-view.json",
+  "title": "MultiBugViewResult",
+  "description": "Result of a multi-ID `bug view`.",
+  "type": "object",
+  "properties": {
+    "bugs": {
+      "type": "array",
+      "items": {
+        "$ref": "bug.json"
+      }
+    },
+    "failed": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "error"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "bugs",
+    "failed"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/product.json
+++ b/schemas/product.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/product.json",
+  "title": "Product",
+  "description": "A Bugzilla product as emitted in `--format json` output.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "is_active": {
+      "type": "boolean"
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "$ref": "component.json"
+      }
+    },
+    "versions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "name": {
+            "type": "string"
+          },
+          "sort_key": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "is_active": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "sort_key",
+          "is_active"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "milestones": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "name": {
+            "type": "string"
+          },
+          "sort_key": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "is_active": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "sort_key",
+          "is_active"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "description",
+    "is_active",
+    "components",
+    "versions",
+    "milestones"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/search-result.json
+++ b/schemas/search-result.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/search-result.json",
+  "title": "SearchResult",
+  "description": "Result of `comment search-tags`.",
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "items"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/tag-result.json
+++ b/schemas/tag-result.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/tag-result.json",
+  "title": "TagResult",
+  "description": "Result of `comment tag`.",
+  "type": "object",
+  "properties": {
+    "comment_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "resource": {
+      "type": "string",
+      "enum": ["bug", "attachment", "comment", "user", "group", "product", "component", "server"]
+    },
+    "action": {
+      "type": "string",
+      "enum": ["created", "updated", "added", "removed", "renamed", "downloaded", "dry-run"]
+    }
+  },
+  "required": [
+    "comment_id",
+    "tags",
+    "resource",
+    "action"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/upload-result.json
+++ b/schemas/upload-result.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/upload-result.json",
+  "title": "UploadResult",
+  "description": "Result of uploading an attachment to a bug.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "bug_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "size": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "resource": {
+      "type": "string",
+      "enum": ["bug", "attachment", "comment", "user", "group", "product", "component", "server"]
+    },
+    "action": {
+      "type": "string",
+      "enum": ["created", "updated", "added", "removed", "renamed", "downloaded", "dry-run"]
+    }
+  },
+  "required": [
+    "id",
+    "bug_id",
+    "size",
+    "resource",
+    "action"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/user.json
+++ b/schemas/user.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/user.json",
+  "title": "User",
+  "description": "A Bugzilla user (`BugzillaUser`) as emitted in `--format json` output.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "name": {
+      "type": "string"
+    },
+    "real_name": {
+      "type": ["string", "null"]
+    },
+    "email": {
+      "type": ["string", "null"]
+    },
+    "groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "can_login": {
+      "type": ["boolean", "null"]
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "real_name",
+    "email",
+    "groups",
+    "can_login"
+  ],
+  "additionalProperties": false
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -117,10 +117,13 @@ pub struct Cli {
     #[arg(long, value_name = "EMAIL", global = true, requires = "server_url")]
     pub server_email: Option<String>,
 
-    /// Output format: `table` (default at a TTY) or `json`.
+    /// Output format: `table` (default at a TTY), `json`, or `ndjson`.
     ///
-    /// When stdout is piped, the default flips to `json` unless this
-    /// flag or `BZR_OUTPUT` overrides it. Precedence:
+    /// `ndjson` emits newline-delimited JSON — one compact value per line for
+    /// list results (a single object, e.g. one bug or a result envelope, prints
+    /// as one compact line) — ideal for streaming into agents and `jq -c`. When
+    /// stdout is piped, the default flips to `json` unless this flag or
+    /// `BZR_OUTPUT` overrides it. Precedence:
     /// `--json` > `--output` > `BZR_OUTPUT` > auto-detect.
     #[arg(long, global = true)]
     pub output: Option<OutputFormat>,
@@ -589,6 +592,24 @@ pub enum Commands {
     Completion {
         /// Shell to generate completions for.
         shell: clap_complete::Shell,
+    },
+
+    /// Print a published JSON Schema for a command's JSON output.
+    ///
+    /// `--format json` shapes are documented as checked-in JSON Schema
+    /// (draft 2020-12) so agents can validate output against a contract
+    /// instead of branching per command. Run without a name to list the
+    /// available schema names; pass one to print that schema:
+    ///
+    ///   bzr schema                # list schema names
+    ///   bzr schema bug            # the bug object (list elements / view)
+    ///   bzr schema batch-result   # the batch `bug update` envelope
+    ///
+    /// Purely local: no config, network, or auth.
+    #[command(verbatim_doc_comment)]
+    Schema {
+        /// Schema name to print; omit to list all available schema names.
+        name: Option<String>,
     },
 }
 

--- a/src/commands/bug/create.rs
+++ b/src/commands/bug/create.rs
@@ -448,7 +448,7 @@ fn overlay_cli(mut json: JsonCreateBug, action: &BugAction) -> Result<JsonCreate
 /// created-IDs line plus per-item failures on stderr in table mode.
 fn write_batch_create(result: &BatchCreateResult, format: OutputFormat, w: &mut Writers<'_>) {
     match format {
-        OutputFormat::Json => write_result(result, "", format, w.out),
+        OutputFormat::Json | OutputFormat::Ndjson => write_result(result, "", format, w.out),
         OutputFormat::Table => {
             if !result.created.is_empty() {
                 let ids: Vec<String> = result.created.iter().map(|id| format!("#{id}")).collect();

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -115,7 +115,7 @@ pub async fn execute(
                     validate_table_columns(spec)?;
                 }
             }
-            OutputFormat::Json => {
+            OutputFormat::Json | OutputFormat::Ndjson => {
                 if !is_view {
                     validate_json_field_selection(spec)?;
                 }

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -214,7 +214,7 @@ async fn update_single(
 ) -> Result<()> {
     client.update_bug(id, params).await?;
     match format {
-        OutputFormat::Json => {
+        OutputFormat::Json | OutputFormat::Ndjson => {
             write_result(
                 &ActionResult::updated(id, ResourceKind::Bug),
                 "",
@@ -237,7 +237,7 @@ fn write_batch_result(
     w: &mut Writers<'_>,
 ) {
     match format {
-        OutputFormat::Json => {
+        OutputFormat::Json | OutputFormat::Ndjson => {
             write_result(batch, "", format, w.out);
         }
         OutputFormat::Table => {

--- a/src/commands/bug/view.rs
+++ b/src/commands/bug/view.rs
@@ -220,7 +220,7 @@ fn write_batch(
             let rows = batch.into_table_rows();
             write_multi_bug_view(&rows, spec, w.out);
         }
-        OutputFormat::Json => {
+        OutputFormat::Json | OutputFormat::Ndjson => {
             // Project each bug to the selected fields; the wrapper keys and the
             // per-failure metadata (`id`, `error`) stay untrimmed so `jq`
             // consumers can always rely on `.bugs[]` / `.failed[]`.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod inline_server;
 pub(crate) mod paging;
 pub mod product;
 pub mod query;
+pub mod schema;
 pub mod server;
 mod shared;
 pub mod template;

--- a/src/commands/paging.rs
+++ b/src/commands/paging.rs
@@ -135,7 +135,9 @@ pub(crate) fn write_truncation_note(
         OutputFormat::Table => {
             let _ = writeln!(w.out, "{msg}");
         }
-        OutputFormat::Json => {
+        // For machine output the note goes to stderr so stdout stays a clean,
+        // parseable document (pretty JSON or one NDJSON record per line).
+        OutputFormat::Json | OutputFormat::Ndjson => {
             let _ = writeln!(w.err, "{msg}");
         }
     }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -436,7 +436,7 @@ async fn handle_run(
     };
     match format {
         OutputFormat::Table => validate_table_columns(spec)?,
-        OutputFormat::Json => {
+        OutputFormat::Json | OutputFormat::Ndjson => {
             validate_json_field_selection(spec)?;
             warn_unknown_fields(spec, w.err);
         }

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -12,70 +12,39 @@ use crate::output::result_types::write_result;
 use crate::output::writers::Writers;
 use crate::types::OutputFormat;
 
+/// Build the `(name, embedded-json)` registry from a bare list of schema names,
+/// deriving each `schemas/<name>.json` path so a name is written exactly once.
+macro_rules! schema_registry {
+    ($($name:literal),* $(,)?) => {
+        &[ $( ($name, include_str!(concat!("../../schemas/", $name, ".json"))) ),* ]
+    };
+}
+
 /// Every published schema as `(name, schema-json)`, embedded from `schemas/`.
 /// Names are agent-facing and stable; keep this list sorted for the `schema`
 /// listing and the not-found hint.
-pub(crate) const SCHEMAS: &[(&str, &str)] = &[
-    (
-        "action-result",
-        include_str!("../../schemas/action-result.json"),
-    ),
-    ("attachment", include_str!("../../schemas/attachment.json")),
-    (
-        "batch-create-result",
-        include_str!("../../schemas/batch-create-result.json"),
-    ),
-    (
-        "batch-result",
-        include_str!("../../schemas/batch-result.json"),
-    ),
-    ("bug", include_str!("../../schemas/bug.json")),
-    (
-        "classification",
-        include_str!("../../schemas/classification.json"),
-    ),
-    ("comment", include_str!("../../schemas/comment.json")),
-    ("component", include_str!("../../schemas/component.json")),
-    (
-        "config-result",
-        include_str!("../../schemas/config-result.json"),
-    ),
-    (
-        "count-result",
-        include_str!("../../schemas/count-result.json"),
-    ),
-    (
-        "download-result",
-        include_str!("../../schemas/download-result.json"),
-    ),
-    (
-        "dry-run-result",
-        include_str!("../../schemas/dry-run-result.json"),
-    ),
-    (
-        "field-value",
-        include_str!("../../schemas/field-value.json"),
-    ),
-    ("group", include_str!("../../schemas/group.json")),
-    (
-        "membership-result",
-        include_str!("../../schemas/membership-result.json"),
-    ),
-    (
-        "multi-bug-view",
-        include_str!("../../schemas/multi-bug-view.json"),
-    ),
-    ("product", include_str!("../../schemas/product.json")),
-    (
-        "search-result",
-        include_str!("../../schemas/search-result.json"),
-    ),
-    ("tag-result", include_str!("../../schemas/tag-result.json")),
-    (
-        "upload-result",
-        include_str!("../../schemas/upload-result.json"),
-    ),
-    ("user", include_str!("../../schemas/user.json")),
+pub(crate) const SCHEMAS: &[(&str, &str)] = schema_registry![
+    "action-result",
+    "attachment",
+    "batch-create-result",
+    "batch-result",
+    "bug",
+    "classification",
+    "comment",
+    "component",
+    "config-result",
+    "count-result",
+    "download-result",
+    "dry-run-result",
+    "field-value",
+    "group",
+    "membership-result",
+    "multi-bug-view",
+    "product",
+    "search-result",
+    "tag-result",
+    "upload-result",
+    "user",
 ];
 
 /// Look up a schema by name.

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -1,0 +1,128 @@
+//! `bzr schema` — publish JSON Schemas for the tool's JSON output shapes.
+//!
+//! Purely local: no config, network, or auth. Each schema describes the
+//! `--format json` body of a command family so agents can validate output
+//! against a contract instead of branching per command. The schema files are
+//! checked into `schemas/` at the repo root and embedded here at build time;
+//! a drift test (see `schema_tests.rs`) validates representative serialized
+//! values against them, so a struct change that breaks a schema fails CI.
+
+use crate::error::{BzrError, Result};
+use crate::output::result_types::write_result;
+use crate::output::writers::Writers;
+use crate::types::OutputFormat;
+
+/// Every published schema as `(name, schema-json)`, embedded from `schemas/`.
+/// Names are agent-facing and stable; keep this list sorted for the `schema`
+/// listing and the not-found hint.
+pub(crate) const SCHEMAS: &[(&str, &str)] = &[
+    (
+        "action-result",
+        include_str!("../../schemas/action-result.json"),
+    ),
+    ("attachment", include_str!("../../schemas/attachment.json")),
+    (
+        "batch-create-result",
+        include_str!("../../schemas/batch-create-result.json"),
+    ),
+    (
+        "batch-result",
+        include_str!("../../schemas/batch-result.json"),
+    ),
+    ("bug", include_str!("../../schemas/bug.json")),
+    (
+        "classification",
+        include_str!("../../schemas/classification.json"),
+    ),
+    ("comment", include_str!("../../schemas/comment.json")),
+    ("component", include_str!("../../schemas/component.json")),
+    (
+        "config-result",
+        include_str!("../../schemas/config-result.json"),
+    ),
+    (
+        "count-result",
+        include_str!("../../schemas/count-result.json"),
+    ),
+    (
+        "download-result",
+        include_str!("../../schemas/download-result.json"),
+    ),
+    (
+        "dry-run-result",
+        include_str!("../../schemas/dry-run-result.json"),
+    ),
+    (
+        "field-value",
+        include_str!("../../schemas/field-value.json"),
+    ),
+    ("group", include_str!("../../schemas/group.json")),
+    (
+        "membership-result",
+        include_str!("../../schemas/membership-result.json"),
+    ),
+    (
+        "multi-bug-view",
+        include_str!("../../schemas/multi-bug-view.json"),
+    ),
+    ("product", include_str!("../../schemas/product.json")),
+    (
+        "search-result",
+        include_str!("../../schemas/search-result.json"),
+    ),
+    ("tag-result", include_str!("../../schemas/tag-result.json")),
+    (
+        "upload-result",
+        include_str!("../../schemas/upload-result.json"),
+    ),
+    ("user", include_str!("../../schemas/user.json")),
+];
+
+/// Look up a schema by name.
+fn find(name: &str) -> Option<&'static str> {
+    SCHEMAS
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, body)| *body)
+}
+
+/// Print a published JSON Schema, or the list of available schema names when
+/// `name` is `None`.
+pub fn execute(name: Option<&str>, format: OutputFormat, w: &mut Writers<'_>) -> Result<()> {
+    let Some(name) = name else {
+        write_list(format, w);
+        return Ok(());
+    };
+    write_one(name, w)
+}
+
+/// Write a single named schema verbatim. A schema is itself a JSON document, so
+/// it is emitted as-is regardless of `--format` (no table/NDJSON projection).
+fn write_one(name: &str, w: &mut Writers<'_>) -> Result<()> {
+    let Some(body) = find(name) else {
+        return Err(BzrError::InputValidation(format!(
+            "unknown schema '{name}'; available: {}",
+            available_names().join(", ")
+        )));
+    };
+    // Embedded files already end with a newline; write verbatim.
+    let _ = write!(w.out, "{body}");
+    Ok(())
+}
+
+/// List available schema names: one per line for table, a JSON array for
+/// `--json`, one name per line for `--ndjson`.
+fn write_list(format: OutputFormat, w: &mut Writers<'_>) {
+    let names = available_names();
+    let table = names.join("\n");
+    write_result(&names, &table, format, w.out);
+}
+
+/// The published schema names, in registry order.
+fn available_names() -> Vec<&'static str> {
+    SCHEMAS.iter().map(|(name, _)| *name).collect()
+}
+
+#[cfg(test)]
+#[path = "schema_tests.rs"]
+mod tests;

--- a/src/commands/schema_tests.rs
+++ b/src/commands/schema_tests.rs
@@ -1,0 +1,419 @@
+#![expect(clippy::unwrap_used)]
+
+//! Drift guard for the published JSON Schemas.
+//!
+//! Each schema is validated against the *actual serialized output* of a
+//! representative typed value: every serialized key must be declared in the
+//! schema's `properties` (unless the schema is open via `additionalProperties:
+//! true`), and every `required` key must be present in the serialization. A
+//! field added, removed, or renamed on a result type therefore fails CI here
+//! until its schema is updated — keeping the published contract honest without
+//! a runtime schema-validation dependency.
+
+use serde_json::{json, Value};
+
+use super::SCHEMAS;
+use crate::output::result_types::{
+    ActionKind, ActionResult, BatchCreateResult, BatchFailure, BatchResult, BugViewFailure,
+    ConfigResult, CountResult, CreateFailure, DownloadResult, DryRunResult, MembershipResult,
+    MultiBugViewResult, ResourceKind, SearchResult, TagResult, UploadResult,
+};
+use crate::test_helpers::CapturedIo;
+use crate::types::{
+    Attachment, BugzillaUser, Classification, Comment, Component, FieldValue, GroupInfo,
+};
+
+/// Look up a schema body by registry name.
+fn schema_for(name: &str) -> Value {
+    let (_, body) = SCHEMAS
+        .iter()
+        .find(|(n, _)| *n == name)
+        .unwrap_or_else(|| panic!("no schema registered for {name}"));
+    serde_json::from_str(body).unwrap_or_else(|e| panic!("schema {name} is not valid JSON: {e}"))
+}
+
+/// Assert `value` (the serialized form of a typed result) conforms to the named
+/// schema's property/required contract.
+///
+/// `value` must be **maximally populated** — every optional field set — so the
+/// check is a bijection for closed schemas: every serialized key must be a
+/// declared property (no undocumented field), AND every declared property must
+/// appear in the serialization (no *phantom* property the type never emits).
+/// `required` keys must all be present. Open schemas (`additionalProperties:
+/// true`, e.g. `bug`) skip the bijection since custom fields flatten in.
+fn assert_conforms(name: &str, value: &Value) {
+    let schema = schema_for(name);
+    let obj = value
+        .as_object()
+        .unwrap_or_else(|| panic!("{name} sample is not a JSON object"));
+    let properties = schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .unwrap_or_else(|| panic!("{name} schema has no properties object"));
+    let open = schema
+        .get("additionalProperties")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    if !open {
+        for key in obj.keys() {
+            assert!(
+                properties.contains_key(key),
+                "{name}: serialized key '{key}' is not declared in the schema's properties \
+                 (schema drift — update schemas/{name}.json)"
+            );
+        }
+        // No phantom properties: a maximally-populated value must exercise every
+        // declared property, or the schema advertises a field that cannot occur.
+        for prop in properties.keys() {
+            assert!(
+                obj.contains_key(prop),
+                "{name}: schema declares property '{prop}' but a maximally-populated value \
+                 never serializes it (phantom property — fix schemas/{name}.json or the sample)"
+            );
+        }
+    }
+
+    if let Some(required) = schema.get("required").and_then(Value::as_array) {
+        for req in required {
+            let req = req.as_str().unwrap();
+            assert!(
+                obj.contains_key(req),
+                "{name}: schema requires '{req}' but a representative value did not serialize it"
+            );
+        }
+    }
+}
+
+fn to_value(value: &impl serde::Serialize) -> Value {
+    serde_json::to_value(value).unwrap()
+}
+
+/// A representative wire bug, deserialized through `Bug`'s real `Deserialize`.
+fn sample_bug() -> crate::types::Bug {
+    serde_json::from_value(json!({
+        "id": 1,
+        "summary": "s",
+        "status": "NEW",
+        "keywords": [],
+        "blocks": [],
+        "depends_on": [],
+        "cc": [],
+    }))
+    .unwrap()
+}
+
+// ── Envelope / result types ──────────────────────────────────────────
+
+#[test]
+fn action_result_conforms() {
+    // Maximal: both optional `id` and `name` populated so the phantom-property
+    // check exercises every declared property.
+    assert_conforms(
+        "action-result",
+        &to_value(&ActionResult::created_named(
+            7,
+            "acme",
+            ResourceKind::Product,
+        )),
+    );
+}
+
+#[test]
+fn count_result_conforms() {
+    assert_conforms("count-result", &to_value(&CountResult::new(5)));
+}
+
+#[test]
+fn batch_result_conforms() {
+    let batch = BatchResult::new(
+        vec![1, 2],
+        vec![BatchFailure {
+            id: 3,
+            error: "boom".into(),
+        }],
+    );
+    assert_conforms("batch-result", &to_value(&batch));
+}
+
+#[test]
+fn batch_create_result_conforms() {
+    let batch = BatchCreateResult::new(
+        vec![10],
+        vec![CreateFailure {
+            index: 0,
+            error: "boom".into(),
+        }],
+    );
+    assert_conforms("batch-create-result", &to_value(&batch));
+}
+
+#[test]
+fn multi_bug_view_conforms() {
+    let result = MultiBugViewResult {
+        bugs: vec![sample_bug()],
+        failed: vec![BugViewFailure {
+            id: "missing".into(),
+            error: "not found".into(),
+        }],
+    };
+    assert_conforms("multi-bug-view", &to_value(&result));
+}
+
+#[test]
+fn tag_result_conforms() {
+    assert_conforms(
+        "tag-result",
+        &to_value(&TagResult::updated(7, vec!["triage".into()])),
+    );
+}
+
+#[test]
+fn membership_result_conforms() {
+    assert_conforms(
+        "membership-result",
+        &to_value(&MembershipResult::added("alice", "editbugs")),
+    );
+}
+
+#[test]
+fn download_result_conforms() {
+    assert_conforms(
+        "download-result",
+        &to_value(&DownloadResult::new(1, "patch.diff", 2048)),
+    );
+}
+
+#[test]
+fn upload_result_conforms() {
+    assert_conforms("upload-result", &to_value(&UploadResult::new(9, 1, 2048)));
+}
+
+#[test]
+fn config_result_conforms() {
+    // Maximal: previous_name + url + is_default all populated. No public
+    // constructor sets all three (each models a distinct operation), so build
+    // the widest shape directly to exercise every declared property.
+    let maximal = ConfigResult {
+        name: "new".into(),
+        previous_name: Some("old".into()),
+        url: Some("https://bugs.example.com".into()),
+        is_default: Some(true),
+        config_file: "/cfg.toml".into(),
+        resource: ResourceKind::Server,
+        action: ActionKind::Renamed,
+    };
+    assert_conforms("config-result", &to_value(&maximal));
+}
+
+#[test]
+fn search_result_conforms() {
+    assert_conforms(
+        "search-result",
+        &to_value(&SearchResult::new(vec!["regression".into()])),
+    );
+}
+
+#[test]
+fn dry_run_result_conforms() {
+    let ids = [1u64, 2];
+    let changes = json!({ "summary": "new title" });
+    let dry = DryRunResult::new(ResourceKind::Bug, &ids, &changes);
+    assert_conforms("dry-run-result", &to_value(&dry));
+}
+
+// ── Resource object types ────────────────────────────────────────────
+
+#[test]
+fn comment_conforms() {
+    let comment: Comment = serde_json::from_value(json!({
+        "id": 1, "bug_id": 2, "text": "hi", "creator": "a@b.c",
+        "creation_time": "2026-01-01T00:00:00Z", "count": 0,
+        "is_private": false, "attachment_id": null,
+    }))
+    .unwrap();
+    assert_conforms("comment", &to_value(&comment));
+}
+
+#[test]
+fn attachment_conforms() {
+    let attachment: Attachment = serde_json::from_value(json!({
+        "id": 1, "bug_id": 2, "file_name": "f.txt", "summary": "s",
+        "content_type": "text/plain", "creator": "a@b.c",
+        "creation_time": "t", "last_change_time": "t", "size": 10,
+        "is_obsolete": false, "is_private": false, "is_patch": false,
+        "data": "aGVsbG8=",
+    }))
+    .unwrap();
+    assert_conforms("attachment", &to_value(&attachment));
+}
+
+#[test]
+fn field_value_conforms() {
+    // Maximal: the optional `can_change_to` populated so the schema's declared
+    // property is exercised.
+    let field_value: FieldValue = serde_json::from_value(json!({
+        "name": "NEW", "sort_key": 0, "is_active": true,
+        "can_change_to": [{"name": "ASSIGNED"}],
+    }))
+    .unwrap();
+    assert_conforms("field-value", &to_value(&field_value));
+}
+
+#[test]
+fn component_conforms() {
+    let component: Component = serde_json::from_value(json!({
+        "id": 1, "name": "core", "description": "d", "is_active": true,
+        "default_assignee": "a@b.c",
+    }))
+    .unwrap();
+    assert_conforms("component", &to_value(&component));
+}
+
+#[test]
+fn classification_conforms() {
+    let classification: Classification = serde_json::from_value(json!({
+        "id": 1, "name": "Unclassified", "description": "d", "sort_key": 0,
+        "products": [{"id": 2, "name": "p", "description": "pd"}],
+    }))
+    .unwrap();
+    assert_conforms("classification", &to_value(&classification));
+}
+
+#[test]
+fn user_conforms() {
+    let user: BugzillaUser = serde_json::from_value(json!({
+        "id": 1, "name": "alice", "real_name": "Alice", "email": "a@b.c",
+        "groups": [{"id": 2, "name": "editbugs", "description": "d"}],
+        "can_login": true,
+    }))
+    .unwrap();
+    assert_conforms("user", &to_value(&user));
+}
+
+#[test]
+fn group_conforms() {
+    let group: GroupInfo = serde_json::from_value(json!({
+        "id": 1, "name": "editbugs", "description": "d", "is_active": true,
+        "membership": [{"id": 2, "name": "alice", "real_name": "Alice", "email": "a@b.c"}],
+    }))
+    .unwrap();
+    assert_conforms("group", &to_value(&group));
+}
+
+#[test]
+fn bug_object_is_open_and_documents_builtins() {
+    // bug.json is intentionally open (additionalProperties: true) for flattened
+    // custom fields, so conformance is trivial; assert the built-ins are still
+    // documented so the schema stays useful.
+    let schema = schema_for("bug");
+    let props = schema.get("properties").and_then(Value::as_object).unwrap();
+    for field in ["id", "summary", "status", "keywords", "custom_fields"]
+        .iter()
+        .filter(|f| **f != "custom_fields")
+    {
+        assert!(props.contains_key(*field), "bug schema missing '{field}'");
+    }
+    assert_eq!(
+        schema.get("additionalProperties").and_then(Value::as_bool),
+        Some(true)
+    );
+}
+
+// ── Registry / well-formedness ───────────────────────────────────────
+
+#[test]
+fn every_schema_is_wellformed_and_named_draft_2020_12() {
+    assert!(!SCHEMAS.is_empty());
+    for (name, body) in SCHEMAS {
+        let schema: Value =
+            serde_json::from_str(body).unwrap_or_else(|e| panic!("{name}: invalid JSON: {e}"));
+        assert_eq!(
+            schema.get("$schema").and_then(Value::as_str),
+            Some("https://json-schema.org/draft/2020-12/schema"),
+            "{name}: wrong or missing $schema"
+        );
+        assert!(
+            schema.get("title").and_then(Value::as_str).is_some(),
+            "{name}: missing title"
+        );
+        assert!(
+            schema.get("type").is_some(),
+            "{name}: missing top-level type"
+        );
+        assert!(
+            body.ends_with('\n'),
+            "{name}: schema file must end with a newline"
+        );
+    }
+}
+
+// ── Command behavior ─────────────────────────────────────────────────
+
+fn run(name: Option<&str>, format: crate::types::OutputFormat) -> (CapturedIo, bool) {
+    let mut io = CapturedIo::new();
+    let ok = super::execute(name, format, &mut io.writers()).is_ok();
+    (io, ok)
+}
+
+#[test]
+fn execute_prints_named_schema_verbatim() {
+    let (io, ok) = run(Some("bug"), crate::types::OutputFormat::Json);
+    assert!(ok);
+    let parsed: Value = serde_json::from_str(io.out_str()).unwrap();
+    assert_eq!(parsed.get("title").and_then(Value::as_str), Some("Bug"));
+}
+
+#[test]
+fn execute_unknown_schema_errors_with_available_list() {
+    let (io, ok) = run(Some("nope"), crate::types::OutputFormat::Json);
+    assert!(!ok);
+    assert!(
+        io.out_str().is_empty(),
+        "nothing should be written on error"
+    );
+}
+
+#[test]
+fn execute_list_json_is_array_of_names() {
+    let (io, ok) = run(None, crate::types::OutputFormat::Json);
+    assert!(ok);
+    let parsed: Value = serde_json::from_str(io.out_str()).unwrap();
+    let names = parsed.as_array().unwrap();
+    assert!(names.iter().any(|n| n == "bug"));
+    assert!(names.iter().any(|n| n == "batch-result"));
+}
+
+#[test]
+fn execute_list_ndjson_is_one_name_per_line() {
+    let (io, ok) = run(None, crate::types::OutputFormat::Ndjson);
+    assert!(ok);
+    let lines: Vec<&str> = io.out_str().lines().collect();
+    assert_eq!(lines.len(), SCHEMAS.len());
+    // Each line is a bare JSON string.
+    for line in lines {
+        let v: Value = serde_json::from_str(line).unwrap();
+        assert!(v.is_string());
+    }
+}
+
+#[test]
+fn execute_list_table_is_one_name_per_line() {
+    let (io, ok) = run(None, crate::types::OutputFormat::Table);
+    assert!(ok);
+    assert_eq!(io.out_str().lines().count(), SCHEMAS.len());
+}
+
+#[test]
+fn registry_is_sorted_and_unique() {
+    let names: Vec<&str> = SCHEMAS.iter().map(|(n, _)| *n).collect();
+    let mut sorted = names.clone();
+    sorted.sort_unstable();
+    assert_eq!(names, sorted, "SCHEMAS registry must stay sorted by name");
+    sorted.dedup();
+    assert_eq!(
+        sorted.len(),
+        names.len(),
+        "duplicate schema name in registry"
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ pub async fn dispatch(
             commands::query::execute(action, server, format, api, w).await
         }
         cli::Commands::Completion { shell } => commands::completion::execute(*shell, w),
+        cli::Commands::Schema { name } => commands::schema::execute(name.as_deref(), format, w),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,11 +81,12 @@ fn exit_code(e: &BzrError) -> ExitCode {
 
 /// Render a dispatch error for the user.
 ///
-/// JSON output renders a structured object with `type`, `message`, and
-/// `exit_code` fields. Table output renders the conventional `error: …`
-/// prefix.
+/// JSON-family output (`json` and `ndjson`) renders a structured error object
+/// with `type`, `message`, and `exit_code` fields — one compact line, so an
+/// `ndjson` stream stays parseable. Table output renders the conventional
+/// `error: …` prefix.
 fn format_dispatch_error(err: &BzrError, format: OutputFormat) -> String {
-    if format == OutputFormat::Json {
+    if format.is_json_family() {
         let json_err = serde_json::json!({
             "error": {
                 "type": err.error_type(),

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -234,6 +234,21 @@ fn format_dispatch_error_renders_json() {
 }
 
 #[test]
+fn format_dispatch_error_ndjson_renders_compact_json_object() {
+    // Under --output ndjson the error must stay a parseable JSON object (one
+    // compact line), not degrade to the human `error: …` table form.
+    let err = BzrError::Config("bad config".into());
+    let out = format_dispatch_error(&err, OutputFormat::Ndjson);
+    assert!(
+        !out.starts_with("error:"),
+        "ndjson error must be JSON: {out}"
+    );
+    assert!(!out.contains('\n'), "ndjson error must be one line: {out}");
+    let parsed: serde_json::Value = serde_json::from_str(&out).expect("output must be valid JSON");
+    assert_eq!(parsed["error"]["exit_code"], err.exit_code());
+}
+
+#[test]
 fn format_dispatch_error_renders_table() {
     let err = BzrError::Config("bad config".into());
     let out = format_dispatch_error(&err, OutputFormat::Table);

--- a/src/output/formatting.rs
+++ b/src/output/formatting.rs
@@ -16,6 +16,41 @@ pub(super) fn write_json<W: Write + ?Sized>(value: &(impl Serialize + ?Sized), o
     );
 }
 
+/// Newline-delimited JSON. A top-level array emits one compact element per line
+/// (the streaming shape agents iterate); any other value emits as one compact
+/// line. An empty array emits nothing — zero records is zero lines.
+pub(crate) fn write_ndjson<W: Write + ?Sized>(value: &(impl Serialize + ?Sized), out: &mut W) {
+    let value = serde_json::to_value(value).expect("serializable to JSON");
+    match value {
+        serde_json::Value::Array(items) => {
+            for item in &items {
+                let _ = writeln!(out, "{item}");
+            }
+        }
+        other => {
+            let _ = writeln!(out, "{other}");
+        }
+    }
+}
+
+/// Render a value in whichever JSON family `format` selects: pretty-printed for
+/// [`OutputFormat::Json`], newline-delimited for [`OutputFormat::Ndjson`]. Used
+/// by the bespoke `match format` sites whose `Table` arm renders something
+/// other than a serialized value; [`write_formatted`] is the simpler entry
+/// point when the table form is also a function of the same value.
+pub(crate) fn write_json_family<W: Write + ?Sized>(
+    value: &(impl Serialize + ?Sized),
+    format: OutputFormat,
+    out: &mut W,
+) {
+    match format {
+        OutputFormat::Ndjson => write_ndjson(value, out),
+        // `Table` is unreachable — callers gate this on `is_json_family()` — but
+        // folding it into the pretty-JSON arm keeps the match exhaustive.
+        OutputFormat::Json | OutputFormat::Table => write_json(value, out),
+    }
+}
+
 pub(super) fn write_formatted<T, W>(
     value: &T,
     format: OutputFormat,
@@ -27,6 +62,7 @@ pub(super) fn write_formatted<T, W>(
 {
     match format {
         OutputFormat::Json => write_json(value, out),
+        OutputFormat::Ndjson => write_ndjson(value, out),
         OutputFormat::Table => table_fn(value, out),
     }
 }

--- a/src/output/formatting_tests.rs
+++ b/src/output/formatting_tests.rs
@@ -139,11 +139,59 @@ fn output_format_from_str() {
         OutputFormat::Table
     );
     assert_eq!("json".parse::<OutputFormat>().unwrap(), OutputFormat::Json);
+    assert_eq!(
+        "ndjson".parse::<OutputFormat>().unwrap(),
+        OutputFormat::Ndjson
+    );
     assert!("JSON".parse::<OutputFormat>().is_err());
     assert!("Table".parse::<OutputFormat>().is_err());
     assert!("xml".parse::<OutputFormat>().is_err());
     let err = "XML".parse::<OutputFormat>().unwrap_err();
-    assert!(err.contains("expected 'table' or 'json'"));
+    assert!(err.contains("expected 'table', 'json', or 'ndjson'"));
+}
+
+// ── NDJSON rendering ─────────────────────────────────────────────
+
+#[test]
+fn ndjson_array_emits_one_compact_line_per_element() {
+    let value = serde_json::json!([{"id": 1}, {"id": 2}, {"id": 3}]);
+    let mut buf = Vec::new();
+    write_ndjson(&value, &mut buf);
+    let out = String::from_utf8(buf).unwrap();
+    assert_eq!(out, "{\"id\":1}\n{\"id\":2}\n{\"id\":3}\n");
+}
+
+#[test]
+fn ndjson_empty_array_emits_nothing() {
+    let value = serde_json::json!([]);
+    let mut buf = Vec::new();
+    write_ndjson(&value, &mut buf);
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn ndjson_single_object_emits_one_compact_line() {
+    let value = serde_json::json!({"resource": "bug", "action": "updated", "id": 7});
+    let mut buf = Vec::new();
+    write_ndjson(&value, &mut buf);
+    let out = String::from_utf8(buf).unwrap();
+    // One line, no pretty-print whitespace, trailing newline only.
+    assert_eq!(out.lines().count(), 1);
+    assert!(!out.contains("  "));
+    assert!(out.ends_with('\n'));
+}
+
+#[test]
+fn json_family_json_is_pretty_ndjson_is_compact() {
+    let value = serde_json::json!([{"id": 1}]);
+    let mut pretty = Vec::new();
+    write_json_family(&value, OutputFormat::Json, &mut pretty);
+    let pretty = String::from_utf8(pretty).unwrap();
+    assert!(pretty.contains('\n') && pretty.contains("  "));
+
+    let mut compact = Vec::new();
+    write_json_family(&value, OutputFormat::Ndjson, &mut compact);
+    assert_eq!(String::from_utf8(compact).unwrap(), "{\"id\":1}\n");
 }
 
 #[test]

--- a/src/output/resources/attachment.rs
+++ b/src/output/resources/attachment.rs
@@ -198,7 +198,9 @@ pub fn write_attachment_batch<O, E>(
     E: Write + ?Sized,
 {
     match format {
-        OutputFormat::Json => crate::output::formatting::write_json(result, out),
+        OutputFormat::Json | OutputFormat::Ndjson => {
+            crate::output::formatting::write_json_family(result, format, out);
+        }
         OutputFormat::Table => write_attachment_batch_table(result, out, err),
     }
 }

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -7,7 +7,7 @@ use tabled::builder::Builder;
 
 use crate::output::formatting::{
     colorize_status, shorten_email, truncate, write_divider, write_field, write_formatted,
-    write_json, write_list_field, write_optional_field, SUMMARY_TRUNCATE_WIDTH,
+    write_json_family, write_list_field, write_optional_field, SUMMARY_TRUNCATE_WIDTH,
 };
 use crate::types::{Bug, HistoryEntry, OutputFormat};
 
@@ -528,7 +528,9 @@ pub fn write_bugs<W: Write + ?Sized, E: Write + ?Sized>(
     err: &mut E,
 ) {
     match format {
-        OutputFormat::Json => write_json(&bugs_to_json(bugs, spec), out),
+        OutputFormat::Json | OutputFormat::Ndjson => {
+            write_json_family(&bugs_to_json(bugs, spec), format, out);
+        }
         OutputFormat::Table => {
             if bugs.is_empty() {
                 let _ = writeln!(out, "No bugs found.");
@@ -552,7 +554,9 @@ pub fn write_bug_detail<W: Write + ?Sized>(
     out: &mut W,
 ) {
     match format {
-        OutputFormat::Json => write_json(&bug_to_json(bug, spec), out),
+        OutputFormat::Json | OutputFormat::Ndjson => {
+            write_json_family(&bug_to_json(bug, spec), format, out);
+        }
         OutputFormat::Table => write_bug_detail_table(bug, spec, out),
     }
 }

--- a/src/output/resources/bug_tests.rs
+++ b/src/output/resources/bug_tests.rs
@@ -120,6 +120,38 @@ fn write_bugs_table_empty_says_no_bugs_found() {
 }
 
 #[test]
+fn write_bugs_ndjson_emits_one_object_per_line() {
+    let bugs = vec![
+        make_bug(1, "first", "NEW"),
+        make_bug(2, "second", "ASSIGNED"),
+    ];
+    let output = capture_bugs(OutputFormat::Ndjson, &bugs);
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(lines.len(), 2);
+    let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    assert_eq!(first["id"], 1);
+    assert_eq!(second["id"], 2);
+    // Compact: no pretty-print indentation on any line.
+    assert!(!output.contains("  \""));
+}
+
+#[test]
+fn write_bugs_ndjson_empty_emits_nothing() {
+    let output = capture_bugs(OutputFormat::Ndjson, &[]);
+    assert!(output.is_empty());
+}
+
+#[test]
+fn write_bug_detail_ndjson_emits_single_line() {
+    let bug = make_bug(99, "detail", "NEW");
+    let output = capture_bug_detail(OutputFormat::Ndjson, &bug);
+    assert_eq!(output.lines().count(), 1);
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+    assert_eq!(parsed["id"], 99);
+}
+
+#[test]
 fn write_bugs_json_empty_renders_empty_array() {
     let output = capture_bugs(OutputFormat::Json, &[]);
     let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();

--- a/src/output/resources/query.rs
+++ b/src/output/resources/query.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use crate::types::{OutputFormat, QueryKind, SavedQuery};
 
 use crate::output::formatting::{
-    write_field, write_formatted, write_json_family, write_list_field, write_optional_field,
+    write_field, write_formatted, write_list_field, write_optional_field,
 };
 
 fn kind_label(kind: &QueryKind) -> &'static str {
@@ -51,18 +51,12 @@ pub fn write_query_saved<W: Write + ?Sized>(
     format: OutputFormat,
     out: &mut W,
 ) {
-    match format {
-        OutputFormat::Json | OutputFormat::Ndjson => {
-            write_json_family(
-                &serde_json::json!({"name": name, "action": verb.to_lowercase()}),
-                format,
-                out,
-            );
-        }
-        OutputFormat::Table => {
-            let _ = writeln!(out, "{}", query_saved_message(name, verb));
-        }
-    }
+    crate::output::result_types::write_result(
+        &serde_json::json!({"name": name, "action": verb.to_lowercase()}),
+        &query_saved_message(name, verb),
+        format,
+        out,
+    );
 }
 
 pub fn write_query_list<W: Write + ?Sized, S: ::std::hash::BuildHasher>(

--- a/src/output/resources/query.rs
+++ b/src/output/resources/query.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use crate::types::{OutputFormat, QueryKind, SavedQuery};
 
 use crate::output::formatting::{
-    write_field, write_formatted, write_json, write_list_field, write_optional_field,
+    write_field, write_formatted, write_json_family, write_list_field, write_optional_field,
 };
 
 fn kind_label(kind: &QueryKind) -> &'static str {
@@ -52,9 +52,10 @@ pub fn write_query_saved<W: Write + ?Sized>(
     out: &mut W,
 ) {
     match format {
-        OutputFormat::Json => {
-            write_json(
+        OutputFormat::Json | OutputFormat::Ndjson => {
+            write_json_family(
                 &serde_json::json!({"name": name, "action": verb.to_lowercase()}),
+                format,
                 out,
             );
         }

--- a/src/output/resources/template.rs
+++ b/src/output/resources/template.rs
@@ -3,9 +3,7 @@ use std::io::Write;
 
 use crate::types::{BugTemplate, OutputFormat};
 
-use crate::output::formatting::{
-    write_field, write_formatted, write_json_family, write_optional_field,
-};
+use crate::output::formatting::{write_field, write_formatted, write_optional_field};
 
 fn template_saved_message(name: &str, verb: &str) -> String {
     format!("{verb} template '{name}'")
@@ -38,18 +36,12 @@ pub fn write_template_saved<W: Write + ?Sized>(
     format: OutputFormat,
     out: &mut W,
 ) {
-    match format {
-        OutputFormat::Json | OutputFormat::Ndjson => {
-            write_json_family(
-                &serde_json::json!({"name": name, "action": verb.to_lowercase()}),
-                format,
-                out,
-            );
-        }
-        OutputFormat::Table => {
-            let _ = writeln!(out, "{}", template_saved_message(name, verb));
-        }
-    }
+    crate::output::result_types::write_result(
+        &serde_json::json!({"name": name, "action": verb.to_lowercase()}),
+        &template_saved_message(name, verb),
+        format,
+        out,
+    );
 }
 
 pub fn write_template_list<W: Write + ?Sized, S: ::std::hash::BuildHasher>(

--- a/src/output/resources/template.rs
+++ b/src/output/resources/template.rs
@@ -3,7 +3,9 @@ use std::io::Write;
 
 use crate::types::{BugTemplate, OutputFormat};
 
-use crate::output::formatting::{write_field, write_formatted, write_json, write_optional_field};
+use crate::output::formatting::{
+    write_field, write_formatted, write_json_family, write_optional_field,
+};
 
 fn template_saved_message(name: &str, verb: &str) -> String {
     format!("{verb} template '{name}'")
@@ -37,9 +39,10 @@ pub fn write_template_saved<W: Write + ?Sized>(
     out: &mut W,
 ) {
     match format {
-        OutputFormat::Json => {
-            write_json(
+        OutputFormat::Json | OutputFormat::Ndjson => {
+            write_json_family(
                 &serde_json::json!({"name": name, "action": verb.to_lowercase()}),
+                format,
                 out,
             );
         }

--- a/src/output/result_types.rs
+++ b/src/output/result_types.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use serde::Serialize;
 
-use super::formatting::write_json;
+use super::formatting::write_json_family;
 use crate::types::OutputFormat;
 
 // ── Result output ───────────────────────────────────────────────────
@@ -14,7 +14,7 @@ pub fn write_result<W: Write + ?Sized>(
     out: &mut W,
 ) {
     match format {
-        OutputFormat::Json => write_json(value, out),
+        OutputFormat::Json | OutputFormat::Ndjson => write_json_family(value, format, out),
         OutputFormat::Table => {
             let _ = writeln!(out, "{human_message}");
         }

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -73,6 +73,24 @@ pub enum OutputFormat {
     #[default]
     Table,
     Json,
+    /// Newline-delimited JSON: array outputs emit one compact value per line;
+    /// single objects emit one compact line. Streaming-friendly for agents.
+    Ndjson,
+}
+
+impl OutputFormat {
+    /// Whether this format is a machine-readable JSON family (`json` or
+    /// `ndjson`) as opposed to the human `table`. The two JSON families share
+    /// every routing decision — serialization, error objects, stderr-only
+    /// notes — and differ only in how the JSON is laid out, so call sites that
+    /// branch "machine vs human" test this rather than spelling out both arms.
+    #[must_use]
+    pub fn is_json_family(self) -> bool {
+        match self {
+            OutputFormat::Json | OutputFormat::Ndjson => true,
+            OutputFormat::Table => false,
+        }
+    }
 }
 
 impl std::str::FromStr for OutputFormat {
@@ -81,8 +99,9 @@ impl std::str::FromStr for OutputFormat {
         match s {
             "table" => Ok(OutputFormat::Table),
             "json" => Ok(OutputFormat::Json),
+            "ndjson" => Ok(OutputFormat::Ndjson),
             _ => Err(format!(
-                "invalid output format '{s}': expected 'table' or 'json'"
+                "invalid output format '{s}': expected 'table', 'json', or 'ndjson'"
             )),
         }
     }

--- a/src/types/common_tests.rs
+++ b/src/types/common_tests.rs
@@ -84,12 +84,24 @@ fn output_format_from_str_valid() {
         OutputFormat::Table
     );
     assert_eq!("json".parse::<OutputFormat>().unwrap(), OutputFormat::Json);
+    assert_eq!(
+        "ndjson".parse::<OutputFormat>().unwrap(),
+        OutputFormat::Ndjson
+    );
+}
+
+#[test]
+fn output_format_is_json_family() {
+    assert!(OutputFormat::Json.is_json_family());
+    assert!(OutputFormat::Ndjson.is_json_family());
+    assert!(!OutputFormat::Table.is_json_family());
 }
 
 #[test]
 fn output_format_from_str_invalid() {
     let err = "xml".parse::<OutputFormat>().unwrap_err();
     assert!(err.contains("invalid output format"));
+    assert!(err.contains("ndjson"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #305. JSON output shapes differ across `bzr` command families (bare arrays, `{bugs, failed}`, `{resource, action, …}`, `comment_id`, name-keyed maps), there was no machine-readable contract to validate against, and no streaming-friendly format for large result sets. This adds two additive capabilities. **Existing `table`/`json` shapes are unchanged** — no envelope was imposed on current consumers.

| Capability | What |
|------------|------|
| NDJSON | `--output ndjson` / `BZR_OUTPUT=ndjson` — newline-delimited JSON for streaming |
| `bzr schema [NAME]` | Published JSON Schemas (draft 2020-12) for each command's JSON output |

## NDJSON output

A third `OutputFormat` variant. List/array results emit one compact JSON value per line; a single object or result envelope emits as one compact line. An empty list emits no lines.

- All JSON emission funnels through one `write_json_family` choke point, so every JSON-emitting command honors `ndjson` (enforced by exhaustive matching — the compiler rejects a path that forgets it).
- New `OutputFormat::is_json_family()` predicate drives the machine-vs-human branch. This also fixes the **dispatch-error path**, which previously checked `== Json` and so degraded to human `error: …` text under `--output ndjson`; errors now stay a one-line JSON object.
- The `bug list`/`search` truncation note goes to stderr under `ndjson` (as under `json`), keeping stdout one clean record per line.

```bash
bzr --output ndjson bug search "memory leak" | jq -c '{id, summary}'
```

## `bzr schema`

A local command (no network) publishing checked-in JSON Schemas embedded via `include_str!`:

- `bzr schema` lists the available schema names (honors `--output`); `bzr schema <name>` prints the schema; unknown name exits 7 with the valid list.
- Covers the read-resource objects (`bug`, `comment`, `attachment`, `product`, `component`, `classification`, `user`, `group`, `field-value`) and the mutation/result envelopes (`action-result`, `batch-result`, `batch-create-result`, `multi-bug-view`, `tag-result`, `membership-result`, `count-result`, `download-result`, `upload-result`, `config-result`, `search-result`, `dry-run-result`) — i.e. the documented shape exceptions.

### Why checked-in schemas, not derived (`schemars`)

The `bug` JSON is **dynamic**: its hand-written `Serialize` flattens server-specific custom fields to the top level, and `--fields` projects the key set at render time. A derive-based generator would describe the Rust struct (a nested `custom_fields` map), not the real wire shape. So `bug.json` is intentionally open (`additionalProperties: true`) and the schemas are authored to match real output.

A **drift test** keeps them honest: it validates a representative serialized value of each type against its schema **bidirectionally** — no undocumented key, no phantom property (checked with maximally-populated samples), all `required` present — so a struct field add/remove/rename fails CI until the schema is updated. No runtime schema-validation dependency was added.

## Review notes

- The over-arching design (NDJSON funnel + `is_json_family`, schema registry + drift test) is documented in `docs/superpowers/specs/2026-06-19-json-envelope-ndjson-design.md`.
- The optional `{data, meta}` unified envelope from the issue is intentionally **not** implemented — no current consumer, and the schema command + NDJSON cover the stated agent need without a breaking shape change.
- Known coverage edge: the drift test's bijection check covers top-level shapes; nested *inline* sub-shapes (e.g. product's `versions`/`milestones` items) are not recursively validated. Those types are stable; flagged rather than over-built.

## Validation

`cargo test --features test-helpers` (1531 + integration green), `cargo clippy --locked --features test-helpers -- -D warnings` clean, `cargo fmt --check` clean, flag-drift check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
