### PR TITLE
test(functional): cover --version filter and --keywords round-trip

### DIFF
--- a/tests/functional/phases/08b-bugs-paging.sh
+++ b/tests/functional/phases/08b-bugs-paging.sh
@@ -56,5 +56,24 @@ run_bzr bug list --whiteboard "$_PGMARK"
 if assert_success && assert_json_exists ".[] | select(.id==$P1)" &&
     assert_json "[.[] | select(.id==$PX)] | length" "0"; then test_pass; fi
 
-unset _PGMARK _PGOTHER _PG_CREATE P1 P2 P3 PX
+# --version filter: two products with distinct, per-run-unique versions prove the
+# filter discriminates (present-by-id / absent-by-id). Versions are created via
+# `product create --version`, so this needs no container fixture or code change.
+_VPA="vpa$$x${RANDOM}"
+_VPB="vpb$$x${RANDOM}"
+_VVA="va$$x${RANDOM}"
+_VVB="vb$$x${RANDOM}"
+run_bzr product create --name "$_VPA" --description d --version "$_VVA"
+run_bzr component create --product "$_VPA" --name C --description d --default-assignee "$ADMIN_EMAIL"
+run_bzr product create --name "$_VPB" --description d --version "$_VVB"
+run_bzr component create --product "$_VPB" --name C --description d --default-assignee "$ADMIN_EMAIL"
+VBA=$(make_bug --product "$_VPA" --component C --op-sys Linux --rep-platform PC --description d --version "$_VVA" --summary "ver filter a")
+VBB=$(make_bug --product "$_VPB" --component C --op-sys Linux --rep-platform PC --description d --version "$_VVB" --summary "ver filter b")
+
+test_begin "141a. bug list --version filters discriminatingly"
+run_bzr bug list --version "$_VVA"
+if assert_success && assert_json_exists ".[] | select(.id==$VBA)" &&
+    assert_json "[.[] | select(.id==$VBB)] | length" "0"; then test_pass; fi
+
+unset _PGMARK _PGOTHER _PG_CREATE P1 P2 P3 PX _VPA _VPB _VVA _VVB VBA VBB
 echo ""

--- a/tests/functional/phases/08c-bugs-create-fields.sh
+++ b/tests/functional/phases/08c-bugs-create-fields.sh
@@ -56,6 +56,16 @@ if assert_success; then
     if assert_json '.summary' "cli wins"; then test_pass; fi
 fi
 
+# --keywords round-trip. The fix-needed keyword is seeded only on bz52+; gate so
+# older Bugzilla (no keyword definition) skips cleanly rather than erroring.
+test_begin "146a. bug create --keywords round-trips"
+if require_version 520 "fix-needed keyword seeded on bz52+"; then
+    KID=$(make_bug "${_CF[@]}" --summary "kw create" --keywords fix-needed)
+    run_bzr bug view "$KID"
+    if assert_success && assert_json_contains '.keywords | join(",")' "fix-needed"; then test_pass; fi
+fi
+unset KID
+
 rm -rf "$_FJ"
 unset _CF _FJ _WB CFID FID OID
 echo ""


### PR DESCRIPTION
## Summary

Adds the functional coverage from the deferred "container fixtures" task that is
achievable without a bzr code change: the `bug list --version` filter and the
`bug create --keywords` round-trip. Verified on Bugzilla 5.0, 5.2, and 5.3.

## Changes

- **`08b-bugs-paging.sh`** — `bug list --version` filter, using two products with
  distinct per-run-unique versions to prove the filter discriminates
  (present-by-id / absent-by-id). Versions are created via `product create
  --version`, so no container fixture or code change is needed.
- **`08c-bugs-create-fields.sh`** — `bug create --keywords` round-trip, version-gated
  (the `fix-needed` keyword is seeded only on bz52+, so bz50 skips cleanly).

## Testing

- Full suite, fresh DBs: **bz50 224/0/2, bz52 225/0/1, bz53 226/0/0**. New tests pass
  on all versions; `--keywords` skips on bz50 as designed.

## Notes

- `--flag` and `--target-milestone` round-trips are **not** included. Investigation
  while building this showed the flag-type fixture works (flags persist server-side),
  but `bzr bug view` / `attachment view` omit the `flags` and `target_milestone`
  fields entirely (`src/types/bug.rs:46-69` has neither), so the round-trip cannot be
  asserted through bzr's own output. That gap — which also means users can't see flags
  or the target milestone today — is filed as #351; the deferred coverage lands once
  those fields surface.

relates to #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)
