### PR TITLE
fix(bug): target stock statuses for close/reopen with --status override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Breaking:** `bug close` and `bug reopen` now target stock Bugzilla 5.x
+  statuses by default — `close` sets `VERIFIED` (was `CLOSED`) and `reopen` sets
+  `CONFIRMED` (was `REOPENED`). Neither old status is part of the default
+  Bugzilla workflow, so both verbs previously failed against a stock install
+  with API error 51. A new `--status <STATUS>` flag on each verb overrides the
+  default for installs that define custom statuses (e.g. `--status CLOSED`). The
+  target status is validated against the server's status list before writing; an
+  unknown status now exits 7 (input validation) listing the valid statuses,
+  rather than reaching the server as the opaque API error. Matching is exact and
+  case-sensitive. Scripts relying on the old `CLOSED`/`REOPENED` targets must
+  pass `--status CLOSED` / `--status REOPENED`. (#349)
+
 - **Breaking:** attachment boolean flags now use a uniform `--x` / `--no-x`
   presence grammar across `attachment upload` and `attachment update`, so the
   same concept uses the same flag everywhere. `attachment upload` keeps

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -129,8 +129,8 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │   │                   [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
 │   │                   [--expect-unchanged-since <TIMESTAMP>]
 │   ├── resolve <ID...> [--as <RESOLUTION>] [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
-│   ├── close <ID...> [--as <RESOLUTION>] [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
-│   ├── reopen <ID...> [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
+│   ├── close <ID...> [--status <STATUS>] [--as <RESOLUTION>] [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
+│   ├── reopen <ID...> [--status <STATUS>] [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
 │   └── dup <ID> <TARGET> [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
 ├── comment
 │   ├── list <BUG_ID> [--since <DATE>]
@@ -697,22 +697,29 @@ partial-failure reporting, exit code 11) is inherited from `bug update`.
 ```bash
 bzr bug resolve 12345                       # → update --status RESOLVED --resolution FIXED
 bzr bug resolve 12345 12346 --as WONTFIX    # batch, custom resolution
-bzr bug close 12345 --comment "Shipped"     # → update --status CLOSED (resolution preserved)
+bzr bug close 12345 --comment "Shipped"     # → update --status VERIFIED (resolution preserved)
 bzr bug close 12345 --as INVALID            # close an open bug with a resolution
-bzr bug reopen 12345                         # → update --status REOPENED
+bzr bug close 12345 --status CLOSED         # install with a custom closed status
+bzr bug reopen 12345                         # → update --status CONFIRMED
+bzr bug reopen 12345 --status REOPENED       # install with a custom open status
 bzr bug dup 12345 100                        # → update --dupe-of 100
 ```
 
 | Verb | Equivalent `update` | Notes |
 |------|---------------------|-------|
 | `resolve <ID...> [--as <R>]` | `--status RESOLVED --resolution <R>` | `--as` defaults to `FIXED` |
-| `close <ID...> [--as <R>]` | `--status CLOSED [--resolution <R>]` | resolution set only when `--as` is given, otherwise the existing one is preserved |
-| `reopen <ID...>` | `--status REOPENED` | Bugzilla clears the resolution automatically |
+| `close <ID...> [--status <S>] [--as <R>]` | `--status <S> [--resolution <R>]` | `--status` defaults to `VERIFIED`; resolution set only when `--as` is given, otherwise the existing one is preserved |
+| `reopen <ID...> [--status <S>]` | `--status <S>` | `--status` defaults to `CONFIRMED`; Bugzilla clears the resolution automatically |
 | `dup <ID> <TARGET>` | `--dupe-of <TARGET>` | Bugzilla sets RESOLVED/DUPLICATE automatically |
 
-The status strings (`RESOLVED`, `CLOSED`, `REOPENED`) follow the conventional
-Bugzilla workflow; on a server with a customized workflow, an unsupported
-transition fails with the same server error `bug update` would return.
+`close` and `reopen` default to the stock Bugzilla 5.x statuses `VERIFIED` and
+`CONFIRMED`. Installs that define custom statuses (e.g. `CLOSED`, `REOPENED`)
+reach them with `--status`. The target status is validated against the server's
+status list before writing; an unknown status exits 7 (input validation) with
+the list of valid statuses, instead of the server's opaque API error. The match
+is exact and case-sensitive. Validation confirms the status exists; an
+otherwise-legal status whose *transition* the workflow forbids still fails with
+the same server error `bug update` would return.
 
 ---
 

--- a/docs/decisions/0002-close-reopen-target-statuses.md
+++ b/docs/decisions/0002-close-reopen-target-statuses.md
@@ -1,0 +1,94 @@
+# 0002 — `bug close` / `bug reopen` target stock-workflow statuses, validated
+
+- Status: Accepted
+- Date: 2026-06-20
+- Issue: [#349](https://github.com/randomparity/bzr/issues/349)
+
+## Context
+
+The convenience verbs `bug close` and `bug reopen` hardcoded the target
+statuses `CLOSED` and `REOPENED`. Neither is part of the **default Bugzilla
+5.x workflow**, whose status set is `UNCONFIRMED, CONFIRMED, IN_PROGRESS,
+RESOLVED, VERIFIED`. `CLOSED` and `REOPENED` are optional statuses some
+installations add; `REOPENED` was dropped from the default workflow entirely.
+
+Against any stock install both verbs therefore failed with Bugzilla API
+error 51 (`There is no status named 'CLOSED'.` / `'REOPENED'.`), exit code 4.
+The sibling verbs `resolve` (targets `RESOLVED`) and `dup` (uses `dupe_of`)
+work because their targets are in the default workflow.
+
+The failure surfaced only against real containers; `verbs_tests.rs` mocked a
+server that accepted `CLOSED`, so the unit tests passed (see #350 / #349).
+
+## Decision
+
+1. **Change the defaults to stock-workflow statuses.**
+   - `reopen` targets `CONFIRMED` (a default open status; Bugzilla clears the
+     resolution automatically when moving to an open status).
+   - `close` targets `VERIFIED` (the default terminal status). `close` already
+     preserves any existing resolution and is intended for already-resolved
+     bugs, so `VERIFIED` is the natural stock target.
+
+2. **Add a `--status <STATUS>` override** to both verbs so installations that
+   *do* define `CLOSED` / `REOPENED` (or any other custom status) can still
+   reach them: `bzr bug close <id> --status CLOSED`.
+
+3. **Validate the target status against the server before writing.** Before
+   the `Bug.update` call, fetch the legal `status` field values
+   (`get_field_values("status")`) and confirm the chosen status is among them.
+   The match is **exact and case-sensitive** against the names the server
+   returns (Bugzilla statuses are uppercase, e.g. `CONFIRMED`), and the value
+   that passed validation is sent verbatim — so a wrong-case override such as
+   `--status confirmed` is rejected up front rather than passing validation and
+   failing server-side. On mismatch, fail with `InputValidation` (exit 7) and a
+   message naming the invalid status and listing the server's valid statuses —
+   instead of letting the request reach the server and surface as the opaque
+   API error 51 (exit 4).
+
+   Validation proves the status *exists*; it does not prove the *transition*
+   from the bug's current status to the target is legal in the server's
+   workflow. An existing-but-illegal transition (e.g. a workflow that forbids
+   `RESOLVED → CONFIRMED`) still surfaces from the server. The validation
+   specifically replaces the nonexistent-status case (the error 51 in #349),
+   not transition-legality enforcement, which is intentionally left to the
+   server.
+
+   Both the write (`update_bug` → `put_json`) and this validation
+   (`get_field_values` → `get_json`) use the REST path, so the verbs already
+   require REST to write at all; the pre-validation adds no new API-mode
+   dependency.
+
+   Validation runs only on the real-write path. Under `--dry-run` it is
+   skipped: dry-run is a local preview that performs no mutation, and the
+   preview already shows the exact status that would be sent.
+
+## Consequences
+
+- On a stock install `bzr bug close <id>` and `bzr bug reopen <id>` now succeed
+  with no flags. This is a **behavior change** to the status these verbs send
+  (`CLOSED`→`VERIFIED`, `REOPENED`→`CONFIRMED`), reflected in the verb doc
+  comments, `docs/bzr-cli.md`, and `CHANGELOG.md`.
+- Installations relying on the old `CLOSED` / `REOPENED` targets must now pass
+  `--status CLOSED` / `--status REOPENED` explicitly. This is surfaced in the
+  changelog as a behavior change.
+- A wrong `--status` value is caught client-side with an actionable error and a
+  distinct exit code (7, input validation) rather than the server's generic
+  error 51 (4, API). The trade-off is one extra `GET field/bug/bug_status`
+  round-trip per `close` / `reopen` invocation on the real-write path.
+- `resolve` and `dup` are unchanged: their targets are always in the default
+  workflow, so they need neither an override nor pre-validation.
+
+## Considered & rejected
+
+- **Change defaults only, no override, no validation.** Simplest, but
+  installations that use `CLOSED` / `REOPENED` lose any way to reach those
+  statuses through the verbs, and a typo'd status still surfaces as the opaque
+  server error 51.
+- **Add `--status` but keep the `CLOSED` / `REOPENED` defaults.** Backward
+  compatible, but leaves the verbs broken-by-default on every stock install —
+  the exact bug being fixed.
+- **Per-server config key for the close/reopen target status.** More machinery
+  than the problem needs; an explicit `--status` flag plus stock defaults
+  covers the same ground without a new persisted config surface.
+- **Validate inside `--dry-run` too.** Rejected to keep dry-run a pure local
+  preview with no extra network reads; the preview already shows the status.

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -1006,9 +1006,13 @@ pub enum BugAction {
     ///   bzr bug resolve 12345 --comment "Fixed in 9.1"
     #[command(verbatim_doc_comment)]
     Resolve(ResolveArgs),
-    /// Close one or more bugs (sets status CLOSED).
+    /// Close one or more bugs (sets status VERIFIED by default).
     ///
-    /// Sugar for `bug update <IDs> --status CLOSED`. By default the bug's
+    /// Sugar for `bug update <IDs> --status VERIFIED`. `VERIFIED` is a stock
+    /// Bugzilla 5.x closed status; override with `--status <STATUS>` for
+    /// installs that define a custom closed status such as `CLOSED`. The
+    /// target status is validated against the server's status list (exact,
+    /// case-sensitive); an unknown value exits 7. By default the bug's
     /// existing resolution is preserved (so close an already-resolved bug);
     /// pass `--as <RESOLUTION>` to set one when closing directly. Accepts
     /// multiple IDs (batch) and the same `--comment` flags as `bug update`.
@@ -1016,18 +1020,24 @@ pub enum BugAction {
     /// Examples:
     ///
     ///   bzr bug close 12345
+    ///   bzr bug close 12345 --status CLOSED          # install with custom status
     ///   bzr bug close 12345 12346 --as WONTFIX --comment "Out of scope"
     #[command(verbatim_doc_comment)]
     Close(CloseArgs),
-    /// Reopen one or more bugs (sets status REOPENED).
+    /// Reopen one or more bugs (sets status CONFIRMED by default).
     ///
-    /// Sugar for `bug update <IDs> --status REOPENED`. Bugzilla clears the
-    /// resolution automatically on reopen. Accepts multiple IDs (batch) and
-    /// the same `--comment` flags as `bug update`.
+    /// Sugar for `bug update <IDs> --status CONFIRMED`. `CONFIRMED` is a stock
+    /// Bugzilla 5.x open status; override with `--status <STATUS>` for installs
+    /// that define a custom open status such as `REOPENED`. Bugzilla clears the
+    /// resolution automatically when moving to an open status. The target
+    /// status is validated against the server's status list (exact,
+    /// case-sensitive); an unknown value exits 7. Accepts multiple IDs (batch)
+    /// and the same `--comment` flags as `bug update`.
     ///
     /// Examples:
     ///
     ///   bzr bug reopen 12345
+    ///   bzr bug reopen 12345 --status REOPENED       # install with custom status
     ///   bzr bug reopen 12345 --comment "Regressed in 9.2"
     #[command(verbatim_doc_comment)]
     Reopen(ReopenArgs),
@@ -1064,6 +1074,12 @@ pub struct CloseArgs {
     /// Bug ID(s) to close.
     #[arg(required = true, num_args = 1..)]
     pub ids: Vec<u64>,
+    /// Status to transition to (default `VERIFIED`, a stock Bugzilla 5.x
+    /// closed status). Override for installs with a custom closed status
+    /// (e.g. `--status CLOSED`). Validated against the server's status list;
+    /// an unknown value exits 7. Matched exactly and case-sensitively.
+    #[arg(long, value_name = "STATUS", default_value = "VERIFIED")]
+    pub status: String,
     /// Resolution to set when closing an unresolved bug. Omit to
     /// preserve any existing resolution.
     #[arg(long = "as", value_name = "RESOLUTION")]
@@ -1078,6 +1094,12 @@ pub struct ReopenArgs {
     /// Bug ID(s) to reopen.
     #[arg(required = true, num_args = 1..)]
     pub ids: Vec<u64>,
+    /// Status to transition to (default `CONFIRMED`, a stock Bugzilla 5.x
+    /// open status). Override for installs with a custom open status
+    /// (e.g. `--status REOPENED`). Validated against the server's status
+    /// list; an unknown value exits 7. Matched exactly and case-sensitively.
+    #[arg(long, value_name = "STATUS", default_value = "CONFIRMED")]
+    pub status: String,
     #[command(flatten)]
     pub comment: CommentArgs,
 }

--- a/src/commands/bug/verbs.rs
+++ b/src/commands/bug/verbs.rs
@@ -5,7 +5,7 @@
 
 use crate::cli::{CloseArgs, CommentArgs, DupArgs, ReopenArgs, ResolveArgs};
 use crate::client::BugzillaClient;
-use crate::error::Result;
+use crate::error::{BzrError, Result};
 use crate::output::writers::Writers;
 use crate::types::{CommentUpdate, OutputFormat, UpdateBugParams};
 
@@ -17,6 +17,40 @@ fn comment_update(args: &CommentArgs) -> Result<Option<CommentUpdate>> {
         args.comment_file.as_deref(),
         args.comment_private,
     )
+}
+
+/// Confirm the `close` / `reopen` target status exists on the server before
+/// writing, so an unknown status fails with an actionable client-side error
+/// (exit 7) rather than the server's opaque "no status named X" API error.
+///
+/// The match is exact and case-sensitive against the names the server returns
+/// (Bugzilla statuses are uppercase). The check proves the status *exists*; the
+/// legality of the transition from the bug's current status is still left to
+/// the server. Skipped under `--dry-run`, which performs no mutation and whose
+/// preview already shows the status that would be sent.
+async fn validate_target_status(client: &BugzillaClient, status: &str) -> Result<()> {
+    if crate::commands::runtime::dry_run::enabled() {
+        return Ok(());
+    }
+    if status.trim().is_empty() {
+        return Err(BzrError::InputValidation("--status cannot be empty".into()));
+    }
+    let values = client.get_field_values("status").await?;
+    if values
+        .iter()
+        .any(|v| !v.name.is_empty() && v.name == status)
+    {
+        return Ok(());
+    }
+    let valid: Vec<&str> = values
+        .iter()
+        .map(|v| v.name.as_str())
+        .filter(|n| !n.is_empty())
+        .collect();
+    Err(BzrError::InputValidation(format!(
+        "no status named '{status}' on this server; valid statuses: {}",
+        valid.join(", ")
+    )))
 }
 
 pub(super) async fn resolve(
@@ -40,10 +74,14 @@ pub(super) async fn close(
     format: OutputFormat,
     w: &mut Writers<'_>,
 ) -> Result<()> {
+    // Resolve the comment (local validation) before the network status check so
+    // a bad --comment-private combination fails without a round-trip.
+    let comment = comment_update(&args.comment)?;
+    validate_target_status(client, &args.status).await?;
     let params = UpdateBugParams {
-        status: Some("CLOSED".into()),
+        status: Some(args.status.clone()),
         resolution: args.as_resolution.clone(),
-        comment: comment_update(&args.comment)?,
+        comment,
         ..Default::default()
     };
     super::update::apply(client, args.ids.clone(), params, format, w).await
@@ -55,9 +93,11 @@ pub(super) async fn reopen(
     format: OutputFormat,
     w: &mut Writers<'_>,
 ) -> Result<()> {
+    let comment = comment_update(&args.comment)?;
+    validate_target_status(client, &args.status).await?;
     let params = UpdateBugParams {
-        status: Some("REOPENED".into()),
-        comment: comment_update(&args.comment)?,
+        status: Some(args.status.clone()),
+        comment,
         ..Default::default()
     };
     super::update::apply(client, args.ids.clone(), params, format, w).await

--- a/src/commands/bug/verbs_tests.rs
+++ b/src/commands/bug/verbs_tests.rs
@@ -12,6 +12,25 @@ fn ok_put(id: u64) -> ResponseTemplate {
         .set_body_json(serde_json::json!({"bugs": [{"id": id, "changes": {}}]}))
 }
 
+/// JSON body for a `GET field/bug/bug_status` response listing `statuses` as
+/// the legal values. A leading null-named entry is included to mirror real
+/// Bugzilla 5.0, which carries an unset/default entry the validator must skip.
+fn status_field_body(statuses: &[&str]) -> serde_json::Value {
+    let mut values = vec![serde_json::json!({"name": serde_json::Value::Null})];
+    values.extend(statuses.iter().map(|s| serde_json::json!({"name": s})));
+    serde_json::json!({"fields": [{"values": values}]})
+}
+
+/// Mount the `GET field/bug/bug_status` mock the close/reopen status validator
+/// queries before writing.
+async fn mount_status_field(mock: &wiremock::MockServer, statuses: &[&str]) {
+    Mock::given(method("GET"))
+        .and(path("/rest/field/bug/bug_status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_field_body(statuses)))
+        .mount(mock)
+        .await;
+}
+
 /// Mount a PUT mock on `/rest/bug/{id}` asserting the exact JSON body, then run
 /// `execute` for `action` and assert success.
 async fn run_verb_expecting_body(action: BugAction, id: u64, body: serde_json::Value) {
@@ -29,6 +48,51 @@ async fn run_verb_expecting_body(action: BugAction, id: u64, body: serde_json::V
         crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
             .await;
     assert!(result.is_ok(), "verb failed: {:?}", result.err());
+}
+
+/// Like [`run_verb_expecting_body`] but also mounts the status-field mock the
+/// close/reopen validator queries. `statuses` are the server's legal statuses.
+async fn run_status_verb(action: BugAction, id: u64, body: serde_json::Value, statuses: &[&str]) {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mount_status_field(&mock, statuses).await;
+    Mock::given(method("PUT"))
+        .and(path(format!("/rest/bug/{id}")))
+        .and(body_json(body))
+        .respond_with(ok_put(id))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    assert!(result.is_ok(), "verb failed: {:?}", result.err());
+}
+
+const DEFAULT_STATUSES: &[&str] = &[
+    "UNCONFIRMED",
+    "CONFIRMED",
+    "IN_PROGRESS",
+    "RESOLVED",
+    "VERIFIED",
+];
+
+fn close_args(ids: Vec<u64>, status: &str, as_resolution: Option<&str>) -> CloseArgs {
+    CloseArgs {
+        ids,
+        status: status.into(),
+        as_resolution: as_resolution.map(Into::into),
+        comment: CommentArgs::default(),
+    }
+}
+
+fn reopen_args(ids: Vec<u64>, status: &str) -> ReopenArgs {
+    ReopenArgs {
+        ids,
+        status: status.into(),
+        comment: CommentArgs::default(),
+    }
 }
 
 #[tokio::test]
@@ -93,38 +157,151 @@ async fn resolve_with_as_override() {
 }
 
 #[tokio::test]
-async fn close_without_resolution_preserves_existing() {
-    let action = BugAction::Close(CloseArgs {
-        ids: vec![9],
-        as_resolution: None,
-        comment: CommentArgs::default(),
-    });
+async fn close_defaults_to_verified_and_preserves_resolution() {
+    let action = BugAction::Close(close_args(vec![9], "VERIFIED", None));
     // No resolution key — the server keeps any existing resolution.
-    run_verb_expecting_body(action, 9, serde_json::json!({"status": "CLOSED"})).await;
-}
-
-#[tokio::test]
-async fn close_with_as_sets_resolution() {
-    let action = BugAction::Close(CloseArgs {
-        ids: vec![9],
-        as_resolution: Some("WONTFIX".into()),
-        comment: CommentArgs::default(),
-    });
-    run_verb_expecting_body(
+    run_status_verb(
         action,
         9,
-        serde_json::json!({"status": "CLOSED", "resolution": "WONTFIX"}),
+        serde_json::json!({"status": "VERIFIED"}),
+        DEFAULT_STATUSES,
     )
     .await;
 }
 
 #[tokio::test]
-async fn reopen_sends_reopened_status() {
-    let action = BugAction::Reopen(ReopenArgs {
-        ids: vec![3],
-        comment: CommentArgs::default(),
-    });
-    run_verb_expecting_body(action, 3, serde_json::json!({"status": "REOPENED"})).await;
+async fn close_with_as_sets_resolution() {
+    let action = BugAction::Close(close_args(vec![9], "VERIFIED", Some("WONTFIX")));
+    run_status_verb(
+        action,
+        9,
+        serde_json::json!({"status": "VERIFIED", "resolution": "WONTFIX"}),
+        DEFAULT_STATUSES,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn close_status_override_targets_custom_status() {
+    // An install that defines a custom CLOSED status reaches it via --status.
+    let action = BugAction::Close(close_args(vec![9], "CLOSED", None));
+    let mut statuses = DEFAULT_STATUSES.to_vec();
+    statuses.push("CLOSED");
+    run_status_verb(
+        action,
+        9,
+        serde_json::json!({"status": "CLOSED"}),
+        &statuses,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn reopen_defaults_to_confirmed() {
+    let action = BugAction::Reopen(reopen_args(vec![3], "CONFIRMED"));
+    run_status_verb(
+        action,
+        3,
+        serde_json::json!({"status": "CONFIRMED"}),
+        DEFAULT_STATUSES,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn reopen_status_override_targets_custom_status() {
+    let action = BugAction::Reopen(reopen_args(vec![3], "REOPENED"));
+    let mut statuses = DEFAULT_STATUSES.to_vec();
+    statuses.push("REOPENED");
+    run_status_verb(
+        action,
+        3,
+        serde_json::json!({"status": "REOPENED"}),
+        &statuses,
+    )
+    .await;
+}
+
+/// A status the server does not define is rejected client-side (exit 7) with a
+/// message naming the bad value and listing valid statuses — and no PUT fires.
+#[tokio::test]
+async fn reopen_unknown_status_is_rejected() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mount_status_field(&mock, DEFAULT_STATUSES).await;
+    Mock::given(method("PUT"))
+        .respond_with(ok_put(3))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let action = BugAction::Reopen(reopen_args(vec![3], "REOPENED"));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let err =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await
+            .unwrap_err();
+    assert!(
+        matches!(&err, crate::error::BzrError::InputValidation(m)
+            if m.contains("REOPENED") && m.contains("CONFIRMED")),
+        "got {err:?}"
+    );
+}
+
+/// Matching is exact and case-sensitive: a wrong-case override is rejected up
+/// front rather than passing validation and failing server-side.
+#[tokio::test]
+async fn close_wrong_case_status_is_rejected() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mount_status_field(&mock, DEFAULT_STATUSES).await;
+    Mock::given(method("PUT"))
+        .respond_with(ok_put(9))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let action = BugAction::Close(close_args(vec![9], "verified", None));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let err =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await
+            .unwrap_err();
+    assert!(
+        matches!(&err, crate::error::BzrError::InputValidation(m) if m.contains("verified")),
+        "got {err:?}"
+    );
+}
+
+/// Under --dry-run no status-field GET and no PUT fire; the preview shows the
+/// status that would be sent, even one this server would reject.
+#[tokio::test]
+async fn reopen_dry_run_skips_validation_and_write() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/field/bug/bug_status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(status_field_body(DEFAULT_STATUSES)))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    crate::commands::runtime::dry_run::set(true);
+
+    // REOPENED is not in DEFAULT_STATUSES, but dry-run skips validation.
+    let action = BugAction::Reopen(reopen_args(vec![3], "REOPENED"));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    let output = io.out_str().to_string();
+    crate::commands::runtime::dry_run::set(false);
+
+    assert!(result.is_ok(), "dry-run reopen failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["changes"]["status"], "REOPENED");
 }
 
 #[tokio::test]
@@ -191,11 +368,14 @@ async fn resolve_batch_updates_each_id() {
     assert_eq!(parsed["succeeded"].as_array().unwrap().len(), 2);
 }
 
+/// The local comment-private validation fires before the network status check,
+/// so no status-field GET is needed for this rejection.
 #[tokio::test]
 async fn close_private_comment_without_body_is_rejected() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
     let action = BugAction::Close(CloseArgs {
         ids: vec![5],
+        status: "VERIFIED".into(),
         as_resolution: None,
         comment: CommentArgs {
             comment: None,


### PR DESCRIPTION
## Summary

`bug close` and `bug reopen` hardcoded the target statuses `CLOSED` and
`REOPENED`, neither of which is part of the default Bugzilla 5.x workflow
(`UNCONFIRMED, CONFIRMED, IN_PROGRESS, RESOLVED, VERIFIED`). Against any stock
install both verbs failed with Bugzilla API error 51 (exit 4).

This changes the defaults to stock-workflow statuses, adds a `--status`
override, and validates the target status against the server before writing.

## Changes

- `close` now targets `VERIFIED` (was `CLOSED`); `reopen` now targets
  `CONFIRMED` (was `REOPENED`). Both are stock Bugzilla 5.x statuses.
- New `--status <STATUS>` flag on `close` and `reopen` overrides the default,
  so installs with custom statuses can still reach `CLOSED` / `REOPENED`.
- The target status is validated against the server's status field list before
  the write. An unknown status exits 7 (input validation) with the list of
  valid statuses, instead of reaching the server as the opaque API error 51.
  The match is exact and case-sensitive; validation is skipped under `--dry-run`.
- Validation proves the status exists, not that the transition is legal — an
  existing-but-forbidden transition still surfaces from the server.

Decision recorded in `docs/decisions/0002-close-reopen-target-statuses.md`.

## Testing

- `cargo test` green; new unit tests cover the new defaults, the `--status`
  override, unknown-status rejection (exit 7), wrong-case rejection, and the
  dry-run skip-validation path.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`,
  `make check-test-layout`, and the agent-skills flag-drift check all pass.

## Compatibility

**Breaking:** scripts relying on the old `CLOSED` / `REOPENED` targets must now
pass `--status CLOSED` / `--status REOPENED`. Documented in `CHANGELOG.md`.

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)