### PR TITLE
feat(view): surface flags and target_milestone in bug/attachment view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `bug view` and `attachment view` now surface Bugzilla `flags`, and `bug view`
+  also surfaces `target_milestone` — fields the REST API returns but which were
+  previously dropped. Each flag renders as `name` + status token with the
+  requestee in parentheses (e.g. `review+`, `needinfo?(qa@example.com)`). Both
+  fields are selectable via `--fields` (e.g. `bug view <id> --fields id,flags`)
+  and appear in `--json` (flags as an array, always present; `target_milestone`
+  as a string). The unset target-milestone sentinel `---` and empty flag lists
+  are suppressed in table detail but kept verbatim in JSON. (#351)
+
 - NDJSON output via `--output ndjson` (or `BZR_OUTPUT=ndjson`): list/array
   results print one compact JSON value per line and single objects print as one
   compact line — the streaming shape for agents and `jq -c`. An empty list emits

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -363,6 +363,15 @@ upstream Bugzilla and `bzl-search`.
 
 Display detailed information about one or more bugs.
 
+The detail view includes the bug's `target_milestone` and `flags` when set.
+Each flag renders as `name` + status token, with the requestee in parentheses
+when present (e.g. `review+`, `needinfo?(qa@example.com)`) — the same syntax
+`--flag` accepts. The Target Milestone row is omitted when the milestone is
+unset (Bugzilla's `---` sentinel) and the Flags row is omitted when there are
+no flags; under `--json` both are always present (the raw `target_milestone`
+string and the full flag objects, including `setter`). Both are selectable via
+`--fields` (e.g. `--fields id,flags`).
+
 Under `--json` the returned object is trimmed to the selected fields
 (gh-style) on every transport, since trimming happens client-side after
 the fetch. On XML-RPC servers, single-bug `bzr bug view` fetches the full
@@ -807,10 +816,15 @@ bzr --json attachment list 12345
 ### `bzr attachment view`
 
 Show a single attachment's metadata by attachment ID — summary, bug, file
-name, content type, size, flags (patch/obsolete/private), creator, and
-timestamps — **without** downloading its bytes. On REST the `data` field is
-excluded server-side, so inspecting a large attachment is cheap. The `data`
-field is omitted from `--json` output.
+name, content type, size, the boolean state markers (patch/obsolete/private),
+creator, and timestamps — **without** downloading its bytes. On REST the
+`data` field is excluded server-side, so inspecting a large attachment is
+cheap. The `data` field is omitted from `--json` output.
+
+Bugzilla review `flags` set on the attachment are shown when present, each
+rendered as `name` + status token with the requestee in parentheses (e.g.
+`review+`, `review?(qa@example.com)`). Under `--json` the `flags` array is
+always present (empty `[]` when there are none).
 
 ```bash
 bzr attachment view 9876

--- a/docs/decisions/0003-surface-view-flags-and-target-milestone.md
+++ b/docs/decisions/0003-surface-view-flags-and-target-milestone.md
@@ -1,0 +1,116 @@
+# 0003 — Surface `flags` and `target_milestone` in `bug view` / `attachment view`
+
+- Status: Accepted
+- Date: 2026-06-20
+- Issue: [#351](https://github.com/randomparity/bzr/issues/351)
+
+## Context
+
+The Bugzilla REST API returns a `flags` array on bugs and attachments, and a
+`target_milestone` string on bugs, but bzr's view types never deserialized them:
+
+- The view `Bug` struct (`src/types/bug.rs`) lists explicit built-in fields and
+  collects everything else via `#[serde(flatten)] extra`, but `From<BugWire>`
+  keeps only `cf_*` keys (`is_custom_field_name`) — so `flags` and
+  `target_milestone` land in `extra` and are then dropped.
+- The view `Attachment` struct (`src/types/attachment.rs`) has no `flags` field;
+  the `flags: Vec<FlagUpdate>` that exists there is on the *upload/update request*
+  payloads, not the view response.
+
+So a `--flag` / `--target-milestone` value written via `bug create` / `update`
+is persisted server-side but invisible through `bug view` / `attachment view`,
+and `bug view <id> --fields flags` returns `{}`. This also blocks functional
+coverage of `--flag` / `--target-milestone` round-trips (see #350).
+
+`FlagUpdate` (`src/types/common.rs`) is a *write* type: `{ name, status:
+FlagStatus, requestee }`, where `FlagStatus` is a strict enum that only accepts
+`+ - ? X` and **errors** on anything else. It is not suitable for the read path.
+
+## Decision
+
+1. **Add a read-side `Flag` type** in `src/types/common.rs`, distinct from the
+   write-side `FlagUpdate`:
+
+   ```rust
+   pub struct Flag {
+       pub name: String,
+       pub status: String,           // raw server token: "+", "-", "?"
+       pub setter: Option<String>,
+       pub requestee: Option<String>,
+   }
+   ```
+
+   - `status` is a **plain `String`**, not the `FlagStatus` enum. The view path
+     must be tolerant: a status value the enum does not model must not make
+     `bug view` fail to deserialize. The raw token is also exactly what we
+     display.
+   - Fields beyond these (`id`, `type_id`, `creation_date`,
+     `modification_date`) are not surfaced — they are not useful in the view and
+     would be speculative. Every field uses `#[serde(default)]` so a server that
+     omits one still deserializes. Derives `Serialize, Deserialize`.
+
+2. **Add `flags: Vec<Flag>` and `target_milestone: Option<String>` to the view
+   `Bug`** (struct, `BugWire`, `From`, and the manual `Serialize` impl). Bump
+   `BUG_BUILT_IN_FIELD_COUNT` 23 → 25. `flags` serializes as an array (empty →
+   `[]`, matching `keywords`/`cc`); `target_milestone` as a nullable string.
+
+3. **Add `flags: Vec<Flag>` to the view `Attachment`** (`#[serde(default)]`,
+   serialized always, empty → `[]`).
+
+4. **Register `flags` and `target_milestone` in the bug column registry**
+   (`COLUMNS` in `src/output/resources/bug.rs`) with canonical keys `flags` and
+   `target_milestone` that match the serialized JSON keys. This makes
+   `--fields flags` / `--fields target_milestone` work for both table columns
+   and JSON field-selection (the registry drives `bug_to_json` key retention and
+   the server `include_fields` payload).
+
+5. **Add `flags` and `target_milestone` to `BUG_DEFAULT_FIELDS`**
+   (`src/client/bug.rs`). This is load-bearing: a default `bug view` (no
+   `--fields`) sends `include_fields = BUG_DEFAULT_FIELDS`, so without these two
+   names the server never returns the data and the new struct fields stay empty.
+   When `--fields flags` is given, the canonical token `flags` is sent verbatim
+   as `include_fields` and Bugzilla's `Bug.get` returns the array; the same for
+   `target_milestone`. (XML-RPC ignores field lists and returns the full record,
+   so both fields surface there once the struct deserializes them.)
+
+6. **Render in detail/table output.** A flag renders as its `name` followed by
+   the status token, with the requestee in parentheses when present —
+   symmetric with the `name?(user@example.com)` input syntax:
+   - `review+`, `review-`, `review?`, `review?(bob@example.com)`
+   The bug detail view gets `Target Milestone` and `Flags` rows; the attachment
+   detail view gets a `Flags` row.
+
+   **Unset sentinels are suppressed in the table detail, not in JSON.** Bugzilla
+   returns `target_milestone` as the literal `---` (its default "no milestone"
+   value), not null, so a naive row would print `Target Milestone: ---` on
+   nearly every bug. The detail view therefore omits the Target Milestone row
+   when the value is absent, empty, or `---`; likewise the Flags row is omitted
+   when there are no flags. JSON stays faithful — it carries the raw
+   `target_milestone` string (including `---`) and the full `Flag` objects
+   (including `setter`) — so machine consumers see exactly what the server
+   returned.
+
+## Consequences
+
+- `bug view` / `attachment view` now show flags and (for bugs) the target
+  milestone, in table and JSON. `bug view <id> --fields flags` returns the
+  flags. The deferred functional coverage for `--flag` /
+  `--target-milestone` (#350) is unblocked.
+- Two new selectable bug fields (`flags`, `target_milestone`) appear in
+  `--fields` / table columns. `docs/bzr-cli.md` and `CHANGELOG.md` are updated.
+- Additive only: no existing field changes shape. New fields default to empty /
+  null, so servers that omit them (or transports that don't return them) keep
+  working.
+
+## Considered & rejected
+
+- **Reuse `FlagUpdate` / `FlagStatus` for the view.** Rejected: `FlagStatus`
+  deserialization errors on any token outside `+ - ? X`, so an unexpected server
+  value would break the whole `bug view`. The read path must be lenient, and a
+  write-shaped type (with `requestee` but no `setter`) is the wrong shape for
+  display.
+- **Drop `flags` into `custom_fields` / `extra` generically.** Rejected: those
+  are typed for `cf_*` custom fields and render as opaque JSON blobs; `flags`
+  deserves a real typed field and a readable rendering.
+- **Surface every flag sub-field (`id`, `type_id`, dates).** Rejected as
+  speculative; `name`/`status`/`setter`/`requestee` are what a user reads.

--- a/schemas/attachment.json
+++ b/schemas/attachment.json
@@ -44,6 +44,18 @@
     "is_patch": {
       "type": "boolean"
     },
+    "flags": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "status": { "type": "string" },
+          "setter": { "type": ["string", "null"] },
+          "requestee": { "type": ["string", "null"] }
+        }
+      }
+    },
     "data": {
       "type": ["string", "null"]
     }
@@ -60,7 +72,8 @@
     "size",
     "is_obsolete",
     "is_private",
-    "is_patch"
+    "is_patch",
+    "flags"
   ],
   "additionalProperties": false
 }

--- a/schemas/bug.json
+++ b/schemas/bug.json
@@ -89,6 +89,21 @@
     },
     "rep_platform": {
       "type": ["string", "null"]
+    },
+    "target_milestone": {
+      "type": ["string", "null"]
+    },
+    "flags": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "status": { "type": "string" },
+          "setter": { "type": ["string", "null"] },
+          "requestee": { "type": ["string", "null"] }
+        }
+      }
     }
   },
   "required": [],

--- a/src/client/bug.rs
+++ b/src/client/bug.rs
@@ -15,7 +15,8 @@ use crate::types::{
 /// crash when serializing certain fields (e.g. group visibility) via the REST API.
 const BUG_DEFAULT_FIELDS: &str = "id,summary,status,resolution,dupe_of,product,component,version,\
     assigned_to,priority,severity,creation_time,last_change_time,creator,\
-    url,whiteboard,keywords,blocks,depends_on,cc,op_sys,rep_platform,deadline";
+    url,whiteboard,keywords,blocks,depends_on,cc,op_sys,rep_platform,deadline,\
+    target_milestone,flags";
 
 /// Ensure `id` is present in an include list and absent from an exclude list,
 /// so the non-defaulted `Bug.id` always deserializes. `None` include is left

--- a/src/client/bug_tests.rs
+++ b/src/client/bug_tests.rs
@@ -158,7 +158,7 @@ async fn get_bug_default_fields_include_bug_json_fields() {
         .and(path("/rest/bug/1"))
         .and(query_param(
             "include_fields",
-            "id,summary,status,resolution,dupe_of,product,component,version,assigned_to,priority,severity,creation_time,last_change_time,creator,url,whiteboard,keywords,blocks,depends_on,cc,op_sys,rep_platform,deadline",
+            "id,summary,status,resolution,dupe_of,product,component,version,assigned_to,priority,severity,creation_time,last_change_time,creator,url,whiteboard,keywords,blocks,depends_on,cc,op_sys,rep_platform,deadline,target_milestone,flags",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(
             serde_json::json!({"bugs": [{"id": 1, "summary": "test", "status": "NEW"}]}),

--- a/src/commands/bug/search_tests.rs
+++ b/src/commands/bug/search_tests.rs
@@ -96,7 +96,8 @@ async fn handle_search_from_url_does_not_infer_custom_fields_from_columnlist() {
     let default_fields = concat!(
         "id,summary,status,resolution,dupe_of,product,component,version,",
         "assigned_to,priority,severity,creation_time,last_change_time,creator,",
-        "url,whiteboard,keywords,blocks,depends_on,cc,op_sys,rep_platform,deadline"
+        "url,whiteboard,keywords,blocks,depends_on,cc,op_sys,rep_platform,deadline,",
+        "target_milestone,flags"
     );
 
     Mock::given(method("GET"))

--- a/src/output/formatting.rs
+++ b/src/output/formatting.rs
@@ -4,9 +4,20 @@ use colored::{ColoredString, Colorize};
 use serde::Serialize;
 use tabled::builder::Builder;
 
-use crate::types::OutputFormat;
+use crate::types::{Flag, OutputFormat};
 
 // ── Formatting primitives ───────────────────────────────────────────
+
+/// Join a bug or attachment's flags into the concise comma-separated
+/// `name<status>[(requestee)]` inline form used by table columns and detail
+/// rows on both resources.
+pub(super) fn render_flags_inline(flags: &[Flag]) -> String {
+    flags
+        .iter()
+        .map(Flag::render_inline)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
 
 pub(super) fn write_json<W: Write + ?Sized>(value: &(impl Serialize + ?Sized), out: &mut W) {
     let _ = writeln!(

--- a/src/output/resources/attachment.rs
+++ b/src/output/resources/attachment.rs
@@ -62,6 +62,15 @@ pub fn write_attachment<W: Write + ?Sized>(a: &Attachment, format: OutputFormat,
         write_optional_field(out, "Creator", a.creator.as_deref());
         write_optional_field(out, "Created", a.creation_time.as_deref());
         write_optional_field(out, "Modified", a.last_change_time.as_deref());
+        if !a.flags.is_empty() {
+            let rendered = a
+                .flags
+                .iter()
+                .map(crate::types::Flag::render_inline)
+                .collect::<Vec<_>>()
+                .join(", ");
+            write_field(out, "Flags", &rendered);
+        }
     });
 }
 

--- a/src/output/resources/attachment.rs
+++ b/src/output/resources/attachment.rs
@@ -3,7 +3,9 @@ use std::io::Write;
 use colored::Colorize;
 use serde::Serialize;
 
-use crate::output::formatting::{write_field, write_formatted, write_optional_field};
+use crate::output::formatting::{
+    render_flags_inline, write_field, write_formatted, write_optional_field,
+};
 use crate::types::{Attachment, OutputFormat};
 
 /// Write the colored `Attachment #<id> - <summary> [FLAGS]` header line.
@@ -63,13 +65,7 @@ pub fn write_attachment<W: Write + ?Sized>(a: &Attachment, format: OutputFormat,
         write_optional_field(out, "Created", a.creation_time.as_deref());
         write_optional_field(out, "Modified", a.last_change_time.as_deref());
         if !a.flags.is_empty() {
-            let rendered = a
-                .flags
-                .iter()
-                .map(crate::types::Flag::render_inline)
-                .collect::<Vec<_>>()
-                .join(", ");
-            write_field(out, "Flags", &rendered);
+            write_field(out, "Flags", &render_flags_inline(&a.flags));
         }
     });
 }

--- a/src/output/resources/attachment_tests.rs
+++ b/src/output/resources/attachment_tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::test_helpers::make_attachment;
-use crate::types::{Attachment, OutputFormat};
+use crate::types::{Attachment, Flag, OutputFormat};
 
 fn output_attachment(id: u64, summary: &str) -> Attachment {
     make_attachment(id, 42, &format!("file_{id}.patch"), summary, None)
@@ -22,6 +22,31 @@ fn capture_batch(format: OutputFormat, result: &AttachmentBatchResult) -> (Strin
         String::from_utf8(out).unwrap(),
         String::from_utf8(err).unwrap(),
     )
+}
+
+#[test]
+fn write_attachment_detail_shows_flags() {
+    let mut a = output_attachment(10, "Fix patch");
+    a.flags = vec![Flag {
+        name: "review".into(),
+        status: "+".into(),
+        setter: Some("alice@example.com".into()),
+        requestee: None,
+    }];
+    let mut buf = Vec::new();
+    write_attachment(&a, OutputFormat::Table, &mut buf);
+    let output = String::from_utf8(buf).unwrap();
+
+    assert!(output.contains("Flags"), "got: {output}");
+    assert!(output.contains("review+"), "got: {output}");
+}
+
+#[test]
+fn attachment_json_includes_flags_array() {
+    let a = output_attachment(10, "Fix patch");
+    let value = serde_json::to_value(&a).unwrap();
+    // flags is always present (empty -> []), so consumers can rely on the key.
+    assert_eq!(value["flags"], serde_json::json!([]));
 }
 
 #[test]
@@ -114,6 +139,7 @@ fn write_attachments_table_missing_optional_fields_render_dash() {
         is_obsolete: false,
         is_private: false,
         is_patch: false,
+        flags: Vec::new(),
         data: None,
     }];
     let output = capture(OutputFormat::Table, &attachments);

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -9,7 +9,7 @@ use crate::output::formatting::{
     colorize_status, shorten_email, truncate, write_divider, write_field, write_formatted,
     write_json_family, write_list_field, write_optional_field, SUMMARY_TRUNCATE_WIDTH,
 };
-use crate::types::{Bug, HistoryEntry, OutputFormat};
+use crate::types::{Bug, Flag, HistoryEntry, OutputFormat};
 
 /// Which fields the caller asked to include / exclude, as the raw
 /// comma-separated `--fields` / `--exclude-fields` values. `Default`
@@ -172,7 +172,31 @@ const COLUMNS: &[BugColumn] = &[
         header: "DUPE_OF",
         render: |b| b.dupe_of.map(|id| id.to_string()).unwrap_or_default(),
     },
+    BugColumn {
+        aliases: &["target_milestone", "milestone"],
+        header: "MILESTONE",
+        render: |b| b.target_milestone.clone().unwrap_or_default(),
+    },
+    BugColumn {
+        aliases: &["flags"],
+        header: "FLAGS",
+        render: |b| render_flags_inline(&b.flags),
+    },
 ];
+
+/// Join a bug or attachment's flags into the concise `name<status>[(requestee)]`
+/// inline form used by table columns and detail rows.
+fn render_flags_inline(flags: &[Flag]) -> String {
+    flags
+        .iter()
+        .map(Flag::render_inline)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Bugzilla's sentinel for "no target milestone set". Suppressed in detail
+/// output so a bug without a milestone does not print a noise row.
+const UNSET_MILESTONE: &str = "---";
 
 #[derive(Clone, Copy)]
 enum SelectedBugField<'a> {
@@ -590,6 +614,13 @@ fn write_bug_detail_table(bug: &Bug, spec: ColumnSpec<'_>, out: &mut (impl Write
     if field_selected(spec, "component") {
         write_optional_field(out, "Component", bug.component.as_deref());
     }
+    if field_selected(spec, "target_milestone") {
+        if let Some(milestone) = bug.target_milestone.as_deref() {
+            if !milestone.is_empty() && milestone != UNSET_MILESTONE {
+                write_field(out, "Target Milestone", milestone);
+            }
+        }
+    }
     if field_selected(spec, "assigned_to") {
         write_optional_field(out, "Assignee", bug.assigned_to.as_deref());
     }
@@ -616,6 +647,9 @@ fn write_bug_detail_table(bug: &Bug, spec: ColumnSpec<'_>, out: &mut (impl Write
     }
     if field_selected(spec, "depends_on") {
         write_id_list_field(out, "Depends on", &bug.depends_on);
+    }
+    if field_selected(spec, "flags") && !bug.flags.is_empty() {
+        write_field(out, "Flags", &render_flags_inline(&bug.flags));
     }
     for name in selected_custom_detail_fields(spec) {
         write_field(out, name, &render_custom_value(bug.custom_fields.get(name)));

--- a/src/output/resources/bug.rs
+++ b/src/output/resources/bug.rs
@@ -6,10 +6,11 @@ use serde_json::Value;
 use tabled::builder::Builder;
 
 use crate::output::formatting::{
-    colorize_status, shorten_email, truncate, write_divider, write_field, write_formatted,
-    write_json_family, write_list_field, write_optional_field, SUMMARY_TRUNCATE_WIDTH,
+    colorize_status, render_flags_inline, shorten_email, truncate, write_divider, write_field,
+    write_formatted, write_json_family, write_list_field, write_optional_field,
+    SUMMARY_TRUNCATE_WIDTH,
 };
-use crate::types::{Bug, Flag, HistoryEntry, OutputFormat};
+use crate::types::{Bug, HistoryEntry, OutputFormat};
 
 /// Which fields the caller asked to include / exclude, as the raw
 /// comma-separated `--fields` / `--exclude-fields` values. `Default`
@@ -183,16 +184,6 @@ const COLUMNS: &[BugColumn] = &[
         render: |b| render_flags_inline(&b.flags),
     },
 ];
-
-/// Join a bug or attachment's flags into the concise `name<status>[(requestee)]`
-/// inline form used by table columns and detail rows.
-fn render_flags_inline(flags: &[Flag]) -> String {
-    flags
-        .iter()
-        .map(Flag::render_inline)
-        .collect::<Vec<_>>()
-        .join(", ")
-}
 
 /// Bugzilla's sentinel for "no target milestone set". Suppressed in detail
 /// output so a bug without a milestone does not print a noise row.
@@ -615,10 +606,9 @@ fn write_bug_detail_table(bug: &Bug, spec: ColumnSpec<'_>, out: &mut (impl Write
         write_optional_field(out, "Component", bug.component.as_deref());
     }
     if field_selected(spec, "target_milestone") {
-        if let Some(milestone) = bug.target_milestone.as_deref() {
-            if !milestone.is_empty() && milestone != UNSET_MILESTONE {
-                write_field(out, "Target Milestone", milestone);
-            }
+        let milestone = bug.target_milestone.as_deref().unwrap_or_default();
+        if !milestone.is_empty() && milestone != UNSET_MILESTONE {
+            write_field(out, "Target Milestone", milestone);
         }
     }
     if field_selected(spec, "assigned_to") {

--- a/src/output/resources/bug_tests.rs
+++ b/src/output/resources/bug_tests.rs
@@ -1,7 +1,16 @@
 #![expect(clippy::unwrap_used)]
 
 use super::*;
-use crate::types::{Bug, FieldChange, HistoryEntry};
+use crate::types::{Bug, FieldChange, Flag, HistoryEntry};
+
+fn review_flag(status: &str, requestee: Option<&str>) -> Flag {
+    Flag {
+        name: "review".into(),
+        status: status.into(),
+        setter: Some("alice@example.com".into()),
+        requestee: requestee.map(Into::into),
+    }
+}
 
 fn make_bug(id: u64, summary: &str, status: &str) -> Bug {
     Bug {
@@ -28,6 +37,8 @@ fn make_bug(id: u64, summary: &str, status: &str) -> Bug {
         cc: vec!["watcher@example.com".into()],
         op_sys: None,
         rep_platform: None,
+        target_milestone: None,
+        flags: Vec::new(),
         custom_fields: std::collections::BTreeMap::new(),
     }
 }
@@ -428,6 +439,63 @@ fn write_bug_detail_table_renders_all_fields() {
 }
 
 #[test]
+fn write_bug_detail_table_shows_flags_and_milestone() {
+    let mut bug = make_bug(7, "has flags", "NEW");
+    bug.target_milestone = Some("9.0".into());
+    bug.flags = vec![
+        review_flag("+", None),
+        review_flag("?", Some("bob@example.com")),
+    ];
+    let mut out = Vec::new();
+
+    write_bug_detail(&bug, ColumnSpec::default(), OutputFormat::Table, &mut out);
+    let output = String::from_utf8(out).unwrap();
+
+    assert!(output.contains("Target Milestone"), "got: {output}");
+    assert!(output.contains("9.0"));
+    assert!(output.contains("Flags"));
+    assert!(output.contains("review+"), "got: {output}");
+    assert!(output.contains("review?(bob@example.com)"), "got: {output}");
+}
+
+#[test]
+fn write_bug_detail_table_suppresses_unset_milestone_and_empty_flags() {
+    let mut bug = make_bug(7, "no milestone", "NEW");
+    bug.target_milestone = Some("---".into());
+    // flags left empty
+    let mut out = Vec::new();
+
+    write_bug_detail(&bug, ColumnSpec::default(), OutputFormat::Table, &mut out);
+    let output = String::from_utf8(out).unwrap();
+
+    assert!(
+        !output.contains("Target Milestone"),
+        "should suppress ---: {output}"
+    );
+    assert!(
+        !output.contains("Flags"),
+        "should suppress empty flags: {output}"
+    );
+}
+
+#[test]
+fn bug_to_json_keeps_flags_when_selected() {
+    let mut bug = make_bug(7, "s", "NEW");
+    bug.flags = vec![review_flag("+", None)];
+    let spec = ColumnSpec::new(Some("id,flags"), None);
+
+    let value = bug_to_json(&bug, spec);
+    let map = value.as_object().unwrap();
+
+    assert!(map.contains_key("id"));
+    assert!(map.contains_key("flags"));
+    assert_eq!(map["flags"][0]["name"], "review");
+    // Trimmed to the selection: summary and status are gone.
+    assert!(!map.contains_key("summary"));
+    assert!(!map.contains_key("status"));
+}
+
+#[test]
 fn write_bug_detail_table_shows_dupe_of() {
     let bug = crate::types::Bug {
         id: 42,
@@ -453,6 +521,8 @@ fn write_bug_detail_table_shows_dupe_of() {
         cc: vec![],
         op_sys: None,
         rep_platform: None,
+        target_milestone: None,
+        flags: Vec::new(),
         custom_fields: std::collections::BTreeMap::new(),
     };
     let mut out = Vec::new();
@@ -495,6 +565,8 @@ fn write_bug_detail_table_handles_minimal_bug() {
         cc: vec![],
         op_sys: None,
         rep_platform: None,
+        target_milestone: None,
+        flags: Vec::new(),
         custom_fields: std::collections::BTreeMap::new(),
     };
     let output = capture_bug_detail(OutputFormat::Table, &bug);
@@ -690,6 +762,8 @@ fn sample_bug(id: u64, summary: &str) -> Bug {
         cc: vec![],
         op_sys: None,
         rep_platform: None,
+        target_milestone: None,
+        flags: Vec::new(),
         custom_fields: std::collections::BTreeMap::new(),
     }
 }
@@ -841,7 +915,7 @@ fn validate_table_columns_ok_for_all_blank_include() {
 /// The serde key sequence of `Bug`, in struct-declaration order. Locks the
 /// `preserve_order` decision (Finding 4) and is the reference for the registry
 /// drift guard (Finding 3).
-const BUG_STRUCT_KEY_ORDER: [&str; 23] = [
+const BUG_STRUCT_KEY_ORDER: [&str; 25] = [
     "id",
     "summary",
     "status",
@@ -865,6 +939,8 @@ const BUG_STRUCT_KEY_ORDER: [&str; 23] = [
     "cc",
     "op_sys",
     "rep_platform",
+    "target_milestone",
+    "flags",
 ];
 
 fn keys_of(value: &serde_json::Value) -> Vec<String> {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -84,6 +84,7 @@ pub fn make_attachment(
         is_obsolete: false,
         is_private: false,
         is_patch: false,
+        flags: Vec::new(),
         data,
     }
 }

--- a/src/types/attachment.rs
+++ b/src/types/attachment.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Deserializer, Serialize};
 
-use super::common::FlagUpdate;
+use super::common::{Flag, FlagUpdate};
 
 /// Deserialize a boolean that may arrive as an integer (0/1) from Bugzilla 5.0.
 fn bool_from_int_or_bool<'de, D: Deserializer<'de>>(d: D) -> Result<bool, D::Error> {
@@ -42,6 +42,8 @@ pub struct Attachment {
     pub is_private: bool,
     #[serde(default, deserialize_with = "bool_from_int_or_bool")]
     pub is_patch: bool,
+    #[serde(default)]
+    pub flags: Vec<Flag>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
 }

--- a/src/types/attachment_tests.rs
+++ b/src/types/attachment_tests.rs
@@ -3,6 +3,22 @@
 use super::*;
 
 #[test]
+fn attachment_deserializes_flags_and_defaults_empty() {
+    let with = r#"{"id":1,"bug_id":10,"flags":[{"name":"review","status":"+","setter":"a@x"}]}"#;
+    let att: Attachment = serde_json::from_str(with).unwrap();
+    assert_eq!(att.flags.len(), 1);
+    assert_eq!(att.flags[0].name, "review");
+    assert_eq!(att.flags[0].status, "+");
+    assert_eq!(att.flags[0].setter.as_deref(), Some("a@x"));
+
+    let without: Attachment = serde_json::from_str(r#"{"id":2,"bug_id":10}"#).unwrap();
+    assert!(without.flags.is_empty());
+    // flags serializes always as an array so consumers can rely on the key.
+    let value = serde_json::to_value(&without).unwrap();
+    assert_eq!(value["flags"], serde_json::json!([]));
+}
+
+#[test]
 fn bool_from_int_or_bool_deserializes_true() {
     let json = r#"{"id":1,"bug_id":10,"is_obsolete":true,"is_private":false}"#;
     let att: Attachment = serde_json::from_str(json).unwrap();

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -4,9 +4,9 @@ use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
-use super::common::FlagUpdate;
+use super::common::{Flag, FlagUpdate};
 
-const BUG_BUILT_IN_FIELD_COUNT: usize = 23;
+const BUG_BUILT_IN_FIELD_COUNT: usize = 25;
 
 fn is_custom_field_name(name: &str) -> bool {
     name.starts_with("cf_")
@@ -66,6 +66,8 @@ pub struct Bug {
     pub cc: Vec<String>,
     pub op_sys: Option<String>,
     pub rep_platform: Option<String>,
+    pub target_milestone: Option<String>,
+    pub flags: Vec<Flag>,
     pub custom_fields: BTreeMap<String, Value>,
 }
 
@@ -116,6 +118,10 @@ struct BugWire {
     op_sys: Option<String>,
     #[serde(default)]
     rep_platform: Option<String>,
+    #[serde(default)]
+    target_milestone: Option<String>,
+    #[serde(default)]
+    flags: Vec<Flag>,
     #[serde(flatten)]
     extra: BTreeMap<String, Value>,
 }
@@ -146,6 +152,8 @@ impl From<BugWire> for Bug {
             cc: wire.cc,
             op_sys: wire.op_sys,
             rep_platform: wire.rep_platform,
+            target_milestone: wire.target_milestone,
+            flags: wire.flags,
             custom_fields: wire
                 .extra
                 .into_iter()
@@ -199,6 +207,8 @@ impl Serialize for Bug {
         map.serialize_entry("cc", &self.cc)?;
         map.serialize_entry("op_sys", &self.op_sys)?;
         map.serialize_entry("rep_platform", &self.rep_platform)?;
+        map.serialize_entry("target_milestone", &self.target_milestone)?;
+        map.serialize_entry("flags", &self.flags)?;
         for (name, value) in self
             .custom_fields
             .iter()

--- a/src/types/bug_tests.rs
+++ b/src/types/bug_tests.rs
@@ -32,6 +32,62 @@ fn bug_deserializes_deadline() {
 }
 
 #[test]
+fn bug_deserializes_target_milestone_and_flags() {
+    let json = r#"{
+        "id": 42,
+        "target_milestone": "9.0",
+        "flags": [
+            {"name": "review", "status": "+", "setter": "alice@example.com"},
+            {"name": "needinfo", "status": "?", "requestee": "bob@example.com"}
+        ]
+    }"#;
+    let bug: Bug = serde_json::from_str(json).unwrap();
+
+    assert_eq!(bug.target_milestone.as_deref(), Some("9.0"));
+    assert_eq!(bug.flags.len(), 2);
+    assert_eq!(bug.flags[0].name, "review");
+    assert_eq!(bug.flags[0].status, "+");
+    assert_eq!(bug.flags[0].setter.as_deref(), Some("alice@example.com"));
+    assert_eq!(bug.flags[1].status, "?");
+    assert_eq!(bug.flags[1].requestee.as_deref(), Some("bob@example.com"));
+}
+
+#[test]
+fn bug_without_flags_defaults_to_empty_and_serializes_array() {
+    let bug: Bug = serde_json::from_str(r#"{"id": 42}"#).unwrap();
+    assert!(bug.flags.is_empty());
+    assert!(bug.target_milestone.is_none());
+
+    let serialized = serde_json::to_value(&bug).unwrap();
+    // flags is always present as an array (empty -> []), target_milestone null.
+    assert_eq!(serialized["flags"], serde_json::json!([]));
+    assert!(serialized["target_milestone"].is_null());
+}
+
+#[test]
+fn bug_serializes_flags_and_target_milestone() {
+    let json =
+        r#"{"id": 7, "target_milestone": "---", "flags": [{"name": "review", "status": "+"}]}"#;
+    let bug: Bug = serde_json::from_str(json).unwrap();
+    let serialized = serde_json::to_value(&bug).unwrap();
+
+    // JSON stays faithful: the raw "---" sentinel is preserved (only the table
+    // detail suppresses it).
+    assert_eq!(serialized["target_milestone"], "---");
+    assert_eq!(serialized["flags"][0]["name"], "review");
+    assert_eq!(serialized["flags"][0]["status"], "+");
+}
+
+#[test]
+fn flag_with_unexpected_status_token_still_deserializes() {
+    // The read-side Flag.status is a plain String, so a token the FlagStatus
+    // enum does not model must not break bug view.
+    let json = r#"{"id": 1, "flags": [{"name": "weird", "status": "??"}]}"#;
+    let bug: Bug = serde_json::from_str(json).unwrap();
+    assert_eq!(bug.flags[0].status, "??");
+}
+
+#[test]
 fn bug_deserializes_custom_fields() {
     let json = r#"{"id": 42, "summary": "s", "cf_release": "9.6"}"#;
     let bug: Bug = serde_json::from_str(json).unwrap();

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -202,6 +202,38 @@ pub struct FlagUpdate {
     pub requestee: Option<String>,
 }
 
+/// A flag as returned on a bug or attachment view response.
+///
+/// Distinct from the write-side [`FlagUpdate`]: `status` is the raw server
+/// token (`"+"`, `"-"`, `"?"`) kept as a plain `String` so an unexpected value
+/// cannot make a view fail to deserialize, and `setter` (who set the flag) is
+/// surfaced. Every field defaults so a server that omits one still parses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Flag {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub setter: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requestee: Option<String>,
+}
+
+impl Flag {
+    /// Concise one-line rendering for table/detail output, symmetric with the
+    /// `name?(user@example.com)` flag-input syntax: `name` + status token, with
+    /// the requestee in parentheses when present (e.g. `review?`, `review+`,
+    /// `review?(bob@example.com)`).
+    pub fn render_inline(&self) -> String {
+        match &self.requestee {
+            Some(requestee) => format!("{}{}({requestee})", self.name, self.status),
+            None => format!("{}{}", self.name, self.status),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ServerVersion {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,8 +17,8 @@ pub use bug::{
 pub use classification::{Classification, ClassificationProduct};
 pub use comment::{Comment, UpdateCommentTagsParams};
 pub use common::{
-    ApiMode, AuthMethod, ExtensionInfo, FlagStatus, FlagUpdate, OutputFormat, ServerExtensions,
-    ServerInfoResponse, ServerVersion, SortDirection,
+    ApiMode, AuthMethod, ExtensionInfo, Flag, FlagStatus, FlagUpdate, OutputFormat,
+    ServerExtensions, ServerInfoResponse, ServerVersion, SortDirection,
 };
 pub use component::{Component, CreateComponentParams, UpdateComponentParams};
 pub use group::{CreateGroupParams, GroupInfo, GroupMember, UpdateGroupParams};

--- a/src/xmlrpc/attachment.rs
+++ b/src/xmlrpc/attachment.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use crate::error::{BzrError, Result};
 use crate::xmlrpc::client::XmlRpcClient;
 use crate::xmlrpc::mappers::{
-    get_bool_flag, get_datetime_str, get_nonempty_str, get_str, get_u64, lookup_bug_entry,
-    require_u64, EXPECTED_STRUCT_RESPONSE,
+    get_bool_flag, get_datetime_str, get_flags, get_nonempty_str, get_str, get_u64,
+    lookup_bug_entry, require_u64, EXPECTED_STRUCT_RESPONSE,
 };
 use crate::xmlrpc::value::Value;
 
@@ -127,6 +127,7 @@ fn value_to_attachment(val: &Value) -> Result<crate::types::Attachment> {
         is_obsolete: get_bool_flag(m, "is_obsolete"),
         is_private: get_bool_flag(m, "is_private"),
         is_patch: get_bool_flag(m, "is_patch"),
+        flags: get_flags(m, "flags"),
         data,
     })
 }

--- a/src/xmlrpc/bug.rs
+++ b/src/xmlrpc/bug.rs
@@ -4,7 +4,7 @@ use crate::error::{BzrError, Result};
 use crate::types::{partition_filters, Bug, SearchParams, FIELD_MAPPINGS};
 use crate::xmlrpc::client::XmlRpcClient;
 use crate::xmlrpc::mappers::{
-    get_datetime_str, get_int_array, get_nonempty_str, get_str, get_str_array, get_u64,
+    get_datetime_str, get_flags, get_int_array, get_nonempty_str, get_str, get_str_array, get_u64,
     require_u64, xmlrpc_value_to_json, EXPECTED_STRUCT_RESPONSE,
 };
 use crate::xmlrpc::value::Value;
@@ -152,6 +152,8 @@ fn value_to_bug(val: &Value) -> Result<Bug> {
         cc: get_str_array(m, "cc"),
         op_sys: get_nonempty_str(m, "op_sys"),
         rep_platform: get_nonempty_str(m, "rep_platform"),
+        target_milestone: get_nonempty_str(m, "target_milestone"),
+        flags: get_flags(m, "flags"),
         custom_fields: custom_fields_from_xmlrpc(m),
     })
 }

--- a/src/xmlrpc/mappers.rs
+++ b/src/xmlrpc/mappers.rs
@@ -73,6 +73,27 @@ pub(crate) fn get_str_array(m: &BTreeMap<String, Value>, key: &str) -> Vec<Strin
         .unwrap_or_default()
 }
 
+/// Parse a `flags` array of flag structs into view-side [`Flag`] objects.
+/// Non-struct array elements are skipped; missing members default (name/status
+/// to empty, setter/requestee to `None`), matching the REST deserializer's
+/// tolerance.
+pub(crate) fn get_flags(m: &BTreeMap<String, Value>, key: &str) -> Vec<crate::types::Flag> {
+    m.get(key)
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(Value::as_struct)
+                .map(|fm| crate::types::Flag {
+                    name: get_str(fm, "name").unwrap_or_default(),
+                    status: get_str(fm, "status").unwrap_or_default(),
+                    setter: get_nonempty_str(fm, "setter"),
+                    requestee: get_nonempty_str(fm, "requestee"),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 pub(crate) fn get_int_array(m: &BTreeMap<String, Value>, key: &str) -> Vec<u64> {
     m.get(key)
         .and_then(Value::as_array)

--- a/src/xmlrpc/mappers_tests.rs
+++ b/src/xmlrpc/mappers_tests.rs
@@ -1,8 +1,33 @@
 use std::collections::BTreeMap;
 
-use super::{get_datetime_str, get_int_array, get_nonempty_str, get_str_array, require_u64};
+use super::{
+    get_datetime_str, get_flags, get_int_array, get_nonempty_str, get_str_array, require_u64,
+};
 use crate::error::BzrError;
 use crate::xmlrpc::value::Value;
+
+#[test]
+fn get_flags_parses_structs_and_skips_non_structs() {
+    let mut flag = BTreeMap::new();
+    flag.insert("name".into(), Value::String("review".into()));
+    flag.insert("status".into(), Value::String("+".into()));
+    flag.insert("setter".into(), Value::String("alice@example.com".into()));
+
+    let mut m = BTreeMap::new();
+    m.insert(
+        "flags".into(),
+        Value::Array(vec![Value::Struct(flag), Value::Int(7)]),
+    );
+
+    let flags = get_flags(&m, "flags");
+    assert_eq!(flags.len(), 1, "non-struct element should be skipped");
+    assert_eq!(flags[0].name, "review");
+    assert_eq!(flags[0].status, "+");
+    assert_eq!(flags[0].setter.as_deref(), Some("alice@example.com"));
+    assert!(flags[0].requestee.is_none());
+
+    assert!(get_flags(&m, "missing").is_empty());
+}
 
 #[test]
 fn get_nonempty_str_filters_empty_and_non_string() {


### PR DESCRIPTION
## Summary

`bug view` did not surface `flags` or `target_milestone`, and `attachment view`
did not surface `flags`, even though the Bugzilla REST API returns them — values
set via `--flag` / `--target-milestone` were written but invisible. This adds
them to the view types and output.

## Changes

- New read-side `Flag` type (`types/common.rs`), distinct from the write-side
  `FlagUpdate`: `status` is a plain `String` (tolerant of any server token) and
  `setter` is surfaced. All fields default so a server that omits one still
  parses.
- `flags` + `target_milestone` added to the view `Bug` (struct, wire, `From`,
  manual `Serialize`); `flags` added to the view `Attachment`. Both populated
  from REST and parsed from XML-RPC (`xmlrpc/mappers.rs::get_flags`).
- `BUG_DEFAULT_FIELDS` extended so a default `bug view` (no `--fields`) actually
  receives the data; both fields are registered as selectable columns so
  `bug view <id> --fields flags` works.
- Table detail renders flags as `name<status>[(requestee)]` (e.g. `review+`,
  `review?(bob@example.com)`) and a Target Milestone row, suppressing the unset
  `---` milestone sentinel and empty flag lists. JSON stays faithful (raw
  `target_milestone`, full flag objects including `setter`).

Decision recorded in `docs/decisions/0003-surface-view-flags-and-target-milestone.md`.

## Testing

- `cargo test` green; new tests cover deserialization (incl. an unexpected
  status token), serialization (empty `[]`, null milestone, raw `---`), table
  rendering, `---`/empty suppression, the `--fields flags` round-trip, attachment
  flags, and the XML-RPC `get_flags` parser.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`,
  `make check-test-layout`, and the agent-skills flag-drift check all pass.
- `schemas/bug.json` and `schemas/attachment.json` updated for the new fields.

## Compatibility

Additive: new fields default to empty/null, so servers that omit them keep
working. `bug list --json` now additively includes `flags` and
`target_milestone` per row. Documented in `CHANGELOG.md`. Unblocks the deferred
`--flag` / `--target-milestone` functional coverage noted in #350.

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)