### PR TITLE
test: cover untested branches found by mutation testing

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -127,4 +127,13 @@ exclude_re = [
     'delete match arm BzrError::Http\(re\) in classify_and_handle_tls_failure',
     # `handle_tofu` and `handle_pin_rotation` are skipped via
     # `#[cfg_attr(test, mutants::skip)]` in src/commands/shared.rs.
+    # The `--paginate` safety-cap warning in src/commands/runtime/paging.rs
+    # only fires when `fetch_all_pages` runs all MAX_PAGES (10_000) iterations
+    # without a short page — a server that ignores `offset`. Reaching it in a
+    # unit test would require 10_000 full-page mock responses, and its sole
+    # effect is a `tracing::warn!` with no return-value or writer impact (same
+    # untestable-side-effect category as the warn_* family above). Deleting the
+    # `!` so the warning fires on the normal path instead is observationally
+    # equivalent under any feasible test.
+    'delete ! in fetch_all_pages',
 ]

--- a/src/commands/bug/create_tests.rs
+++ b/src/commands/bug/create_tests.rs
@@ -1223,3 +1223,181 @@ async fn from_json_batch_dry_run_emits_single_object_and_no_write() {
     assert_eq!(parsed["action"], "dry-run");
     assert_eq!(parsed["changes"].as_array().unwrap().len(), 2);
 }
+
+#[test]
+fn preview_params_propagates_every_merged_field() {
+    // The editor preview is built from MergedFields::preview_params. Every
+    // resolved field must flow into the CreateBugParams the editor template
+    // renders; dropping any one (or replacing the whole body with a default)
+    // would silently show the user a blank field in the $EDITOR buffer.
+    let merged = super::MergedFields {
+        product: "Prod".into(),
+        component: "Comp".into(),
+        version: Some("9.9".into()),
+        priority: Some("P1".into()),
+        severity: Some("blocker".into()),
+        assigned_to: Some("dev@example.com".into()),
+        op_sys: Some("Linux".into()),
+        rep_platform: Some("ARM".into()),
+        template_description: None,
+    };
+
+    let p = merged.preview_params();
+
+    assert_eq!(p.product, "Prod");
+    assert_eq!(p.component, "Comp");
+    assert_eq!(p.version, "9.9");
+    assert_eq!(p.priority.as_deref(), Some("P1"));
+    assert_eq!(p.severity.as_deref(), Some("blocker"));
+    assert_eq!(p.assigned_to.as_deref(), Some("dev@example.com"));
+    assert_eq!(p.op_sys.as_deref(), Some("Linux"));
+    assert_eq!(p.rep_platform.as_deref(), Some("ARM"));
+}
+
+#[tokio::test]
+async fn run_editor_flow_returns_parsed_editor_output() {
+    // run_editor_flow renders the template, launches $EDITOR, and parses the
+    // buffer back into (summary, description). The TTY gate that decides
+    // *whether* to enter the editor lives a layer up in `handle`, so this
+    // function is exercisable directly with a fake editor — no terminal needed.
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    let script = install_fake_editor();
+    let prev = std::env::var("EDITOR").ok();
+    // SAFETY: setup_test_env holds bzr::ENV_LOCK for the test duration,
+    // serializing env access across all tests that use it.
+    unsafe { std::env::set_var("EDITOR", &script) };
+
+    let merged = super::MergedFields {
+        product: "Prod".into(),
+        component: "Comp".into(),
+        version: None,
+        priority: None,
+        severity: None,
+        assigned_to: None,
+        op_sys: None,
+        rep_platform: None,
+        template_description: None,
+    };
+    let result = super::run_editor_flow(Some("Pre-fill"), &merged);
+
+    // SAFETY: see above.
+    unsafe {
+        if let Some(p) = prev {
+            std::env::set_var("EDITOR", p);
+        } else {
+            std::env::remove_var("EDITOR");
+        }
+    }
+    let _ = std::fs::remove_file(&script);
+
+    let (summary, description) = result.unwrap();
+    assert_eq!(summary, "Editor summary");
+    assert_eq!(description, "Editor description");
+}
+
+#[test]
+fn build_editor_template_separates_no_newline_body_from_sentinel() {
+    use crate::types::CreateBugParams;
+    let params = CreateBugParams {
+        product: "P".into(),
+        component: "C".into(),
+        version: "1".into(),
+        ..Default::default()
+    };
+    // The body has no trailing newline; the renderer must add one so a blank
+    // line sits between the body and the sentinel. The `delete !` mutant drops
+    // that, butting the body directly against the sentinel line.
+    let buf = super::build_editor_template(None, Some("Body line"), &params);
+    assert!(
+        buf.contains("Body line\n\n"),
+        "a blank line must follow a body lacking its own trailing newline, got: {buf:?}"
+    );
+}
+
+#[tokio::test]
+async fn from_json_cli_description_overrides_json_description() {
+    // explicit_description resolves --description for the JSON path; a supplied
+    // value must overwrite the JSON `description`. Mutants that always return
+    // None / a constant would let the JSON value through (or inject garbage).
+    let (_lock, mock, tmp) = setup_test_env().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .and(body_string_contains("\"description\":\"cli-desc\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 9})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let json = r#"{"product":"P","component":"C","summary":"S","description":"json-desc"}"#;
+    let mut action = from_json_action(&write_json_file(&tmp, json));
+    if let BugAction::Create(crate::cli::CreateArgs { description, .. }) = &mut action {
+        *description = Some("cli-desc".into());
+    }
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    assert!(
+        result.is_ok(),
+        "CLI --description must override the JSON description on the wire: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn from_json_preserves_blocks_and_depends_on_without_cli_override() {
+    // overlay_cli keeps the JSON `blocks`/`depends_on` when no --blocks/
+    // --depends-on flag is supplied (the `!is_empty()` guards). The `delete !`
+    // mutants invert that, clobbering the JSON arrays with the empty CLI vecs.
+    let (_lock, mock, tmp) = setup_test_env().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .and(body_string_contains("\"blocks\":[10,20]"))
+        .and(body_string_contains("\"depends_on\":[30]"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 12})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let json =
+        r#"{"product":"P","component":"C","summary":"S","blocks":[10,20],"depends_on":[30]}"#;
+    let action = from_json_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    assert!(
+        result.is_ok(),
+        "JSON blocks/depends_on must reach the wire unchanged: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn from_json_batch_table_lists_created_ids() {
+    // The table-mode batch summary prints "Created bugs: …" only when at least
+    // one bug was created (`!created.is_empty()`). The `delete !` mutant inverts
+    // the guard, suppressing the line on a successful batch.
+    let (_lock, mock, tmp) = setup_test_env().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 11})))
+        .expect(2)
+        .mount(&mock)
+        .await;
+
+    let json = r#"[{"product":"P","component":"C","summary":"one"},
+                   {"product":"P","component":"C","summary":"two"}]"#;
+    let action = from_json_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Table, None, &mut io.writers())
+            .await;
+    assert!(
+        result.is_ok(),
+        "table batch create should succeed: {result:?}"
+    );
+    assert!(
+        io.out_str().contains("Created bugs: #11"),
+        "table output must list the created ids, got: {:?}",
+        io.out_str()
+    );
+}

--- a/src/commands/query_tests.rs
+++ b/src/commands/query_tests.rs
@@ -1727,3 +1727,76 @@ async fn query_update_sets_dates_and_sort() {
     assert!(q.last_change_time.is_some());
     assert!(q.order.is_some());
 }
+
+#[tokio::test]
+async fn query_update_only_product_is_a_change() {
+    // Updating ONLY --product must register as a change. apply_query_updates
+    // starts `changed = false` and ORs in each merge result; the `&=` mutant on
+    // the product line would keep `changed` false and the update would be
+    // rejected as "no changes". product/component are the only merge_vec fields
+    // without a sole-field update test, so this closes that coverage gap.
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run_q(&save_action("q")).await.unwrap(); // product=Firefox, status=NEW
+
+    let mut a = empty_update("q");
+    if let QueryAction::Update(UpdateArgs { product, .. }) = &mut a {
+        *product = vec!["Thunderbird".into()];
+    }
+    run_q(&a).await.unwrap(); // must NOT fail with "no changes"
+
+    let config = Config::load().unwrap();
+    assert_eq!(
+        config.queries["q"].product,
+        vec!["Thunderbird".to_string()],
+        "a sole --product update must be applied"
+    );
+}
+
+#[tokio::test]
+async fn query_update_only_component_is_a_change() {
+    // Companion to the product case: a sole --component update must also count
+    // as a change. The `&=` mutant on the component line would swallow it.
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run_q(&save_action("q")).await.unwrap();
+
+    let mut a = empty_update("q");
+    if let QueryAction::Update(UpdateArgs { component, .. }) = &mut a {
+        *component = vec!["General".into()];
+    }
+    run_q(&a).await.unwrap();
+
+    let config = Config::load().unwrap();
+    assert_eq!(
+        config.queries["q"].component,
+        vec!["General".to_string()],
+        "a sole --component update must be applied"
+    );
+}
+
+#[tokio::test]
+async fn query_run_without_sort_keeps_saved_order() {
+    // A saved query carrying an explicit order must keep it when `run` is
+    // invoked without --sort. The bug_id default must fire only when the saved
+    // order is absent AND no raw `order` param exists (`&&`). The `||` mutant
+    // would clobber the saved order with the default whenever there is no raw
+    // order param — exactly the common case of a structured saved query.
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    let mut save = product_save_action("ordered", "TestProduct", 10);
+    if let QueryAction::Save(SaveArgs { sort_args, .. }) = &mut save {
+        sort_args.sort = Some("last_change_time".into());
+        sort_args.order = crate::types::SortDirection::Desc;
+    }
+    run_q(&save).await.unwrap();
+
+    // The wire must carry the SAVED order, not the bug_id default.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("order", "last_change_time DESC, bug_id"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    run_q(&run_action("ordered")).await.unwrap();
+}

--- a/src/commands/runtime/paging_tests.rs
+++ b/src/commands/runtime/paging_tests.rs
@@ -3,7 +3,7 @@
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use super::{fetch_page, write_truncation_note, Page};
+use super::{fetch_page, resolve_offset, write_truncation_note, Page};
 use crate::client::test_helpers::test_client;
 use crate::types::{Bug, OutputFormat, SearchParams};
 
@@ -144,4 +144,102 @@ fn truncation_note_noop_when_not_truncated() {
     );
     assert!(io.out_str().is_empty());
     assert!(io.err_str().is_empty());
+}
+
+#[test]
+fn resolve_offset_folds_url_offset_into_field() {
+    // A `--from-url` import (or a saved query from one) leaves `offset=` sitting
+    // in `raw_params`. `resolve_offset` must match that *specific* key, fold its
+    // value into the struct field, and strip the raw copy so the request never
+    // sends two conflicting `offset` params. Matching "any param except offset"
+    // (the `k != "offset"` mutant) would leave the field unset.
+    let mut params = SearchParams {
+        raw_params: vec![("offset".to_string(), "5".to_string())],
+        ..Default::default()
+    };
+
+    resolve_offset(&mut params, None);
+
+    assert_eq!(
+        params.offset,
+        Some(5),
+        "the url's offset=5 must be folded into the structured field"
+    );
+    assert!(
+        !params.raw_params.iter().any(|(k, _)| k == "offset"),
+        "the raw offset copy must be stripped to avoid a duplicate query param"
+    );
+}
+
+#[test]
+fn resolve_offset_cli_overrides_url() {
+    // An explicit `--offset` on the command line wins over a url-carried offset.
+    let mut params = SearchParams {
+        raw_params: vec![("offset".to_string(), "5".to_string())],
+        ..Default::default()
+    };
+
+    resolve_offset(&mut params, Some(9));
+
+    assert_eq!(
+        params.offset,
+        Some(9),
+        "explicit --offset 9 overrides url offset=5"
+    );
+}
+
+#[tokio::test]
+async fn fetch_page_exact_fill_is_not_truncated() {
+    let mock = MockServer::start().await;
+    // limit 2 → over-fetch requests limit=3, but the server has exactly 2 rows.
+    // The window is filled precisely with nothing beyond it: `len > limit` is
+    // false. The `>=` mutant would read 2 >= 2 as "more available" and wrongly
+    // flag truncation. This is the off-by-one boundary the other tests skip
+    // (they return strictly more, or strictly fewer, than the limit).
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("limit", "3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(bugs_body(2)))
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let page = fetch_page(&client, &params_with_limit(2), false)
+        .await
+        .unwrap();
+
+    assert!(
+        !page.truncated,
+        "exactly `limit` rows means the window is full with nothing beyond it"
+    );
+    assert_eq!(page.bugs.len(), 2);
+}
+
+#[tokio::test]
+async fn fetch_page_paginate_zero_limit_makes_single_unbounded_request() {
+    let mock = MockServer::start().await;
+    // A zero limit means "no window": `--paginate` must collapse to one
+    // unbounded request rather than entering the offset-stepping loop. The
+    // `*l > 0` guard filters the 0 out. The `*l >= 0` mutant (always true for
+    // u32) would admit a `page_size` of 0 and step `offset += 0` forever; the
+    // bounded mock turns that runaway loop into a hard error on the 2nd request.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(bugs_body(1)))
+        .up_to_n_times(1)
+        .mount(&mock)
+        .await;
+
+    let client = test_client(&mock.uri());
+    let params = SearchParams {
+        limit: Some(0),
+        ..Default::default()
+    };
+    let page = fetch_page(&client, &params, true).await.unwrap();
+
+    assert_eq!(
+        page.bugs.len(),
+        1,
+        "a single unbounded request returns the one page as-is"
+    );
 }


### PR DESCRIPTION
## Summary

Adds 13 unit tests that close test gaps found by running `cargo-mutants` over three recently-added files. Each gap was a surviving mutant: a one-line code change (a flipped comparison, an inverted guard, a deleted struct field, or a replaced return value) that no existing test detected. Every new test was confirmed to fail against its specific injected mutant and pass on the unmodified code.

## Changes

- **`commands/runtime/paging.rs`** (4 tests): `resolve_offset` had no test; added coverage for folding a URL `offset` into the struct field and CLI precedence. Added the exact-fill truncation boundary (`len == limit`) and the zero-limit `--paginate` short-circuit, neither of which the existing tests exercised.
- **`commands/query.rs`** (3 tests): `product` and `component` were the only `apply_query_updates` change-flags without a sole-field update test, so flipping their `|=` to `&=` went undetected; added a sole-field update test for each. Added a test that a saved query's explicit order survives a `run` without `--sort` (the `&&` guard in `handle_run`).
- **`commands/bug/create.rs`** (6 tests): direct test of the `MergedFields` → `CreateBugParams` mapping in `preview_params` (previously unasserted); direct test of `run_editor_flow` via a fake `$EDITOR`; the no-trailing-newline body separator in `build_editor_template`; and three `--from-json` cases (CLI `--description` override, `blocks`/`depends_on` preservation, and the table-mode created-ids line).
- **`.cargo/mutants.toml`**: excludes the one paging survivor that is not unit-testable — the `--paginate` safety-cap warning fires only after 10,000 full pages and its sole effect is a `tracing::warn!`, matching the existing untestable-side-effect exclusions in this file.

## Testing

- 13 new tests; full suite goes from 1547 to 1560 passing.
- `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo fmt` clean.
- Each test was verified against its mutant in an isolated worktree: 14 mutation injections across the three files, each confirmed to turn the target test red, then green on revert.

## Notes

- `xmlrpc/mappers.rs` was also swept (37 mutants) and had zero survivors — its functions are already covered by the broader xmlrpc test suite — so it needed no changes.
- No production code changes; this PR is tests plus one mutation-config exclusion.
