### PR TITLE
release: prep v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
-
+## [0.5.0] - 2026-06-21
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzr"
-version = "0.4.5-dev"
+version = "0.5.0"
 dependencies = [
  "apple-native-keyring-store",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 
 [package]
 name = "bzr"
-version = "0.4.5-dev"
+version = "0.5.0"
 edition = "2021"
 description = "A CLI for Bugzilla, inspired by gh"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release prep for v0.5.0. Bumps the version off the `-dev` placeholder and dates the CHANGELOG so the merge commit can be tagged `v0.5.0`. A minor bump is required because the release carries breaking changes (`bug close`/`reopen` default statuses and the attachment boolean-flag grammar).

## Changes

- `Cargo.toml`: `0.4.5-dev` → `0.5.0`
- `Cargo.lock`: regenerated for the new version
- `CHANGELOG.md`: `## [Unreleased]` → `## [0.5.0] - 2026-06-21`

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — 79 passed, 0 failed
- `cargo build --release` — `bzr --version` reports `bzr 0.5.0`
- `cargo publish --dry-run` — 402 files packaged and verified

## Notes

- MSRV is unchanged (`rust-version = "1.89"`), so the README badge and "Requires Rust 1.89+" line need no edit.
- After this merges, tag the merge commit `v0.5.0` to trigger `release.yml` and `publish-crates.yml`.
