### PR TITLE
fix(ci): trust tap formula before bottle merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -641,6 +641,13 @@ jobs:
           # Tap (read-only https clone) so `--merge` can resolve and edit the
           # formula at $(brew --repository randomparity/tap)/Formula/bzr.rb.
           brew tap randomparity/tap
+          # Homebrew 6.0.0 refuses to load a formula from a non-official tap
+          # unless it is trusted. `brew bottle --merge` loads the formula by
+          # tap context (the JSON names it), so it hits this check -- unlike
+          # the `bottles` job, which installs by fully-qualified name
+          # (`randomparity/tap/bzr`), the documented exemption that needs no
+          # trust. Trust the single formula (not the whole tap) before merging.
+          brew trust --formula randomparity/tap/bzr
           brew bottle --merge --write --no-commit bottle-json/*.json
 
           tap_dir="$(brew --repository randomparity/tap)"


### PR DESCRIPTION
## Summary

The v0.5.0 release's `bottles-merge` job failed: Homebrew 6.0.0 (released 2026-06-11) now refuses to load a formula from a non-official tap unless it is explicitly trusted.

```
Refusing to load formula randomparity/tap/bzr from untrusted tap randomparity/tap.
```

`brew bottle --merge` loads the formula by tap context (the JSON names it), so it trips the new check. The `bottles` build job is unaffected because it installs by fully-qualified name (`randomparity/tap/bzr`) — the documented trust exemption.

## Changes

- `release.yml`: `brew trust --formula randomparity/tap/bzr` before `brew bottle --merge` in the bottles-merge step (trusts the single formula, not the whole tap).

## Testing

- `actionlint` clean
- Verified the same procedure locally to repair v0.5.0's tap formula: `brew trust --formula randomparity/tap/bzr` then `brew bottle --merge --write` succeeded and produced the correct `bottle do` block (already merged to the tap).

## Notes

- No CHANGELOG entry: this repairs the release pipeline only; the shipped binary is unchanged.
- v0.5.0's bottles were already restored out-of-band (randomparity/homebrew-tap#1).