### PR TITLE
Increase OpenSSF Scorecard score: signed releases, pinned installers, openssl CVE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,13 @@ jobs:
       # Signed-Releases check only inspects release assets, so the bundle has
       # to travel with the artifacts too. The upload-artifact glob below
       # (bzr-<tag>-<target>.*) picks this file up automatically.
+      #
+      # Skipped on Windows: the bundle-path output is backslash-separated
+      # there, which `cp` under Git Bash mishandles. Windows binaries still
+      # get provenance via the attestations API (above); Scorecard only needs
+      # one .intoto.jsonl asset per release, which the non-Windows legs supply.
       - name: Stage provenance bundle as release asset
+        if: runner.os != 'Windows'
         shell: bash
         env:
           BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
@@ -471,7 +477,12 @@ jobs:
               Write-Error "install.ps1 checksum mismatch: expected=$expectedHash actual=$actualHash"
               exit 1
           }
-          & ./install.ps1
+          # Execute the verified content as a string rather than invoking the
+          # downloaded file directly: Invoke-WebRequest stamps the file with the
+          # internet-zone Mark-of-the-Web, which a RemoteSigned execution policy
+          # would refuse. Hashing the on-disk file first preserves the integrity
+          # check; piping its content to iex avoids the policy/MOTW gate.
+          Get-Content install.ps1 -Raw | Invoke-Expression
           $installed = & (Join-Path $env:BZR_INSTALL_DIR 'bzr.exe') --version
           $expected = (Select-String -Path Cargo.toml -Pattern '^version = "(.*)"' |
                        Select-Object -First 1).Matches[0].Groups[1].Value

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,12 +281,26 @@ jobs:
         shell: bash
 
       - name: Attest build provenance
+        id: attest
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4
         with:
           subject-path: |
             bzr-${{ github.ref_name }}-${{ matrix.target }}.${{ matrix.archive }}
             *.deb
             *.rpm
+
+      # Persist the provenance bundle as a release asset (.intoto.jsonl).
+      # attest-build-provenance already publishes it to the GitHub
+      # attestations API (for `gh attestation verify`), but Scorecard's
+      # Signed-Releases check only inspects release assets, so the bundle has
+      # to travel with the artifacts too. The upload-artifact glob below
+      # (bzr-<tag>-<target>.*) picks this file up automatically.
+      - name: Stage provenance bundle as release asset
+        shell: bash
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+          DEST: bzr-${{ github.ref_name }}-${{ matrix.target }}.intoto.jsonl
+        run: cp "$BUNDLE_PATH" "$DEST"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
@@ -419,7 +433,14 @@ jobs:
         run: |
           set -euo pipefail
           export BZR_INSTALL_DIR="$HOME/.local/bin"
-          curl -fsSL "https://github.com/randomparity/bzr/releases/download/${TAG}/install.sh" | sh
+          BASE="https://github.com/randomparity/bzr/releases/download/${TAG}"
+          # Download the installer and the release checksum manifest, then
+          # verify the installer against the manifest before running it. This
+          # avoids piping a network download straight into a shell.
+          curl -fsSL -o install.sh "${BASE}/install.sh"
+          curl -fsSL -o SHA256SUMS "${BASE}/SHA256SUMS"
+          grep -E '  install\.sh$' SHA256SUMS | sha256sum --check --strict -
+          sh ./install.sh
           installed_version="$("$BZR_INSTALL_DIR/bzr" --version 2>&1)"
           expected="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
           echo "installed: $installed_version"
@@ -436,8 +457,21 @@ jobs:
           TAG: ${{ github.ref_name }}
         shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
           $env:BZR_INSTALL_DIR = Join-Path $env:LOCALAPPDATA 'Programs\bzr'
-          irm "https://github.com/randomparity/bzr/releases/download/$env:TAG/install.ps1" | iex
+          $base = "https://github.com/randomparity/bzr/releases/download/$env:TAG"
+          # Download the installer and checksum manifest, then verify before
+          # running -- avoids piping a network download straight into iex.
+          Invoke-WebRequest -Uri "$base/install.ps1" -OutFile install.ps1
+          Invoke-WebRequest -Uri "$base/SHA256SUMS" -OutFile SHA256SUMS
+          $expectedHash = ((Get-Content SHA256SUMS |
+                            Where-Object { $_ -match 'install\.ps1$' }) -split '\s+')[0]
+          $actualHash = (Get-FileHash install.ps1 -Algorithm SHA256).Hash.ToLower()
+          if ($expectedHash -ne $actualHash) {
+              Write-Error "install.ps1 checksum mismatch: expected=$expectedHash actual=$actualHash"
+              exit 1
+          }
+          & ./install.ps1
           $installed = & (Join-Path $env:BZR_INSTALL_DIR 'bzr.exe') --version
           $expected = (Select-String -Path Cargo.toml -Pattern '^version = "(.*)"' |
                        Select-Object -First 1).Matches[0].Groups[1].Value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+
+- Bump the transitive `openssl` dependency (via the `keyring` feature's
+  `dbus-secret-service` on Linux) to 0.10.81, addressing CVE-2026-45784
+  (GHSA-phqj-4mhp-q6mq): a potential out-of-bounds write in
+  `CipherCtxRef::cipher_update_inplace` for AES-KW-PAD ciphers.
+
+### Changed
+
+- Release artifacts now ship a SLSA provenance bundle (`*.intoto.jsonl`) as a
+  release asset alongside each binary, in addition to the existing GitHub
+  attestations API publication. The installer smoke tests now download and
+  verify installers against the published `SHA256SUMS` before executing them
+  instead of piping the download straight into a shell.
+
 ## [0.5.0] - 2026-06-21
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1356,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Raises the OpenSSF Scorecard score (currently 7.8/10) by addressing the lowest-scoring checks that are fully in our control.

## Changes

**Signed-Releases.** `actions/attest-build-provenance` already generates a SLSA provenance bundle but only publishes it to the GitHub attestations API. Scorecard's Signed-Releases check scans *release assets* only, so it saw no provenance. Each non-Windows build leg now persists its bundle as a `bzr-<tag>-<target>.intoto.jsonl` release asset; the existing `upload-artifact` glob carries it through to the release.

Scoring note: Scorecard computes this check as `floor(sum(per-release score) / number of recent releases)`, averaged over the last 5 releases (a release with a `.intoto.jsonl` asset scores 10). So the score does **not** jump to 10 on merge — it accrues as new releases ship, reaching full marks once the 5 most recent releases all carry provenance (e.g. ~2 after the first such release, ~4 after the second). Older already-published releases cannot be retrofitted.

(Windows binaries still get provenance via the attestations API — `gh attestation verify` works — but their bundle is not staged as a release asset, because `attest-build-provenance` emits a backslash bundle-path that `cp` under Git Bash mishandles. Scorecard only needs one `.intoto.jsonl` asset per release, which the Linux/macOS legs supply.)

**Pinned-Dependencies (9 → 10).** The installer smoke tests piped `curl … | sh` (and `irm … | iex`) — flagged as an unpinned `downloadThenRun`. They now download the installer plus the published `SHA256SUMS`, verify the checksum, then run. The PowerShell path verifies the on-disk hash and executes the content via `Invoke-Expression` (rather than running the downloaded file directly, which a RemoteSigned execution policy would refuse due to the Mark-of-the-Web). This clears the check and closes a real compromised-release/MITM gap.

**Vulnerabilities (9 → 10).** OSV flagged `openssl` (transitive, via the `keyring` feature's `dbus-secret-service` on Linux) for CVE-2026-45784 / GHSA-phqj-4mhp-q6mq — an out-of-bounds write in `CipherCtxRef::cipher_update_inplace` for AES-KW-PAD ciphers. Bumped to 0.10.81 (lockfile-only). `cargo audit` did not catch this because RustSec has not yet mirrored the GitHub advisory. The bump is exercised by this PR's CI (`ci.yml` builds `--release --locked` with default features on `ubuntu-latest`, which links openssl).

## Not included (require decisions / external action)

- **Branch-Protection** currently *errors* on the public Scorecard (its token can't read protection rules). Adding `repo_token: ${{ secrets.SCORECARD_TOKEN }}` to `scorecard.yml` would expose the existing (decent) config. Needs a fine-grained PAT secret.
- **Code-Review (0)** needs approved PRs; requiring approvals with `enforce_admins` on and a single maintainer would block self-merges. Left as-is per discussion.
- **CII-Best-Practices (0)** needs registering at bestpractices.dev.

## Verification

- `actionlint .github/workflows/release.yml` — clean
- `cargo update -p openssl` resolved to 0.10.81; lockfile consistent; openssl link path covered by `ci.yml` on Linux
- Release-only workflow effects (provenance asset, verified installers) are not exercised by PR CI; they run on the next tagged release and are covered by the existing installer-smoke job

🤖 Generated with [Claude Code](https://claude.com/claude-code)