### PR TITLE
feat(bug): guard convenience verbs against stale updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - `bug update` now accepts `--url` and `--target-milestone`, matching fields
   that `bug create` can already set. (#363)
+- `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept
+  `--expect-unchanged-since`, matching `bug update`'s optimistic-concurrency
+  guard. (#364)
 
 ### Changed
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -85,7 +85,7 @@ Agent note: at an interactive TTY, `bzr` defaults to table output. For agent wor
 | 11 | Batch partial failure (some operations succeeded, some failed) |
 | 12 | Keyring error (OS keychain access failed, e.g. locked keyring or missing daemon) |
 | 13 | TLS error (certificate pin mismatch or issuer changed; use `--tls-pin-now` to re-pin or `--tls-pin-clear` to remove the pin) |
-| 14 | Mid-air collision (`bug update --expect-unchanged-since`: the bug changed since the given time; re-read and retry) |
+| 14 | Mid-air collision (`bug update`/convenience verb `--expect-unchanged-since`: the bug changed since the given time; re-read and retry) |
 
 *Exit code 2 is produced by clap for argument errors before bzr's error handling runs, in addition to resource-not-found errors from bzr itself.
 
@@ -129,10 +129,15 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │   │                   [--see-also-add <URL>] [--see-also-remove <URL>]
 │   │                   [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
 │   │                   [--expect-unchanged-since <TIMESTAMP>]
-│   ├── resolve <ID...> [--as <RESOLUTION>] [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
-│   ├── close <ID...> [--status <STATUS>] [--as <RESOLUTION>] [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
-│   ├── reopen <ID...> [--status <STATUS>] [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
+│   ├── resolve <ID...> [--as <RESOLUTION>] [--comment <BODY>] [--comment-file <PATH>]
+│   │                   [--comment-private] [--expect-unchanged-since <TIMESTAMP>]
+│   ├── close <ID...> [--status <STATUS>] [--as <RESOLUTION>] [--comment <BODY>]
+│   │                 [--comment-file <PATH>] [--comment-private]
+│   │                 [--expect-unchanged-since <TIMESTAMP>]
+│   ├── reopen <ID...> [--status <STATUS>] [--comment <BODY>] [--comment-file <PATH>]
+│   │                  [--comment-private] [--expect-unchanged-since <TIMESTAMP>]
 │   └── dup <ID> <TARGET> [--comment <BODY>] [--comment-file <PATH>] [--comment-private]
+│                       [--expect-unchanged-since <TIMESTAMP>]
 ├── comment
 │   ├── list <BUG_ID> [--since <DATE>]
 │   ├── add <BUG_ID> [--body <TEXT>] [--body-file <PATH>] [--private]
@@ -706,6 +711,9 @@ time. Each accepts multiple IDs (batch, except `dup`) and the same
 `--comment` / `--comment-file` / `--comment-private` flags as `bug update`,
 posting the comment atomically with the change. Batch behavior (per-bug
 partial-failure reporting, exit code 11) is inherited from `bug update`.
+`--expect-unchanged-since <TIMESTAMP>` is also inherited from `bug update`: it
+re-reads each target and exits 14 without writing if `last_change_time` differs
+from the supplied value.
 
 ```bash
 bzr bug resolve 12345                       # → update --status RESOLVED --resolution FIXED
@@ -720,10 +728,10 @@ bzr bug dup 12345 100                        # → update --dupe-of 100
 
 | Verb | Equivalent `update` | Notes |
 |------|---------------------|-------|
-| `resolve <ID...> [--as <R>]` | `--status RESOLVED --resolution <R>` | `--as` defaults to `FIXED` |
-| `close <ID...> [--status <S>] [--as <R>]` | `--status <S> [--resolution <R>]` | `--status` defaults to `VERIFIED`; resolution set only when `--as` is given, otherwise the existing one is preserved |
-| `reopen <ID...> [--status <S>]` | `--status <S>` | `--status` defaults to `CONFIRMED`; Bugzilla clears the resolution automatically |
-| `dup <ID> <TARGET>` | `--dupe-of <TARGET>` | Bugzilla sets RESOLVED/DUPLICATE automatically |
+| `resolve <ID...> [--as <R>] [--expect-unchanged-since <T>]` | `--status RESOLVED --resolution <R>` | `--as` defaults to `FIXED` |
+| `close <ID...> [--status <S>] [--as <R>] [--expect-unchanged-since <T>]` | `--status <S> [--resolution <R>]` | `--status` defaults to `VERIFIED`; resolution set only when `--as` is given, otherwise the existing one is preserved |
+| `reopen <ID...> [--status <S>] [--expect-unchanged-since <T>]` | `--status <S>` | `--status` defaults to `CONFIRMED`; Bugzilla clears the resolution automatically |
+| `dup <ID> <TARGET> [--expect-unchanged-since <T>]` | `--dupe-of <TARGET>` | Bugzilla sets RESOLVED/DUPLICATE automatically |
 
 `close` and `reopen` default to the stock Bugzilla 5.x statuses `VERIFIED` and
 `CONFIRMED`. Installs that define custom statuses (e.g. `CLOSED`, `REOPENED`)

--- a/docs/superpowers/specs/2026-06-21-issue-364-bug-verbs-expect-unchanged-design.md
+++ b/docs/superpowers/specs/2026-06-21-issue-364-bug-verbs-expect-unchanged-design.md
@@ -1,0 +1,73 @@
+# Issue #364: Convenience Verb Concurrency Guard Design
+
+## Context
+
+Issue #364 asks for the optimistic-concurrency guard from `bug update` to be
+available on the state-transition convenience verbs:
+
+- `bug resolve`
+- `bug close`
+- `bug reopen`
+- `bug dup`
+
+`bug update --expect-unchanged-since` already re-reads every target bug before
+writing and exits 14 if any `last_change_time` differs. The convenience verbs
+currently build `UpdateBugParams` and call `update::apply` directly, bypassing
+that guard.
+
+## Design
+
+Add `--expect-unchanged-since <TIMESTAMP>` to the four convenience verb argument
+structs. The flag keeps the same timestamp contract and error wording as
+`bug update`.
+
+Move the guard invocation into a shared update-application helper that accepts a
+small request struct:
+
+- target IDs
+- `UpdateBugParams`
+- optional expected timestamp
+
+`bug update` and all four convenience verbs call that helper. The helper runs
+the guard before `update::apply`, skips the guard under `--dry-run`, and preserves
+the existing batch confirmation/write behavior.
+
+`bug close` and `bug reopen` still validate the target status before the guard.
+That preserves their existing local validation order: malformed comment/private
+usage fails before network I/O, then status validity is checked, then the
+concurrency guard runs before any PUT.
+
+## Files
+
+- `src/cli/bug.rs`: add the flag to `ResolveArgs`, `CloseArgs`, `ReopenArgs`,
+  and `DupArgs`; update verb help text.
+- `src/commands/bug/update.rs`: add a guarded apply helper and reuse it from
+  `handle`.
+- `src/commands/bug/verbs.rs`: pass each verb's expected timestamp to the shared
+  guarded helper.
+- `src/cli/mod_tests.rs`: prove each verb parses the flag.
+- `src/commands/bug/verbs_tests.rs`: prove each verb aborts on a mismatch and no
+  PUT fires; prove a matching timestamp still writes the normal verb payload.
+- `docs/bzr-cli.md`: document the flag for all four convenience verbs.
+- `CHANGELOG.md`: add an Unreleased entry.
+
+## Testing
+
+- `cargo test parse_bug_verbs_expect_unchanged_since`
+- `cargo test bug_verbs_expect_unchanged_since --lib`
+- `cargo test commands::bug::verbs::tests --lib`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+
+## Out of Scope
+
+- Changing the client-side compare-and-set semantics.
+- Adding server-side idempotency or atomic update behavior.
+- Changing dry-run behavior; dry-run still previews without a guard re-read.
+
+## Self-Review
+
+- The design uses the existing guard implementation rather than creating a new
+  comparison path.
+- The test plan covers all four verbs, the no-write invariant, and the guarded
+  success path.
+- The status validation order for `close`/`reopen` remains explicit.

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -1070,6 +1070,9 @@ pub struct ResolveArgs {
     /// Resolution to set (default `FIXED`).
     #[arg(long = "as", value_name = "RESOLUTION", default_value = "FIXED")]
     pub as_resolution: String,
+    /// Only apply the update if the bug has not changed since this time.
+    #[arg(long, value_name = "TIMESTAMP")]
+    pub expect_unchanged_since: Option<String>,
     #[command(flatten)]
     pub comment: CommentArgs,
 }
@@ -1090,6 +1093,9 @@ pub struct CloseArgs {
     /// preserve any existing resolution.
     #[arg(long = "as", value_name = "RESOLUTION")]
     pub as_resolution: Option<String>,
+    /// Only apply the update if the bug has not changed since this time.
+    #[arg(long, value_name = "TIMESTAMP")]
+    pub expect_unchanged_since: Option<String>,
     #[command(flatten)]
     pub comment: CommentArgs,
 }
@@ -1106,6 +1112,9 @@ pub struct ReopenArgs {
     /// list; an unknown value exits 7. Matched exactly and case-sensitively.
     #[arg(long, value_name = "STATUS", default_value = "CONFIRMED")]
     pub status: String,
+    /// Only apply the update if the bug has not changed since this time.
+    #[arg(long, value_name = "TIMESTAMP")]
+    pub expect_unchanged_since: Option<String>,
     #[command(flatten)]
     pub comment: CommentArgs,
 }
@@ -1117,6 +1126,9 @@ pub struct DupArgs {
     pub id: u64,
     /// The canonical bug this one duplicates.
     pub target: u64,
+    /// Only apply the update if the bug has not changed since this time.
+    #[arg(long, value_name = "TIMESTAMP")]
+    pub expect_unchanged_since: Option<String>,
     #[command(flatten)]
     pub comment: CommentArgs,
 }

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -180,6 +180,73 @@ fn parse_update_expect_unchanged_since() {
 }
 
 #[test]
+fn parse_bug_verbs_expect_unchanged_since() {
+    let since = "2026-06-19T12:00:00Z";
+    let cases: Vec<(Vec<&str>, &str)> = vec![
+        (
+            vec![
+                "bzr",
+                "bug",
+                "resolve",
+                "42",
+                "--expect-unchanged-since",
+                since,
+            ],
+            "resolve",
+        ),
+        (
+            vec![
+                "bzr",
+                "bug",
+                "close",
+                "42",
+                "--expect-unchanged-since",
+                since,
+            ],
+            "close",
+        ),
+        (
+            vec![
+                "bzr",
+                "bug",
+                "reopen",
+                "42",
+                "--expect-unchanged-since",
+                since,
+            ],
+            "reopen",
+        ),
+        (
+            vec![
+                "bzr",
+                "bug",
+                "dup",
+                "42",
+                "99",
+                "--expect-unchanged-since",
+                since,
+            ],
+            "dup",
+        ),
+    ];
+
+    for (argv, name) in cases {
+        let cli = Cli::try_parse_from(argv).unwrap();
+        let Commands::Bug { action } = cli.command else {
+            panic!("expected bug command for {name}");
+        };
+        let parsed = match action {
+            BugAction::Resolve(args) => args.expect_unchanged_since,
+            BugAction::Close(args) => args.expect_unchanged_since,
+            BugAction::Reopen(args) => args.expect_unchanged_since,
+            BugAction::Dup(args) => args.expect_unchanged_since,
+            _ => panic!("expected {name} action"),
+        };
+        assert_eq!(parsed.as_deref(), Some(since), "{name}");
+    }
+}
+
+#[test]
 fn parse_bug_update_url_and_target_milestone() {
     let cli = Cli::try_parse_from([
         "bzr",

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -301,15 +301,17 @@ pub(super) async fn handle(
     w: &mut Writers<'_>,
 ) -> Result<()> {
     let (ids, params) = build_update_params(args)?;
-    let expect_unchanged_since = &args.expect_unchanged_since;
-    // Optimistic-concurrency guard, before any write. Skipped under --dry-run,
-    // which performs no write (and `apply` short-circuits to a preview anyway).
-    if let Some(expected) = expect_unchanged_since {
-        if !crate::commands::runtime::dry_run::enabled() {
-            ensure_unchanged_since(client, &ids, expected).await?;
-        }
-    }
-    apply(client, ids, params, format, w).await
+    apply_checked(
+        client,
+        ApplyRequest {
+            ids,
+            params,
+            expect_unchanged_since: args.expect_unchanged_since.as_deref(),
+        },
+        format,
+        w,
+    )
+    .await
 }
 
 /// Emit the would-be update without writing: the affected IDs and the payload
@@ -337,8 +339,7 @@ fn write_update_dry_run(
 /// Apply an already-built `UpdateBugParams` to one or more bug IDs, dispatching
 /// to the single- or batch-update path. Shared by `bug update` and the
 /// convenience verbs (`resolve`/`close`/`reopen`/`dup`). Under `--dry-run`,
-/// previews the change without calling the write API. The optimistic-concurrency
-/// guard (`--expect-unchanged-since`) runs in `handle`, before this is called.
+/// previews the change without calling the write API.
 pub(super) async fn apply(
     client: &BugzillaClient,
     ids: Vec<u64>,
@@ -359,6 +360,30 @@ pub(super) async fn apply(
     } else {
         update_batch(client, &ids, &params, format, w).await
     }
+}
+
+pub(super) struct ApplyRequest<'a> {
+    pub ids: Vec<u64>,
+    pub params: UpdateBugParams,
+    pub expect_unchanged_since: Option<&'a str>,
+}
+
+/// Apply an update after running the optional optimistic-concurrency guard.
+///
+/// The guard is skipped under `--dry-run`, which performs no write and whose
+/// preview still uses the same payload validation path.
+pub(super) async fn apply_checked(
+    client: &BugzillaClient,
+    request: ApplyRequest<'_>,
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) -> Result<()> {
+    if let Some(expected) = request.expect_unchanged_since {
+        if !crate::commands::runtime::dry_run::enabled() {
+            ensure_unchanged_since(client, &request.ids, expected).await?;
+        }
+    }
+    apply(client, request.ids, request.params, format, w).await
 }
 
 /// Optimistic-concurrency guard for `--expect-unchanged-since`: refuse the

--- a/src/commands/bug/verbs.rs
+++ b/src/commands/bug/verbs.rs
@@ -65,7 +65,17 @@ pub(super) async fn resolve(
         comment: comment_update(&args.comment)?,
         ..Default::default()
     };
-    super::update::apply(client, args.ids.clone(), params, format, w).await
+    super::update::apply_checked(
+        client,
+        super::update::ApplyRequest {
+            ids: args.ids.clone(),
+            params,
+            expect_unchanged_since: args.expect_unchanged_since.as_deref(),
+        },
+        format,
+        w,
+    )
+    .await
 }
 
 pub(super) async fn close(
@@ -84,7 +94,17 @@ pub(super) async fn close(
         comment,
         ..Default::default()
     };
-    super::update::apply(client, args.ids.clone(), params, format, w).await
+    super::update::apply_checked(
+        client,
+        super::update::ApplyRequest {
+            ids: args.ids.clone(),
+            params,
+            expect_unchanged_since: args.expect_unchanged_since.as_deref(),
+        },
+        format,
+        w,
+    )
+    .await
 }
 
 pub(super) async fn reopen(
@@ -100,7 +120,17 @@ pub(super) async fn reopen(
         comment,
         ..Default::default()
     };
-    super::update::apply(client, args.ids.clone(), params, format, w).await
+    super::update::apply_checked(
+        client,
+        super::update::ApplyRequest {
+            ids: args.ids.clone(),
+            params,
+            expect_unchanged_since: args.expect_unchanged_since.as_deref(),
+        },
+        format,
+        w,
+    )
+    .await
 }
 
 pub(super) async fn dup(
@@ -114,7 +144,17 @@ pub(super) async fn dup(
         comment: comment_update(&args.comment)?,
         ..Default::default()
     };
-    super::update::apply(client, vec![args.id], params, format, w).await
+    super::update::apply_checked(
+        client,
+        super::update::ApplyRequest {
+            ids: vec![args.id],
+            params,
+            expect_unchanged_since: args.expect_unchanged_since.as_deref(),
+        },
+        format,
+        w,
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/src/commands/bug/verbs_tests.rs
+++ b/src/commands/bug/verbs_tests.rs
@@ -70,6 +70,34 @@ async fn run_status_verb(action: BugAction, id: u64, body: serde_json::Value, st
     assert!(result.is_ok(), "verb failed: {:?}", result.err());
 }
 
+async fn run_verb_collision_expecting_no_write(action: BugAction, id: u64) {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mount_status_field(&mock, DEFAULT_STATUSES).await;
+    Mock::given(method("GET"))
+        .and(path(format!("/rest/bug/{id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": id, "last_change_time": "2026-06-19T12:05:00Z"}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+
+    assert!(
+        matches!(result, Err(crate::error::BzrError::MidAirCollision { .. })),
+        "expected mid-air collision, got {result:?}"
+    );
+}
+
 const DEFAULT_STATUSES: &[&str] = &[
     "UNCONFIRMED",
     "CONFIRMED",
@@ -83,6 +111,7 @@ fn close_args(ids: Vec<u64>, status: &str, as_resolution: Option<&str>) -> Close
         ids,
         status: status.into(),
         as_resolution: as_resolution.map(Into::into),
+        expect_unchanged_since: None,
         comment: CommentArgs::default(),
     }
 }
@@ -91,6 +120,7 @@ fn reopen_args(ids: Vec<u64>, status: &str) -> ReopenArgs {
     ReopenArgs {
         ids,
         status: status.into(),
+        expect_unchanged_since: None,
         comment: CommentArgs::default(),
     }
 }
@@ -109,6 +139,7 @@ async fn resolve_dry_run_makes_no_write() {
     let action = BugAction::Resolve(ResolveArgs {
         ids: vec![5],
         as_resolution: "FIXED".into(),
+        expect_unchanged_since: None,
         comment: CommentArgs::default(),
     });
     let mut io = crate::test_helpers::CapturedIo::new();
@@ -131,6 +162,7 @@ async fn resolve_defaults_to_fixed() {
     let action = BugAction::Resolve(ResolveArgs {
         ids: vec![5],
         as_resolution: "FIXED".into(),
+        expect_unchanged_since: None,
         comment: CommentArgs::default(),
     });
     run_verb_expecting_body(
@@ -146,6 +178,7 @@ async fn resolve_with_as_override() {
     let action = BugAction::Resolve(ResolveArgs {
         ids: vec![7],
         as_resolution: "WONTFIX".into(),
+        expect_unchanged_since: None,
         comment: CommentArgs::default(),
     });
     run_verb_expecting_body(
@@ -154,6 +187,92 @@ async fn resolve_with_as_override() {
         serde_json::json!({"status": "RESOLVED", "resolution": "WONTFIX"}),
     )
     .await;
+}
+
+#[tokio::test]
+async fn bug_verbs_expect_unchanged_since_collision_skips_write() {
+    let since = "2026-06-19T12:00:00Z";
+
+    run_verb_collision_expecting_no_write(
+        BugAction::Resolve(ResolveArgs {
+            ids: vec![5],
+            as_resolution: "FIXED".into(),
+            expect_unchanged_since: Some(since.into()),
+            comment: CommentArgs::default(),
+        }),
+        5,
+    )
+    .await;
+
+    run_verb_collision_expecting_no_write(
+        BugAction::Close(CloseArgs {
+            ids: vec![6],
+            status: "VERIFIED".into(),
+            as_resolution: None,
+            expect_unchanged_since: Some(since.into()),
+            comment: CommentArgs::default(),
+        }),
+        6,
+    )
+    .await;
+
+    run_verb_collision_expecting_no_write(
+        BugAction::Reopen(ReopenArgs {
+            ids: vec![7],
+            status: "CONFIRMED".into(),
+            expect_unchanged_since: Some(since.into()),
+            comment: CommentArgs::default(),
+        }),
+        7,
+    )
+    .await;
+
+    run_verb_collision_expecting_no_write(
+        BugAction::Dup(DupArgs {
+            id: 8,
+            target: 80,
+            expect_unchanged_since: Some(since.into()),
+            comment: CommentArgs::default(),
+        }),
+        8,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn bug_verbs_expect_unchanged_since_match_writes_update() {
+    let since = "2026-06-19T12:00:00Z";
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/5"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 5, "last_change_time": since}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/5"))
+        .and(body_json(
+            serde_json::json!({"status": "RESOLVED", "resolution": "FIXED"}),
+        ))
+        .respond_with(ok_put(5))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = BugAction::Resolve(ResolveArgs {
+        ids: vec![5],
+        as_resolution: "FIXED".into(),
+        expect_unchanged_since: Some(since.into()),
+        comment: CommentArgs::default(),
+    });
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+
+    assert!(result.is_ok(), "guarded resolve failed: {result:?}");
 }
 
 #[tokio::test]
@@ -309,6 +428,7 @@ async fn dup_sends_dupe_of() {
     let action = BugAction::Dup(DupArgs {
         id: 12,
         target: 100,
+        expect_unchanged_since: None,
         comment: CommentArgs::default(),
     });
     run_verb_expecting_body(action, 12, serde_json::json!({"dupe_of": 100})).await;
@@ -319,6 +439,7 @@ async fn resolve_posts_comment_atomically() {
     let action = BugAction::Resolve(ResolveArgs {
         ids: vec![5],
         as_resolution: "FIXED".into(),
+        expect_unchanged_since: None,
         comment: CommentArgs {
             comment: Some("done in 9.1".into()),
             comment_file: None,
@@ -356,6 +477,7 @@ async fn resolve_batch_updates_each_id() {
     let action = BugAction::Resolve(ResolveArgs {
         ids: vec![1, 2],
         as_resolution: "FIXED".into(),
+        expect_unchanged_since: None,
         comment: CommentArgs::default(),
     });
     let mut io = crate::test_helpers::CapturedIo::new();
@@ -377,6 +499,7 @@ async fn close_private_comment_without_body_is_rejected() {
         ids: vec![5],
         status: "VERIFIED".into(),
         as_resolution: None,
+        expect_unchanged_since: None,
         comment: CommentArgs {
             comment: None,
             comment_file: None,


### PR DESCRIPTION
## Summary
- add `--expect-unchanged-since` to `bug resolve`, `bug close`, `bug reopen`, and `bug dup`
- route `bug update` and the convenience verbs through the shared guarded apply path
- document the new flags and add #364 design notes

Closes #364

## Tests
- `cargo test parse_bug_verbs_expect_unchanged_since`
- `cargo test bug_verbs_expect_unchanged_since --lib`
- `cargo test commands::bug::verbs::tests --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- pre-push `cargo test`