### PR TITLE
feat(query): add count output to saved query runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept
   `--expect-unchanged-since`, matching `bug update`'s optimistic-concurrency
   guard. (#364)
+- `query run` now accepts `--count`, matching the count-only output shape used
+  by bug search-backed commands. (#368)
 
 ### Changed
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -219,7 +219,8 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │   │                 [--limit <N>] [--fields <F>] [--exclude-fields <F>] [--created-since <D>]
 │   │                 [--changed-since <D>] [--clear <FIELD>] [--sort <FIELD>] [--order asc|desc]
 │   ├── delete <NAME>
-│   └── run <NAME> [--limit <N>] [--offset <N>] [--paginate] [--fields <F>] [--exclude-fields <F>] [--server <NAME>]
+│   └── run <NAME> [--limit <N>] [--offset <N>] [--paginate] [--count]
+│                  [--fields <F>] [--exclude-fields <F>] [--server <NAME>]
 │                  [--resolution <R>...] [--version <V>...] [--op-sys <OS>...] [--platform <P>...]
 │                  [--whiteboard <W>] [--target-milestone <M>...] [--qa-contact <Q>...] [--url <U>]
 │                  [--created-since <D>] [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
@@ -1677,7 +1678,8 @@ bzr query delete firefox-new
 
 ### `bzr query run`
 
-Execute a saved query. Supports runtime overrides for limit, fields, exclude-fields, and server.
+Execute a saved query. Supports runtime overrides for limit, fields,
+exclude-fields, server, and count-only output.
 
 ```bash
 # Run a saved query
@@ -1685,6 +1687,9 @@ bzr query run firefox-new
 
 # Run with a different limit
 bzr query run firefox-new --limit 10
+
+# Count matching bugs without printing rows
+bzr query run firefox-new --count
 
 # Run with field selection
 bzr query run firefox-new --fields id,summary,status
@@ -1701,8 +1706,9 @@ bzr query run recent-firefox --changed-since 2026-05-01
 |--------|----------|-------------|
 | `<NAME>` | Yes | Query name |
 | `--limit <N>` | No | Override the saved limit |
-| `--offset <N>` | No | Skip the first N matches (manual paging past `--limit`). Mutually exclusive with `--paginate`. |
-| `--paginate` | No | Retrieve every matching page, looping internally past `--limit`. |
+| `--offset <N>` | No | Skip the first N matches (manual paging past `--limit`). Mutually exclusive with `--paginate`; cannot be combined with `--count`. |
+| `--paginate` | No | Retrieve every matching page, looping internally past `--limit`. Cannot be combined with `--count`. |
+| `--count` | No | Print only the count of matching bugs — an integer (table) or `{"count": N}` (JSON). Fetches ids only and lifts the row limit, so the count reflects all matches (bounded by the server's max-results setting). Ignores saved and per-run `--fields` and `--limit`; sort settings do not affect the count output. |
 | `--fields <F>` | No | Comma-separated built-in fields or Bugzilla custom fields named `cf_*` requested from the server; in table output, selects which columns to show (in order). Under `--json`, the object contains only the selected fields (gh-style; `id` is included only when requested). |
 | `--exclude-fields <F>` | No | Comma-separated fields dropped from the server request; in table output, removes those columns. Under `--json`, the object omits the dropped fields (including custom `cf_*` fields and `id`, when excluded). |
 | `--server <NAME>` | No | Override the server to run the query against. Takes precedence over the server stored in the saved query. The global `--server` flag takes precedence over this flag. |

--- a/docs/superpowers/specs/2026-06-21-issue-368-query-run-count-design.md
+++ b/docs/superpowers/specs/2026-06-21-issue-368-query-run-count-design.md
@@ -1,0 +1,73 @@
+# Issue #368: Query Run Count Design
+
+## Context
+
+Issue #368 asks for `bzr query run <NAME> --count` to match the count-only
+behavior already available on `bug list`, `bug search`, and `bug my`.
+
+`query run` already converts saved queries into `SearchParams`, applies runtime
+overrides, resolves URL-sourced offsets, applies deterministic ordering, and then
+uses the same Bugzilla search client as the bug commands. The missing piece is
+the CLI flag and the count branch.
+
+## Design
+
+Add `--count` to `query run`.
+
+The handler should:
+
+- reject `--count` with `--offset` or `--paginate` using the existing
+  `ensure_no_paging_with_count` helper;
+- apply saved-query and runtime overrides exactly as today, including date/filter
+  validation;
+- when counting, rewrite the resolved `SearchParams` with the existing
+  `count_search_params` helper so only ids are fetched and `limit=0` lifts the
+  client-side row limit;
+- clear saved URL offsets in the count helper so URL-sourced saved queries count
+  the full match set instead of a saved result window;
+- skip field-selection validation, output column selection, paging fetch, and
+  truncation notes in the count branch;
+- print through the existing `write_count` helper, preserving bare table integer
+  and `{"count": N}` JSON/NDJSON output.
+
+Saved/per-run `--fields` and `--limit` are accepted but ignored for the count
+result, matching the established bug command count semantics. Saved/per-run sort
+settings may still be carried into the search params, as they are for existing
+count paths, but they do not affect the count output.
+
+## Files
+
+- `src/cli/query.rs`: add the `count` flag to `RunArgs` and help text.
+- `src/commands/query.rs`: reject paging/count conflicts and add the count
+  branch.
+- `src/cli/mod_tests.rs`: prove the flag parses and conflicts with paging.
+- `src/commands/query_tests.rs`: prove JSON and table count output, id-only
+  search params, lifted limit, saved URL offset clearing, and conflict
+  validation.
+- `docs/bzr-cli.md`: document `query run --count`.
+- `CHANGELOG.md`: add an Unreleased entry.
+
+## Testing
+
+- `cargo test parse_query_run_count`
+- `cargo test query_run_count --lib`
+- `cargo test commands::query::tests --lib`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `git diff --check`
+
+## Out of Scope
+
+- Adding server-side total-count APIs; Bugzilla search has no separate total
+  endpoint.
+- Changing saved-query storage shape.
+- Changing `bug list`, `bug search`, or `bug my` count behavior.
+
+## Self-Review
+
+- The design reuses the existing count helpers and output shape.
+- Count happens after saved-query resolution and override validation, so invalid
+  dates and malformed field override syntax keep existing behavior where relevant.
+- The count branch avoids table/JSON field projection because the result is not a
+  bug list.
+- The shared count helper clears offset so saved URL windows do not leak into
+  count-only requests.

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -1462,6 +1462,20 @@ fn parse_query_run_with_limit_override() {
 }
 
 #[test]
+fn parse_query_run_count() {
+    let cli = Cli::try_parse_from(["bzr", "query", "run", "firefox-new", "--count"]).unwrap();
+    match cli.command {
+        Commands::Query {
+            action: QueryAction::Run(super::query::RunArgs { name, count, .. }),
+        } => {
+            assert_eq!(name, "firefox-new");
+            assert!(count);
+        }
+        _ => panic!("expected Query Run"),
+    }
+}
+
+#[test]
 fn parse_query_list() {
     let cli = Cli::try_parse_from(["bzr", "query", "list"]).unwrap();
     assert!(matches!(

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -210,6 +210,13 @@ pub struct RunArgs {
     /// Override the saved limit
     #[arg(long)]
     pub limit: Option<u32>,
+    /// Print only the count of matching bugs.
+    ///
+    /// Requests id-only results and lifts the row limit, matching
+    /// `bug list --count` / `bug search --count`. Cannot be combined
+    /// with `--offset` or `--paginate`.
+    #[arg(long)]
+    pub count: bool,
     /// Fields to request from the server (comma-separated). Table:
     /// selects which columns to show (in order). --json: the JSON object
     /// contains only the selected fields (id is included only if requested).

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -36,13 +36,16 @@ fn bug_column_spec(action: &BugAction) -> Option<ColumnSpec<'_>> {
 
 /// Rewrite search params for `--count`: fetch only IDs (smallest payload) and
 /// lift the row limit (`0` = all matches, bounded by the server's max-results)
-/// so the count reflects the full match set, not a page of it.
+/// so the count reflects the full match set, not a page of it. Clear offsets
+/// that may have come from saved Bugzilla URLs for the same reason.
 pub(super) fn count_search_params(
     mut params: crate::types::SearchParams,
 ) -> crate::types::SearchParams {
     params.include_fields = Some("id".to_string());
     params.exclude_fields = None;
     params.limit = Some(0);
+    params.offset = None;
+    params.raw_params.retain(|(key, _)| key != "offset");
     params
 }
 

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -363,6 +363,7 @@ async fn handle_run(
     let crate::cli::query::RunArgs {
         name,
         limit,
+        count,
         fields,
         exclude_fields,
         server: server_override,
@@ -379,6 +380,8 @@ async fn handle_run(
         sort_args,
         page_args: crate::cli::PageArgs { offset, paginate },
     } = args;
+
+    super::bug::ensure_no_paging_with_count(*count, *offset, *paginate)?;
 
     let creation_time_override =
         crate::validation::parse_optional_date(created_since.as_deref(), "--created-since")?;
@@ -426,6 +429,15 @@ async fn handle_run(
         ));
     } else if params.order.is_none() && !params.raw_params.iter().any(|(k, _)| k == "order") {
         params.order = Some(crate::validation::build_order(None, sort_args.order));
+    }
+
+    if *count {
+        let client = super::runtime::shared::connect_and_configure(effective_server, api).await?;
+        let bugs = client
+            .search_bugs(&super::bug::count_search_params(params))
+            .await?;
+        crate::output::result_types::write_count(bugs.len(), format, w.out);
+        return Ok(());
     }
 
     // Source columns from the resolved params (saved-query fields + CLI

--- a/src/commands/query_tests.rs
+++ b/src/commands/query_tests.rs
@@ -5,7 +5,7 @@ use crate::cli::QueryAction;
 use crate::config::Config;
 use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
-use wiremock::matchers::{method, path, query_param};
+use wiremock::matchers::{method, path, query_param, query_param_is_missing};
 use wiremock::{Mock, ResponseTemplate};
 
 fn save_action(name: &str) -> QueryAction {
@@ -129,6 +129,7 @@ fn run_action(name: &str) -> QueryAction {
     QueryAction::Run(RunArgs {
         page_args: crate::cli::PageArgs::default(),
         name: name.into(),
+        count: false,
         limit: None,
         fields: None,
         exclude_fields: None,
@@ -145,6 +146,15 @@ fn run_action(name: &str) -> QueryAction {
         url: vec![],
         sort_args: crate::cli::SortArgs::default(),
     })
+}
+
+fn count_run_action(name: &str) -> QueryAction {
+    let mut action = run_action(name);
+    let QueryAction::Run(RunArgs { count, .. }) = &mut action else {
+        unreachable!()
+    };
+    *count = true;
+    action
 }
 
 #[tokio::test]
@@ -491,6 +501,188 @@ async fn query_run_honors_saved_custom_fields() {
 }
 
 #[tokio::test]
+async fn query_run_count_json_emits_count_object() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    let save_action = product_save_action("count-json-test", "TestProduct", 25);
+    let mut save_io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &save_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut save_io.writers(),
+    )
+    .await;
+    assert!(result.is_ok(), "query save failed: {result:?}");
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("product", "TestProduct"))
+        .and(query_param("include_fields", "id"))
+        .and(query_param("limit", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1}, {"id": 2}, {"id": 3}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = count_run_action("count-json-test");
+
+    let mut run_io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut run_io.writers(),
+    )
+    .await;
+
+    assert!(result.is_ok(), "query run --count failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(run_io.out_str().trim()).unwrap();
+    assert_eq!(parsed["count"], 3);
+}
+
+#[tokio::test]
+async fn query_run_count_table_prints_integer_only() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    let save_action = product_save_action("count-table-test", "TestProduct", 25);
+    let mut save_io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &save_action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut save_io.writers(),
+    )
+    .await;
+    assert!(result.is_ok(), "query save failed: {result:?}");
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 10}, {"id": 11}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = count_run_action("count-table-test");
+
+    let mut run_io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Table,
+        None,
+        &mut run_io.writers(),
+    )
+    .await;
+
+    assert!(result.is_ok(), "query run --count failed: {result:?}");
+    assert_eq!(run_io.out_str().trim(), "2");
+}
+
+#[tokio::test]
+async fn query_run_count_rejects_offset_and_paginate() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    for (offset, paginate) in [(Some(10), false), (None, true)] {
+        let action = QueryAction::Run(RunArgs {
+            page_args: crate::cli::PageArgs { offset, paginate },
+            name: "count-conflict-test".into(),
+            count: true,
+            limit: None,
+            fields: None,
+            exclude_fields: None,
+            server: None,
+            created_since: None,
+            changed_since: None,
+            whiteboard: vec![],
+            target_milestone: vec![],
+            version: vec![],
+            op_sys: vec![],
+            platform: vec![],
+            resolution: vec![],
+            qa_contact: vec![],
+            url: vec![],
+            sort_args: crate::cli::SortArgs::default(),
+        });
+        let mut run_io = crate::test_helpers::CapturedIo::new();
+        let result = super::execute(
+            &action,
+            None,
+            OutputFormat::Json,
+            None,
+            &mut run_io.writers(),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(crate::error::BzrError::InputValidation(ref message)) if message.contains("--count")),
+            "expected count paging conflict, got {result:?}"
+        );
+    }
+
+    let received = mock.received_requests().await.unwrap();
+    assert!(
+        received.is_empty(),
+        "expected conflict validation before network I/O, got {} request(s)",
+        received.len()
+    );
+}
+
+#[tokio::test]
+async fn query_run_count_ignores_saved_url_offset() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Config::update_locked(|config| {
+        config.queries.insert(
+            "count-offset-test".into(),
+            crate::types::SavedQuery {
+                product: vec!["TestProduct".into()],
+                raw_params: vec![("offset".into(), "50".into())],
+                ..crate::types::SavedQuery::default()
+            },
+        );
+        Ok(())
+    })
+    .unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("product", "TestProduct"))
+        .and(query_param("include_fields", "id"))
+        .and(query_param("limit", "0"))
+        .and(query_param_is_missing("offset"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = count_run_action("count-offset-test");
+
+    let mut run_io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut run_io.writers(),
+    )
+    .await;
+
+    assert!(result.is_ok(), "query run --count failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(run_io.out_str().trim()).unwrap();
+    assert_eq!(parsed["count"], 4);
+}
+
+#[tokio::test]
 async fn query_run_with_limit_override() {
     let (_lock, mock, _tmp) = setup_test_env().await;
 
@@ -518,6 +710,7 @@ async fn query_run_with_limit_override() {
     let run_action = QueryAction::Run(RunArgs {
         page_args: crate::cli::PageArgs::default(),
         name: "override-test".into(),
+        count: false,
         limit: Some(5),
         fields: None,
         exclude_fields: None,
@@ -742,6 +935,7 @@ async fn query_run_applies_field_overrides() {
     let run_action = QueryAction::Run(RunArgs {
         page_args: crate::cli::PageArgs::default(),
         name: "fields-test".into(),
+        count: false,
         limit: None,
         fields: Some("id,summary".into()),
         exclude_fields: Some("comments".into()),
@@ -889,6 +1083,7 @@ async fn query_run_with_server_override() {
     let run_action = QueryAction::Run(RunArgs {
         page_args: crate::cli::PageArgs::default(),
         name: "server-test".into(),
+        count: false,
         limit: None,
         fields: None,
         exclude_fields: None,
@@ -1114,6 +1309,7 @@ async fn query_run_rejects_malformed_created_since_override() {
     let action = QueryAction::Run(RunArgs {
         page_args: crate::cli::PageArgs::default(),
         name: "recent".into(),
+        count: false,
         limit: None,
         fields: None,
         exclude_fields: None,
@@ -1303,6 +1499,7 @@ async fn query_run_overrides_replace_saved_field_filters() {
     let run_action = QueryAction::Run(RunArgs {
         page_args: crate::cli::PageArgs::default(),
         name: "field-override-test".into(),
+        count: false,
         limit: None,
         fields: None,
         exclude_fields: None,


### PR DESCRIPTION
## Summary
- add `query run --count` with the shared count output shape
- reuse the bug count helpers so count requests fetch ids only and lift the limit
- clear saved URL offsets for count requests so saved windows do not limit totals
- document the flag and add #368 design notes

Closes #368

## Tests
- `cargo test parse_query_run_count`
- `cargo test query_run_count --lib`
- `cargo test commands::query::tests --lib`
- `cargo test handle_search_count_emits_count_object --lib`
- `cargo test bug_list_count_json_emits_count_object --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- pre-push `cargo test`