### PR TITLE
feat(bug): add structured update input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept
   `--expect-unchanged-since`, matching `bug update`'s optimistic-concurrency
   guard. (#364)
+- `bug update` now accepts `--from-json <PATH|->` structured input for object
+  and array update payloads. (#365)
 - `query run` now accepts `--count`, matching the count-only output shape used
   by bug search-backed commands. (#368)
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -116,8 +116,8 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │   │              [--description <D>] [--priority <P>] [--severity <S>] [--assignee <A>]
 │   │              [--op-sys <OS>] [--rep-platform <PLAT>]
 │   │              [--no-comment] [--add-depends-on] [--add-blocks] [--no-cc] [--no-keywords]
-│   ├── update <ID...> [--status <S>] [--resolution <R>] [--dupe-of <ID>] [--assignee <A>]
-│   │                   [--priority <P>] [--severity <S>] [--summary <S>]
+│   ├── update [<ID...>] [--from-json <PATH>] [--status <S>] [--resolution <R>] [--dupe-of <ID>]
+│   │                   [--assignee <A>] [--priority <P>] [--severity <S>] [--summary <S>]
 │   │                   [--alias <A>] [--deadline <DATE>] [--estimated-time <HOURS>]
 │   │                   [--remaining-time <HOURS>] [--work-time <HOURS>]
 │   │                   [--whiteboard <W>] [--url <U>] [--target-milestone <M>]
@@ -612,7 +612,7 @@ Accepted keys match the create flag names: `product`, `component`, `summary`, `v
 
 **Precedence:** an explicit CLI flag overrides the corresponding JSON field, applied uniformly to every element of an array — e.g. `--product Fedora --from-json bugs.json` forces `product` on all entries. `--from-json` is mutually exclusive with `--template` and bypasses the `$EDITOR` flow.
 
-`bug update` and the other resource commands do not yet accept `--from-json`; that is tracked as follow-up work.
+`bug update` accepts its own structured update input via `--from-json`; other resource commands do not yet accept `--from-json`.
 
 ```bash
 printf '%s' '{"product":"Fedora","component":"kernel","summary":"S"}' \
@@ -676,11 +676,14 @@ bzr bug update 12345 --see-also-add https://example.com/issue/42 \
 bzr bug update 12345 --status RESOLVED --resolution FIXED \
     --comment "Fixed by patch in #200"
 bzr bug update 100 200 300 --status RESOLVED --resolution WONTFIX
+bzr bug update 12345 --from-json update.json
+bzr bug update --from-json updates.json --json | jq '.failed'
 ```
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `<ID...>` | Yes | Bug ID(s) — pass multiple for batch updates |
+| `<ID...>` | Yes unless `--from-json` supplies targets | Bug ID(s) — pass multiple for batch updates |
+| `--from-json <PATH>` | No | Apply structured update input from a JSON object or array (`-` reads stdin). See [Structured update input](#structured-update-input---from-json) below. |
 | `--status <S>` | No | New status |
 | `--resolution <R>` | No | Resolution (FIXED, WONTFIX, DUPLICATE, etc.) |
 | `--dupe-of <ID>` | No | Mark this bug as a duplicate of another bug; Bugzilla sets status/resolution |
@@ -715,6 +718,44 @@ bzr bug update 100 200 300 --status RESOLVED --resolution WONTFIX
 | `--comment-file <PATH>` | No | Read the comment body from a UTF-8 file; `-` reads stdin (mutually exclusive with `--comment`; missing or non-UTF-8 paths exit 7) |
 | `--comment-private` | No | Mark the comment private (requires `--comment` or `--comment-file`) |
 | `--expect-unchanged-since <TIMESTAMP>` | No | Optimistic-concurrency guard: only apply if the bug's `last_change_time` still equals this value (pass the `last_change_time` from a preceding `bug view`). Re-reads each target before writing and exits 14 (collision) without writing on a mismatch. Client-side, so a narrow check-then-write window remains; with multiple IDs any mismatch aborts the whole batch |
+
+#### Structured update input (`--from-json`)
+
+`--from-json <PATH>` applies bug updates from a structured JSON document; `-`
+reads the document from stdin.
+
+- A top-level **object** applies one update to the positional `<ID...>` targets.
+  If no positional ID is supplied, the object must include `id`. Positional IDs
+  and object `id` are mutually exclusive.
+- A top-level **array** applies one independent update per element. Each element
+  must include `id`; positional IDs are rejected with array input. Array input
+  always emits the batch result shape, even for one element.
+
+Accepted update keys are `id`, `status`, `resolution`, `dupe_of`, `alias`,
+`deadline`, `estimated_time`, `remaining_time`, `work_time`,
+`reset_assigned_to`, `reset_qa_contact`, `assignee`, `priority`, `severity`,
+`summary`, `whiteboard`, `url`, `target_milestone`, `flags`,
+`blocks_add`, `blocks_remove`, `depends_on_add`, `depends_on_remove`,
+`keywords_add`, `keywords_remove`, `cc_add`, `cc_remove`, `groups_add`,
+`groups_remove`, `see_also_add`, `see_also_remove`, `comment`,
+`comment_file`, `comment_private`, and `expect_unchanged_since`.
+**Unknown keys are rejected** (exit 7).
+
+List fields use the same add/remove semantics as the flags: for example,
+`"keywords_add": ["fix-needed"]` sends `{"keywords":{"add":["fix-needed"]}}`.
+`flags` is an array of normal `--flag` syntax strings.
+
+**Precedence:** explicit CLI flags override the corresponding JSON field. For
+arrays, overrides apply to every element. CLI `--comment -` / `--comment-file -`
+cannot be combined with `--from-json -`, and array input rejects CLI stdin
+comment sources. JSON `comment_file` must name a file path; `"-"` is rejected.
+
+```bash
+printf '%s' '{"status":"ASSIGNED","comment":"Taking this"}' \
+  | bzr bug update 12345 --from-json -
+
+bzr bug update --from-json updates.json --json | jq '.succeeded'
+```
 
 When updating multiple bugs, failures on individual bugs do not abort the batch. A summary is printed showing which bugs succeeded and which failed.
 

--- a/docs/superpowers/specs/2026-06-21-issue-365-bug-update-from-json-design.md
+++ b/docs/superpowers/specs/2026-06-21-issue-365-bug-update-from-json-design.md
@@ -1,0 +1,145 @@
+# Issue #365: Bug Update Structured Input Design
+
+## Context
+
+`bug create --from-json` lets agents submit a structured JSON object or array
+instead of flattening a bug model into shell flags. `bug update` still requires
+flags, so an agent that already has an update object must translate it into
+`--status`, `--keywords-add`, `--comment`, and similar flags.
+
+Issue #365 asks for the same structured-input contract on `bug update`:
+unknown-key rejection, explicit CLI flags overriding JSON fields, list
+add/remove semantics, comment-source coverage, optimistic-concurrency coverage,
+and the existing exit-11 partial-failure model.
+
+## Input Shapes
+
+Add `--from-json <PATH|->` to `bug update`.
+
+Top-level object:
+
+- `bzr bug update <ID...> --from-json update.json` applies one structured edit
+  to the positional IDs.
+- The object may also carry `id` for the single-target form
+  `bzr bug update --from-json update.json`.
+- Positional IDs and object `id` are mutually exclusive. Target IDs are
+  higher-blast-radius than ordinary update fields, so `bzr` rejects mixed target
+  sources instead of silently choosing one.
+- Multiple positional IDs keep the current `bug update` semantics: the same
+  update is applied to every ID, and partial server failures use the existing
+  batch-result shape.
+
+Top-level array:
+
+- `bzr bug update --from-json updates.json` applies one independent edit per
+  array element.
+- Each array element must include `id`.
+- Positional IDs are rejected with top-level arrays so a caller cannot
+  accidentally apply every array element to the same bug set.
+- A one-element array still emits the batch-result shape, matching
+  `bug create --from-json`'s "output follows input shape" rule.
+
+Any other top-level shape exits 7.
+
+## Accepted Keys
+
+Update keys match the public update flag names converted to JSON object keys:
+
+- scalar fields: `status`, `resolution`, `dupe_of`, `alias`, `deadline`,
+  `estimated_time`, `remaining_time`, `work_time`, `assignee`, `priority`,
+  `severity`, `summary`, `whiteboard`, `url`, `target_milestone`
+- reset booleans: `reset_assigned_to`, `reset_qa_contact`
+- flag updates: `flags` as an array of normal `--flag` syntax strings
+- ID-list deltas: `blocks_add`, `blocks_remove`, `depends_on_add`,
+  `depends_on_remove`
+- string-list deltas: `keywords_add`, `keywords_remove`, `cc_add`,
+  `cc_remove`, `groups_add`, `groups_remove`, `see_also_add`,
+  `see_also_remove`
+- comment fields: `comment`, `comment_file`, `comment_private`
+- optimistic concurrency: `expect_unchanged_since`
+- array/object target key: `id`
+
+Unknown keys are rejected via `serde(deny_unknown_fields)`. Custom-field writes
+stay out of scope until #283 makes a deliberate design decision.
+
+## CLI Override Rules
+
+Explicit CLI values override corresponding JSON values:
+
+- `Some` scalar flags replace JSON scalar values.
+- non-empty repeatable flags replace JSON arrays for the matching field.
+- true boolean flags set the JSON boolean to true; absent boolean flags leave
+  JSON true/false/absent unchanged.
+- `--comment` or `--comment-file` replaces the JSON comment source uniformly.
+- `--comment-private` sets all resulting comments private.
+- `--expect-unchanged-since` replaces JSON `expect_unchanged_since` uniformly.
+
+For arrays, overrides apply to every element. Positional IDs are not an override
+for arrays; they are rejected for that shape.
+
+## Validation and Writes
+
+All JSON entries are parsed and converted to `UpdateBugParams` before any write:
+
+- invalid JSON or wrong top-level shape exits 7;
+- empty arrays exit 7;
+- array elements without `id` exit 7;
+- object input without positional IDs and without `id` exits 7;
+- object input with positional IDs and JSON `id` exits 7;
+- `comment` and `comment_file` are mutually exclusive;
+- `comment_private` without a comment source exits 7;
+- malformed deadlines, malformed flags, empty list values, and no-op updates
+  reuse the existing update validation;
+- `alias` with multiple target IDs remains invalid;
+- `dupe_of` combined with `status` or `resolution` remains invalid outside
+  clap-validated CLI parsing, so JSON cannot bypass the CLI conflict.
+
+`--from-json -` and `--comment -` / `--comment-file -` cannot both consume
+stdin. Reject that combination with an input-validation error. JSON
+`comment_file` must name a file path; `comment_file: "-"` is rejected. For
+per-entry comments, put the comment text in JSON. For a uniform stdin comment,
+use CLI `--comment -` only with top-level object input when `--from-json` reads
+from a file. Array input rejects CLI stdin comment sources because stdin cannot
+be consumed separately for each element.
+
+Object input reuses the existing `apply_checked` path, preserving current
+single/batch output and all-or-nothing optimistic-concurrency behavior for a
+multi-ID object update.
+
+Array input validates every entry first, then processes entries independently:
+
+- dry-run emits one dry-run result whose `changes` array contains one object per
+  array element;
+- success/failure output uses the existing `BatchResult` shape;
+- per-entry `expect_unchanged_since` is checked before writing that entry;
+- a stale entry is recorded as a failure for its `id` and later entries still
+  run;
+- any failure exits 11 after output is written.
+
+## Files
+
+- `src/cli/bug.rs`: add `UpdateArgs::from_json`, relax positional IDs when
+  `--from-json` is present, and document the flag in long help.
+- `src/cli/mod_tests.rs`: prove `bug update --from-json -` parses without
+  positional IDs.
+- `src/commands/bug/update.rs`: parse/overlay structured input, convert it
+  through existing update validation, and add array batch handling.
+- `src/commands/bug/update_tests.rs`: add parser, validation, override,
+  comment/concurrency, partial-failure, and request-body tests.
+- `docs/bzr-cli.md`: document object and array shapes.
+- `CHANGELOG.md`: add an Unreleased entry.
+
+## Testing
+
+- `cargo test parse_bug_update_from_json_stdin`
+- `cargo test bug_update_from_json --lib`
+- `cargo test commands::bug::update::tests --lib`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `git diff --check`
+
+## Out of Scope
+
+- `bug update` custom-field writes.
+- Input schemas for this payload; #366 covers `bzr schema` input contracts.
+- Structured input for admin resources; #369 covers those resources.
+- Changing existing flag-only `bug update` behavior.

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -495,13 +495,25 @@ pub struct CloneArgs {
 /// Arguments for `bug update`.
 #[derive(Args, Debug, Default)]
 pub struct UpdateArgs {
+    /// Apply one or more structured bug updates from JSON.
+    ///
+    /// A value of `-` reads the JSON from stdin; otherwise it is a
+    /// file path. A top-level object applies one edit to the
+    /// positional IDs, or to its own `id` when no positional ID is
+    /// given. A top-level array applies one independent edit per
+    /// element; each element must include `id` and returns the
+    /// existing batch result shape (exit 11 if any element fails).
+    /// Unknown keys are rejected, and explicit CLI flags override
+    /// corresponding JSON fields.
+    #[arg(long, value_name = "PATH")]
+    pub from_json: Option<String>,
     /// Bug ID(s).
     ///
     /// One or more IDs. When more than one is supplied, the
     /// same field changes are applied to every bug; partial
     /// failures (some bugs updated, others rejected) exit with
     /// code 11 and the JSON output enumerates per-bug results.
-    #[arg(required = true, num_args = 1..)]
+    #[arg(required_unless_present = "from_json", num_args = 1..)]
     pub ids: Vec<u64>,
     /// New status (e.g. `NEW`, `ASSIGNED`, `RESOLVED`, `CLOSED`).
     ///

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -366,6 +366,19 @@ fn bug_create_from_json_conflicts_with_template() {
 }
 
 #[test]
+fn parse_bug_update_from_json_stdin() {
+    let cli = Cli::try_parse_from(["bzr", "bug", "update", "--from-json", "-"]).unwrap();
+    let Commands::Bug {
+        action: BugAction::Update(super::UpdateArgs { from_json, ids, .. }),
+    } = cli.command
+    else {
+        panic!("expected bug update");
+    };
+    assert_eq!(from_json.as_deref(), Some("-"));
+    assert!(ids.is_empty());
+}
+
+#[test]
 fn parse_bug_list_offset_and_paginate() {
     let cli =
         Cli::try_parse_from(["bzr", "bug", "list", "--limit", "10", "--offset", "20"]).unwrap();

--- a/src/commands/bug/update.rs
+++ b/src/commands/bug/update.rs
@@ -1,5 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 use crate::cli::{BugAction, UpdateArgs};
 use crate::client::BugzillaClient;
+use crate::commands::runtime::shared::{merge_set, merge_vec};
 use crate::error::Result;
 use crate::output::result_types::{
     write_result, ActionResult, BatchFailure, BatchResult, DryRunResult, ResourceKind,
@@ -105,6 +108,11 @@ pub(super) fn validate_action(action: &BugAction) -> Result<()> {
 /// Reject `--alias` combined with multiple IDs (Bugzilla allows alias updates
 /// for a single bug only).
 fn validate_args(args: &UpdateArgs) -> Result<()> {
+    if args.dupe_of.is_some() && (args.status.is_some() || args.resolution.is_some()) {
+        return Err(crate::error::BzrError::InputValidation(
+            "--dupe-of cannot be combined with --status or --resolution".into(),
+        ));
+    }
     if args.alias.is_some() && args.ids.len() > 1 {
         return Err(crate::error::BzrError::InputValidation(
             "--alias can only be used when updating one bug".into(),
@@ -117,6 +125,7 @@ fn build_update_params(args: &UpdateArgs) -> Result<(Vec<u64>, UpdateBugParams)>
     validate_args(args)?;
 
     let UpdateArgs {
+        from_json: _,
         ids,
         status,
         resolution,
@@ -211,6 +220,311 @@ fn build_update_params(args: &UpdateArgs) -> Result<(Vec<u64>, UpdateBugParams)>
     Ok((ids.clone(), params))
 }
 
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct JsonUpdateBug {
+    id: Option<u64>,
+    status: Option<String>,
+    resolution: Option<String>,
+    dupe_of: Option<u64>,
+    alias: Option<String>,
+    deadline: Option<String>,
+    estimated_time: Option<f64>,
+    remaining_time: Option<f64>,
+    work_time: Option<f64>,
+    reset_assigned_to: Option<bool>,
+    reset_qa_contact: Option<bool>,
+    assignee: Option<String>,
+    priority: Option<String>,
+    severity: Option<String>,
+    summary: Option<String>,
+    whiteboard: Option<String>,
+    url: Option<String>,
+    target_milestone: Option<String>,
+    comment: Option<String>,
+    comment_file: Option<std::path::PathBuf>,
+    comment_private: Option<bool>,
+    #[serde(default)]
+    flags: Vec<String>,
+    #[serde(default)]
+    blocks_add: Vec<u64>,
+    #[serde(default)]
+    blocks_remove: Vec<u64>,
+    #[serde(default)]
+    depends_on_add: Vec<u64>,
+    #[serde(default)]
+    depends_on_remove: Vec<u64>,
+    #[serde(default)]
+    keywords_add: Vec<String>,
+    #[serde(default)]
+    keywords_remove: Vec<String>,
+    #[serde(default)]
+    cc_add: Vec<String>,
+    #[serde(default)]
+    cc_remove: Vec<String>,
+    #[serde(default)]
+    groups_add: Vec<String>,
+    #[serde(default)]
+    groups_remove: Vec<String>,
+    #[serde(default)]
+    see_also_add: Vec<String>,
+    #[serde(default)]
+    see_also_remove: Vec<String>,
+    expect_unchanged_since: Option<String>,
+}
+
+#[derive(Debug)]
+enum JsonUpdateInput {
+    One(Box<JsonUpdateBug>),
+    Many(Vec<JsonUpdateBug>),
+}
+
+#[derive(Debug, Serialize)]
+struct JsonUpdateRequest {
+    id: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expect_unchanged_since: Option<String>,
+    #[serde(flatten)]
+    params: UpdateBugParams,
+}
+
+fn read_from_json(arg: &str) -> Result<String> {
+    if arg == "-" {
+        crate::commands::runtime::shared::read_stdin_to_string()
+    } else {
+        crate::commands::runtime::shared::read_file_with_context(
+            std::path::Path::new(arg),
+            "--from-json",
+        )
+    }
+}
+
+fn parse_json_updates(raw: &str) -> Result<JsonUpdateInput> {
+    let value: serde_json::Value = serde_json::from_str(raw).map_err(|e| {
+        crate::error::BzrError::InputValidation(format!("--from-json: invalid JSON: {e}"))
+    })?;
+    match value {
+        serde_json::Value::Array(items) => {
+            let entries = items
+                .into_iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    serde_json::from_value(v).map_err(|e| {
+                        crate::error::BzrError::InputValidation(format!(
+                            "--from-json item {i}: {e}"
+                        ))
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(JsonUpdateInput::Many(entries))
+        }
+        serde_json::Value::Object(_) => {
+            let one = serde_json::from_value(value).map_err(|e| {
+                crate::error::BzrError::InputValidation(format!("--from-json: {e}"))
+            })?;
+            Ok(JsonUpdateInput::One(Box::new(one)))
+        }
+        _ => Err(crate::error::BzrError::InputValidation(
+            "--from-json expects a JSON object or an array of objects".into(),
+        )),
+    }
+}
+
+fn merge_copy<T: Copy>(target: &mut Option<T>, value: Option<T>) {
+    if let Some(value) = value {
+        *target = Some(value);
+    }
+}
+
+fn merge_bool_true(target: &mut Option<bool>, value: bool) {
+    if value {
+        *target = Some(true);
+    }
+}
+
+fn merge_path(target: &mut Option<std::path::PathBuf>, value: Option<&std::path::Path>) {
+    if let Some(value) = value {
+        *target = Some(value.to_path_buf());
+    }
+}
+
+fn merge_vec_u64(target: &mut Vec<u64>, value: &[u64]) {
+    if !value.is_empty() {
+        *target = value.to_vec();
+    }
+}
+
+fn overlay_cli(mut json: JsonUpdateBug, args: &UpdateArgs) -> JsonUpdateBug {
+    merge_set(&mut json.status, args.status.as_deref());
+    merge_set(&mut json.resolution, args.resolution.as_deref());
+    merge_copy(&mut json.dupe_of, args.dupe_of);
+    merge_set(&mut json.alias, args.alias.as_deref());
+    merge_set(&mut json.deadline, args.deadline.as_deref());
+    merge_copy(&mut json.estimated_time, args.estimated_time);
+    merge_copy(&mut json.remaining_time, args.remaining_time);
+    merge_copy(&mut json.work_time, args.work_time);
+    merge_bool_true(&mut json.reset_assigned_to, args.reset_assigned_to);
+    merge_bool_true(&mut json.reset_qa_contact, args.reset_qa_contact);
+    merge_set(&mut json.assignee, args.assignee.as_deref());
+    merge_set(&mut json.priority, args.priority.as_deref());
+    merge_set(&mut json.severity, args.severity.as_deref());
+    merge_set(&mut json.summary, args.summary.as_deref());
+    merge_set(&mut json.whiteboard, args.whiteboard.as_deref());
+    merge_set(&mut json.url, args.url.as_deref());
+    merge_set(&mut json.target_milestone, args.target_milestone.as_deref());
+    if let Some(comment) = args.comment.as_deref() {
+        json.comment = Some(comment.to_string());
+        json.comment_file = None;
+    }
+    if args.comment_file.is_some() {
+        json.comment = None;
+        merge_path(&mut json.comment_file, args.comment_file.as_deref());
+    }
+    merge_bool_true(&mut json.comment_private, args.comment_private);
+    merge_vec(&mut json.flags, &args.flag);
+    merge_vec_u64(&mut json.blocks_add, &args.blocks_add);
+    merge_vec_u64(&mut json.blocks_remove, &args.blocks_remove);
+    merge_vec_u64(&mut json.depends_on_add, &args.depends_on_add);
+    merge_vec_u64(&mut json.depends_on_remove, &args.depends_on_remove);
+    merge_vec(&mut json.keywords_add, &args.keywords_add);
+    merge_vec(&mut json.keywords_remove, &args.keywords_remove);
+    merge_vec(&mut json.cc_add, &args.cc_add);
+    merge_vec(&mut json.cc_remove, &args.cc_remove);
+    merge_vec(&mut json.groups_add, &args.groups_add);
+    merge_vec(&mut json.groups_remove, &args.groups_remove);
+    merge_vec(&mut json.see_also_add, &args.see_also_add);
+    merge_vec(&mut json.see_also_remove, &args.see_also_remove);
+    merge_set(
+        &mut json.expect_unchanged_since,
+        args.expect_unchanged_since.as_deref(),
+    );
+    json
+}
+
+fn reject_json_comment_file_stdin(entry: &JsonUpdateBug) -> Result<()> {
+    if entry.comment_file.as_deref() == Some(std::path::Path::new("-")) {
+        return Err(crate::error::BzrError::InputValidation(
+            "--from-json comment_file cannot read from stdin; use comment text in JSON instead"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+fn cli_comment_uses_stdin(args: &UpdateArgs) -> bool {
+    args.comment.as_deref() == Some("-")
+        || args.comment_file.as_deref() == Some(std::path::Path::new("-"))
+}
+
+fn reject_cli_stdin_comment_source(
+    args: &UpdateArgs,
+    from_json_arg: &str,
+    is_array: bool,
+) -> Result<()> {
+    if !cli_comment_uses_stdin(args) {
+        return Ok(());
+    }
+    if from_json_arg == "-" {
+        return Err(crate::error::BzrError::InputValidation(
+            "--from-json - cannot be combined with --comment - or --comment-file -".into(),
+        ));
+    }
+    if is_array {
+        return Err(crate::error::BzrError::InputValidation(
+            "--from-json array input cannot combine with --comment - or --comment-file -; \
+             put per-entry comments in JSON"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+fn object_ids(entry: &JsonUpdateBug, args: &UpdateArgs) -> Result<Vec<u64>> {
+    if !args.ids.is_empty() {
+        if entry.id.is_some() {
+            return Err(crate::error::BzrError::InputValidation(
+                "--from-json object cannot combine positional IDs with JSON id".into(),
+            ));
+        }
+        return Ok(args.ids.clone());
+    }
+    entry.id.map(|id| vec![id]).ok_or_else(|| {
+        crate::error::BzrError::InputValidation(
+            "--from-json object requires positional IDs or an id field".into(),
+        )
+    })
+}
+
+fn update_args_from_json(entry: JsonUpdateBug, ids: Vec<u64>) -> UpdateArgs {
+    UpdateArgs {
+        from_json: None,
+        ids,
+        status: entry.status,
+        resolution: entry.resolution,
+        dupe_of: entry.dupe_of,
+        alias: entry.alias,
+        deadline: entry.deadline,
+        estimated_time: entry.estimated_time,
+        remaining_time: entry.remaining_time,
+        work_time: entry.work_time,
+        reset_assigned_to: entry.reset_assigned_to.unwrap_or(false),
+        reset_qa_contact: entry.reset_qa_contact.unwrap_or(false),
+        assignee: entry.assignee,
+        priority: entry.priority,
+        severity: entry.severity,
+        summary: entry.summary,
+        whiteboard: entry.whiteboard,
+        url: entry.url,
+        target_milestone: entry.target_milestone,
+        comment: entry.comment,
+        comment_file: entry.comment_file,
+        comment_private: entry.comment_private.unwrap_or(false),
+        flag: entry.flags,
+        blocks_add: entry.blocks_add,
+        blocks_remove: entry.blocks_remove,
+        depends_on_add: entry.depends_on_add,
+        depends_on_remove: entry.depends_on_remove,
+        keywords_add: entry.keywords_add,
+        keywords_remove: entry.keywords_remove,
+        cc_add: entry.cc_add,
+        cc_remove: entry.cc_remove,
+        groups_add: entry.groups_add,
+        groups_remove: entry.groups_remove,
+        see_also_add: entry.see_also_add,
+        see_also_remove: entry.see_also_remove,
+        expect_unchanged_since: entry.expect_unchanged_since,
+    }
+}
+
+fn build_from_json(
+    entry: JsonUpdateBug,
+    args: &UpdateArgs,
+    ids: Vec<u64>,
+) -> Result<(Vec<u64>, UpdateBugParams, Option<String>)> {
+    reject_json_comment_file_stdin(&entry)?;
+    let entry = overlay_cli(entry, args);
+    let update_args = update_args_from_json(entry, ids);
+    let expected = update_args.expect_unchanged_since.clone();
+    let (ids, params) = build_update_params(&update_args)?;
+    Ok((ids, params, expected))
+}
+
+fn build_array_request(
+    entry: JsonUpdateBug,
+    args: &UpdateArgs,
+    index: usize,
+) -> Result<JsonUpdateRequest> {
+    let id = entry.id.ok_or_else(|| {
+        crate::error::BzrError::InputValidation(format!("--from-json item {index}: id is required"))
+    })?;
+    let (_ids, params, expect_unchanged_since) = build_from_json(entry, args, vec![id])?;
+    Ok(JsonUpdateRequest {
+        id,
+        expect_unchanged_since,
+        params,
+    })
+}
+
 async fn update_single(
     client: &BugzillaClient,
     id: u64,
@@ -294,12 +608,126 @@ async fn update_batch(
     ensure_batch_complete(batch.succeeded.len(), batch.failed.len())
 }
 
+fn write_json_array_dry_run(
+    requests: &[JsonUpdateRequest],
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) {
+    let ids: Vec<u64> = requests.iter().map(|request| request.id).collect();
+    let ids_str: Vec<String> = ids.iter().map(|id| format!("#{id}")).collect();
+    write_result(
+        &DryRunResult::new(ResourceKind::Bug, &ids, &requests),
+        &format!(
+            "Dry run: would update bug(s) {} (no changes made)",
+            ids_str.join(", ")
+        ),
+        format,
+        w.out,
+    );
+}
+
+async fn update_many_from_json(
+    client: &BugzillaClient,
+    requests: &[JsonUpdateRequest],
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) -> Result<()> {
+    if crate::commands::runtime::dry_run::enabled() {
+        write_json_array_dry_run(requests, format, w);
+        return Ok(());
+    }
+    if !confirm_batch(requests.len(), w)? {
+        let _ = writeln!(w.err, "Aborted; no changes made.");
+        return Ok(());
+    }
+
+    let mut succeeded = Vec::new();
+    let mut failed = Vec::new();
+    for request in requests {
+        if let Some(expected) = request.expect_unchanged_since.as_deref() {
+            if let Err(e) = ensure_unchanged_since(client, &[request.id], expected).await {
+                failed.push(BatchFailure {
+                    id: request.id,
+                    error: e.to_string(),
+                });
+                continue;
+            }
+        }
+        match client.update_bug(request.id, &request.params).await {
+            Ok(()) => succeeded.push(request.id),
+            Err(e) => failed.push(BatchFailure {
+                id: request.id,
+                error: e.to_string(),
+            }),
+        }
+    }
+
+    let batch = BatchResult::new(succeeded, failed);
+    let with_comment = requests
+        .iter()
+        .any(|request| request.params.comment.is_some());
+    write_batch_result(&batch, format, with_comment, w);
+    ensure_batch_complete(batch.succeeded.len(), batch.failed.len())
+}
+
+async fn handle_from_json(
+    client: &BugzillaClient,
+    args: &UpdateArgs,
+    arg: &str,
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) -> Result<()> {
+    if arg == "-" && cli_comment_uses_stdin(args) {
+        reject_cli_stdin_comment_source(args, arg, false)?;
+    }
+    let raw = read_from_json(arg)?;
+    match parse_json_updates(&raw)? {
+        JsonUpdateInput::One(entry) => {
+            reject_cli_stdin_comment_source(args, arg, false)?;
+            let ids = object_ids(&entry, args)?;
+            let (ids, params, expect_unchanged_since) = build_from_json(*entry, args, ids)?;
+            apply_checked(
+                client,
+                ApplyRequest {
+                    ids,
+                    params,
+                    expect_unchanged_since: expect_unchanged_since.as_deref(),
+                },
+                format,
+                w,
+            )
+            .await
+        }
+        JsonUpdateInput::Many(entries) => {
+            reject_cli_stdin_comment_source(args, arg, true)?;
+            if !args.ids.is_empty() {
+                return Err(crate::error::BzrError::InputValidation(
+                    "--from-json array input cannot be combined with positional IDs".into(),
+                ));
+            }
+            if entries.is_empty() {
+                return Err(crate::error::BzrError::InputValidation(
+                    "--from-json: empty array, nothing to update".into(),
+                ));
+            }
+            let mut requests = Vec::with_capacity(entries.len());
+            for (index, entry) in entries.into_iter().enumerate() {
+                requests.push(build_array_request(entry, args, index)?);
+            }
+            update_many_from_json(client, &requests, format, w).await
+        }
+    }
+}
+
 pub(super) async fn handle(
     client: &BugzillaClient,
     args: &UpdateArgs,
     format: OutputFormat,
     w: &mut Writers<'_>,
 ) -> Result<()> {
+    if let Some(arg) = args.from_json.as_deref() {
+        return handle_from_json(client, args, arg, format, w).await;
+    }
     let (ids, params) = build_update_params(args)?;
     apply_checked(
         client,

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use wiremock::matchers::{body_json, method, path};
+use wiremock::matchers::{body_json, body_partial_json, method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::BugAction;
@@ -115,6 +115,15 @@ async fn mock_get_bug_lct(mock: &wiremock::MockServer, id: u64, lct: &str) {
         .await;
 }
 
+async fn received_put_count(mock: &wiremock::MockServer) -> usize {
+    mock.received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|request| request.method.as_str() == "PUT")
+        .count()
+}
+
 fn update_action_expect_unchanged(ids: Vec<u64>, since: &str) -> BugAction {
     let mut action = make_update_action(ids);
     if let BugAction::Update(crate::cli::UpdateArgs {
@@ -125,6 +134,419 @@ fn update_action_expect_unchanged(ids: Vec<u64>, since: &str) -> BugAction {
         *expect_unchanged_since = Some(since.to_string());
     }
     action
+}
+
+fn from_json_update_action(path: &str) -> BugAction {
+    BugAction::Update(crate::cli::UpdateArgs {
+        from_json: Some(path.to_string()),
+        ..Default::default()
+    })
+}
+
+fn from_json_update_action_with_ids(ids: Vec<u64>, path: &str) -> BugAction {
+    BugAction::Update(crate::cli::UpdateArgs {
+        from_json: Some(path.to_string()),
+        ids,
+        ..Default::default()
+    })
+}
+
+fn write_json_file(tmp: &tempfile::TempDir, json: &str) -> String {
+    let path = tmp.path().join("update-input.json");
+    std::fs::write(&path, json).unwrap();
+    path.to_string_lossy().into_owned()
+}
+
+#[tokio::test]
+async fn bug_update_from_json_object_uses_positional_id() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/42"))
+        .and(body_json(serde_json::json!({"status": "ASSIGNED"})))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"bugs": [{"id": 42, "changes": {}}]})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let json = r#"{"status":"ASSIGNED"}"#;
+    let action = from_json_update_action_with_ids(vec![42], &write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+
+    assert!(
+        result.is_ok(),
+        "JSON object update should succeed: {result:?}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["action"], "updated");
+    assert_eq!(parsed["id"], 42);
+}
+
+#[tokio::test]
+async fn bug_update_from_json_cli_flag_overrides_json_field() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/42"))
+        .and(body_json(serde_json::json!({"status": "ASSIGNED"})))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"bugs": [{"id": 42, "changes": {}}]})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let json = r#"{"id":42,"status":"NEW"}"#;
+    let mut action = from_json_update_action(&write_json_file(&tmp, json));
+    if let BugAction::Update(crate::cli::UpdateArgs { status, .. }) = &mut action {
+        *status = Some("ASSIGNED".into());
+    }
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+
+    assert!(
+        result.is_ok(),
+        "CLI status should override JSON: {result:?}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["action"], "updated");
+    assert_eq!(parsed["id"], 42);
+}
+
+#[tokio::test]
+async fn bug_update_from_json_list_fields_use_add_remove_shapes() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/42"))
+        .and(body_partial_json(serde_json::json!({
+            "keywords": {"add": ["fix-needed"], "remove": ["stale"]},
+            "blocks": {"add": [100]},
+            "depends_on": {"remove": [50]},
+            "see_also": {"add": ["https://example.com/issue/1"]},
+        })))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"bugs": [{"id": 42, "changes": {}}]})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let json = r#"{
+        "keywords_add":["fix-needed"],
+        "keywords_remove":["stale"],
+        "blocks_add":[100],
+        "depends_on_remove":[50],
+        "see_also_add":["https://example.com/issue/1"]
+    }"#;
+    let action = from_json_update_action_with_ids(vec![42], &write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+
+    assert!(result.is_ok(), "JSON list deltas should update: {result:?}");
+}
+
+#[tokio::test]
+async fn bug_update_from_json_array_batches_per_id() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/1"))
+        .and(body_json(serde_json::json!({"status": "ASSIGNED"})))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"bugs": [{"id": 1, "changes": {}}]})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/2"))
+        .and(body_json(serde_json::json!({"priority": "high"})))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"bugs": [{"id": 2, "changes": {}}]})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let json = r#"[{"id":1,"status":"ASSIGNED"},{"id":2,"priority":"high"}]"#;
+    let action = from_json_update_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+
+    assert!(result.is_ok(), "array update should succeed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["succeeded"], serde_json::json!([1, 2]));
+    assert_eq!(parsed["failed"], serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn bug_update_from_json_single_element_array_returns_batch_shape() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/8"))
+        .and(body_json(serde_json::json!({"status": "ASSIGNED"})))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"bugs": [{"id": 8, "changes": {}}]})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let json = r#"[{"id":8,"status":"ASSIGNED"}]"#;
+    let action = from_json_update_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+
+    assert!(
+        result.is_ok(),
+        "one-element array should update: {result:?}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["succeeded"], serde_json::json!([8]));
+    assert_eq!(parsed["failed"], serde_json::json!([]));
+    assert!(
+        parsed.get("id").is_none(),
+        "array input must not use the single-object shape"
+    );
+}
+
+#[tokio::test]
+async fn bug_update_from_json_array_dry_run_emits_single_object_and_no_write() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/1"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let json = r#"[{"id":1,"status":"ASSIGNED"},{"id":2,"priority":"high"}]"#;
+    let action = from_json_update_action(&write_json_file(&tmp, json));
+    crate::commands::runtime::dry_run::set(true);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    crate::commands::runtime::dry_run::set(false);
+
+    assert!(result.is_ok(), "array dry-run should succeed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["ids"], serde_json::json!([1, 2]));
+    assert_eq!(parsed["changes"].as_array().unwrap().len(), 2);
+    assert_eq!(received_put_count(&mock).await, 0);
+}
+
+#[tokio::test]
+async fn bug_update_from_json_array_partial_failure_exits_11() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    mock_put_bug_ok(&mock, 1).await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/2"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let json = r#"[{"id":1,"status":"ASSIGNED"},{"id":2,"status":"ASSIGNED"}]"#;
+    let action = from_json_update_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+
+    let err = result.unwrap_err();
+    assert!(matches!(
+        err,
+        crate::error::BzrError::BatchPartialFailure {
+            succeeded: 1,
+            failed: 1
+        }
+    ));
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["succeeded"], serde_json::json!([1]));
+    assert_eq!(parsed["failed"][0]["id"], 2);
+}
+
+#[tokio::test]
+async fn bug_update_from_json_comment_and_expect_guard() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    mock_get_bug_lct(&mock, 42, "2026-06-21T12:00:00Z").await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/42"))
+        .and(body_partial_json(serde_json::json!({
+            "status": "ASSIGNED",
+            "comment": {
+                "body": "ready",
+                "is_private": true,
+            },
+        })))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"bugs": [{"id": 42, "changes": {}}]})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let json = r#"{
+        "id":42,
+        "status":"ASSIGNED",
+        "comment":"ready",
+        "comment_private":true,
+        "expect_unchanged_since":"2026-06-21T12:00:00Z"
+    }"#;
+    let action = from_json_update_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+
+    assert!(
+        result.is_ok(),
+        "JSON comment/concurrency update should succeed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn bug_update_from_json_rejects_unknown_field() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    let json = r#"{"id":42,"status":"ASSIGNED","bogus":true}"#;
+    let action = from_json_update_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let err =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await
+            .unwrap_err();
+
+    assert!(
+        matches!(err, crate::error::BzrError::InputValidation(ref msg) if msg.contains("bogus") || msg.contains("unknown field")),
+        "expected unknown-field validation, got {err:?}"
+    );
+    assert_eq!(received_put_count(&mock).await, 0);
+}
+
+#[tokio::test]
+async fn bug_update_from_json_rejects_empty_array() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    let action = from_json_update_action(&write_json_file(&tmp, "[]"));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let err =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await
+            .unwrap_err();
+
+    assert!(
+        matches!(err, crate::error::BzrError::InputValidation(ref msg) if msg.contains("empty array")),
+        "expected empty-array validation, got {err:?}"
+    );
+    assert_eq!(received_put_count(&mock).await, 0);
+}
+
+#[tokio::test]
+async fn bug_update_from_json_rejects_array_item_without_id() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    let json = r#"[{"status":"ASSIGNED"}]"#;
+    let action = from_json_update_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let err =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await
+            .unwrap_err();
+
+    assert!(
+        matches!(err, crate::error::BzrError::InputValidation(ref msg) if msg.contains("id is required")),
+        "expected array-item id validation, got {err:?}"
+    );
+    assert_eq!(received_put_count(&mock).await, 0);
+}
+
+#[tokio::test]
+async fn bug_update_from_json_rejects_object_without_target_id() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    let json = r#"{"status":"ASSIGNED"}"#;
+    let action = from_json_update_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let err =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await
+            .unwrap_err();
+
+    assert!(
+        matches!(err, crate::error::BzrError::InputValidation(ref msg) if msg.contains("requires positional IDs") && msg.contains("id field")),
+        "expected object target validation, got {err:?}"
+    );
+    assert_eq!(received_put_count(&mock).await, 0);
+}
+
+#[tokio::test]
+async fn bug_update_from_json_rejects_mixed_positional_and_json_id() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    let json = r#"{"id":42,"status":"ASSIGNED"}"#;
+    let action = from_json_update_action_with_ids(vec![43], &write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let err =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await
+            .unwrap_err();
+
+    assert!(
+        matches!(err, crate::error::BzrError::InputValidation(ref msg) if msg.contains("id") && msg.contains("positional")),
+        "expected mixed-id-source validation, got {err:?}"
+    );
+    assert_eq!(received_put_count(&mock).await, 0);
+}
+
+#[tokio::test]
+async fn bug_update_from_json_rejects_dupe_of_with_status() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    let json = r#"{"id":42,"dupe_of":99,"status":"RESOLVED"}"#;
+    let action = from_json_update_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let err =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await
+            .unwrap_err();
+
+    assert!(
+        matches!(err, crate::error::BzrError::InputValidation(ref msg) if msg.contains("--dupe-of") && msg.contains("--status")),
+        "expected dupe/status conflict validation, got {err:?}"
+    );
+    assert_eq!(received_put_count(&mock).await, 0);
+}
+
+#[tokio::test]
+async fn bug_update_from_json_rejects_json_comment_file_stdin() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    let json = r#"{"id":42,"status":"ASSIGNED","comment_file":"-"}"#;
+    let action = from_json_update_action(&write_json_file(&tmp, json));
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let err =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await
+            .unwrap_err();
+
+    assert!(
+        matches!(err, crate::error::BzrError::InputValidation(ref msg) if msg.contains("comment_file") && msg.contains("stdin")),
+        "expected comment_file stdin validation, got {err:?}"
+    );
+    assert_eq!(received_put_count(&mock).await, 0);
 }
 
 #[tokio::test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -871,6 +871,7 @@ async fn bug_update_integration() {
         .await;
 
     let action = bzr::cli::BugAction::Update(bzr::cli::UpdateArgs {
+        from_json: None,
         ids: vec![42],
         status: Some("RESOLVED".to_string()),
         resolution: Some("FIXED".to_string()),
@@ -950,6 +951,7 @@ async fn bug_update_scalar_parity_fields_integration() {
         .await;
 
     let action = bzr::cli::BugAction::Update(bzr::cli::UpdateArgs {
+        from_json: None,
         ids: vec![42],
         status: None,
         resolution: None,
@@ -1024,6 +1026,7 @@ async fn bug_update_with_comment_integration() {
         .await;
 
     let action = bzr::cli::BugAction::Update(bzr::cli::UpdateArgs {
+        from_json: None,
         ids: vec![42],
         status: Some("RESOLVED".to_string()),
         resolution: Some("FIXED".to_string()),


### PR DESCRIPTION
## Summary

- add `bug update --from-json <PATH|->` for structured update objects and arrays
- reuse existing update validation, dry-run, optimistic concurrency, and batch partial-failure output
- document object/array payload shapes and add #365 design notes

Closes #365

## Verification

- `cargo test parse_bug_update_from_json_stdin`
- `cargo test bug_update_from_json --lib`
- `cargo test commands::bug::update::tests --lib`
- `cargo test --test integration cli_and_docs_avoid_misleading_trim_phrasing`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- `BZR_BIN=target/debug/bzr sh agent-skills/tests/flag-drift-check.sh`
- `BZR_BIN=target/debug/bzr sh agent-skills/tests/drift-check.sh`
- pre-push `cargo test`
