### PR TITLE
feat(schema): publish structured input contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   guard. (#364)
 - `bug update` now accepts `--from-json <PATH|->` structured input for object
   and array update payloads. (#365)
+- `schema` now publishes `bug-create-input` and `bug-update-input` JSON
+  Schemas for the structured payloads accepted by `--from-json`. (#366)
 - `query run` now accepts `--count`, matching the count-only output shape used
   by bug search-backed commands. (#368)
 

--- a/agent-skills/skills/bzr-reference/reference/commands.md
+++ b/agent-skills/skills/bzr-reference/reference/commands.md
@@ -110,3 +110,5 @@ Operate on bugs.
 ## schema
 - `bzr schema`            # list the published JSON Schema names
 - `bzr schema bug`        # print one schema (draft 2020-12) for `--json` output
+- `bzr schema bug-create-input`  # `bug create --from-json` payload
+- `bzr schema bug-update-input`  # `bug update --from-json` payload

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -612,7 +612,9 @@ Accepted keys match the create flag names: `product`, `component`, `summary`, `v
 
 **Precedence:** an explicit CLI flag overrides the corresponding JSON field, applied uniformly to every element of an array — e.g. `--product Fedora --from-json bugs.json` forces `product` on all entries. `--from-json` is mutually exclusive with `--template` and bypasses the `$EDITOR` flow.
 
-`bug update` accepts its own structured update input via `--from-json`; other resource commands do not yet accept `--from-json`.
+The `bug create` payload shape is published as `bzr schema bug-create-input`.
+`bug update` accepts its own structured update input via `--from-json`; other
+resource commands do not yet accept `--from-json`.
 
 ```bash
 printf '%s' '{"product":"Fedora","component":"kernel","summary":"S"}' \
@@ -749,6 +751,7 @@ List fields use the same add/remove semantics as the flags: for example,
 arrays, overrides apply to every element. CLI `--comment -` / `--comment-file -`
 cannot be combined with `--from-json -`, and array input rejects CLI stdin
 comment sources. JSON `comment_file` must name a file path; `"-"` is rejected.
+The payload shape is published as `bzr schema bug-update-input`.
 
 ```bash
 printf '%s' '{"status":"ASSIGNED","comment":"Taking this"}' \
@@ -1815,11 +1818,11 @@ installed and sourced by your shell startup. For zsh, the file name must be
 
 ## `bzr schema` -- Published JSON Schemas
 
-Print a JSON Schema (draft 2020-12) describing the `--format json` output of a
-command family. The schemas are checked into `schemas/` and embedded in the
-binary, so a consumer can validate `bzr` output against a contract instead of
-branching over the per-command shape differences. This command is local: it
-makes no network calls and needs no configured server.
+Print a JSON Schema (draft 2020-12) describing a JSON contract used by `bzr`.
+The schemas are checked into `schemas/` and embedded in the binary, so a
+consumer can validate `bzr` output or selected `--from-json` input payloads
+against a contract instead of branching over per-command shape differences.
+This command is local: it makes no network calls and needs no configured server.
 
 ```
 bzr schema [NAME]
@@ -1834,6 +1837,8 @@ Run without a name to list the available schemas; pass one to print it:
 ```bash
 bzr schema                      # list schema names
 bzr schema bug                  # the bug object (bug view / list elements)
+bzr schema bug-create-input     # `bug create --from-json` payload
+bzr schema bug-update-input     # `bug update --from-json` payload
 bzr schema batch-result | jq .  # the batch `bug update` envelope
 ```
 
@@ -1847,7 +1852,8 @@ Available schemas: `bug`, `comment`, `attachment`, `product`, `component`,
 mutation/result envelopes `action-result`, `batch-result`,
 `batch-create-result`, `multi-bug-view`, `tag-result`, `membership-result`,
 `count-result`, `download-result`, `upload-result`, `config-result`,
-`search-result`, `dry-run-result`.
+`search-result`, `dry-run-result`; and the structured input contracts
+`bug-create-input`, `bug-update-input`.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-21-issue-366-input-schema-design.md
+++ b/docs/superpowers/specs/2026-06-21-issue-366-input-schema-design.md
@@ -1,0 +1,45 @@
+# Issue 366: Input Schemas for `--from-json`
+
+## Context
+
+`bzr schema` publishes checked-in JSON Schemas for JSON output shapes, but the
+structured input accepted by `bug create --from-json` and `bug update
+--from-json` has no equivalent contract. Agents can submit these payloads, but
+cannot validate key names or value kinds before invoking `bzr`.
+
+## Decision
+
+Add two schema names to the existing file-backed registry:
+
+- `bug-create-input`
+- `bug-update-input`
+
+Each schema describes the whole payload accepted by `--from-json`: either a
+top-level object or a top-level array of objects. The object schema is kept in a
+`$defs` entry so drift tests can compare its `properties` with the serde
+`deny_unknown_fields` parser for the corresponding input struct.
+
+These schemas describe the JSON payload shape, not every command-level
+precondition after CLI overlay:
+
+- `bug-create-input` does not mark `product`, `component`, or `summary` as
+  required because those may be supplied by explicit CLI flags.
+- `bug-update-input` does not require `id` on the object form because
+  positional IDs may provide the target. The array-item definition requires
+  `id`, matching the array path.
+
+Unknown keys remain disallowed with `additionalProperties: false`, matching the
+parser. Custom-field writes stay out of scope until the custom-field input
+surface is decided.
+
+## Drift Guard
+
+Add parser-local unit tests beside `bug create` and `bug update` that:
+
+- derive the accepted key set from serde's `deny_unknown_fields` error;
+- compare that key set to the schema object's `properties`;
+- parse each schema property's example value through the real JSON input struct.
+
+This keeps the published key set and representative value types aligned with
+the parser without adding a runtime schema-generation dependency.
+

--- a/schemas/bug-create-input.json
+++ b/schemas/bug-create-input.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/bug-create-input.json",
+  "title": "BugCreateInput",
+  "description": "Payload accepted by `bug create --from-json`. A top-level object creates one bug; a top-level array creates one bug per element and uses the batch-create result shape. Required create fields may be supplied by JSON or explicit CLI flags, so this schema describes payload shape rather than post-merge command validity.",
+  "type": ["object", "array"],
+  "oneOf": [
+    {
+      "$ref": "#/$defs/bugCreateInputObject"
+    },
+    {
+      "description": "Batch form: each element is one bug-create object.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/bugCreateInputObject"
+      }
+    }
+  ],
+  "$defs": {
+    "bugCreateInputObject": {
+      "description": "One structured bug-create payload. Unknown keys are rejected.",
+      "type": "object",
+      "properties": {
+        "product": {
+          "type": ["string", "null"],
+          "examples": ["Fedora"]
+        },
+        "component": {
+          "type": ["string", "null"],
+          "examples": ["kernel"]
+        },
+        "summary": {
+          "type": ["string", "null"],
+          "examples": ["Crash on suspend"]
+        },
+        "version": {
+          "type": ["string", "null"],
+          "examples": ["unspecified"]
+        },
+        "description": {
+          "type": ["string", "null"],
+          "examples": ["Steps to reproduce..."]
+        },
+        "priority": {
+          "type": ["string", "null"],
+          "examples": ["P2"]
+        },
+        "severity": {
+          "type": ["string", "null"],
+          "examples": ["normal"]
+        },
+        "assignee": {
+          "type": ["string", "null"],
+          "examples": ["dev@example.com"]
+        },
+        "op_sys": {
+          "type": ["string", "null"],
+          "examples": ["Linux"]
+        },
+        "rep_platform": {
+          "type": ["string", "null"],
+          "examples": ["x86_64"]
+        },
+        "alias": {
+          "type": ["string", "null"],
+          "examples": ["suspend-crash"]
+        },
+        "url": {
+          "type": ["string", "null"],
+          "examples": ["https://example.com/reproducer"]
+        },
+        "whiteboard": {
+          "type": ["string", "null"],
+          "examples": ["needs-triage"]
+        },
+        "target_milestone": {
+          "type": ["string", "null"],
+          "examples": ["5.0"]
+        },
+        "deadline": {
+          "type": ["string", "null"],
+          "format": "date",
+          "examples": ["2026-12-31"]
+        },
+        "blocks": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "examples": [[100, 200]]
+        },
+        "depends_on": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "examples": [[50]]
+        },
+        "cc": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["alice@example.com"]]
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["regression"]]
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["security"]]
+        },
+        "flags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["review?(alice@example.com)"]]
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/bug-update-input.json
+++ b/schemas/bug-update-input.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/bug-update-input.json",
+  "title": "BugUpdateInput",
+  "description": "Payload accepted by `bug update --from-json`. A top-level object applies one update to positional IDs or to its own `id`; a top-level array applies one independent update per element and always uses the batch result shape. This schema describes payload shape rather than every post-merge command precondition.",
+  "type": ["object", "array"],
+  "oneOf": [
+    {
+      "$ref": "#/$defs/bugUpdateInputObject"
+    },
+    {
+      "description": "Batch form: each element is one bug-update object and must include `id`.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/bugUpdateInputArrayItem"
+      }
+    }
+  ],
+  "$defs": {
+    "bugUpdateInputObject": {
+      "description": "One structured bug-update payload. Unknown keys are rejected.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "examples": [12345]
+        },
+        "status": {
+          "type": ["string", "null"],
+          "examples": ["ASSIGNED"]
+        },
+        "resolution": {
+          "type": ["string", "null"],
+          "examples": ["FIXED"]
+        },
+        "dupe_of": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "examples": [67890]
+        },
+        "alias": {
+          "type": ["string", "null"],
+          "examples": ["short-name"]
+        },
+        "deadline": {
+          "type": ["string", "null"],
+          "format": "date",
+          "examples": ["2026-12-31"]
+        },
+        "estimated_time": {
+          "type": ["number", "null"],
+          "examples": [3.5]
+        },
+        "remaining_time": {
+          "type": ["number", "null"],
+          "examples": [1.25]
+        },
+        "work_time": {
+          "type": ["number", "null"],
+          "examples": [0.5]
+        },
+        "reset_assigned_to": {
+          "type": ["boolean", "null"],
+          "examples": [true]
+        },
+        "reset_qa_contact": {
+          "type": ["boolean", "null"],
+          "examples": [true]
+        },
+        "assignee": {
+          "type": ["string", "null"],
+          "examples": ["dev@example.com"]
+        },
+        "priority": {
+          "type": ["string", "null"],
+          "examples": ["P2"]
+        },
+        "severity": {
+          "type": ["string", "null"],
+          "examples": ["normal"]
+        },
+        "summary": {
+          "type": ["string", "null"],
+          "examples": ["Updated summary"]
+        },
+        "whiteboard": {
+          "type": ["string", "null"],
+          "examples": ["needs-triage"]
+        },
+        "url": {
+          "type": ["string", "null"],
+          "examples": ["https://example.com/reproducer"]
+        },
+        "target_milestone": {
+          "type": ["string", "null"],
+          "examples": ["5.0"]
+        },
+        "comment": {
+          "type": ["string", "null"],
+          "examples": ["Taking this bug."]
+        },
+        "comment_file": {
+          "type": ["string", "null"],
+          "examples": ["comment.txt"]
+        },
+        "comment_private": {
+          "type": ["boolean", "null"],
+          "examples": [true]
+        },
+        "flags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["review?(alice@example.com)"]]
+        },
+        "blocks_add": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "examples": [[100]]
+        },
+        "blocks_remove": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "examples": [[200]]
+        },
+        "depends_on_add": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "examples": [[50]]
+        },
+        "depends_on_remove": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "examples": [[60]]
+        },
+        "keywords_add": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["regression"]]
+        },
+        "keywords_remove": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["stale"]]
+        },
+        "cc_add": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["alice@example.com"]]
+        },
+        "cc_remove": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["bob@example.com"]]
+        },
+        "groups_add": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["security"]]
+        },
+        "groups_remove": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["old-security"]]
+        },
+        "see_also_add": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["https://example.com/issue/42"]]
+        },
+        "see_also_remove": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["https://example.com/old/42"]]
+        },
+        "expect_unchanged_since": {
+          "type": ["string", "null"],
+          "examples": ["2026-06-21T12:34:56Z"]
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    "bugUpdateInputArrayItem": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/bugUpdateInputObject"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "required": ["id"]
+        }
+      ]
+    }
+  }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -598,15 +598,17 @@ pub enum Commands {
         shell: clap_complete::Shell,
     },
 
-    /// Print a published JSON Schema for a command's JSON output.
+    /// Print a published JSON Schema for a command's JSON contract.
     ///
-    /// `--format json` shapes are documented as checked-in JSON Schema
-    /// (draft 2020-12) so agents can validate output against a contract
-    /// instead of branching per command. Run without a name to list the
-    /// available schema names; pass one to print that schema:
+    /// `--format json` output shapes and selected `--from-json` input payloads
+    /// are documented as checked-in JSON Schema (draft 2020-12) so agents can
+    /// validate against a contract instead of branching per command. Run
+    /// without a name to list the available schema names; pass one to print
+    /// that schema:
     ///
     ///   bzr schema                # list schema names
     ///   bzr schema bug            # the bug object (list elements / view)
+    ///   bzr schema bug-create-input  # `bug create --from-json` payload
     ///   bzr schema batch-result   # the batch `bug update` envelope
     ///
     /// Purely local: no config, network, or auth.

--- a/src/commands/bug/create_tests.rs
+++ b/src/commands/bug/create_tests.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::unwrap_used, clippy::panic)]
 
-use std::io::Write;
+use std::{collections::BTreeSet, io::Write};
 
 use wiremock::matchers::{body_string_contains, method, path};
 use wiremock::{Mock, ResponseTemplate};
@@ -9,6 +9,8 @@ use crate::cli::{BugAction, TemplateAction, TemplateFields};
 use crate::error::BzrError;
 use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
+
+use super::JsonCreateBug;
 
 fn create_action() -> BugAction {
     BugAction::Create(crate::cli::CreateArgs {
@@ -29,6 +31,99 @@ fn create_action() -> BugAction {
         depends_on: vec![],
         create_fields: crate::cli::CreateFieldArgs::default(),
     })
+}
+
+fn schema_value(name: &str) -> serde_json::Value {
+    let (_, body) = crate::commands::schema::SCHEMAS
+        .iter()
+        .find(|(schema_name, _)| *schema_name == name)
+        .unwrap_or_else(|| panic!("schema '{name}' is not registered"));
+    serde_json::from_str(body).unwrap_or_else(|err| panic!("schema '{name}' is invalid: {err}"))
+}
+
+fn schema_object_properties(
+    name: &str,
+    def_name: &str,
+) -> serde_json::Map<String, serde_json::Value> {
+    let pointer = format!("/$defs/{def_name}/properties");
+    schema_value(name)
+        .pointer(&pointer)
+        .and_then(serde_json::Value::as_object)
+        .unwrap_or_else(|| panic!("schema '{name}' missing {pointer}"))
+        .clone()
+}
+
+fn parser_fields_from_unknown_error<T>() -> BTreeSet<String>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let err = match serde_json::from_value::<T>(serde_json::json!({
+        "__bzr_unknown_field__": true,
+    })) {
+        Ok(_) => panic!("unknown sentinel field unexpectedly parsed"),
+        Err(err) => err.to_string(),
+    };
+    let expected = err
+        .split_once("expected ")
+        .unwrap_or_else(|| panic!("serde error did not list expected fields: {err}"))
+        .1;
+    expected
+        .split('`')
+        .skip(1)
+        .step_by(2)
+        .map(ToString::to_string)
+        .collect()
+}
+
+#[test]
+fn bug_create_input_schema_matches_parser_keys() {
+    let schema_keys: BTreeSet<String> =
+        schema_object_properties("bug-create-input", "bugCreateInputObject")
+            .keys()
+            .cloned()
+            .collect();
+    let parser_keys = parser_fields_from_unknown_error::<JsonCreateBug>();
+
+    assert_eq!(schema_keys, parser_keys);
+}
+
+#[test]
+fn bug_create_input_schema_examples_parse() {
+    for (key, property_schema) in
+        schema_object_properties("bug-create-input", "bugCreateInputObject")
+    {
+        let example = property_schema
+            .get("examples")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|examples| examples.first())
+            .unwrap_or_else(|| panic!("bug-create-input property '{key}' missing example"))
+            .clone();
+        let mut object = serde_json::Map::new();
+        object.insert(key.clone(), example);
+
+        serde_json::from_value::<JsonCreateBug>(serde_json::Value::Object(object))
+            .unwrap_or_else(|err| panic!("schema example for '{key}' did not parse: {err}"));
+    }
+}
+
+#[test]
+fn bug_create_input_schema_documents_array_form() {
+    let schema = schema_value("bug-create-input");
+    let one_of = schema
+        .get("oneOf")
+        .and_then(serde_json::Value::as_array)
+        .unwrap_or_else(|| panic!("bug-create-input schema missing oneOf"));
+    let array_branch = one_of
+        .iter()
+        .find(|branch| branch.get("type").and_then(serde_json::Value::as_str) == Some("array"))
+        .unwrap_or_else(|| panic!("bug-create-input schema does not document array input"));
+
+    assert_eq!(
+        array_branch
+            .get("minItems")
+            .and_then(serde_json::Value::as_u64),
+        Some(1)
+    );
 }
 
 #[tokio::test]

--- a/src/commands/bug/update_tests.rs
+++ b/src/commands/bug/update_tests.rs
@@ -1,11 +1,15 @@
 #![expect(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
+use std::collections::BTreeSet;
+
 use wiremock::matchers::{body_json, body_partial_json, method, path};
 use wiremock::{Mock, ResponseTemplate};
 
 use crate::cli::BugAction;
 use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
+
+use super::JsonUpdateBug;
 
 /// Borrow the inner `UpdateArgs` from a `BugAction::Update` test fixture.
 fn as_update_args(action: &BugAction) -> &crate::cli::UpdateArgs {
@@ -155,6 +159,90 @@ fn write_json_file(tmp: &tempfile::TempDir, json: &str) -> String {
     let path = tmp.path().join("update-input.json");
     std::fs::write(&path, json).unwrap();
     path.to_string_lossy().into_owned()
+}
+
+fn schema_value(name: &str) -> serde_json::Value {
+    let (_, body) = crate::commands::schema::SCHEMAS
+        .iter()
+        .find(|(schema_name, _)| *schema_name == name)
+        .unwrap_or_else(|| panic!("schema '{name}' is not registered"));
+    serde_json::from_str(body).unwrap_or_else(|err| panic!("schema '{name}' is invalid: {err}"))
+}
+
+fn schema_object_properties(
+    name: &str,
+    def_name: &str,
+) -> serde_json::Map<String, serde_json::Value> {
+    let pointer = format!("/$defs/{def_name}/properties");
+    schema_value(name)
+        .pointer(&pointer)
+        .and_then(serde_json::Value::as_object)
+        .unwrap_or_else(|| panic!("schema '{name}' missing {pointer}"))
+        .clone()
+}
+
+fn parser_fields_from_unknown_error<T>() -> BTreeSet<String>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let err = match serde_json::from_value::<T>(serde_json::json!({
+        "__bzr_unknown_field__": true,
+    })) {
+        Ok(_) => panic!("unknown sentinel field unexpectedly parsed"),
+        Err(err) => err.to_string(),
+    };
+    let expected = err
+        .split_once("expected ")
+        .unwrap_or_else(|| panic!("serde error did not list expected fields: {err}"))
+        .1;
+    expected
+        .split('`')
+        .skip(1)
+        .step_by(2)
+        .map(ToString::to_string)
+        .collect()
+}
+
+#[test]
+fn bug_update_input_schema_matches_parser_keys() {
+    let schema_keys: BTreeSet<String> =
+        schema_object_properties("bug-update-input", "bugUpdateInputObject")
+            .keys()
+            .cloned()
+            .collect();
+    let parser_keys = parser_fields_from_unknown_error::<JsonUpdateBug>();
+
+    assert_eq!(schema_keys, parser_keys);
+}
+
+#[test]
+fn bug_update_input_schema_examples_parse() {
+    for (key, property_schema) in
+        schema_object_properties("bug-update-input", "bugUpdateInputObject")
+    {
+        let example = property_schema
+            .get("examples")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|examples| examples.first())
+            .unwrap_or_else(|| panic!("bug-update-input property '{key}' missing example"))
+            .clone();
+        let mut object = serde_json::Map::new();
+        object.insert(key.clone(), example);
+
+        serde_json::from_value::<JsonUpdateBug>(serde_json::Value::Object(object))
+            .unwrap_or_else(|err| panic!("schema example for '{key}' did not parse: {err}"));
+    }
+}
+
+#[test]
+fn bug_update_input_schema_array_items_require_id() {
+    let schema = schema_value("bug-update-input");
+    let required = schema
+        .pointer("/$defs/bugUpdateInputArrayItem/allOf/1/required")
+        .and_then(serde_json::Value::as_array)
+        .unwrap_or_else(|| panic!("bug-update-input array item schema missing required list"));
+
+    assert!(required.iter().any(|field| field.as_str() == Some("id")));
 }
 
 #[tokio::test]

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -1,11 +1,12 @@
-//! `bzr schema` — publish JSON Schemas for the tool's JSON output shapes.
+//! `bzr schema` — publish JSON Schemas for the tool's JSON contracts.
 //!
-//! Purely local: no config, network, or auth. Each schema describes the
-//! `--format json` body of a command family so agents can validate output
-//! against a contract instead of branching per command. The schema files are
-//! checked into `schemas/` at the repo root and embedded here at build time;
-//! a drift test (see `schema_tests.rs`) validates representative serialized
-//! values against them, so a struct change that breaks a schema fails CI.
+//! Purely local: no config, network, or auth. Each schema describes either a
+//! `--format json` output body or a `--from-json` input payload so agents can
+//! validate against a contract instead of branching per command. The schema
+//! files are checked into `schemas/` at the repo root and embedded here at build
+//! time; drift tests validate representative serialized values and structured
+//! input parsers against them, so a contract change fails CI until the schema is
+//! updated.
 
 use crate::error::{BzrError, Result};
 use crate::output::result_types::write_result;
@@ -29,6 +30,8 @@ pub(crate) const SCHEMAS: &[(&str, &str)] = schema_registry![
     "batch-create-result",
     "batch-result",
     "bug",
+    "bug-create-input",
+    "bug-update-input",
     "classification",
     "comment",
     "component",

--- a/src/commands/schema_tests.rs
+++ b/src/commands/schema_tests.rs
@@ -2,13 +2,14 @@
 
 //! Drift guard for the published JSON Schemas.
 //!
-//! Each schema is validated against the *actual serialized output* of a
+//! Output schemas are validated against the *actual serialized output* of a
 //! representative typed value: every serialized key must be declared in the
 //! schema's `properties` (unless the schema is open via `additionalProperties:
-//! true`), and every `required` key must be present in the serialization. A
-//! field added, removed, or renamed on a result type therefore fails CI here
-//! until its schema is updated — keeping the published contract honest without
-//! a runtime schema-validation dependency.
+//! true`), and every `required` key must be present in the serialization.
+//! Structured input schemas are guarded beside their parsers. A field added,
+//! removed, or renamed therefore fails CI until its schema is updated, keeping
+//! the published contract honest without a runtime schema-validation
+//! dependency.
 
 use serde_json::{json, Value};
 
@@ -383,6 +384,8 @@ fn execute_list_json_is_array_of_names() {
     let parsed: Value = serde_json::from_str(io.out_str()).unwrap();
     let names = parsed.as_array().unwrap();
     assert!(names.iter().any(|n| n == "bug"));
+    assert!(names.iter().any(|n| n == "bug-create-input"));
+    assert!(names.iter().any(|n| n == "bug-update-input"));
     assert!(names.iter().any(|n| n == "batch-result"));
 }
 

--- a/tests/functional/phases/18-completion-schema.sh
+++ b/tests/functional/phases/18-completion-schema.sh
@@ -3,6 +3,7 @@
 # orchestrator preamble (constants, shared globals, cleanup trap).
 # Reads: none. Creates: none. Local commands — no Bugzilla server needed.
 # shellcheck shell=bash
+# shellcheck disable=SC2016
 
 # ══════════════════════════════════════════════════════════════════════
 # Phase 18: Completion & Schema (local commands, no network)
@@ -37,15 +38,23 @@ if assert_exit_code 2 && assert_stderr_contains "invalid value"; then test_pass;
 # schema: list mode + per-name schema is valid JSON (draft 2020-12).
 test_begin "116. schema (list)"
 run_bzr schema
-if assert_success && assert_json_valid && assert_json_exists 'index("bug")'; then test_pass; fi
+if assert_success && assert_json_valid &&
+	assert_json_exists 'index("bug")' &&
+	assert_json_exists 'index("bug-create-input")'; then test_pass; fi
 
 test_begin "117. schema bug (valid draft 2020-12 schema)"
 run_bzr schema bug
 if assert_success && assert_json_valid &&
-    assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema"; then test_pass; fi
+	assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema"; then test_pass; fi
+
+test_begin "118. schema bug-update-input (valid draft 2020-12 schema)"
+run_bzr schema bug-update-input
+if assert_success && assert_json_valid &&
+	assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema" &&
+	assert_json '.["$defs"].bugUpdateInputObject.additionalProperties' "false"; then test_pass; fi
 
 # Error JSON routes to stderr even under --json, so assert there.
-test_begin "118. schema unknown name (input error, exit 7)"
+test_begin "119. schema unknown name (input error, exit 7)"
 run_bzr schema nosuchschema
 if assert_exit_code 7 && assert_stderr_contains '"type":"input"'; then test_pass; fi
 


### PR DESCRIPTION
## Summary

- add `bug-create-input` and `bug-update-input` schemas for `--from-json` payloads
- register the new schema names in `bzr schema` and document object/array forms
- add parser/schema drift tests for accepted keys and representative value types

Closes #366

## Verification

- `cargo test input_schema --lib`
- `cargo test commands::schema::tests --lib`
- `cargo test --test integration cli_and_docs_avoid_misleading_trim_phrasing`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `shfmt -d tests/functional/phases/18-completion-schema.sh`
- `shellcheck tests/functional/phases/18-completion-schema.sh`
- `git diff --check`
- `cargo build`
- `BZR_BIN=target/debug/bzr sh agent-skills/tests/flag-drift-check.sh`
- `BZR_BIN=target/debug/bzr sh agent-skills/tests/drift-check.sh`
- pre-push `cargo test`
