### PR TITLE
feat(dry-run): preview admin mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   and array update payloads. (#365)
 - `schema` now publishes `bug-create-input` and `bug-update-input` JSON
   Schemas for the structured payloads accepted by `--from-json`. (#366)
+- `--dry-run` now previews product, component, user, and group create/update
+  requests without writing. (#367)
 - `query run` now accepts `--count`, matching the count-only output shape used
   by bug search-backed commands. (#368)
 

--- a/agent-skills/skills/bzr-reference/SKILL.md
+++ b/agent-skills/skills/bzr-reference/SKILL.md
@@ -60,8 +60,8 @@ These work on any command (place them before the subcommand):
 
 - `--json` / `--output ndjson` — JSON, or newline-delimited JSON (one record per
   line) for streaming into `jq -c` or agents.
-- `--dry-run` — preview a bug mutation (`create`/`update`/`clone`/`resolve`/
-  `close`/`reopen`/`dup`) without writing; prints the would-be payload.
+- `--dry-run` — preview supported bug mutations and product/component/user/group
+  create/update without writing; prints the would-be payload.
 - `-y` / `--yes` — skip the confirmation prompt for a batch mutation touching
   more than 10 bugs (interactive terminals only).
 - `--timeout <secs>` / `--retry <n>` — tune per-request timeout and transient

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -47,7 +47,7 @@ For installation and quick start, see [README.md](../README.md).
 | `--api <MODE>` | Override API transport: `rest`, `xmlrpc`, or `hybrid`. Auto-detected from server version if not set. |
 | `--timeout <SECS>` | Per-request timeout in seconds (default 30). Takes precedence over `BZR_TIMEOUT`. The 10s connect timeout is unaffected. |
 | `--retry <N>` | Retry transient failures up to N times with exponential backoff honoring `Retry-After`. 429 and connect failures are retried for any operation; 5xx and read timeouts only for safe reads (GET/HEAD), never for writes (create, update, comment) where a replay could duplicate the effect. Default 0 (disabled); max 10. Exhausted retries exit 5. |
-| `--dry-run` | Preview a bug mutation without writing. Resolves and validates the request, then prints the would-be payload and affected bug IDs as `{"resource":"bug","action":"dry-run","ids":[...],"changes":{...}}` instead of calling the write API. Exits 0 on a valid request. Only valid for `bug create`, `update`, `clone`, `resolve`, `close`, `reopen`, and `dup`; on any other command it exits 7. `clone` still reads the source bug to build the preview. |
+| `--dry-run` | Preview a supported mutation without writing. Resolves and validates the request, then prints the would-be payload and affected IDs as `{"resource":"bug","action":"dry-run","ids":[...],"changes":{...}}` instead of calling the write API. Exits 0 on a valid request. Supported for `bug create`, `update`, `clone`, `resolve`, `close`, `reopen`, `dup`, and `product`/`component`/`user`/`group` `create` and `update`; on any other command it exits 7. `bug clone` still reads the source bug to build the preview. |
 | `-y, --yes` | Skip the confirmation prompt for a large batch mutation. A `bug update`/`resolve`/`close`/`reopen` targeting more than 10 bugs prompts for confirmation at an interactive terminal; `--yes` bypasses it. Non-interactive runs (piped stdin, agents) never prompt, so this is only needed in an interactive session. |
 | `-v, --verbose` | Increase log verbosity (`-v`=info, `-vv`=debug, `-vvv`=trace; `RUST_LOG` overrides) |
 | `-h, --help` | Print help |
@@ -1048,6 +1048,7 @@ Create a new product (requires admin privileges).
 ```bash
 bzr product create --name "New Product" --description "A new product"
 bzr product create --name "New Product" --description "Desc" --version "1.0" --is-open true
+bzr --dry-run product create --name "New Product" --description "Preview"
 ```
 
 | Option | Required | Default | Description |
@@ -1067,6 +1068,7 @@ Update an existing product (requires admin privileges).
 bzr product update "My Product" --description "Updated description"
 bzr product update "My Product" --is-open false
 bzr product update "My Product" --default-milestone "2.0"
+bzr --dry-run product update "My Product" --is-open false
 ```
 
 | Option | Required | Description |
@@ -1138,6 +1140,7 @@ Create a new user (requires admin privileges).
 bzr user create --email alice@example.com --full-name "Alice Smith"
 bzr user create --email bob@example.com --password s3cret
 bzr user create --email carol@example.com --login carol   # Bugzilla 5.3+ with use_email_as_login disabled
+bzr --dry-run user create --email alice@example.com --full-name "Alice Smith"
 ```
 
 | Option | Required | Description |
@@ -1158,6 +1161,7 @@ Update an existing user (requires admin privileges).
 ```bash
 bzr user update alice@example.com --real-name "Alice J. Smith"
 bzr user update alice@example.com --disable-login true --login-denied-text "Account suspended"
+bzr --dry-run user update alice@example.com --disable-login false
 ```
 
 | Option | Required | Description |
@@ -1229,6 +1233,7 @@ Create a new group (requires admin privileges).
 ```bash
 bzr group create --name "qa-team" --description "QA team members"
 bzr group create --name "qa-team" --description "QA" --is-active true
+bzr --dry-run group create --name "qa-team" --description "QA team members"
 ```
 
 | Option | Required | Default | Description |
@@ -1246,6 +1251,7 @@ Update an existing group (requires admin privileges).
 ```bash
 bzr group update qa-team --description "Updated QA team description"
 bzr group update qa-team --is-active false
+bzr --dry-run group update qa-team --is-active false
 ```
 
 | Option | Required | Description |
@@ -1341,6 +1347,8 @@ Create a new component in a product (requires admin privileges).
 ```bash
 bzr component create --product Fedora --name "new-component" \
   --description "Handles new features" --default-assignee dev@example.com
+bzr --dry-run component create --product Fedora --name "new-component" \
+  --description "Handles new features" --default-assignee dev@example.com
 ```
 
 | Option | Required | Description |
@@ -1359,6 +1367,7 @@ Update an existing component (requires admin privileges).
 ```bash
 bzr component update 42 --name "renamed-component"
 bzr component update 42 --default-assignee newdev@example.com
+bzr --dry-run component update 42 --default-assignee newdev@example.com
 ```
 
 | Option | Required | Description |

--- a/docs/superpowers/specs/2026-06-21-issue-367-admin-dry-run-design.md
+++ b/docs/superpowers/specs/2026-06-21-issue-367-admin-dry-run-design.md
@@ -1,0 +1,65 @@
+# Issue 367: Admin Mutation Dry-Run Previews
+
+## Context
+
+`--dry-run` is global but currently supported only by bug mutations. Dispatch
+rejects the flag for every other command so it cannot be silently ignored. The
+admin write commands for products, components, users, and groups still require a
+real write to inspect the outbound request payload.
+
+## Decision
+
+Extend `--dry-run` to exactly these admin mutations:
+
+- `product create`
+- `product update`
+- `component create`
+- `component update`
+- `user create`
+- `user update`
+- `group create`
+- `group update`
+
+Do not include local config/template/query mutations or group membership changes
+in this issue. Those operations have different semantics and should not inherit
+dry-run behavior without a separate design.
+
+The command path still loads config, resolves auth, and builds a client before
+previewing, matching existing bug dry-run behavior. After the command validates
+and builds the normal request params, it emits `DryRunResult` and returns before
+calling POST/PUT.
+
+`dry-run-result.json` already permits `product`, `component`, `user`, and
+`group` resources and keeps `changes` open, so the published schema does not
+need to change.
+
+## Validation
+
+Create commands rely on clap-required arguments. Update commands must reject an
+empty update before either previewing or writing:
+
+- product: no `description`, `default_milestone`, or `is_open`
+- component: no `name`, `description`, or `default_assignee`
+- user: no `real_name`, `email`, or resolved `login_denied_text` from
+  `--disable-login`
+- group: no `description` or `is_active`
+
+This makes dry-run previews match an actual write request instead of presenting
+an empty payload as useful.
+
+## Output
+
+Use the existing dry-run result shape:
+
+```json
+{
+  "resource": "product",
+  "action": "dry-run",
+  "ids": [],
+  "changes": {}
+}
+```
+
+`ids` is populated only when the admin command targets a numeric resource ID
+(`component update`). Name-keyed create/update commands use an empty array, as
+bug create and bug clone already do.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -202,13 +202,13 @@ pub struct Cli {
     #[arg(long, value_name = "N", global = true, value_parser = clap::value_parser!(u32).range(0..=10))]
     pub retry: Option<u32>,
 
-    /// Preview a bug mutation without writing (no API call).
+    /// Preview a supported mutation without writing.
     ///
     /// Resolves and validates the request, then prints the would-be payload
-    /// and affected bug IDs with `"action":"dry-run"` instead of calling the
-    /// write API. Exits 0 on a valid request. Only valid for the bug
-    /// mutations (`create`, `update`, `clone`, `resolve`, `close`, `reopen`,
-    /// `dup`); used on any other command it exits 7.
+    /// and affected IDs with `"action":"dry-run"` instead of calling the
+    /// write API. Exits 0 on a valid request. Supported for bug mutations and
+    /// product/component/user/group `create` and `update`; used on any other
+    /// command it exits 7.
     #[arg(long, global = true)]
     pub dry_run: bool,
 

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -1,7 +1,7 @@
 use crate::cli::ComponentAction;
 use crate::error::{BzrError, Result};
 use crate::output::resources::component::{write_component, write_components};
-use crate::output::result_types::{write_result, ActionResult, ResourceKind};
+use crate::output::result_types::{write_result, ActionResult, DryRunResult, ResourceKind};
 use crate::output::writers::Writers;
 use crate::types::ApiMode;
 use crate::types::OutputFormat;
@@ -14,6 +14,7 @@ pub async fn execute(
     api: Option<ApiMode>,
     w: &mut Writers<'_>,
 ) -> Result<()> {
+    validate_action(action)?;
     let client = super::runtime::shared::connect_and_configure(server, api).await?;
 
     match action {
@@ -45,6 +46,16 @@ pub async fn execute(
                 description: description.clone(),
                 default_assignee: default_assignee.clone(),
             };
+            if super::runtime::dry_run::enabled() {
+                let message = format!("Would create component '{name}' in product '{product}'");
+                write_result(
+                    &DryRunResult::new(ResourceKind::Component, &[], &params),
+                    &message,
+                    format,
+                    w.out,
+                );
+                return Ok(());
+            }
             let id = client.create_component(&params).await?;
             write_result(
                 &ActionResult::created(id, ResourceKind::Component),
@@ -64,6 +75,17 @@ pub async fn execute(
                 description: description.clone(),
                 default_assignee: default_assignee.clone(),
             };
+            if super::runtime::dry_run::enabled() {
+                let ids = [*id];
+                let message = format!("Would update component #{id}");
+                write_result(
+                    &DryRunResult::new(ResourceKind::Component, &ids, &params),
+                    &message,
+                    format,
+                    w.out,
+                );
+                return Ok(());
+            }
             client.update_component(*id, &params).await?;
             write_result(
                 &ActionResult::updated(*id, ResourceKind::Component),
@@ -71,6 +93,31 @@ pub async fn execute(
                 format,
                 w.out,
             );
+        }
+    }
+    Ok(())
+}
+
+#[must_use]
+pub fn is_dry_runnable(action: &ComponentAction) -> bool {
+    matches!(
+        action,
+        ComponentAction::Create { .. } | ComponentAction::Update { .. }
+    )
+}
+
+fn validate_action(action: &ComponentAction) -> Result<()> {
+    if let ComponentAction::Update {
+        name,
+        description,
+        default_assignee,
+        ..
+    } = action
+    {
+        if name.is_none() && description.is_none() && default_assignee.is_none() {
+            return Err(BzrError::InputValidation(
+                "no fields to update; specify at least one field to change".into(),
+            ));
         }
     }
     Ok(())

--- a/src/commands/component_tests.rs
+++ b/src/commands/component_tests.rs
@@ -119,6 +119,39 @@ async fn component_create_succeeds() {
 }
 
 #[tokio::test]
+async fn component_create_dry_run_makes_no_write_and_marks_payload() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/component"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 42})))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let action = ComponentAction::Create {
+        product: "TestProduct".to_string(),
+        name: "Backend".to_string(),
+        description: "Backend component".to_string(),
+        default_assignee: "dev@test.com".to_string(),
+    };
+    crate::commands::runtime::dry_run::set(true);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+    crate::commands::runtime::dry_run::set(false);
+
+    assert!(
+        result.is_ok(),
+        "dry-run component create failed: {result:?}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["resource"], "component");
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["ids"], serde_json::json!([]));
+    assert_eq!(parsed["changes"]["name"], "Backend");
+}
+
+#[tokio::test]
 async fn component_create_http_500_returns_error() {
     let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
@@ -176,4 +209,57 @@ async fn component_update_succeeds() {
     let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["id"], 10);
     assert_eq!(parsed["action"], "updated");
+}
+
+#[tokio::test]
+async fn component_update_dry_run_makes_no_write_and_marks_payload() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/component/10"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 10})))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let action = ComponentAction::Update {
+        id: 10,
+        name: Some("Updated".to_string()),
+        description: None,
+        default_assignee: Some("owner@test.com".to_string()),
+    };
+    crate::commands::runtime::dry_run::set(true);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+    crate::commands::runtime::dry_run::set(false);
+
+    assert!(
+        result.is_ok(),
+        "dry-run component update failed: {result:?}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["resource"], "component");
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["ids"], serde_json::json!([10]));
+    assert_eq!(parsed["changes"]["name"], "Updated");
+    assert_eq!(parsed["changes"]["default_assignee"], "owner@test.com");
+}
+
+#[tokio::test]
+async fn component_update_without_fields_is_rejected() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    let action = ComponentAction::Update {
+        id: 10,
+        name: None,
+        description: None,
+        default_assignee: None,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    assert!(
+        matches!(result, Err(crate::error::BzrError::InputValidation(ref msg))
+            if msg.contains("no fields to update")),
+        "expected input validation, got {result:?}"
+    );
 }

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -1,8 +1,10 @@
 use crate::cli::GroupAction;
-use crate::error::Result;
+use crate::error::{BzrError, Result};
 use crate::output::resources::group::write_group_info;
 use crate::output::resources::user::{write_users, write_users_detailed};
-use crate::output::result_types::{write_result, ActionResult, MembershipResult, ResourceKind};
+use crate::output::result_types::{
+    write_result, ActionResult, DryRunResult, MembershipResult, ResourceKind,
+};
 use crate::output::writers::Writers;
 use crate::types::ApiMode;
 use crate::types::OutputFormat;
@@ -15,6 +17,7 @@ pub async fn execute(
     api: Option<ApiMode>,
     w: &mut Writers<'_>,
 ) -> Result<()> {
+    validate_action(action)?;
     let client = super::runtime::shared::connect_and_configure(server, api).await?;
 
     match action {
@@ -58,6 +61,16 @@ pub async fn execute(
                 description: description.clone(),
                 is_active: *is_active,
             };
+            if super::runtime::dry_run::enabled() {
+                let message = format!("Would create group '{name}'");
+                write_result(
+                    &DryRunResult::new(ResourceKind::Group, &[], &params),
+                    &message,
+                    format,
+                    w.out,
+                );
+                return Ok(());
+            }
             let id = client.create_group(&params).await?;
             write_result(
                 &ActionResult::created_named(id, name.as_str(), ResourceKind::Group),
@@ -75,6 +88,16 @@ pub async fn execute(
                 description: description.clone(),
                 is_active: *is_active,
             };
+            if super::runtime::dry_run::enabled() {
+                let message = format!("Would update group '{group}'");
+                write_result(
+                    &DryRunResult::new(ResourceKind::Group, &[], &params),
+                    &message,
+                    format,
+                    w.out,
+                );
+                return Ok(());
+            }
             client.update_group(group, &params).await?;
             write_result(
                 &ActionResult::updated_named(group.as_str(), None, ResourceKind::Group),
@@ -82,6 +105,30 @@ pub async fn execute(
                 format,
                 w.out,
             );
+        }
+    }
+    Ok(())
+}
+
+#[must_use]
+pub fn is_dry_runnable(action: &GroupAction) -> bool {
+    matches!(
+        action,
+        GroupAction::Create { .. } | GroupAction::Update { .. }
+    )
+}
+
+fn validate_action(action: &GroupAction) -> Result<()> {
+    if let GroupAction::Update {
+        description,
+        is_active,
+        ..
+    } = action
+    {
+        if description.is_none() && is_active.is_none() {
+            return Err(BzrError::InputValidation(
+                "no fields to update; specify at least one field to change".into(),
+            ));
         }
     }
     Ok(())

--- a/src/commands/group_tests.rs
+++ b/src/commands/group_tests.rs
@@ -81,6 +81,35 @@ async fn group_create_sends_post() {
 }
 
 #[tokio::test]
+async fn group_create_dry_run_makes_no_write_and_marks_payload() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/group"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 5})))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let action = GroupAction::Create {
+        name: "new-group".into(),
+        description: "A test group".into(),
+        is_active: true,
+    };
+    crate::commands::runtime::dry_run::set(true);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+    crate::commands::runtime::dry_run::set(false);
+
+    assert!(result.is_ok(), "dry-run group create failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["resource"], "group");
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["ids"], serde_json::json!([]));
+    assert_eq!(parsed["changes"]["name"], "new-group");
+}
+
+#[tokio::test]
 async fn group_update_sends_put() {
     let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, mock, _tmp) = setup_test_env().await;
@@ -109,6 +138,57 @@ async fn group_update_sends_put() {
     )
     .await;
     assert!(result.is_ok(), "group update failed: {result:?}");
+}
+
+#[tokio::test]
+async fn group_update_dry_run_makes_no_write_and_marks_payload() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/group/admin"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"groups": [{"changes": {}}]})),
+        )
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let action = GroupAction::Update {
+        group: "admin".into(),
+        description: Some("Updated description".into()),
+        is_active: Some(false),
+    };
+    crate::commands::runtime::dry_run::set(true);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+    crate::commands::runtime::dry_run::set(false);
+
+    assert!(result.is_ok(), "dry-run group update failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["resource"], "group");
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["ids"], serde_json::json!([]));
+    assert_eq!(parsed["changes"]["description"], "Updated description");
+    assert_eq!(parsed["changes"]["is_active"], false);
+}
+
+#[tokio::test]
+async fn group_update_without_fields_is_rejected() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    let action = GroupAction::Update {
+        group: "admin".into(),
+        description: None,
+        is_active: None,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    assert!(
+        matches!(result, Err(crate::error::BzrError::InputValidation(ref msg))
+            if msg.contains("no fields to update")),
+        "expected input validation, got {result:?}"
+    );
 }
 
 #[tokio::test]

--- a/src/commands/product.rs
+++ b/src/commands/product.rs
@@ -1,7 +1,7 @@
 use crate::cli::ProductAction;
-use crate::error::Result;
+use crate::error::{BzrError, Result};
 use crate::output::resources::product::{write_product_detail, write_products};
-use crate::output::result_types::{write_result, ActionResult, ResourceKind};
+use crate::output::result_types::{write_result, ActionResult, DryRunResult, ResourceKind};
 use crate::output::writers::Writers;
 use crate::types::ApiMode;
 use crate::types::OutputFormat;
@@ -14,6 +14,7 @@ pub async fn execute(
     api: Option<ApiMode>,
     w: &mut Writers<'_>,
 ) -> Result<()> {
+    validate_action(action)?;
     let client = super::runtime::shared::connect_and_configure(server, api).await?;
 
     match action {
@@ -37,6 +38,16 @@ pub async fn execute(
                 version: version.clone(),
                 is_open: *is_open,
             };
+            if super::runtime::dry_run::enabled() {
+                let message = format!("Would create product '{name}'");
+                write_result(
+                    &DryRunResult::new(ResourceKind::Product, &[], &params),
+                    &message,
+                    format,
+                    w.out,
+                );
+                return Ok(());
+            }
             let id = client.create_product(&params).await?;
             write_result(
                 &ActionResult::created_named(id, name.as_str(), ResourceKind::Product),
@@ -56,6 +67,16 @@ pub async fn execute(
                 default_milestone: default_milestone.clone(),
                 is_open: *is_open,
             };
+            if super::runtime::dry_run::enabled() {
+                let message = format!("Would update product '{name}'");
+                write_result(
+                    &DryRunResult::new(ResourceKind::Product, &[], &params),
+                    &message,
+                    format,
+                    w.out,
+                );
+                return Ok(());
+            }
             client.update_product(name, &params).await?;
             write_result(
                 &ActionResult::updated_named(name.as_str(), None, ResourceKind::Product),
@@ -63,6 +84,31 @@ pub async fn execute(
                 format,
                 w.out,
             );
+        }
+    }
+    Ok(())
+}
+
+#[must_use]
+pub fn is_dry_runnable(action: &ProductAction) -> bool {
+    matches!(
+        action,
+        ProductAction::Create { .. } | ProductAction::Update { .. }
+    )
+}
+
+fn validate_action(action: &ProductAction) -> Result<()> {
+    if let ProductAction::Update {
+        description,
+        default_milestone,
+        is_open,
+        ..
+    } = action
+    {
+        if description.is_none() && default_milestone.is_none() && is_open.is_none() {
+            return Err(BzrError::InputValidation(
+                "no fields to update; specify at least one field to change".into(),
+            ));
         }
     }
     Ok(())

--- a/src/commands/product_tests.rs
+++ b/src/commands/product_tests.rs
@@ -148,6 +148,36 @@ async fn product_create_returns_id() {
 }
 
 #[tokio::test]
+async fn product_create_dry_run_makes_no_write_and_marks_payload() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/product"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 5})))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let action = ProductAction::Create {
+        name: "NewProduct".to_string(),
+        description: "New product".to_string(),
+        version: "1.0".to_string(),
+        is_open: true,
+    };
+    crate::commands::runtime::dry_run::set(true);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+    crate::commands::runtime::dry_run::set(false);
+
+    assert!(result.is_ok(), "dry-run product create failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["resource"], "product");
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["ids"], serde_json::json!([]));
+    assert_eq!(parsed["changes"]["name"], "NewProduct");
+}
+
+#[tokio::test]
 async fn product_update_succeeds() {
     let (_lock, mock, _tmp) = setup_test_env().await;
 
@@ -178,4 +208,56 @@ async fn product_update_succeeds() {
     assert!(result.is_ok());
     let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["action"], "updated");
+}
+
+#[tokio::test]
+async fn product_update_dry_run_makes_no_write_and_marks_payload() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/product/Firefox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "products": [{"id": 1, "changes": {}}]
+        })))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let action = ProductAction::Update {
+        name: "Firefox".to_string(),
+        description: Some("Updated".to_string()),
+        default_milestone: None,
+        is_open: Some(false),
+    };
+    crate::commands::runtime::dry_run::set(true);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+    crate::commands::runtime::dry_run::set(false);
+
+    assert!(result.is_ok(), "dry-run product update failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["resource"], "product");
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["ids"], serde_json::json!([]));
+    assert_eq!(parsed["changes"]["description"], "Updated");
+    assert_eq!(parsed["changes"]["is_open"], false);
+}
+
+#[tokio::test]
+async fn product_update_without_fields_is_rejected() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    let action = ProductAction::Update {
+        name: "Firefox".to_string(),
+        description: None,
+        default_milestone: None,
+        is_open: None,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    assert!(
+        matches!(result, Err(crate::error::BzrError::InputValidation(ref msg))
+            if msg.contains("no fields to update")),
+        "expected input validation, got {result:?}"
+    );
 }

--- a/src/commands/runtime/dry_run.rs
+++ b/src/commands/runtime/dry_run.rs
@@ -2,8 +2,8 @@
 //!
 //! `--dry-run` is a global CLI flag. Like the network-tuning globals (see
 //! `lib::apply_network_tuning`), it is installed once per process by
-//! `dispatch` and read by the bug mutation handlers, which short-circuit
-//! before any write API call and emit a `"action":"dry-run"` payload instead.
+//! `dispatch` and read by mutation handlers, which short-circuit before any
+//! write API call and emit a `"action":"dry-run"` payload instead.
 //!
 //! Using a process-global avoids threading a `dry_run` bool through every
 //! command handler signature (and every test call site). The CLI runs a

--- a/src/commands/schema_tests.rs
+++ b/src/commands/schema_tests.rs
@@ -223,6 +223,21 @@ fn dry_run_result_conforms() {
     assert_conforms("dry-run-result", &to_value(&dry));
 }
 
+#[test]
+fn dry_run_result_schema_allows_admin_resources() {
+    let schema = schema_for("dry-run-result");
+    let resources = schema
+        .pointer("/properties/resource/enum")
+        .and_then(Value::as_array)
+        .unwrap();
+    for resource in ["product", "component", "user", "group"] {
+        assert!(
+            resources.contains(&Value::String(resource.into())),
+            "dry-run-result schema must allow {resource} dry-run previews"
+        );
+    }
+}
+
 // ── Resource object types ────────────────────────────────────────────
 
 #[test]

--- a/src/commands/user.rs
+++ b/src/commands/user.rs
@@ -1,7 +1,7 @@
 use crate::cli::UserAction;
-use crate::error::Result;
+use crate::error::{BzrError, Result};
 use crate::output::resources::user::{write_users, write_users_detailed};
-use crate::output::result_types::{write_result, ActionResult, ResourceKind};
+use crate::output::result_types::{write_result, ActionResult, DryRunResult, ResourceKind};
 use crate::output::writers::Writers;
 use crate::types::ApiMode;
 use crate::types::OutputFormat;
@@ -29,6 +29,7 @@ pub async fn execute(
     api: Option<ApiMode>,
     w: &mut Writers<'_>,
 ) -> Result<()> {
+    validate_action(action)?;
     let client = super::runtime::shared::connect_and_configure(server, api).await?;
 
     match action {
@@ -52,6 +53,16 @@ pub async fn execute(
                 full_name: full_name.clone(),
                 password: password.clone(),
             };
+            if super::runtime::dry_run::enabled() {
+                let message = format!("Would create user '{email}'");
+                write_result(
+                    &DryRunResult::new(ResourceKind::User, &[], &params),
+                    &message,
+                    format,
+                    w.out,
+                );
+                return Ok(());
+            }
             let id = client.create_user(&params).await?;
             write_result(
                 &ActionResult::created_named(id, email.as_str(), ResourceKind::User),
@@ -75,6 +86,16 @@ pub async fn execute(
                 email: email.clone(),
                 login_denied_text: denied_text,
             };
+            if super::runtime::dry_run::enabled() {
+                let message = format!("Would update user '{user}'");
+                write_result(
+                    &DryRunResult::new(ResourceKind::User, &[], &params),
+                    &message,
+                    format,
+                    w.out,
+                );
+                return Ok(());
+            }
             client.update_user(user, &params).await?;
             write_result(
                 &ActionResult::updated_named(user.as_str(), None, ResourceKind::User),
@@ -82,6 +103,33 @@ pub async fn execute(
                 format,
                 w.out,
             );
+        }
+    }
+    Ok(())
+}
+
+#[must_use]
+pub fn is_dry_runnable(action: &UserAction) -> bool {
+    matches!(
+        action,
+        UserAction::Create { .. } | UserAction::Update { .. }
+    )
+}
+
+fn validate_action(action: &UserAction) -> Result<()> {
+    if let UserAction::Update {
+        real_name,
+        email,
+        disable_login,
+        login_denied_text,
+        ..
+    } = action
+    {
+        let denied_text = resolve_login_denied_text(*disable_login, login_denied_text.as_deref());
+        if real_name.is_none() && email.is_none() && denied_text.is_none() {
+            return Err(BzrError::InputValidation(
+                "no fields to update; specify at least one field to change".into(),
+            ));
         }
     }
     Ok(())

--- a/src/commands/user_tests.rs
+++ b/src/commands/user_tests.rs
@@ -148,6 +148,62 @@ async fn update_user_enable_login_sends_empty_denied_text() {
 }
 
 #[tokio::test]
+async fn user_update_dry_run_makes_no_write_and_marks_payload() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/user/alice%40test%2Ecom"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let action = UserAction::Update {
+        user: "alice@test.com".to_string(),
+        real_name: Some("Alice Smith".to_string()),
+        email: None,
+        disable_login: Some(true),
+        login_denied_text: Some("Closed".to_string()),
+    };
+    crate::commands::runtime::dry_run::set(true);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+    crate::commands::runtime::dry_run::set(false);
+
+    assert!(result.is_ok(), "dry-run user update failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["resource"], "user");
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["ids"], serde_json::json!([]));
+    assert_eq!(
+        parsed["changes"]["names"],
+        serde_json::json!(["alice@test.com"])
+    );
+    assert_eq!(parsed["changes"]["real_name"], "Alice Smith");
+    assert_eq!(parsed["changes"]["login_denied_text"], "Closed");
+}
+
+#[tokio::test]
+async fn user_update_without_fields_is_rejected() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    let action = UserAction::Update {
+        user: "alice@test.com".to_string(),
+        real_name: None,
+        email: None,
+        disable_login: None,
+        login_denied_text: None,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    assert!(
+        matches!(result, Err(crate::error::BzrError::InputValidation(ref msg))
+            if msg.contains("no fields to update")),
+        "expected input validation, got {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn user_create_sends_post() {
     let (_lock, mock, _tmp) = setup_test_env().await;
 
@@ -179,6 +235,37 @@ async fn user_create_sends_post() {
         serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
     assert_eq!(parsed["action"], "created");
     assert_eq!(parsed["id"], 99);
+}
+
+#[tokio::test]
+async fn user_create_dry_run_makes_no_write_and_marks_payload() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/user"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({"id": 99})))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let action = UserAction::Create {
+        email: "new@test.com".into(),
+        login: Some("newuser".into()),
+        full_name: Some("New User".into()),
+        password: None,
+    };
+    crate::commands::runtime::dry_run::set(true);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+    crate::commands::runtime::dry_run::set(false);
+
+    assert!(result.is_ok(), "dry-run user create failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["resource"], "user");
+    assert_eq!(parsed["action"], "dry-run");
+    assert_eq!(parsed["ids"], serde_json::json!([]));
+    assert_eq!(parsed["changes"]["email"], "new@test.com");
+    assert_eq!(parsed["changes"]["login"], "newuser");
 }
 
 #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,20 +163,27 @@ fn resolve_inline_server(cli: &cli::Cli) -> Option<commands::runtime::inline_ser
 /// Reject `--dry-run` on commands that don't honor it.
 ///
 /// `--dry-run` is a global flag (so it can appear after any subcommand), but
-/// only the bug mutations preview without writing. Allowing it elsewhere would
+/// only selected mutations preview without writing. Allowing it elsewhere would
 /// silently ignore it — e.g. `bzr comment add --dry-run` would still post the
 /// comment. Fail fast (exit 7) instead of writing when a preview was asked for.
 fn ensure_dry_run_supported(cli: &cli::Cli) -> error::Result<()> {
     if !cli.dry_run {
         return Ok(());
     }
-    if let cli::Commands::Bug { action } = &cli.command {
-        if commands::bug::is_dry_runnable(action) {
-            return Ok(());
-        }
+    let supported = match &cli.command {
+        cli::Commands::Bug { action } => commands::bug::is_dry_runnable(action),
+        cli::Commands::Product { action } => commands::product::is_dry_runnable(action),
+        cli::Commands::Component { action } => commands::component::is_dry_runnable(action),
+        cli::Commands::User { action } => commands::user::is_dry_runnable(action),
+        cli::Commands::Group { action } => commands::group::is_dry_runnable(action),
+        _ => false,
+    };
+    if supported {
+        return Ok(());
     }
     Err(error::BzrError::InputValidation(
-        "--dry-run is only supported for bug create, update, clone, resolve, close, reopen, and dup"
+        "--dry-run is only supported for bug create/update/clone/resolve/close/reopen/dup, \
+         product create/update, component create/update, user create/update, and group create/update"
             .into(),
     ))
 }

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -106,3 +106,63 @@ async fn dispatch_allows_dry_run_on_bug_update() {
     assert_eq!(parsed["action"], "dry-run");
     assert_eq!(parsed["ids"], serde_json::json!([5]));
 }
+
+#[tokio::test]
+async fn dispatch_allows_dry_run_on_admin_create() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let cli = cli::Cli::try_parse_from([
+        "bzr",
+        "--server",
+        "test",
+        "--json",
+        "--dry-run",
+        "product",
+        "create",
+        "--name",
+        "DryRun",
+        "--description",
+        "Preview",
+    ])
+    .unwrap();
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = dispatch(&cli, OutputFormat::Json, &mut io.writers()).await;
+    let output = io.out_str().to_string();
+
+    assert!(result.is_ok(), "dry-run dispatch failed: {result:?}");
+    let parsed = serde_json::from_str::<serde_json::Value>(output.trim()).unwrap();
+    assert_eq!(parsed["resource"], "product");
+    assert_eq!(parsed["action"], "dry-run");
+}
+
+#[tokio::test]
+async fn dispatch_rejects_dry_run_on_group_membership_mutation() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let cli = cli::Cli::try_parse_from([
+        "bzr",
+        "--server",
+        "test",
+        "--dry-run",
+        "group",
+        "add-user",
+        "--group",
+        "editbugs",
+        "--user",
+        "alice@example.com",
+    ])
+    .unwrap();
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = dispatch(&cli, OutputFormat::Json, &mut io.writers()).await;
+
+    assert!(matches!(
+        result,
+        Err(error::BzrError::InputValidation(ref msg)) if msg.contains("product create")
+            && msg.contains("group create/update")
+    ));
+}

--- a/src/output/result_types.rs
+++ b/src/output/result_types.rs
@@ -446,10 +446,9 @@ impl ActionResult {
 /// Typed result payload for a `--dry-run` mutation preview.
 ///
 /// Serializes the normal mutation marker (`resource`, `action: "dry-run"`)
-/// plus the affected existing bug `ids` (empty for `create`/`clone`, which
-/// produce a new bug) and the `changes` payload that *would* be sent to the
-/// write API. `changes` is generic over the request type so `create`
-/// (`CreateBugParams`) and `update` (`UpdateBugParams`) can share one shape
+/// plus affected existing resource `ids` when available and the `changes`
+/// payload that *would* be sent to the write API. `changes` is generic over the
+/// request type so create and update payloads can share one result shape
 /// without an intermediate `serde_json::Value`.
 #[derive(Debug, Serialize)]
 #[non_exhaustive]
@@ -461,9 +460,9 @@ pub struct DryRunResult<'a, P: Serialize> {
 }
 
 impl<'a, P: Serialize> DryRunResult<'a, P> {
-    /// Build a dry-run preview for `resource`, listing the existing bug `ids`
-    /// that would be affected (empty for create-shaped operations) and the
-    /// would-be request `changes`.
+    /// Build a dry-run preview for `resource`, listing numeric resource `ids`
+    /// when available (empty for name-keyed or create-shaped operations) and
+    /// the would-be request `changes`.
     pub fn new(resource: ResourceKind, ids: &'a [u64], changes: &'a P) -> Self {
         Self {
             resource,

--- a/tests/functional/phases/17b-arg-validation.sh
+++ b/tests/functional/phases/17b-arg-validation.sh
@@ -44,6 +44,6 @@ if assert_exit_code 2 && assert_stderr_contains "unexpected argument"; then test
 # --dry-run rejected on a non-mutation command (input error, exit 7).
 test_begin "127. --dry-run on non-mutation (exit 7)"
 run_bzr --dry-run server info
-if assert_exit_code 7 && assert_stderr_contains "only supported for bug"; then test_pass; fi
+if assert_exit_code 7 && assert_stderr_contains "only supported for bug create"; then test_pass; fi
 
 echo ""


### PR DESCRIPTION
## Summary

- extend `--dry-run` to product, component, user, and group create/update commands
- keep unsupported writes, including group membership changes, rejected by the global dry-run gate
- reject empty admin updates before previewing or writing

Closes #367

## Verification

- `cargo test dry_run --lib`
- `cargo test without_fields_is_rejected --lib`
- `cargo test commands::product::tests --lib`
- `cargo test commands::component::tests --lib`
- `cargo test commands::user::tests --lib`
- `cargo test commands::group::tests --lib`
- `cargo test --test integration cli_and_docs_avoid_misleading_trim_phrasing`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `shfmt -d tests/functional/phases/17b-arg-validation.sh`
- `shellcheck tests/functional/phases/17b-arg-validation.sh`
- `git diff --check`
- `git diff --cached --check`
- `cargo build`
- `BZR_BIN=target/debug/bzr sh agent-skills/tests/flag-drift-check.sh`
- `BZR_BIN=target/debug/bzr sh agent-skills/tests/drift-check.sh`
- pre-push `cargo test` (1607 lib tests, 23 main tests, 2 lock tests, 79 integration tests, doc-tests)
