### PR TITLE
Allow credentialless read-only servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Named and ad-hoc Bugzilla servers can be used without credentials for
+  read-only commands. Writes and identity-derived commands now fail fast when
+  no credential source is available. (#380)
 - `bug update` now accepts `--url` and `--target-milestone`, matching fields
   that `bug create` can already set. (#363)
 - `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept

--- a/README.md
+++ b/README.md
@@ -288,6 +288,11 @@ cargo install --path . --locked
 ### 2. Configure your first server
 
 ```bash
+# Public read-only exploration can omit credentials
+bzr config set-server public-bz --url https://bugzilla.example.org
+bzr --server public-bz bug list --product Firefox --limit 10
+bzr --server-url https://bugzilla.example.org bug view 12345
+
 # Preferred: read the API key from an environment variable
 export BZR_API_KEY=YOUR_API_KEY
 bzr config set-server myserver --url https://bugzilla.example.com --api-key-env BZR_API_KEY
@@ -302,11 +307,11 @@ bzr config set-server myserver --url https://bugzilla.example.com --api-key YOUR
 To store the API key in your OS keychain instead of an env var, see
 [Credential storage](#credential-storage).
 
-### 3. Verify authentication
+### 3. Verify connectivity and authentication
 
 ```bash
-bzr whoami
 bzr server info
+bzr whoami  # requires credentials
 ```
 
 ### 4. Run your first queries
@@ -428,7 +433,7 @@ Configuration is stored in `~/.config/bzr/config.toml` with support for multiple
 
 ## Authentication
 
-`bzr` authenticates using Bugzilla API keys. Prefer `--api-key-env` so the secret stays out of `config.toml`, shell history, and most process listings. `bzr` warns when the config directory or file permissions are too broad on Unix systems. It also auto-detects whether your server supports header-based auth (`X-BUGZILLA-API-KEY`) or query parameter auth (`Bugzilla_api_key`), and caches the result. See [docs/bzr-cli.md](docs/bzr-cli.md#authentication) for details on generating and configuring API keys.
+`bzr` authenticates using Bugzilla API keys when a command needs an identity or write access. Public Bugzilla servers can omit credentials for read-only commands; writes and identity-derived reads such as `whoami` and `bug my` fail fast until a credential source is configured. Prefer `--api-key-env` so the secret stays out of `config.toml`, shell history, and most process listings. `bzr` warns when the config directory or file permissions are too broad on Unix systems. It also auto-detects whether your server supports header-based auth (`X-BUGZILLA-API-KEY`) or query parameter auth (`Bugzilla_api_key`), and caches the result. See [docs/bzr-cli.md](docs/bzr-cli.md#authentication) for details on generating and configuring API keys.
 
 ## Credential storage
 

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -36,7 +36,7 @@ For installation and quick start, see [README.md](../README.md).
 | Option | Description |
 |--------|-------------|
 | `--server <NAME>` | Use a specific server from config instead of the default |
-| `--server-url <URL>` | Connect to an ad-hoc server by URL, without using config. Defines an ephemeral server for this one invocation: nothing is read from or written to the config file. Requires `--server-api-key-env`; conflicts with `--server`. Pairs with `--config` for sandboxed throwaway runs. |
+| `--server-url <URL>` | Connect to an ad-hoc server by URL, without using config. Defines an ephemeral server for this one invocation: nothing is read from or written to the config file. `--server-api-key-env` is optional for read-only commands and required for writes and identity-derived commands; conflicts with `--server`. Pairs with `--config` for sandboxed throwaway runs. |
 | `--server-api-key-env <ENV>` | Environment variable holding the API key for `--server-url`. The key is read from this variable, never passed as a literal flag, so the secret stays out of the process argument list. Only meaningful with `--server-url`. |
 | `--server-email <EMAIL>` | Login email for `--server-url`, for the Bugzilla 5.0 whoami fallback. Optional; only meaningful with `--server-url`. |
 | `--output <FORMAT>` | Output format: `table`, `json`, or `ndjson`. Defaults to table at a TTY; auto-selects json when stdout is not a TTY. `ndjson` emits newline-delimited JSON — one compact value per line for list results (a single object or result envelope prints as one compact line) — for streaming into agents and `jq -c`. |
@@ -184,7 +184,7 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │   ├── create [--from-json <PATH>] [--product <P>] [--name <N>] [--description <D>] [--default-assignee <E>]
 │   └── update [<ID>] [--from-json <PATH>] [--name <N>] [--description <D>] [--default-assignee <E>]
 ├── config
-│   ├── set-server <NAME> --url <URL> (--api-key <KEY> | --api-key-env <ENV_VAR>) [--email <EMAIL>] [--auth-method <METHOD>]
+│   ├── set-server <NAME> --url <URL> [--api-key <KEY> | --api-key-env <ENV_VAR>] [--email <EMAIL>] [--auth-method <METHOD>]
 │   │                     [--tls-insecure] [--tls-ca-cert <PATH>] [--tls-pin-sha256 <HEX>] [--tls-pin-now] [--tls-pin-clear]
 │   ├── set-keyring <NAME> [--service <S>] [--account <A>]
 │   ├── unset-keyring <NAME>
@@ -1415,9 +1415,22 @@ bzr config set-server redhat --url https://bugzilla.redhat.com --api-key-env RED
 bzr config set-server mozilla --url https://bugzilla.mozilla.org --api-key-env MOZILLA_BZ_API_KEY
 bzr config set-server internal --url https://bugzilla.internal --api-key-env INTERNAL_BZ_API_KEY --tls-insecure
 bzr config set-server legacy --url https://bugzilla.example.com --api-key abc123
+bzr config set-server public-bz --url https://bugzilla.example.org
 ```
 
 The `--email` flag is required for older Bugzilla servers (5.0 or earlier) that don't support the `/rest/whoami` endpoint.
+
+Public Bugzilla servers can be configured without an API key for read-only
+exploration:
+
+```bash
+bzr config set-server public-bz --url https://bugzilla.example.org
+bzr --server public-bz bug list --product Firefox --limit 10
+bzr --server-url https://bugzilla.example.org bug view 12345
+```
+
+Writes and identity-derived commands such as `whoami` and `bug my` require a
+credential source and fail before writing when none is configured.
 
 The `--tls-insecure` flag disables TLS certificate verification for the server. Use this for servers with self-signed, expired, or wrong-hostname certificates (e.g. internal Bugzilla instances behind corporate firewalls).
 
@@ -1427,8 +1440,8 @@ The first server added is automatically set as the default.
 |--------|----------|-------------|
 | `<NAME>` | Yes | Server alias name |
 | `--url <URL>` | Yes | Server URL |
-| `--api-key <KEY>` | One of `--api-key` / `--api-key-env` | API key value (less secure: can leak via shell history or process args) |
-| `--api-key-env <ENV_VAR>` | One of `--api-key` / `--api-key-env` | Environment variable name containing the API key |
+| `--api-key <KEY>` | No | API key value (less secure: can leak via shell history or process args) |
+| `--api-key-env <ENV_VAR>` | No | Environment variable name containing the API key |
 | `--email <EMAIL>` | No | Login email (required for Bugzilla 5.0 or earlier) |
 | `--auth-method <METHOD>` | No | Override auto-detected auth method (`header` or `query_param`) |
 | `--tls-insecure` | No | Disable TLS certificate verification (self-signed, expired, wrong hostname) |
@@ -1443,7 +1456,7 @@ The first server added is automatically set as the default.
 | `--tls-pin-now` | Connect and pin the server's current certificate |
 | `--tls-pin-clear` | Remove a stored certificate pin |
 
-Agent note: prefer `--api-key-env` in local shells, CI, and agent environments. API keys passed on the command line may end up in shell history or process listings, and inline keys are stored in `config.toml`. Verify the result with `bzr whoami` or `bzr --json config show`.
+Agent note: prefer `--api-key-env` in local shells, CI, and agent environments. API keys passed on the command line may end up in shell history or process listings, and inline keys are stored in `config.toml`. Verify public connectivity with `bzr server info`; use `bzr whoami` only after adding credentials.
 
 ### `bzr config set-default`
 
@@ -2072,7 +2085,7 @@ severity = "critical"
 
 ## Authentication
 
-`bzr` authenticates using Bugzilla API keys. Prefer `--api-key-env` so the secret is resolved at runtime rather than stored in `~/.config/bzr/config.toml`. On Unix systems, `bzr` warns if the config directory or config file permissions are broader than owner-only access. On first use, it auto-detects whether your server supports header-based auth (`X-BUGZILLA-API-KEY`) or query parameter auth (`Bugzilla_api_key`), and caches the result.
+`bzr` authenticates using Bugzilla API keys when a command needs an identity or write access. Public Bugzilla servers can omit credentials for read-only commands; writes and identity-derived reads such as `whoami` and `bug my` fail fast until a credential source is configured. Prefer `--api-key-env` so the secret is resolved at runtime rather than stored in `~/.config/bzr/config.toml`. On Unix systems, `bzr` warns if the config directory or config file permissions are broader than owner-only access. On first credentialed use, it auto-detects whether your server supports header-based auth (`X-BUGZILLA-API-KEY`) or query parameter auth (`Bugzilla_api_key`), and caches the result.
 
 Detection probes endpoints in order:
 

--- a/docs/superpowers/specs/2026-06-21-issue-380-credentialless-readonly-design.md
+++ b/docs/superpowers/specs/2026-06-21-issue-380-credentialless-readonly-design.md
@@ -1,0 +1,170 @@
+# Issue #380: Credentialless Read-Only Servers Design
+
+## Context
+
+`bzr` currently requires every named server and every ad-hoc `--server-url`
+target to define exactly one API-key source. That blocks first-run exploration
+of public Bugzilla servers even for read commands that Bugzilla can serve
+anonymously.
+
+Issue #380 asks for public/read-only access without credentials while keeping
+write commands fail-fast and preserving existing auth/API-mode detection for
+credentialed servers.
+
+## Decision
+
+Make credentials optional, not fake.
+
+`ServerConfig` should allow zero or one credential source. Multiple sources
+remain a configuration error. A new credential resolution path returns
+`Option<String>`:
+
+- `Some(key)` for inline, env-var, or keyring-backed credentials.
+- `None` for credentialless named or inline servers.
+
+Client construction accepts an optional API key. Request auth attachment becomes
+a no-op when no credential is present. This keeps anonymous reads as real
+anonymous HTTP/XML-RPC requests instead of sending an empty API key.
+
+`--server-url <URL>` no longer requires `--server-api-key-env`. When
+`--server-api-key-env` is supplied, it behaves as it does today. When omitted,
+the inline server is credentialless and remains entirely ephemeral.
+
+## Read vs Write Boundary
+
+Read commands may connect without credentials and let the server decide whether
+anonymous access is allowed:
+
+- `bug list`, `bug view`, `bug search`, `bug history`
+- `comment list`, `comment search-tags`
+- `attachment list`, `attachment view`, `attachment download`
+- `product list`, `product view`
+- `component list`, `component view`
+- `classification list`, `classification view`
+- `field aliases`, `field list`
+- `user search`
+- `group view`, `group list-users`
+- `query run`
+- `server info`
+
+Local-only commands keep their existing behavior and do not need credentials.
+
+Mutation or identity commands require credentials before any network write or
+auth-only probe:
+
+- bug writes: `bug create`, `bug clone`, `bug update`, `bug resolve`,
+  `bug close`, `bug reopen`, `bug dup`
+- comment writes: `comment add`, `comment tag`
+- attachment writes: `attachment upload`, `attachment update`
+- admin writes: product, component, user, and group create/update plus group
+  membership changes
+- identity-derived reads: `bug my`, `whoami`
+
+If a credentialless server is used with one of these commands, exit 3 with a
+configuration/authentication message that names the command category and suggests
+adding `api_key_env`, `api_key`, `api_key_keyring`, or using
+`--server-api-key-env` for an ad-hoc run.
+
+## Detection and Caching
+
+Credentialed servers keep the current behavior:
+
+- detect auth method;
+- detect API mode/version;
+- cache detected auth method and API mode/version for named servers;
+- do not persist anything for inline servers.
+
+Credentialless servers skip auth-method detection because there is no credential
+to test. They still run API-mode/version detection where possible and cache only
+the version/API-mode result for named servers. The cached `auth_method` remains
+unset so a future credential added to the same server still goes through normal
+auth-method detection.
+
+If anonymous API-mode detection fails because the server requires auth even for
+version probes, surface the existing request error. This is still useful:
+credentialless access was attempted, and the server refused it.
+
+## TLS and Inline Server Interaction
+
+Credentialless access does not change TLS trust semantics. Named server TLS
+settings are validated and applied exactly as today. Inline `--server-url`
+continues to persist no detected settings or TOFU pins.
+
+Issue #381 will add explicit TLS flags for ad-hoc inline servers. This issue
+does not add those flags; it only ensures the credentialless inline path can use
+the default TLS trust behavior already available.
+
+## Files
+
+- `src/config.rs`: allow zero credential sources, add optional credential
+  resolution, and keep multiple-source errors unchanged.
+- `src/http.rs`: make auth application accept optional credentials and skip auth
+  when absent.
+- `src/client/mod.rs`: carry optional credentials through `BugzillaClientConfig`
+  and request construction.
+- `src/client/auth/mod.rs`: keep auth-method detection credential-only.
+- `src/client/version.rs`: ensure version/API-mode detection can run without an
+  API key.
+- `src/commands/runtime/inline_server.rs`: make the API-key env var optional on
+  inline server state.
+- `src/commands/runtime/shared.rs`: build credentialless clients for read
+  commands, skip auth detection without credentials, and persist only API mode
+  for credentialless named servers.
+- `src/commands/mod.rs` and resource command modules: enforce the read/write
+  credential boundary before write/auth-only commands.
+- `src/cli/mod.rs`: remove the `requires = "server_api_key_env"` constraint
+  from `--server-url` and update help text.
+- `docs/bzr-cli.md`, `README.md`, and `CHANGELOG.md`: document read-only
+  credentialless use and write-command failure behavior.
+
+## Testing
+
+Add failing-first tests before implementation:
+
+- CLI parsing accepts `bzr --server-url https://bz.example.com bug view 1`
+  without `--server-api-key-env`.
+- CLI parsing still rejects `--server-api-key-env` without `--server-url`.
+- `ServerConfig::validate` accepts zero credential sources and still rejects
+  multiple sources.
+- optional credential resolution returns `None` for credentialless config and
+  errors clearly for missing/empty env vars when an env source is configured.
+- `connect_and_configure` can build a read client for a credentialless named
+  server and does not persist `auth_method`.
+- inline credentialless `--server-url` connects without loading config and
+  persists nothing.
+- a representative read command (`bug view` or `server info`) sends no API-key
+  header or query parameter when credentialless.
+- `bug my` and `whoami` fail before the auth-only identity probe when no
+  credential is available.
+- representative write commands fail before any write request when no credential
+  is available.
+- `query run`, `user search`, and group read commands remain credentialless read
+  paths when the server permits anonymous access.
+- existing credentialed detection tests still pass and verify `auth_method`
+  persists for credentialed named servers.
+
+## Documentation
+
+Docs should show both flows:
+
+```bash
+bzr config set-server public-bz --url https://bugzilla.example.org
+bzr --server public-bz bug list --product Firefox --limit 10
+
+bzr --server-url https://bugzilla.example.org bug view 12345
+bzr --server-url https://bugzilla.example.org \
+  --server-api-key-env BZR_API_KEY bug update 12345 --status RESOLVED
+```
+
+The credential behavior should be stated directly: reads may work without an API
+key when the Bugzilla server allows anonymous access; writes and `whoami` require
+credentials and fail fast before writing when no credential source is configured.
+
+## Out of Scope
+
+- Adding ad-hoc TLS flags for `--server-url`; issue #381 covers that.
+- Adding anonymous fallback after credentialed auth fails. If a user configured
+  a credential source, failures should remain visible.
+- Retrying writes or changing write idempotency.
+- Changing server-side Bugzilla permissions. Anonymous requests can still fail
+  when the server requires authentication for that resource.

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -10,9 +10,10 @@ use crate::types::AuthMethod;
 pub enum ConfigAction {
     /// Add or update a named server in the local config.
     ///
-    /// `--url` is required. Exactly one of `--api-key` (inline) or
-    /// `--api-key-env` (env-var indirection) must be supplied; using
-    /// the OS keychain instead is a separate step
+    /// `--url` is required. `--api-key` (inline) and `--api-key-env`
+    /// (env-var indirection) are optional; omit both for public read-only
+    /// servers. Writes and identity-derived commands require one credential
+    /// source, and using the OS keychain is a separate step
     /// (`bzr config set-keyring`).
     ///
     /// TLS handling is mutually exclusive across these flags:
@@ -48,27 +49,20 @@ pub enum ConfigAction {
         url: String,
         /// API key, stored inline in the config file.
         ///
-        /// Mutually exclusive with `--api-key-env`; one of the two
-        /// is required (or use `bzr config set-keyring` to keep
-        /// the secret in the OS keychain instead). Inline keys can
-        /// leak via shell history, process args, or backup copies
-        /// of `config.toml` -- prefer `--api-key-env` or the
-        /// keyring for anything beyond a throwaway test setup.
-        #[arg(
-            long,
-            conflicts_with = "api_key_env",
-            required_unless_present = "api_key_env"
-        )]
+        /// Mutually exclusive with `--api-key-env`. Inline keys can leak via
+        /// shell history, process args, or backup copies of `config.toml` --
+        /// prefer `--api-key-env` or the keyring for anything beyond a
+        /// throwaway test setup.
+        #[arg(long, conflicts_with = "api_key_env")]
         api_key: Option<String>,
         /// Name of an environment variable that holds the API key.
         ///
-        /// Mutually exclusive with `--api-key`. The variable is
-        /// resolved at command time, not at `set-server` time, so
-        /// rotating the key only requires updating the env var
-        /// (or the secret store backing it). Variable names are
-        /// stored verbatim in the config file; the secret itself
-        /// is not.
-        #[arg(long, conflicts_with = "api_key", required_unless_present = "api_key")]
+        /// Mutually exclusive with `--api-key`. The variable is resolved at
+        /// command time, not at `set-server` time, so rotating the key only
+        /// requires updating the env var (or the secret store backing it).
+        /// Variable names are stored verbatim in the config file; the secret
+        /// itself is not.
+        #[arg(long, conflicts_with = "api_key")]
         api_key_env: Option<String>,
         /// Login email used for fallback auth on older Bugzilla servers.
         ///
@@ -248,9 +242,9 @@ pub enum ConfigAction {
     ///
     /// Deletes the keychain entry for `<server-name>` (or the
     /// service/account configured by `set-keyring`) and clears the
-    /// server's keyring credential reference. The server entry is
-    /// preserved with no API key source; re-run `set-server` or
-    /// `set-keyring` afterward to re-credential it.
+    /// server's keyring credential reference. The server entry is preserved
+    /// with no API key source, so public reads can still work; configure
+    /// `--api-key-env`, `--api-key`, or `set-keyring` before writes.
     ///
     /// Examples:
     ///

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -238,12 +238,11 @@ pub struct Cli {
 pub enum Commands {
     /// Operate on bugs: list, view, search, create, clone, update, history.
     ///
-    /// The `bug` group is the most commonly used part of bzr. Read paths
-    /// (`list`, `view`, `search`, `history`, `my`) work without any
-    /// authentication beyond what the configured server requires; write
-    /// paths (`create`, `clone`, `update`) require credentials and the
-    /// caller must have appropriate Bugzilla permissions on the target
-    /// product.
+    /// The `bug` group is the most commonly used part of bzr. Public read
+    /// paths (`list`, `view`, `search`, `history`) work without any
+    /// authentication beyond what the configured server requires. Write paths
+    /// (`create`, `clone`, `update`) and identity-derived reads (`my`) require
+    /// credentials.
     ///
     /// Filter flags (`--product`, `--component`, `--status`, `--assignee`,
     /// `--creator`, `--priority`, `--severity`) on `list` and `my` are

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -90,9 +90,11 @@ pub struct Cli {
     ///
     /// Defines an ephemeral server for this one invocation: nothing is read
     /// from or written to the config file, so a fully stateless run needs no
-    /// `config set-server` first. Requires `--server-api-key-env`; conflicts
-    /// with `--server` (a named server and an inline one are mutually
-    /// exclusive). Pairs with `--config` for sandboxed throwaway runs.
+    /// `config set-server` first. `--server-api-key-env` is optional for
+    /// public read-only commands, but required for writes and identity-derived
+    /// commands. Conflicts with `--server` (a named server and an inline one
+    /// are mutually exclusive). Pairs with `--config` for sandboxed throwaway
+    /// runs.
     ///
     ///   bzr --server-url https://bz.example.com \
     ///     --server-api-key-env BZR_KEY bug view 123
@@ -101,7 +103,6 @@ pub struct Cli {
         value_name = "URL",
         global = true,
         conflicts_with = "server",
-        requires = "server_api_key_env",
         verbatim_doc_comment
     )]
     pub server_url: Option<String>,

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -295,17 +295,29 @@ fn parse_inline_server_flags() {
 }
 
 #[test]
-fn inline_server_url_requires_api_key_env() {
-    // --server-url alone is rejected: a credential source is mandatory.
-    let result = Cli::try_parse_from([
+fn inline_server_url_no_longer_requires_api_key_env() {
+    let cli = Cli::try_parse_from([
         "bzr",
         "--server-url",
         "https://bz.example.com",
         "bug",
         "view",
         "42",
-    ]);
-    assert!(result.is_err(), "--server-url without env key must fail");
+    ])
+    .unwrap();
+
+    assert_eq!(cli.server_url.as_deref(), Some("https://bz.example.com"));
+    assert_eq!(cli.server_api_key_env, None);
+}
+
+#[test]
+fn inline_server_api_key_env_still_requires_url() {
+    let result =
+        Cli::try_parse_from(["bzr", "--server-api-key-env", "BZR_KEY", "bug", "view", "1"]);
+    assert!(
+        result.is_err(),
+        "--server-api-key-env without --server-url must fail"
+    );
 }
 
 #[test]
@@ -556,6 +568,30 @@ fn parse_config_set_server_with_env_var() {
         cli.command,
         Commands::Config {
             action: ConfigAction::SetServer { .. }
+        }
+    ));
+}
+
+#[test]
+fn parse_config_set_server_without_api_key_source() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "config",
+        "set-server",
+        "public",
+        "--url",
+        "https://bz.example.com",
+    ])
+    .unwrap();
+
+    assert!(matches!(
+        cli.command,
+        Commands::Config {
+            action: ConfigAction::SetServer {
+                api_key: None,
+                api_key_env: None,
+                ..
+            }
         }
     ));
 }

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -13,7 +13,7 @@ use crate::types::{ApiMode, AuthMethod};
 use self::valid_login::{detect_valid_login_auth, verify_header_auth_via_rest, ValidLoginOutcome};
 use self::whoami::{detect_whoami_auth, WhoamiOutcome};
 
-use super::version::{detect_version_and_mode, detect_version_and_mode_without_auth};
+use super::version::{detect_version_and_mode, detect_version_and_mode_without_auth_checked};
 
 /// Result of server settings detection -- auth method, API mode, and
 /// optionally the server version string. Returned by [`detect_server_settings`]
@@ -68,7 +68,7 @@ pub async fn detect_server_settings_without_auth(
     tls_config: &crate::tls::TlsConfig,
 ) -> Result<DetectedServerSettings> {
     let http = crate::tls::build_tls_client(tls_config)?;
-    let (version, api_mode) = detect_version_and_mode_without_auth(&http, url).await;
+    let (version, api_mode) = detect_version_and_mode_without_auth_checked(&http, url).await?;
 
     tracing::info!(
         %api_mode,

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -13,7 +13,7 @@ use crate::types::{ApiMode, AuthMethod};
 use self::valid_login::{detect_valid_login_auth, verify_header_auth_via_rest, ValidLoginOutcome};
 use self::whoami::{detect_whoami_auth, WhoamiOutcome};
 
-use super::version::detect_version_and_mode;
+use super::version::{detect_version_and_mode, detect_version_and_mode_without_auth};
 
 /// Result of server settings detection -- auth method, API mode, and
 /// optionally the server version string. Returned by [`detect_server_settings`]
@@ -21,7 +21,7 @@ use super::version::detect_version_and_mode;
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct DetectedServerSettings {
-    pub auth_method: AuthMethod,
+    pub auth_method: Option<AuthMethod>,
     pub api_mode: ApiMode,
     /// `Some` when the version endpoint responded successfully; `None` on
     /// transient failures. Callers should only persist `api_mode` and
@@ -53,7 +53,31 @@ pub async fn detect_server_settings(
     );
 
     Ok(DetectedServerSettings {
-        auth_method: method,
+        auth_method: Some(method),
+        api_mode,
+        server_version: version,
+    })
+}
+
+/// Detect API mode and server version without credentials.
+///
+/// This is used for public read-only servers. No auth probes are sent, and the
+/// returned settings intentionally have no auth method to cache.
+pub async fn detect_server_settings_without_auth(
+    url: &str,
+    tls_config: &crate::tls::TlsConfig,
+) -> Result<DetectedServerSettings> {
+    let http = crate::tls::build_tls_client(tls_config)?;
+    let (version, api_mode) = detect_version_and_mode_without_auth(&http, url).await;
+
+    tracing::info!(
+        %api_mode,
+        version = version.as_deref().unwrap_or("unknown"),
+        "detected anonymous server settings"
+    );
+
+    Ok(DetectedServerSettings {
+        auth_method: None,
         api_mode,
         server_version: version,
     })

--- a/src/client/auth/mod_tests.rs
+++ b/src/client/auth/mod_tests.rs
@@ -1,11 +1,45 @@
 #![expect(clippy::unwrap_used)]
 
+use std::io::Read as _;
+use std::net::TcpListener;
+use std::sync::Arc;
+
 use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use super::*;
 use crate::client::test_helpers::test_http_client;
+use crate::error::BzrError;
 use crate::http::AUTH_HEADER_NAME;
+
+fn spawn_self_signed_https_server() -> (String, std::thread::JoinHandle<()>) {
+    let params = rcgen::CertificateParams::new(vec!["localhost".to_owned()]).unwrap();
+    let key_pair = rcgen::KeyPair::generate().unwrap();
+    let cert = params.self_signed(&key_pair).unwrap();
+    let cert_der = rustls::pki_types::CertificateDer::from(cert.der().to_vec());
+    let key_der = rustls::pki_types::PrivateKeyDer::Pkcs8(
+        rustls::pki_types::PrivatePkcs8KeyDer::from(key_pair.serialize_der()),
+    );
+    let server_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let handle = std::thread::spawn(move || {
+        let Ok((tcp, _addr)) = listener.accept() else {
+            return;
+        };
+        let Ok(connection) = rustls::ServerConnection::new(Arc::new(server_config)) else {
+            return;
+        };
+        let mut stream = rustls::StreamOwned::new(connection, tcp);
+        let _ = stream.read(&mut [0_u8; 1]);
+    });
+
+    (format!("https://localhost:{port}"), handle)
+}
 
 #[tokio::test]
 async fn header_auth_succeeds() {
@@ -204,6 +238,26 @@ async fn non_tls_network_error_defaults_to_header() {
     assert!(
         matches!(result, Ok(AuthMethod::Header)),
         "non-TLS transport failure should default to header, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn anonymous_detection_propagates_tls_certificate_errors() {
+    let (url, handle) = spawn_self_signed_https_server();
+
+    let result = detect_server_settings_without_auth(&url, &crate::tls::TlsConfig::default()).await;
+    handle.join().unwrap();
+
+    assert!(
+        matches!(&result, Err(BzrError::Http(_))),
+        "expected TLS HTTP error from anonymous detection, got: {result:?}"
+    );
+    let Err(BzrError::Http(err)) = result else {
+        return;
+    };
+    assert!(
+        crate::http::is_tls_cert_error(&err),
+        "anonymous detection should surface TLS cert errors, got: {err:#}"
     );
 }
 

--- a/src/client/auth/mod_tests.rs
+++ b/src/client/auth/mod_tests.rs
@@ -338,7 +338,7 @@ async fn detect_server_settings_returns_all_fields() {
     )
     .await
     .unwrap();
-    assert_eq!(detected.auth_method, AuthMethod::Header);
+    assert_eq!(detected.auth_method, Some(AuthMethod::Header));
     assert_eq!(detected.api_mode, ApiMode::Rest);
     assert_eq!(detected.server_version.as_deref(), Some("5.1.2"));
 }
@@ -386,7 +386,7 @@ async fn detect_server_settings_keeps_version_none_when_probe_fails() {
     )
     .await
     .unwrap();
-    assert_eq!(detected.auth_method, AuthMethod::Header);
+    assert_eq!(detected.auth_method, Some(AuthMethod::Header));
     assert_eq!(detected.api_mode, ApiMode::Hybrid);
     assert!(detected.server_version.is_none());
 }

--- a/src/client/group_tests.rs
+++ b/src/client/group_tests.rs
@@ -373,8 +373,8 @@ async fn xmlrpc_mode_get_group_bypasses_rest() {
 
     let client = super::BugzillaClient::new(crate::client::BugzillaClientConfig {
         base_url: &mock.uri(),
-        credential: "test-key",
-        auth_method: AuthMethod::Header,
+        credential: Some("test-key"),
+        auth_method: Some(AuthMethod::Header),
         api_mode: ApiMode::XmlRpc,
         email_hint: None,
         tls_config: &crate::tls::TlsConfig::default(),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -50,8 +50,8 @@ enum PreparedAuth {
 pub struct BugzillaClient {
     pub(super) http: reqwest::Client,
     pub(super) base_url: String,
-    auth: PreparedAuth,
-    pub(super) api_key: String,
+    auth: Option<PreparedAuth>,
+    pub(super) api_key: Option<String>,
     pub(super) api_mode: ApiMode,
     pub(super) xmlrpc: Option<XmlRpcClient>,
     /// Email hint for Bugzilla 5.0 compatibility (whoami fallback via user lookup).
@@ -66,8 +66,8 @@ pub struct BugzillaClient {
 #[derive(Clone, Copy)]
 pub struct BugzillaClientConfig<'a> {
     pub base_url: &'a str,
-    pub credential: &'a str,
-    pub auth_method: AuthMethod,
+    pub credential: Option<&'a str>,
+    pub auth_method: Option<AuthMethod>,
     pub api_mode: ApiMode,
     pub email_hint: Option<&'a str>,
     pub tls_config: &'a crate::tls::TlsConfig,
@@ -161,13 +161,26 @@ impl BugzillaClient {
             tls_config,
         } = config;
 
-        let auth = match auth_method {
-            AuthMethod::Header => {
-                let value = HeaderValue::from_str(credential)
+        let auth = match (credential, auth_method) {
+            (Some(key), Some(AuthMethod::Header)) => {
+                let value = HeaderValue::from_str(key)
                     .map_err(|_| BzrError::config("invalid API key characters"))?;
-                PreparedAuth::Header(value)
+                Some(PreparedAuth::Header(value))
             }
-            AuthMethod::QueryParam => PreparedAuth::QueryParam(credential.to_string()),
+            (Some(key), Some(AuthMethod::QueryParam)) => {
+                Some(PreparedAuth::QueryParam(key.to_string()))
+            }
+            (None, None) => None,
+            (Some(_), None) => {
+                return Err(BzrError::config(
+                    "internal: credential provided without detected auth method",
+                ));
+            }
+            (None, Some(_)) => {
+                return Err(BzrError::config(
+                    "internal: auth method provided without credential",
+                ));
+            }
         };
 
         let http = crate::tls::build_tls_client(tls_config)?;
@@ -175,7 +188,7 @@ impl BugzillaClient {
         // Always construct the XML-RPC client — even in REST mode, some
         // methods (e.g. Group.get on Bugzilla 5.3+) require XML-RPC fallback
         // because the REST endpoint is broken for them.
-        if api_mode != ApiMode::Rest && auth_method == AuthMethod::Header {
+        if api_mode != ApiMode::Rest && auth_method == Some(AuthMethod::Header) {
             tracing::info!(
                 "XML-RPC always sends API key in request body, \
                  overriding configured header auth for XML-RPC calls"
@@ -183,13 +196,13 @@ impl BugzillaClient {
         }
         let xmlrpc = Some(XmlRpcClient::new(http.clone(), base_url, credential));
 
-        tracing::debug!(base_url, %auth_method, %api_mode, "created Bugzilla client");
+        tracing::debug!(base_url, ?auth_method, %api_mode, "created Bugzilla client");
 
         Ok(BugzillaClient {
             http,
             base_url: base_url.trim_end_matches('/').to_string(),
             auth,
-            api_key: credential.to_string(),
+            api_key: credential.map(String::from),
             api_mode,
             xmlrpc,
             email_hint: email_hint.map(String::from),
@@ -307,17 +320,18 @@ impl BugzillaClient {
         self.parse_json(resp).await
     }
 
-    /// Apply auth credentials to a request. Infallible because the API key
-    /// was validated at client construction time. Delegates to the shared
-    /// [`crate::http::apply_auth_to_request`] primitive.
+    /// Apply auth credentials to a request. Infallible because any configured
+    /// API key was validated at client construction time. Anonymous clients
+    /// leave the request unchanged.
     pub(super) fn apply_auth(&self, builder: RequestBuilder) -> RequestBuilder {
         match &self.auth {
-            PreparedAuth::Header(value) => {
+            Some(PreparedAuth::Header(value)) => {
                 crate::http::apply_auth_to_request(builder, Some(value), None)
             }
-            PreparedAuth::QueryParam(key) => {
+            Some(PreparedAuth::QueryParam(key)) => {
                 crate::http::apply_auth_to_request(builder, None, Some(key))
             }
+            None => builder,
         }
     }
 
@@ -420,6 +434,9 @@ impl BugzillaClient {
         &self,
         retry_builder: Option<RequestBuilder>,
     ) -> Result<Option<reqwest::Response>> {
+        if self.auth.is_none() {
+            return Ok(None);
+        }
         let Some(clone) = retry_builder else {
             return Ok(None);
         };
@@ -438,14 +455,17 @@ impl BugzillaClient {
     }
 
     fn apply_alternate_auth(&self, builder: RequestBuilder) -> Result<RequestBuilder> {
-        match &self.auth {
-            PreparedAuth::Header(_) => Ok(builder.query(&[(AUTH_QUERY_PARAM, &self.api_key)])),
-            PreparedAuth::QueryParam(_) => {
-                let value = HeaderValue::from_str(&self.api_key).map_err(|e| {
+        match (&self.auth, self.api_key.as_deref()) {
+            (Some(PreparedAuth::Header(_)), Some(api_key)) => {
+                Ok(builder.query(&[(AUTH_QUERY_PARAM, api_key)]))
+            }
+            (Some(PreparedAuth::QueryParam(_)), Some(api_key)) => {
+                let value = HeaderValue::from_str(api_key).map_err(|e| {
                     BzrError::Config(format!("API key contains invalid header characters: {e}"))
                 })?;
                 Ok(builder.header(AUTH_HEADER_NAME, value))
             }
+            _ => Ok(builder),
         }
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,8 @@
 mod attachment;
 pub(crate) mod auth;
-pub(crate) use auth::{detect_server_settings, DetectedServerSettings};
+pub(crate) use auth::{
+    detect_server_settings, detect_server_settings_without_auth, DetectedServerSettings,
+};
 mod bug;
 mod classification;
 mod comment;

--- a/src/client/mod_tests.rs
+++ b/src/client/mod_tests.rs
@@ -35,8 +35,8 @@ fn safe_url_preserves_path() {
 fn new_trims_trailing_slash_and_keeps_email_hint() {
     let client = BugzillaClient::new(BugzillaClientConfig {
         base_url: "https://bugzilla.example.com/",
-        credential: "test-key",
-        auth_method: AuthMethod::Header,
+        credential: Some("test-key"),
+        auth_method: Some(AuthMethod::Header),
         api_mode: ApiMode::Rest,
         email_hint: Some("user@example.com"),
         tls_config: &crate::tls::TlsConfig::default(),
@@ -58,12 +58,49 @@ fn apply_auth_adds_query_param_credentials() {
     assert_eq!(request.url().query(), Some(expected_query.as_str()));
 }
 
+#[tokio::test]
+async fn anonymous_client_sends_no_api_key_header_or_query() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/version"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"version": "5.1.2"})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = BugzillaClient::new(BugzillaClientConfig {
+        base_url: &mock.uri(),
+        credential: None,
+        auth_method: None,
+        api_mode: ApiMode::Rest,
+        email_hint: None,
+        tls_config: &crate::tls::TlsConfig::default(),
+    })
+    .unwrap();
+
+    let value = client.get_json_value("version").await.unwrap();
+    assert_eq!(value["version"], "5.1.2");
+
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0]
+        .headers
+        .get(crate::http::AUTH_HEADER_NAME)
+        .is_none());
+    assert!(requests[0]
+        .url
+        .query_pairs()
+        .all(|(name, _)| name != crate::http::AUTH_QUERY_PARAM));
+}
+
 #[test]
 fn alternate_auth_rejects_invalid_header_characters() {
     let client = BugzillaClient::new(BugzillaClientConfig {
         base_url: "https://bugzilla.example.com",
-        credential: "bad\nkey",
-        auth_method: AuthMethod::QueryParam,
+        credential: Some("bad\nkey"),
+        auth_method: Some(AuthMethod::QueryParam),
         api_mode: ApiMode::Rest,
         email_hint: None,
         tls_config: &crate::tls::TlsConfig::default(),
@@ -225,6 +262,36 @@ async fn auth_fallback_both_fail_returns_original_error() {
         msg.contains("410") || msg.contains("log in"),
         "expected auth error: {msg}"
     );
+}
+
+#[tokio::test]
+async fn anonymous_client_does_not_retry_401_with_alternate_auth() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/user"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "error": true,
+            "code": 410,
+            "message": "You must log in."
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = BugzillaClient::new(BugzillaClientConfig {
+        base_url: &mock.uri(),
+        credential: None,
+        auth_method: None,
+        api_mode: ApiMode::Rest,
+        email_hint: None,
+        tls_config: &crate::tls::TlsConfig::default(),
+    })
+    .unwrap();
+
+    let err = client.search_users("alice", false).await.unwrap_err();
+
+    assert!(err.to_string().contains("410"));
+    assert_eq!(mock.received_requests().await.unwrap().len(), 1);
 }
 
 #[tokio::test]

--- a/src/client/test_helpers.rs
+++ b/src/client/test_helpers.rs
@@ -9,8 +9,8 @@ pub fn test_http_client() -> reqwest::Client {
 pub fn test_client(base_url: &str) -> BugzillaClient {
     BugzillaClient::new(BugzillaClientConfig {
         base_url,
-        credential: "test-key",
-        auth_method: AuthMethod::Header,
+        credential: Some("test-key"),
+        auth_method: Some(AuthMethod::Header),
         api_mode: ApiMode::Rest,
         email_hint: None,
         tls_config: &crate::tls::TlsConfig::default(),
@@ -21,8 +21,8 @@ pub fn test_client(base_url: &str) -> BugzillaClient {
 pub fn test_client_hybrid(base_url: &str) -> BugzillaClient {
     BugzillaClient::new(BugzillaClientConfig {
         base_url,
-        credential: "test-key",
-        auth_method: AuthMethod::Header,
+        credential: Some("test-key"),
+        auth_method: Some(AuthMethod::Header),
         api_mode: ApiMode::Hybrid,
         email_hint: None,
         tls_config: &crate::tls::TlsConfig::default(),
@@ -33,8 +33,8 @@ pub fn test_client_hybrid(base_url: &str) -> BugzillaClient {
 pub fn test_client_query_param(base_url: &str) -> BugzillaClient {
     BugzillaClient::new(BugzillaClientConfig {
         base_url,
-        credential: "test-key",
-        auth_method: AuthMethod::QueryParam,
+        credential: Some("test-key"),
+        auth_method: Some(AuthMethod::QueryParam),
         api_mode: ApiMode::Rest,
         email_hint: None,
         tls_config: &crate::tls::TlsConfig::default(),
@@ -45,8 +45,8 @@ pub fn test_client_query_param(base_url: &str) -> BugzillaClient {
 pub fn test_client_xmlrpc(base_url: &str) -> BugzillaClient {
     BugzillaClient::new(BugzillaClientConfig {
         base_url,
-        credential: "test-key",
-        auth_method: AuthMethod::Header,
+        credential: Some("test-key"),
+        auth_method: Some(AuthMethod::Header),
         api_mode: ApiMode::XmlRpc,
         email_hint: None,
         tls_config: &crate::tls::TlsConfig::default(),

--- a/src/client/version.rs
+++ b/src/client/version.rs
@@ -14,13 +14,6 @@ pub(super) async fn detect_version_and_mode(
     detect_version_and_mode_inner(http, base_url, Some((api_key, auth_method))).await
 }
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Task 3 wires anonymous runtime detection to this helper"
-    )
-)]
 pub(super) async fn detect_version_and_mode_without_auth(
     http: &reqwest::Client,
     base_url: &str,

--- a/src/client/version.rs
+++ b/src/client/version.rs
@@ -1,5 +1,12 @@
+use crate::error::{BzrError, Result};
 use crate::http::apply_auth;
 use crate::types::{ApiMode, AuthMethod};
+
+#[derive(Debug, Clone, Copy)]
+enum SendErrorHandling {
+    FallbackToXmlRpc,
+    PropagateTlsCertificate,
+}
 
 /// Detect server version and determine API mode.
 ///
@@ -11,21 +18,35 @@ pub(super) async fn detect_version_and_mode(
     api_key: &str,
     auth_method: AuthMethod,
 ) -> (Option<String>, ApiMode) {
-    detect_version_and_mode_inner(http, base_url, Some((api_key, auth_method))).await
+    detect_version_and_mode_inner(
+        http,
+        base_url,
+        Some((api_key, auth_method)),
+        SendErrorHandling::FallbackToXmlRpc,
+    )
+    .await
+    .unwrap_or((None, ApiMode::XmlRpc))
 }
 
-pub(super) async fn detect_version_and_mode_without_auth(
+pub(super) async fn detect_version_and_mode_without_auth_checked(
     http: &reqwest::Client,
     base_url: &str,
-) -> (Option<String>, ApiMode) {
-    detect_version_and_mode_inner(http, base_url, None).await
+) -> Result<(Option<String>, ApiMode)> {
+    detect_version_and_mode_inner(
+        http,
+        base_url,
+        None,
+        SendErrorHandling::PropagateTlsCertificate,
+    )
+    .await
 }
 
 async fn detect_version_and_mode_inner(
     http: &reqwest::Client,
     base_url: &str,
     auth: Option<(&str, AuthMethod)>,
-) -> (Option<String>, ApiMode) {
+    send_error_handling: SendErrorHandling,
+) -> Result<(Option<String>, ApiMode)> {
     #[derive(serde::Deserialize)]
     struct VersionResponse {
         version: String,
@@ -49,6 +70,13 @@ async fn detect_version_and_mode_inner(
     let resp = match req.send().await {
         Ok(r) => r,
         Err(e) => {
+            if matches!(
+                send_error_handling,
+                SendErrorHandling::PropagateTlsCertificate
+            ) && crate::http::is_tls_cert_error(&e)
+            {
+                return Err(BzrError::Http(e));
+            }
             tracing::warn!(
                 "{}",
                 crate::http::tls_hint(
@@ -56,7 +84,7 @@ async fn detect_version_and_mode_inner(
                     &e,
                 )
             );
-            return (None, ApiMode::XmlRpc);
+            return Ok((None, ApiMode::XmlRpc));
         }
     };
 
@@ -65,23 +93,23 @@ async fn detect_version_and_mode_inner(
             status = %resp.status(),
             "version endpoint not available, assuming pre-5.0"
         );
-        return (None, ApiMode::XmlRpc);
+        return Ok((None, ApiMode::XmlRpc));
     }
 
     let Ok(body) = resp.text().await else {
         tracing::warn!("version response body unreadable, falling back to xmlrpc");
-        return (None, ApiMode::XmlRpc);
+        return Ok((None, ApiMode::XmlRpc));
     };
 
     let Ok(parsed) = serde_json::from_str::<VersionResponse>(&body) else {
         // Endpoint exists (200 OK) but returns non-standard body -- assume a
         // modern server with a custom extension; default to Hybrid.
-        return (None, ApiMode::Hybrid);
+        return Ok((None, ApiMode::Hybrid));
     };
 
     let mode = version_to_api_mode(&parsed.version);
     tracing::debug!(version = %parsed.version, %mode, "determined API mode from version");
-    (Some(parsed.version), mode)
+    Ok((Some(parsed.version), mode))
 }
 
 /// Parse a Bugzilla version string and determine the API mode.

--- a/src/client/version.rs
+++ b/src/client/version.rs
@@ -11,6 +11,28 @@ pub(super) async fn detect_version_and_mode(
     api_key: &str,
     auth_method: AuthMethod,
 ) -> (Option<String>, ApiMode) {
+    detect_version_and_mode_inner(http, base_url, Some((api_key, auth_method))).await
+}
+
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Task 3 wires anonymous runtime detection to this helper"
+    )
+)]
+pub(super) async fn detect_version_and_mode_without_auth(
+    http: &reqwest::Client,
+    base_url: &str,
+) -> (Option<String>, ApiMode) {
+    detect_version_and_mode_inner(http, base_url, None).await
+}
+
+async fn detect_version_and_mode_inner(
+    http: &reqwest::Client,
+    base_url: &str,
+    auth: Option<(&str, AuthMethod)>,
+) -> (Option<String>, ApiMode) {
     #[derive(serde::Deserialize)]
     struct VersionResponse {
         version: String,
@@ -19,13 +41,16 @@ pub(super) async fn detect_version_and_mode(
     let base = base_url.trim_end_matches('/');
     let url = format!("{base}/rest/version");
 
-    let req = match apply_auth(http.get(&url), api_key, auth_method) {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::debug!("auth setup failed for version probe: {e}");
-            // Fall back to unauthenticated request — version endpoint is often public.
-            http.get(&url)
-        }
+    let req = match auth {
+        Some((api_key, auth_method)) => match apply_auth(http.get(&url), api_key, auth_method) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!("auth setup failed for version probe: {e}");
+                // Fall back to unauthenticated request — version endpoint is often public.
+                http.get(&url)
+            }
+        },
+        None => http.get(&url),
     };
 
     let resp = match req.send().await {

--- a/src/client/version_tests.rs
+++ b/src/client/version_tests.rs
@@ -48,6 +48,37 @@ async fn detect_version_returns_rest_for_5_1() {
 }
 
 #[tokio::test]
+async fn detect_version_and_mode_without_auth_sends_no_credentials() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/version"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"version": "5.1.2"})),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let (version, mode) =
+        detect_version_and_mode_without_auth(&test_http_client(), &server.uri()).await;
+
+    assert_eq!(version.as_deref(), Some("5.1.2"));
+    assert_eq!(mode, ApiMode::Rest);
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0]
+        .headers
+        .get(crate::http::AUTH_HEADER_NAME)
+        .is_none());
+    assert!(requests[0]
+        .url
+        .query_pairs()
+        .all(|(name, _)| name != crate::http::AUTH_QUERY_PARAM));
+}
+
+#[tokio::test]
 async fn detect_version_returns_hybrid_for_5_0() {
     let server = MockServer::start().await;
 

--- a/src/client/version_tests.rs
+++ b/src/client/version_tests.rs
@@ -60,8 +60,15 @@ async fn detect_version_and_mode_without_auth_sends_no_credentials() {
         .mount(&server)
         .await;
 
-    let (version, mode) =
-        detect_version_and_mode_without_auth(&test_http_client(), &server.uri()).await;
+    let result =
+        detect_version_and_mode_without_auth_checked(&test_http_client(), &server.uri()).await;
+    assert!(
+        result.is_ok(),
+        "anonymous version probe should succeed: {result:?}"
+    );
+    let Ok((version, mode)) = result else {
+        return;
+    };
 
     assert_eq!(version.as_deref(), Some("5.1.2"));
     assert_eq!(mode, ApiMode::Rest);

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -19,6 +19,16 @@ use crate::types::Attachment;
 use crate::types::OutputFormat;
 use crate::types::{UpdateAttachmentParams, UploadAttachmentParams};
 
+pub(crate) fn requires_credentials(action: &AttachmentAction) -> Option<&'static str> {
+    match action {
+        AttachmentAction::List { .. }
+        | AttachmentAction::View { .. }
+        | AttachmentAction::Download { .. } => None,
+        AttachmentAction::Upload(_) => Some("attachment upload"),
+        AttachmentAction::Update(_) => Some("attachment update"),
+    }
+}
+
 /// Collapse a `--flag` / `--no-flag` presence pair into a tri-state.
 ///
 /// Returns `Some(true)` for the positive flag, `Some(false)` for the negative,

--- a/src/commands/bug/mod.rs
+++ b/src/commands/bug/mod.rs
@@ -81,6 +81,22 @@ pub fn is_dry_runnable(action: &BugAction) -> bool {
     )
 }
 
+pub(crate) fn requires_credentials(action: &BugAction) -> Option<&'static str> {
+    match action {
+        BugAction::List(_) | BugAction::View(_) | BugAction::Search(_) | BugAction::History(_) => {
+            None
+        }
+        BugAction::Create(_) => Some("bug create"),
+        BugAction::My(_) => Some("bug my"),
+        BugAction::Clone(_) => Some("bug clone"),
+        BugAction::Update(_) => Some("bug update"),
+        BugAction::Resolve(_) => Some("bug resolve"),
+        BugAction::Close(_) => Some("bug close"),
+        BugAction::Reopen(_) => Some("bug reopen"),
+        BugAction::Dup(_) => Some("bug dup"),
+    }
+}
+
 /// Dispatch bug actions to their respective handlers.
 pub async fn execute(
     action: &BugAction,

--- a/src/commands/comment.rs
+++ b/src/commands/comment.rs
@@ -11,6 +11,14 @@ use crate::output::writers::Writers;
 use crate::types::ApiMode;
 use crate::types::{OutputFormat, UpdateCommentTagsParams};
 
+pub(crate) fn requires_credentials(action: &CommentAction) -> Option<&'static str> {
+    match action {
+        CommentAction::List { .. } | CommentAction::SearchTags { .. } => None,
+        CommentAction::Add { .. } => Some("comment add"),
+        CommentAction::Tag { .. } => Some("comment tag"),
+    }
+}
+
 pub async fn execute(
     action: &CommentAction,
     server: Option<&str>,

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -134,6 +134,14 @@ pub fn is_dry_runnable(action: &ComponentAction) -> bool {
     )
 }
 
+pub(crate) fn requires_credentials(action: &ComponentAction) -> Option<&'static str> {
+    match action {
+        ComponentAction::List { .. } | ComponentAction::View { .. } => None,
+        ComponentAction::Create { .. } => Some("component create"),
+        ComponentAction::Update { .. } => Some("component update"),
+    }
+}
+
 fn build_create_params(
     from_json: Option<&str>,
     product: Option<&str>,

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -113,8 +113,8 @@ pub async fn execute(
 
 /// Remove a server alias from the config, dropping any keychain entry.
 fn remove_server(name: &str, format: OutputFormat, w: &mut Writers<'_>) -> Result<()> {
-    // Advisory snapshot: read unvalidated so an unrelated credential-less
-    // server (left by `unset-keyring`) does not block the removal.
+    // Advisory snapshot: read unvalidated so an unrelated invalid server does
+    // not block the removal.
     let config = Config::read_unvalidated()?;
     let server = config
         .servers
@@ -140,10 +140,8 @@ fn remove_server(name: &str, format: OutputFormat, w: &mut Writers<'_>) -> Resul
         crate::credentials::keyring::delete(&service, &account)?;
     }
 
-    // `update_locked_without_validation`: removal never introduces a
-    // credential-less server, and the whole-config validator would otherwise
-    // reject the write whenever any *other* server is credential-less (the
-    // state `unset-keyring` deliberately leaves on disk).
+    // `update_locked_without_validation`: removal cannot improve or worsen an
+    // unrelated invalid server, so avoid blocking on whole-config validation.
     Config::update_locked_without_validation(|config| {
         config.servers.remove(name);
         if config.default_server.as_deref() == Some(name) {
@@ -171,8 +169,8 @@ fn rename_server(old: &str, new: &str, format: OutputFormat, w: &mut Writers<'_>
             "new name must differ from the current name",
         ));
     }
-    // Advisory snapshot: read unvalidated so an unrelated credential-less
-    // server (left by `unset-keyring`) does not block the rename.
+    // Advisory snapshot: read unvalidated so an unrelated invalid server does
+    // not block the rename.
     let config = Config::read_unvalidated()?;
     let server = config
         .servers
@@ -199,9 +197,9 @@ fn rename_server(old: &str, new: &str, format: OutputFormat, w: &mut Writers<'_>
         _ => None,
     };
 
-    // `update_locked_without_validation`: a rename preserves the credential
-    // source, so it cannot create a credential-less server, but the validator
-    // would reject the write if any *other* server is already credential-less.
+    // `update_locked_without_validation`: a rename preserves the server
+    // contents, so avoid blocking on whole-config validation for unrelated
+    // invalid entries.
     Config::update_locked_without_validation(|config| {
         let server_cfg = config
             .servers
@@ -282,9 +280,9 @@ async fn set_server(
         return Ok(());
     }
 
-    if api_key.is_some() == api_key_env.is_some() {
+    if api_key.is_some() && api_key_env.is_some() {
         return Err(crate::error::BzrError::InputValidation(
-            "provide exactly one of --api-key or --api-key-env".into(),
+            "provide at most one of --api-key or --api-key-env".into(),
         ));
     }
     let is_update = Config::load()?.servers.contains_key(name);
@@ -339,8 +337,10 @@ async fn set_server(
     }
     if let Some(var_name) = api_key_env {
         let _ = write!(human, "\nAPI key source: env var {var_name}");
-    } else {
+    } else if api_key.is_some() {
         human.push_str("\nAPI key source: inline config value");
+    } else {
+        human.push_str("\nAPI key source: none (read-only)");
     }
     let _ = write!(human, "\nConfig file: {}", path.display());
 
@@ -443,8 +443,9 @@ fn unset_keyring(name: &str, format: OutputFormat, w: &mut Writers<'_>) -> Resul
     let human = format!(
         "Removed keychain entry for server '{name}' (service={service_name}, \
          account={account_name}).\nThe server entry is still present but has \
-         no API key source — re-run `bzr config set-server` or \
-         `bzr config set-keyring` to re-credential.\nConfig file: {}",
+         no API key source; public reads can still work. Configure \
+         `--api-key-env`, `--api-key`, or `bzr config set-keyring` before \
+         writes.\nConfig file: {}",
         path.display()
     );
     write_result(
@@ -498,6 +499,12 @@ fn migrate_to_keyring(
     // to the keychain — otherwise we would silently store to an
     // unintended location when --service/--account differ from the
     // existing ref.
+    let Some(source_kind) = source_kind else {
+        return Err(crate::error::BzrError::config(format!(
+            "server '{name}' has no API key source to migrate"
+        )));
+    };
+
     if source_kind == crate::config::CredentialSourceKind::Keyring {
         return Err(crate::error::BzrError::config(format!(
             "server '{name}' already uses a keyring credential source"

--- a/src/commands/config_tests.rs
+++ b/src/commands/config_tests.rs
@@ -351,6 +351,41 @@ async fn set_server_with_env_var_persists_env_source() {
     assert_eq!(server.api_key_env.as_deref(), Some("BZR_API_KEY"));
 }
 
+#[tokio::test]
+async fn set_server_allows_url_without_api_key_source() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    let (_lock, _tmp) = setup_config_env().await;
+
+    let result = execute(
+        &ConfigAction::SetServer {
+            name: "public".into(),
+            url: "https://public.example.com".into(),
+            api_key: None,
+            api_key_env: None,
+            email: None,
+            auth_method: None,
+            tls_insecure: false,
+            tls_ca_cert: None,
+            tls_pin_sha256: None,
+            tls_pin_now: false,
+            tls_pin_clear: false,
+        },
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
+
+    assert!(result.is_ok(), "set-server failed: {result:?}");
+    let config = Config::load().unwrap();
+    let server = &config.servers["public"];
+    assert!(server.api_key.is_none());
+    assert!(server.api_key_env.is_none());
+    assert!(server.api_key_keyring.is_none());
+    assert!(server.credential_source().unwrap().is_none());
+}
+
 #[cfg(feature = "keyring")]
 #[tokio::test]
 async fn set_keyring_stores_secret_and_rewrites_config() {
@@ -514,6 +549,44 @@ async fn migrate_to_keyring_from_keyring_errors_before_storing() {
 
     // Cleanup: the original entry still exists.
     crate::credentials::keyring::delete("bzr", "migrate-already-kr").unwrap();
+}
+
+#[tokio::test]
+async fn migrate_to_keyring_without_api_key_source_errors() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    let (_lock, _tmp) = setup_config_env().await;
+
+    Config::update_locked_without_validation(|config| {
+        config.servers.insert(
+            "public".into(),
+            ServerConfig {
+                url: "https://public.example.com".into(),
+                ..ServerConfig::default()
+            },
+        );
+        config.default_server = Some("public".into());
+        Ok(())
+    })
+    .unwrap();
+
+    let result = execute(
+        &ConfigAction::MigrateToKeyring {
+            name: "public".into(),
+            service: None,
+            account: None,
+            yes: true,
+        },
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(BzrError::Config(ref msg)) if msg.contains("no API key source")
+    ));
 }
 
 #[tokio::test]

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -155,6 +155,16 @@ pub fn is_dry_runnable(action: &GroupAction) -> bool {
     )
 }
 
+pub(crate) fn requires_credentials(action: &GroupAction) -> Option<&'static str> {
+    match action {
+        GroupAction::ListUsers { .. } | GroupAction::View { .. } => None,
+        GroupAction::AddUser { .. } => Some("group add-user"),
+        GroupAction::RemoveUser { .. } => Some("group remove-user"),
+        GroupAction::Create { .. } => Some("group create"),
+        GroupAction::Update { .. } => Some("group update"),
+    }
+}
+
 fn build_create_params(
     from_json: Option<&str>,
     name: Option<&str>,

--- a/src/commands/product.rs
+++ b/src/commands/product.rs
@@ -122,6 +122,14 @@ pub fn is_dry_runnable(action: &ProductAction) -> bool {
     )
 }
 
+pub(crate) fn requires_credentials(action: &ProductAction) -> Option<&'static str> {
+    match action {
+        ProductAction::List { .. } | ProductAction::View { .. } => None,
+        ProductAction::Create { .. } => Some("product create"),
+        ProductAction::Update { .. } => Some("product update"),
+    }
+}
+
 fn build_create_params(
     from_json: Option<&str>,
     name: Option<&str>,

--- a/src/commands/runtime/inline_server.rs
+++ b/src/commands/runtime/inline_server.rs
@@ -18,13 +18,12 @@ use std::sync::RwLock;
 /// messages and any TLS prompt.
 pub const INLINE_SERVER_NAME: &str = "(inline)";
 
-/// An ad-hoc server defined entirely on the command line, with its API key
-/// sourced from an environment variable (never a literal flag, to keep the
-/// secret out of `argv`).
+/// An ad-hoc server defined entirely on the command line. The API key env var
+/// is optional for public read-only commands.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InlineServer {
     pub url: String,
-    pub api_key_env: String,
+    pub api_key_env: Option<String>,
     pub email: Option<String>,
 }
 

--- a/src/commands/runtime/inline_server_tests.rs
+++ b/src/commands/runtime/inline_server_tests.rs
@@ -9,7 +9,7 @@ async fn set_then_get_round_trips() {
 
     let inline = InlineServer {
         url: "https://bugzilla.example.com".into(),
-        api_key_env: "BZR_KEY".into(),
+        api_key_env: Some("BZR_KEY".into()),
         email: Some("dev@example.com".into()),
     };
     set(Some(inline.clone()));
@@ -17,6 +17,22 @@ async fn set_then_get_round_trips() {
 
     set(None);
     assert_eq!(get(), None, "clearing restores the no-inline state");
+}
+
+#[tokio::test]
+async fn set_then_get_round_trips_without_api_key_env() {
+    let _lock = ENV_LOCK.lock().await;
+    set(None);
+
+    let inline = InlineServer {
+        url: "https://bugzilla.example.com".into(),
+        api_key_env: None,
+        email: None,
+    };
+    set(Some(inline.clone()));
+    assert_eq!(get(), Some(inline));
+
+    set(None);
 }
 
 #[test]

--- a/src/commands/runtime/shared.rs
+++ b/src/commands/runtime/shared.rs
@@ -144,8 +144,8 @@ impl ConnectContext {
     ) -> Result<BugzillaClient> {
         BugzillaClient::new(crate::client::BugzillaClientConfig {
             base_url: &self.url,
-            credential: &self.api_key,
-            auth_method,
+            credential: Some(&self.api_key),
+            auth_method: Some(auth_method),
             api_mode,
             email_hint: self.email_hint(),
             tls_config,

--- a/src/commands/runtime/shared.rs
+++ b/src/commands/runtime/shared.rs
@@ -384,7 +384,16 @@ fn resolve_connect_target(
 ) -> Result<ConnectTarget> {
     if let Some(inline) = crate::commands::runtime::inline_server::get() {
         let name = crate::commands::runtime::inline_server::INLINE_SERVER_NAME;
-        let srv = ServerConfig::from_url_with_env_key(inline.url, inline.api_key_env, inline.email);
+        let srv = match inline.api_key_env {
+            Some(api_key_env) => {
+                ServerConfig::from_url_with_env_key(inline.url, api_key_env, inline.email)
+            }
+            None => ServerConfig {
+                url: inline.url,
+                email: inline.email,
+                ..ServerConfig::default()
+            },
+        };
         srv.validate(name)?;
         let tls_config = srv.tls_config(name);
         let ctx = ConnectContext {

--- a/src/commands/runtime/shared.rs
+++ b/src/commands/runtime/shared.rs
@@ -6,8 +6,9 @@ use crate::tls::TlsConfig;
 use crate::types::{ApiMode, AuthMethod};
 
 /// Persist detected server settings to config under the lock.
-/// Always persists `auth_method` when `persist_auth` is true. Only persists
-/// `api_mode`/`server_version` when version detection succeeded.
+/// Persists `auth_method` when `persist_auth` is true and detection produced
+/// one. Only persists `api_mode`/`server_version` when version detection
+/// succeeded.
 ///
 /// If the server was concurrently removed from disk, this is a no-op (we do
 /// not resurrect a deleted server with detected settings) — logged, not silent.
@@ -24,7 +25,9 @@ fn persist_detected_settings(
             return Ok(());
         };
         if persist_auth {
-            srv.auth_method = Some(settings.auth_method);
+            if let Some(auth_method) = settings.auth_method {
+                srv.auth_method = Some(auth_method);
+            }
         }
         if settings.server_version.is_some() {
             srv.api_mode = Some(settings.api_mode);
@@ -93,7 +96,7 @@ fn extract_hostname(url: &str) -> String {
 struct ConnectContext {
     server_name: String,
     url: String,
-    api_key: String,
+    api_key: Option<String>,
     email: Option<String>,
     api_override: Option<ApiMode>,
     /// Whether detected settings (and TOFU pins) may be written back to the
@@ -138,14 +141,14 @@ impl ConnectContext {
 
     fn build_client(
         &self,
-        auth_method: AuthMethod,
+        auth_method: Option<AuthMethod>,
         api_mode: ApiMode,
         tls_config: &TlsConfig,
     ) -> Result<BugzillaClient> {
         BugzillaClient::new(crate::client::BugzillaClientConfig {
             base_url: &self.url,
-            credential: Some(&self.api_key),
-            auth_method: Some(auth_method),
+            credential: self.api_key.as_deref(),
+            auth_method,
             api_mode,
             email_hint: self.email_hint(),
             tls_config,
@@ -283,12 +286,21 @@ async fn detect_and_build_client(
     ctx: &ConnectContext,
     tls_config: &TlsConfig,
 ) -> Result<BugzillaClient> {
-    let settings =
-        crate::client::detect_server_settings(&ctx.url, &ctx.api_key, ctx.email_hint(), tls_config)
-            .await?;
+    let settings = detect_settings(ctx, tls_config).await?;
     ctx.persist_settings(&settings, true)?;
     let api_mode = ctx.api_override.unwrap_or(settings.api_mode);
     ctx.build_client(settings.auth_method, api_mode, tls_config)
+}
+
+async fn detect_settings(
+    ctx: &ConnectContext,
+    tls_config: &TlsConfig,
+) -> Result<DetectedServerSettings> {
+    if let Some(api_key) = ctx.api_key.as_deref() {
+        crate::client::detect_server_settings(&ctx.url, api_key, ctx.email_hint(), tls_config).await
+    } else {
+        crate::client::detect_server_settings_without_auth(&ctx.url, tls_config).await
+    }
 }
 
 /// Classify a TLS-layer failure and dispatch to the appropriate prompt.
@@ -340,14 +352,7 @@ async fn detect_with_tofu_fallback(
     ctx: &ConnectContext,
     tls_config: &TlsConfig,
 ) -> Result<DetectOrClient> {
-    let err = match crate::client::detect_server_settings(
-        &ctx.url,
-        &ctx.api_key,
-        ctx.email_hint(),
-        tls_config,
-    )
-    .await
-    {
+    let err = match detect_settings(ctx, tls_config).await {
         Ok(settings) => return Ok(DetectOrClient::Settings(settings)),
         Err(e) => e,
     };
@@ -399,7 +404,7 @@ fn resolve_connect_target(
         let ctx = ConnectContext {
             server_name: name.to_string(),
             url: srv.url.clone(),
-            api_key: srv.resolve_api_key(name)?,
+            api_key: srv.resolve_optional_api_key(name)?,
             email: srv.email.clone(),
             api_override,
             persist: false,
@@ -415,10 +420,16 @@ fn resolve_connect_target(
     let config = Config::load()?;
     let (server_name, srv) = config.resolve_server(server)?;
     let tls_config = srv.tls_config(server_name);
+    let api_key = srv.resolve_optional_api_key(server_name)?;
+    let cached_auth = if api_key.is_some() {
+        srv.auth_method
+    } else {
+        None
+    };
     let ctx = ConnectContext {
         server_name: server_name.to_string(),
         url: srv.url.clone(),
-        api_key: srv.resolve_api_key(server_name)?,
+        api_key,
         email: srv.email.clone(),
         api_override,
         persist: true,
@@ -426,15 +437,34 @@ fn resolve_connect_target(
     Ok(ConnectTarget {
         ctx,
         tls_config,
-        cached_auth: srv.auth_method,
+        cached_auth,
         cached_mode: srv.api_mode,
     })
 }
 
+async fn probe_cached_connection(
+    ctx: &ConnectContext,
+    tls_config: &TlsConfig,
+) -> Result<Option<BugzillaClient>> {
+    if tls_config.insecure {
+        return Ok(None);
+    }
+
+    if let Err(e) = probe_tls(&ctx.url, tls_config).await {
+        if let Some(client) = classify_and_handle_tls_failure(&e, ctx, tls_config).await? {
+            return Ok(Some(client));
+        }
+        // Non-TLS transport errors don't block: the actual command will hit
+        // the same condition and report it with full request context.
+    }
+
+    Ok(None)
+}
+
 /// Connect to a Bugzilla server with auto-configuration.
 ///
-/// On first connection to a server, detects auth method and API mode, then
-/// persists these settings to the config file for subsequent connections.
+/// On first connection to a server, detects the auth method when credentials
+/// exist and the API mode, then persists these settings to the config file.
 /// The server's configured email (if any) is stored in the client for
 /// Bugzilla 5.0 whoami fallback.
 ///
@@ -459,9 +489,9 @@ pub async fn connect_and_configure(
         );
     }
 
-    // Three cases: fully cached, partially cached (auth only), or uncached.
-    // An inline server is always uncached (no config entry), so it takes the
-    // detect path and persists nothing.
+    // Cached credentialed servers need auth + mode; cached anonymous servers
+    // need only mode. Inline servers are always uncached (no config entry), so
+    // they take the detect path and persist nothing.
     let (auth, resolved_mode) = match (cached_auth, cached_mode) {
         (Some(method), Some(mode)) => {
             // Even with full cache, surface TLS errors at connect-time so
@@ -470,19 +500,16 @@ pub async fn connect_and_configure(
             // pinned servers and custom-CA servers we still probe so a
             // rotated cert / issuer change is caught here rather than at
             // the first real API call.
-            if !tls_config.insecure {
-                if let Err(e) = probe_tls(&ctx.url, &tls_config).await {
-                    if let Some(client) =
-                        classify_and_handle_tls_failure(&e, &ctx, &tls_config).await?
-                    {
-                        return Ok(client);
-                    }
-                    // Non-TLS transport errors don't block: the actual
-                    // command will hit the same condition and report it
-                    // with full request context.
-                }
+            if let Some(client) = probe_cached_connection(&ctx, &tls_config).await? {
+                return Ok(client);
             }
-            (method, mode)
+            (Some(method), mode)
+        }
+        (None, Some(mode)) if ctx.api_key.is_none() => {
+            if let Some(client) = probe_cached_connection(&ctx, &tls_config).await? {
+                return Ok(client);
+            }
+            (None, mode)
         }
         (Some(method), None) => {
             tracing::debug!("auth_method cached but api_mode missing; re-detecting");
@@ -490,7 +517,7 @@ pub async fn connect_and_configure(
                 DetectOrClient::Client(client) => return Ok(client),
                 DetectOrClient::Settings(settings) => {
                     ctx.persist_settings(&settings, false)?;
-                    (method, settings.api_mode)
+                    (Some(method), settings.api_mode)
                 }
             }
         }

--- a/src/commands/runtime/shared_tests.rs
+++ b/src/commands/runtime/shared_tests.rs
@@ -232,7 +232,7 @@ async fn inline_server_connects_without_config_and_persists_nothing() {
     crate::commands::runtime::inline_server::set(Some(
         crate::commands::runtime::inline_server::InlineServer {
             url: mock.uri(),
-            api_key_env: "BZR_INLINE_TEST_KEY".into(),
+            api_key_env: Some("BZR_INLINE_TEST_KEY".into()),
             email: None,
         },
     ));
@@ -267,7 +267,7 @@ async fn inline_server_missing_env_var_is_clean_error() {
     crate::commands::runtime::inline_server::set(Some(
         crate::commands::runtime::inline_server::InlineServer {
             url: "https://bugzilla.example.com".into(),
-            api_key_env: "BZR_INLINE_ABSENT_KEY".into(),
+            api_key_env: Some("BZR_INLINE_ABSENT_KEY".into()),
             email: None,
         },
     ));

--- a/src/commands/runtime/shared_tests.rs
+++ b/src/commands/runtime/shared_tests.rs
@@ -16,7 +16,7 @@ fn connect_context(
     super::ConnectContext {
         server_name: server_name.to_string(),
         url: url.to_string(),
-        api_key: "test-key".to_string(),
+        api_key: Some("test-key".to_string()),
         email: None,
         api_override,
         persist: true,
@@ -167,6 +167,79 @@ api_key = "test-key"
 }
 
 #[tokio::test]
+async fn credentialless_named_server_persists_api_mode_without_auth_method() {
+    let _lock = ENV_LOCK.lock().await;
+    let server = MockServer::start().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    write_credentialless_config(&tmp, &server.uri(), "");
+
+    Mock::given(method("GET"))
+        .and(path("/rest/version"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"version": "5.1.2"})),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let result = super::connect_and_configure(None, None).await;
+    assert!(
+        result.is_ok(),
+        "credentialless named server should connect anonymously: {:?}",
+        result.err()
+    );
+
+    let reloaded = crate::config::Config::load().unwrap();
+    let srv = &reloaded.servers["test"];
+    assert_eq!(srv.auth_method, None);
+    assert_eq!(srv.api_mode, Some(crate::types::ApiMode::Rest));
+    assert_eq!(srv.server_version.as_deref(), Some("5.1.2"));
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0]
+        .headers
+        .get(crate::http::AUTH_HEADER_NAME)
+        .is_none());
+    assert!(requests[0]
+        .url
+        .query_pairs()
+        .all(|(name, _)| name != crate::http::AUTH_QUERY_PARAM));
+}
+
+#[tokio::test]
+async fn credentialless_cached_mode_builds_anonymous_client() {
+    let _lock = ENV_LOCK.lock().await;
+    let server = MockServer::start().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    write_credentialless_config(&tmp, &server.uri(), "api_mode = \"rest\"");
+
+    Mock::given(method("HEAD"))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let result = super::connect_and_configure(None, None).await;
+    assert!(
+        result.is_ok(),
+        "credentialless cached mode should build an anonymous client: {:?}",
+        result.err()
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0]
+        .headers
+        .get(crate::http::AUTH_HEADER_NAME)
+        .is_none());
+    assert!(requests[0]
+        .url
+        .query_pairs()
+        .all(|(name, _)| name != crate::http::AUTH_QUERY_PARAM));
+}
+
+#[tokio::test]
 async fn connect_client_resolves_env_backed_api_key() {
     let _lock = ENV_LOCK.lock().await;
     let mock = MockServer::start().await;
@@ -250,6 +323,55 @@ async fn inline_server_connects_without_config_and_persists_nothing() {
         !tmp.path().join("bzr").join("config.toml").exists(),
         "an inline connect must not create or write the config file"
     );
+}
+
+#[tokio::test]
+async fn inline_credentialless_server_connects_without_config() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock = MockServer::start().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    // SAFETY: tests are serialized via ENV_LOCK.
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", tmp.path()) };
+
+    Mock::given(method("GET"))
+        .and(path("/rest/version"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"version": "5.1.2"})),
+        )
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    crate::commands::runtime::inline_server::set(Some(
+        crate::commands::runtime::inline_server::InlineServer {
+            url: mock.uri(),
+            api_key_env: None,
+            email: None,
+        },
+    ));
+    let result = super::connect_and_configure(None, None).await;
+    crate::commands::runtime::inline_server::set(None);
+
+    assert!(
+        result.is_ok(),
+        "inline credentialless server should connect with no config file: {:?}",
+        result.err()
+    );
+    assert!(
+        !tmp.path().join("bzr").join("config.toml").exists(),
+        "an inline connect must not create or write the config file"
+    );
+
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0]
+        .headers
+        .get(crate::http::AUTH_HEADER_NAME)
+        .is_none());
+    assert!(requests[0]
+        .url
+        .query_pairs()
+        .all(|(name, _)| name != crate::http::AUTH_QUERY_PARAM));
 }
 
 /// An inline server whose API-key env var is unset fails with a clear config
@@ -403,7 +525,7 @@ async fn persist_detected_settings_skips_unknown_server() {
     write_config(&tmp, "https://example.test", "");
 
     let settings = crate::client::DetectedServerSettings {
-        auth_method: crate::types::AuthMethod::Header,
+        auth_method: Some(crate::types::AuthMethod::Header),
         api_mode: crate::types::ApiMode::Rest,
         server_version: Some("5.1".into()),
     };
@@ -435,6 +557,34 @@ api_key = "test-key"
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&config_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::set_permissions(
+            config_dir.join("config.toml"),
+            std::fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+    }
+    // SAFETY: Tests are serialized via ENV_LOCK.
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", tmp.path()) };
+}
+
+fn write_credentialless_config(tmp: &tempfile::TempDir, server_url: &str, extra: &str) {
+    let config_dir = tmp.path().join("bzr");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let config_content = format!(
+        r#"
+default_server = "test"
+
+[servers.test]
+url = "{server_url}"
+{extra}
+"#,
+    );
+    std::fs::write(config_dir.join("config.toml"), config_content).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
         std::fs::set_permissions(&config_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
         std::fs::set_permissions(
             config_dir.join("config.toml"),

--- a/src/commands/user.rs
+++ b/src/commands/user.rs
@@ -149,6 +149,14 @@ pub fn is_dry_runnable(action: &UserAction) -> bool {
     )
 }
 
+pub(crate) fn requires_credentials(action: &UserAction) -> Option<&'static str> {
+    match action {
+        UserAction::Search { .. } => None,
+        UserAction::Create { .. } => Some("user create"),
+        UserAction::Update { .. } => Some("user update"),
+    }
+}
+
 fn build_create_params(
     from_json: Option<&str>,
     email: Option<&str>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,19 +151,17 @@ impl ServerConfig {
         self.validate_tls(server_name)
     }
 
-    pub fn credential_source(&self) -> Result<CredentialSource<'_>> {
+    pub fn credential_source(&self) -> Result<Option<CredentialSource<'_>>> {
         let count = usize::from(self.api_key.is_some())
             + usize::from(self.api_key_env.is_some())
             + usize::from(self.api_key_keyring.is_some());
         match count {
-            0 => Err(BzrError::config(
-                "server config must define one of 'api_key', 'api_key_env', or 'api_key_keyring'",
-            )),
+            0 => Ok(None),
             1 => {
                 if let Some(api_key) = self.api_key.as_deref() {
-                    Ok(CredentialSource::Inline(api_key))
+                    Ok(Some(CredentialSource::Inline(api_key)))
                 } else if let Some(var_name) = self.api_key_env.as_deref() {
-                    Ok(CredentialSource::EnvVar(var_name))
+                    Ok(Some(CredentialSource::EnvVar(var_name)))
                 } else {
                     let r = self.api_key_keyring.as_ref().ok_or_else(|| {
                         BzrError::config("internal: keyring credential unexpectedly missing")
@@ -173,10 +171,10 @@ impl ServerConfig {
                     // has the server name in scope. We cannot use
                     // KeyringRef::account_or_default here because that would
                     // require plumbing the server name through every caller.
-                    Ok(CredentialSource::Keyring {
+                    Ok(Some(CredentialSource::Keyring {
                         service: r.service_or_default(),
                         account: r.account.as_deref().unwrap_or(""),
-                    })
+                    }))
                 }
             }
             _ => Err(BzrError::config(
@@ -186,14 +184,14 @@ impl ServerConfig {
         }
     }
 
-    pub fn credential_source_kind(&self) -> Result<CredentialSourceKind> {
-        Ok(self.credential_source()?.kind())
+    pub fn credential_source_kind(&self) -> Result<Option<CredentialSourceKind>> {
+        Ok(self.credential_source()?.map(|source| source.kind()))
     }
 
-    pub fn resolve_api_key(&self, server_name: &str) -> Result<String> {
+    pub fn resolve_optional_api_key(&self, server_name: &str) -> Result<Option<String>> {
         match self.credential_source()? {
-            CredentialSource::Inline(api_key) => Ok(api_key.to_string()),
-            CredentialSource::EnvVar(var_name) => {
+            Some(CredentialSource::Inline(api_key)) => Ok(Some(api_key.to_string())),
+            Some(CredentialSource::EnvVar(var_name)) => {
                 let value = std::env::var(var_name).map_err(|_| {
                     BzrError::config(format!(
                         "server '{server_name}' uses API key env var '{var_name}', but it is not set"
@@ -204,9 +202,9 @@ impl ServerConfig {
                         "server '{server_name}' uses API key env var '{var_name}', but it is empty"
                     )));
                 }
-                Ok(value)
+                Ok(Some(value))
             }
-            CredentialSource::Keyring { service, account } => {
+            Some(CredentialSource::Keyring { service, account }) => {
                 // Empty `account` means "default to server_name" (see the
                 // sentinel explanation in credential_source()).
                 let account = if account.is_empty() {
@@ -214,9 +212,18 @@ impl ServerConfig {
                 } else {
                     account
                 };
-                crate::credentials::keyring::retrieve(service, account)
+                crate::credentials::keyring::retrieve(service, account).map(Some)
             }
+            None => Ok(None),
         }
+    }
+
+    pub fn resolve_api_key(&self, server_name: &str) -> Result<String> {
+        self.resolve_optional_api_key(server_name)?.ok_or_else(|| {
+            BzrError::config(format!(
+                "server '{server_name}' has no API key source configured"
+            ))
+        })
     }
 
     pub fn validate_tls(&self, server_name: &str) -> Result<()> {
@@ -309,9 +316,8 @@ impl Config {
     /// `update_locked` (which validates the post-mutation state) and by `load`.
     ///
     /// `pub(crate)` so `config remove-server`/`rename-server` can take an
-    /// advisory snapshot (existence, default pointer, keyring ref) without
-    /// `load`'s credential validator rejecting an unrelated credential-less
-    /// server — the legitimate state `unset-keyring` leaves on disk.
+    /// advisory snapshot (existence, default pointer, keyring ref) even when
+    /// some unrelated server has invalid fields.
     pub(crate) fn read_unvalidated() -> Result<Config> {
         let path = Self::path()?;
         match fs::read_to_string(&path) {
@@ -361,9 +367,8 @@ impl Config {
         Self::update_locked_inner(true, mutator)
     }
 
-    /// Like [`Self::update_locked`] but skips whole-config validation, for the
-    /// one caller (`unset-keyring`) that intentionally leaves a server without a
-    /// credential source.
+    /// Like [`Self::update_locked`] but skips whole-config validation for callers
+    /// that preserve existing invalid config while changing unrelated data.
     pub fn update_locked_without_validation(
         mutator: impl FnOnce(&mut Config) -> Result<()>,
     ) -> Result<Config> {
@@ -388,17 +393,12 @@ impl Config {
         LOCK_HELD.with(|held| held.set(true));
         let _guard = LockGuard { file };
 
-        // Reload WITHOUT validation. `Config::load` validates unconditionally and
-        // rejects a credential-less server (the state `unset-keyring` deliberately
-        // leaves on disk). Validating the *reload* would make `update_locked`
-        // itself fail just from reading such a config — in particular it would
-        // break `update_locked_without_validation` (which must operate on, and
-        // leave, a credential-less server). We validate the *post-mutation* state
-        // instead (when `validate` is true), matching `save()`'s "validate the
-        // whole config before writing" semantics. (Note: the whole-config
-        // validation still rejects a write while *any* server is credential-less;
-        // that pre-existing rule — also enforced by `Config::load` in every
-        // command — is unchanged here and is a separate concern from locking.)
+        // Reload WITHOUT validation. `Config::load` validates unconditionally;
+        // validating the reload would make `update_locked_without_validation`
+        // fail before a caller can repair or preserve unrelated invalid config.
+        // We validate only the post-mutation state when `validate` is true,
+        // matching `save()`'s "validate the whole config before writing"
+        // semantics.
         let mut config = Self::read_unvalidated()?;
         mutator(&mut config)?;
         if validate {
@@ -408,11 +408,10 @@ impl Config {
         Ok(config)
     }
 
-    /// Persist the config **without** running the credential-source validator.
+    /// Persist the config **without** running validation.
     ///
-    /// Used only in tests: seeds a credential-less server to exercise
-    /// `update_locked_without_validation`. Applies the same `0o600`/`0o700`
-    /// hardening as `save` so a recreated config file is never world-readable.
+    /// Used only in tests. Applies the same `0o600`/`0o700` hardening as `save`
+    /// so a recreated config file is never world-readable.
     #[cfg(test)]
     fn save_without_validation(&self) -> Result<()> {
         self.write_to_disk()

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -84,14 +84,20 @@ fn config_file_io_operations() {
 }
 
 #[test]
-fn credential_source_errors_when_no_api_key_source_defined() {
+fn credential_source_allows_no_api_key_source() {
     let mut srv = make_server_config("https://example.com");
     srv.api_key = None;
-    let err = srv.credential_source().unwrap_err();
-    assert!(
-        err.to_string().contains("must define one of"),
-        "expected 'must define one of' message, got: {err}"
-    );
+
+    assert!(srv.credential_source().unwrap().is_none());
+    assert!(srv.validate("public").is_ok());
+}
+
+#[test]
+fn resolve_optional_api_key_none_without_source() {
+    let mut srv = make_server_config("https://example.com");
+    srv.api_key = None;
+
+    assert_eq!(srv.resolve_optional_api_key("public").unwrap(), None);
 }
 
 #[test]
@@ -284,7 +290,7 @@ fn env_backed_server_resolves_api_key_from_environment() {
     assert_eq!(server.resolve_api_key("test").unwrap(), "secret-from-env");
     assert_eq!(
         server.credential_source_kind().unwrap(),
-        CredentialSourceKind::Env
+        Some(CredentialSourceKind::Env)
     );
 }
 
@@ -376,7 +382,7 @@ fn credential_source_keyring_variant() {
         tls_pin_issuer_der: None,
     };
     match server.credential_source().unwrap() {
-        CredentialSource::Keyring { service, account } => {
+        Some(CredentialSource::Keyring { service, account }) => {
             assert_eq!(service, "bzr");
             // account defaults handled at resolve time via server_name
             assert_eq!(account, "");
@@ -385,7 +391,7 @@ fn credential_source_keyring_variant() {
     }
     assert_eq!(
         server.credential_source_kind().unwrap(),
-        CredentialSourceKind::Keyring
+        Some(CredentialSourceKind::Keyring)
     );
 }
 
@@ -688,9 +694,8 @@ fn save_without_validation_hardens_recreated_file() {
     // SAFETY: Tests are serialized via ENV_LOCK; no other threads read this var concurrently.
     unsafe { env::set_var("XDG_CONFIG_HOME", tmp.path()) };
 
-    // A server left without any credential source (the unset-keyring state):
-    // Config::save() would reject this, so unset-keyring uses
-    // save_without_validation — which must still harden the file.
+    // A server without any credential source must still be saved with hardened
+    // file permissions.
     let mut servers = HashMap::new();
     let mut srv = make_server_config("https://bugzilla.example.com");
     srv.api_key = None;
@@ -701,11 +706,6 @@ fn save_without_validation_hardens_recreated_file() {
         templates: HashMap::new(),
         queries: HashMap::new(),
     };
-
-    assert!(
-        config.save().is_err(),
-        "credential-less config must fail validation"
-    );
 
     let config_path = tmp.path().join("bzr").join("config.toml");
     // Force the recreation scenario: ensure no pre-hardened file exists.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,11 +198,6 @@ fn ensure_credentials_for_command(cli: &cli::Cli) -> error::Result<()> {
 }
 
 fn command_requires_credentials(command: &cli::Commands) -> Option<&'static str> {
-    credential_requirement_for_resource(command)
-        .or_else(|| credential_requirement_for_identity(command))
-}
-
-fn credential_requirement_for_resource(command: &cli::Commands) -> Option<&'static str> {
     match command {
         cli::Commands::Bug { action } => commands::bug::requires_credentials(action),
         cli::Commands::Comment { action } => commands::comment::requires_credentials(action),
@@ -211,12 +206,6 @@ fn credential_requirement_for_resource(command: &cli::Commands) -> Option<&'stat
         cli::Commands::Component { action } => commands::component::requires_credentials(action),
         cli::Commands::User { action } => commands::user::requires_credentials(action),
         cli::Commands::Group { action } => commands::group::requires_credentials(action),
-        _ => None,
-    }
-}
-
-fn credential_requirement_for_identity(command: &cli::Commands) -> Option<&'static str> {
-    match command {
         cli::Commands::Whoami => Some("whoami"),
         _ => None,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,21 +143,16 @@ fn apply_network_tuning(cli: &cli::Cli) {
 }
 
 /// Build the inline server definition from the global `--server-url` flags, or
-/// `None` when no inline server was requested. Returns `Some` only when both
-/// the URL and its API-key env var are present; clap's `requires` guarantees
-/// they come as a pair, but this is robust if a `Cli` is constructed directly
-/// (as integration tests do).
+/// `None` when no inline server was requested. The API-key env var is optional
+/// for public read-only commands.
 fn resolve_inline_server(cli: &cli::Cli) -> Option<commands::runtime::inline_server::InlineServer> {
     cli.server_url
         .as_ref()
-        .zip(cli.server_api_key_env.as_ref())
-        .map(
-            |(url, api_key_env)| commands::runtime::inline_server::InlineServer {
-                url: url.clone(),
-                api_key_env: api_key_env.clone(),
-                email: cli.server_email.clone(),
-            },
-        )
+        .map(|url| commands::runtime::inline_server::InlineServer {
+            url: url.clone(),
+            api_key_env: cli.server_api_key_env.clone(),
+            email: cli.server_email.clone(),
+        })
 }
 
 /// Reject `--dry-run` on commands that don't honor it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub async fn dispatch(
 ) -> error::Result<()> {
     apply_network_tuning(cli);
     ensure_dry_run_supported(cli)?;
+    ensure_credentials_for_command(cli)?;
     commands::runtime::dry_run::set(cli.dry_run);
     commands::runtime::confirm::set_yes(cli.yes);
     commands::runtime::inline_server::set(resolve_inline_server(cli));
@@ -181,6 +182,54 @@ fn ensure_dry_run_supported(cli: &cli::Cli) -> error::Result<()> {
          product create/update, component create/update, user create/update, and group create/update"
             .into(),
     ))
+}
+
+fn ensure_credentials_for_command(cli: &cli::Cli) -> error::Result<()> {
+    let Some(command_name) = command_requires_credentials(&cli.command) else {
+        return Ok(());
+    };
+    if active_server_has_credentials(cli)? {
+        return Ok(());
+    }
+    Err(error::BzrError::Config(format!(
+        "{command_name} requires credentials; configure api_key, api_key_env, \
+         api_key_keyring, or pass --server-api-key-env with --server-url"
+    )))
+}
+
+fn command_requires_credentials(command: &cli::Commands) -> Option<&'static str> {
+    credential_requirement_for_resource(command)
+        .or_else(|| credential_requirement_for_identity(command))
+}
+
+fn credential_requirement_for_resource(command: &cli::Commands) -> Option<&'static str> {
+    match command {
+        cli::Commands::Bug { action } => commands::bug::requires_credentials(action),
+        cli::Commands::Comment { action } => commands::comment::requires_credentials(action),
+        cli::Commands::Attachment { action } => commands::attachment::requires_credentials(action),
+        cli::Commands::Product { action } => commands::product::requires_credentials(action),
+        cli::Commands::Component { action } => commands::component::requires_credentials(action),
+        cli::Commands::User { action } => commands::user::requires_credentials(action),
+        cli::Commands::Group { action } => commands::group::requires_credentials(action),
+        _ => None,
+    }
+}
+
+fn credential_requirement_for_identity(command: &cli::Commands) -> Option<&'static str> {
+    match command {
+        cli::Commands::Whoami => Some("whoami"),
+        _ => None,
+    }
+}
+
+fn active_server_has_credentials(cli: &cli::Cli) -> error::Result<bool> {
+    if cli.server_url.is_some() {
+        return Ok(cli.server_api_key_env.is_some());
+    }
+
+    let config = config::Config::load()?;
+    let (_, server) = config.resolve_server(cli.server.as_deref())?;
+    Ok(server.credential_source()?.is_some())
 }
 
 /// Shared mutex for tests that modify the process-global `XDG_CONFIG_HOME` env var.

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -2,7 +2,7 @@
 
 use clap::Parser;
 use wiremock::matchers::{method, path};
-use wiremock::{Mock, ResponseTemplate};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use super::*;
 use crate::test_helpers::setup_test_env;
@@ -165,4 +165,170 @@ async fn dispatch_rejects_dry_run_on_group_membership_mutation() {
         Err(error::BzrError::InputValidation(ref msg)) if msg.contains("product create")
             && msg.contains("group create/update")
     ));
+}
+
+#[tokio::test]
+async fn dispatch_rejects_write_without_credentials_before_network() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock = MockServer::start().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    write_public_config(&tmp, &mock.uri());
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let cli = cli::Cli::try_parse_from([
+        "bzr", "--server", "public", "comment", "add", "1", "--body", "test",
+    ])
+    .unwrap();
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = dispatch(&cli, OutputFormat::Json, &mut io.writers()).await;
+
+    assert!(matches!(
+        result,
+        Err(error::BzrError::Config(ref msg))
+            if msg.contains("comment add") && msg.contains("credentials")
+    ));
+}
+
+#[tokio::test]
+async fn dispatch_rejects_bug_my_without_credentials() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock = MockServer::start().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    write_public_config(&tmp, &mock.uri());
+
+    Mock::given(method("GET"))
+        .and(path("/rest/whoami"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let cli = cli::Cli::try_parse_from(["bzr", "--server", "public", "bug", "my"]).unwrap();
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = dispatch(&cli, OutputFormat::Json, &mut io.writers()).await;
+
+    assert!(matches!(
+        result,
+        Err(error::BzrError::Config(ref msg))
+            if msg.contains("bug my") && msg.contains("credentials")
+    ));
+}
+
+#[tokio::test]
+async fn dispatch_rejects_whoami_without_credentials() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock = MockServer::start().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    write_public_config(&tmp, &mock.uri());
+
+    Mock::given(method("GET"))
+        .and(path("/rest/whoami"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let cli = cli::Cli::try_parse_from(["bzr", "--server", "public", "whoami"]).unwrap();
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = dispatch(&cli, OutputFormat::Json, &mut io.writers()).await;
+
+    assert!(matches!(
+        result,
+        Err(error::BzrError::Config(ref msg))
+            if msg.contains("whoami") && msg.contains("credentials")
+    ));
+}
+
+#[tokio::test]
+async fn dispatch_rejects_inline_write_without_api_key_env_before_network() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let cli = cli::Cli::try_parse_from([
+        "bzr",
+        "--server-url",
+        mock.uri().as_str(),
+        "comment",
+        "add",
+        "1",
+        "--body",
+        "test",
+    ])
+    .unwrap();
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = dispatch(&cli, OutputFormat::Json, &mut io.writers()).await;
+
+    assert!(matches!(
+        result,
+        Err(error::BzrError::Config(ref msg))
+            if msg.contains("comment add") && msg.contains("--server-api-key-env")
+    ));
+}
+
+#[tokio::test]
+async fn dispatch_allows_public_server_info_without_credentials() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock = MockServer::start().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    write_public_config(&tmp, &mock.uri());
+
+    Mock::given(method("GET"))
+        .and(path("/rest/version"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"version": "5.1.2"})),
+        )
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/extensions"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"extensions": {}})),
+        )
+        .mount(&mock)
+        .await;
+
+    let cli = cli::Cli::try_parse_from(["bzr", "--server", "public", "--json", "server", "info"])
+        .unwrap();
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = dispatch(&cli, OutputFormat::Json, &mut io.writers()).await;
+
+    assert!(result.is_ok(), "public server info failed: {result:?}");
+}
+
+fn write_public_config(tmp: &tempfile::TempDir, server_url: &str) {
+    let config_dir = tmp.path().join("bzr");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let config_content = format!(
+        r#"
+default_server = "public"
+
+[servers.public]
+url = "{server_url}"
+"#,
+    );
+    std::fs::write(config_dir.join("config.toml"), config_content).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::set_permissions(&config_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::set_permissions(
+            config_dir.join("config.toml"),
+            std::fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+    }
+    // SAFETY: Tests are serialized via ENV_LOCK.
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", tmp.path()) };
 }

--- a/src/output/resources/config.rs
+++ b/src/output/resources/config.rs
@@ -33,13 +33,13 @@ pub struct ServerDisplayInfo {
 impl ServerDisplayInfo {
     fn from_config(srv: &crate::config::ServerConfig) -> Self {
         let (api_key, api_key_source) = match srv.credential_source() {
-            Ok(CredentialSource::Inline(api_key)) => {
+            Ok(Some(CredentialSource::Inline(api_key))) => {
                 (mask_api_key(api_key), CredentialSourceKind::Inline.as_str())
             }
-            Ok(CredentialSource::EnvVar(var_name)) => {
+            Ok(Some(CredentialSource::EnvVar(var_name))) => {
                 (var_name.to_string(), CredentialSourceKind::Env.as_str())
             }
-            Ok(CredentialSource::Keyring { service, account }) => {
+            Ok(Some(CredentialSource::Keyring { service, account })) => {
                 let display = if account.is_empty() {
                     format!("{service}/<server-name>")
                 } else {
@@ -47,6 +47,7 @@ impl ServerDisplayInfo {
                 };
                 (display, CredentialSourceKind::Keyring.as_str())
             }
+            Ok(None) => ("none".to_string(), "none"),
             Err(_) => ("[invalid config]".to_string(), "invalid"),
         };
         Self {

--- a/src/output/resources/config_tests.rs
+++ b/src/output/resources/config_tests.rs
@@ -111,6 +111,42 @@ fn config_view_from_config_shows_env_backed_keys_without_resolving() {
 }
 
 #[test]
+fn config_view_displays_missing_api_key_source_as_none() {
+    let mut servers = HashMap::new();
+    servers.insert(
+        "public".into(),
+        ServerConfig {
+            url: "https://bugzilla.example".into(),
+            email: None,
+            api_key: None,
+            api_key_env: None,
+            api_key_keyring: None,
+            auth_method: None,
+            api_mode: None,
+            server_version: None,
+            tls_insecure: false,
+            tls_ca_cert: None,
+            tls_pin_sha256: None,
+            tls_pin_issuer: None,
+            tls_pin_issuer_der: None,
+        },
+    );
+    let config = Config {
+        default_server: Some("public".into()),
+        servers,
+        queries: HashMap::new(),
+        templates: HashMap::new(),
+    };
+
+    let view = ConfigView::from_config(&config, Path::new("/tmp/bzr/config.toml"));
+    let server = &view.servers["public"];
+    let json: serde_json::Value = serde_json::to_value(server).unwrap();
+
+    assert_eq!(json["api_key"], "none");
+    assert_eq!(json["api_key_source"], "none");
+}
+
+#[test]
 fn server_display_info_keyring_source() {
     let srv = ServerConfig {
         url: "https://example.com".into(),

--- a/src/xmlrpc/attachment_tests.rs
+++ b/src/xmlrpc/attachment_tests.rs
@@ -82,7 +82,7 @@ async fn xmlrpc_get_attachments_parses_full_response() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let attachments = client.get_attachments(42).await.unwrap();
 
     assert_eq!(attachments.len(), 2);
@@ -116,7 +116,7 @@ async fn xmlrpc_get_attachments_requests_inline_data_field() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let _ = client.get_attachments(42).await.unwrap();
 }
 
@@ -150,7 +150,7 @@ async fn xmlrpc_get_attachment_by_id_request_body_omits_exclude_fields() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let attachment = client.get_attachment_by_id(9).await.unwrap();
     assert_eq!(attachment.data.as_deref(), Some("YmU="));
 }
@@ -179,7 +179,7 @@ async fn xmlrpc_get_attachment_by_id_parses_response() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let attachment = client.get_attachment_by_id(2002).await.unwrap();
     assert_eq!(attachment.id, 2002);
     assert!(attachment.is_private);
@@ -197,7 +197,7 @@ async fn xmlrpc_get_attachment_by_id_not_found_returns_error() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let err = client.get_attachment_by_id(9999).await.unwrap_err();
     assert!(matches!(
         err,
@@ -219,7 +219,7 @@ async fn xmlrpc_get_attachments_returns_empty_when_bug_has_none() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let attachments = client.get_attachments(42).await.unwrap();
     assert!(attachments.is_empty());
 }

--- a/src/xmlrpc/bug_tests.rs
+++ b/src/xmlrpc/bug_tests.rs
@@ -26,7 +26,7 @@ async fn search_bugs_returns_results() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         product: vec!["TestProduct".into()],
         limit: Some(10),
@@ -66,7 +66,7 @@ async fn search_bugs_empty_result() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         product: vec!["Empty".into()],
         ..Default::default()
@@ -87,7 +87,7 @@ async fn get_bug_by_id() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let bug = client.get_bug("100").await.unwrap();
     assert_eq!(bug.id, 100);
     assert_eq!(bug.summary, "Specific bug");
@@ -115,7 +115,7 @@ async fn get_bug_by_id_parses_dupe_of() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let bug = client.get_bug("100").await.unwrap();
 
     assert_eq!(bug.dupe_of, Some(99));
@@ -132,7 +132,7 @@ async fn get_bug_by_alias() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let bug = client.get_bug("my-alias").await.unwrap();
     assert_eq!(bug.id, 55);
     assert_eq!(bug.summary, "Alias bug");
@@ -153,7 +153,7 @@ async fn search_bugs_multi_value_sends_array() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         status: vec!["NEW".into(), "ASSIGNED".into()],
         ..Default::default()
@@ -178,7 +178,7 @@ async fn search_bugs_negation_sends_boolean_chart() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         status: vec!["!CLOSED".into()],
         ..Default::default()
@@ -206,7 +206,7 @@ async fn search_bugs_fields_and_ids_use_xmlrpc_arrays() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         id: vec![42],
         include_fields: Some("id, summary".into()),
@@ -244,7 +244,7 @@ async fn get_bug_empty_result_is_not_found() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let err = client.get_bug("42").await.unwrap_err();
     assert!(matches!(
         err,
@@ -349,7 +349,7 @@ async fn search_bugs_sends_creation_time_and_last_change_time() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         creation_time: Some("2026-04-01T00:00:00Z".into()),
         last_change_time: Some("2026-04-15T00:00:00Z".into()),
@@ -371,7 +371,7 @@ async fn search_bugs_xmlrpc_sends_whiteboard() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         whiteboard: vec!["needs-review".into()],
         ..Default::default()
@@ -392,7 +392,7 @@ async fn search_bugs_xmlrpc_sends_resolution() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         resolution: vec!["FIXED".into()],
         ..Default::default()
@@ -417,7 +417,7 @@ async fn search_bugs_xmlrpc_negation_whiteboard_uses_notsubstring() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         whiteboard: vec!["!wip".into()],
         ..Default::default()
@@ -438,7 +438,7 @@ async fn search_bugs_xmlrpc_sends_target_milestone() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         target_milestone: vec!["5.0".into()],
         ..Default::default()
@@ -459,7 +459,7 @@ async fn search_bugs_xmlrpc_sends_version() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         version: vec!["9.4".into()],
         ..Default::default()
@@ -480,7 +480,7 @@ async fn search_bugs_xmlrpc_sends_op_sys() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         op_sys: vec!["Linux".into()],
         ..Default::default()
@@ -503,7 +503,7 @@ async fn search_bugs_xmlrpc_sends_platform() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         platform: vec!["x86_64".into()],
         ..Default::default()
@@ -524,7 +524,7 @@ async fn search_bugs_xmlrpc_sends_qa_contact() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         qa_contact: vec!["qa@example.com".into()],
         ..Default::default()
@@ -545,7 +545,7 @@ async fn search_bugs_xmlrpc_sends_url() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         url: vec!["github.com/foo".into()],
         ..Default::default()
@@ -570,7 +570,7 @@ async fn search_bugs_xmlrpc_negation_resolution_uses_notequals() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = SearchParams {
         resolution: vec!["!FIXED".into()],
         ..Default::default()

--- a/src/xmlrpc/client.rs
+++ b/src/xmlrpc/client.rs
@@ -9,32 +9,34 @@ use crate::xmlrpc::value::Value;
 pub struct XmlRpcClient {
     http: reqwest::Client,
     base_url: String,
-    api_key: String,
+    api_key: Option<String>,
 }
 
 impl XmlRpcClient {
-    pub fn new(http: reqwest::Client, base_url: &str, api_key: &str) -> Self {
+    pub fn new(http: reqwest::Client, base_url: &str, api_key: Option<&str>) -> Self {
         XmlRpcClient {
             http,
             base_url: base_url.trim_end_matches('/').to_string(),
-            api_key: api_key.to_string(),
+            api_key: api_key.map(String::from),
         }
     }
 
-    // SECURITY: The request body contains Bugzilla_api_key in plain text.
-    // Never log the request body. Response bodies are safe to log at trace
-    // level since Bugzilla does not echo auth credentials back.
+    // SECURITY: When configured, the request body contains Bugzilla_api_key in
+    // plain text. Never log the request body. Response bodies are safe to log
+    // at trace level since Bugzilla does not echo auth credentials back.
     //
-    // NOTE: XML-RPC always transmits the API key in the request body
-    // (as a method parameter), regardless of the REST AuthMethod detected
-    // for this server. This is an inherent XML-RPC protocol constraint —
-    // there is no header-based auth equivalent for XML-RPC calls.
+    // NOTE: XML-RPC transmits the API key in the request body (as a method
+    // parameter), regardless of the REST AuthMethod detected for this server.
+    // This is an inherent XML-RPC protocol constraint; there is no header-based
+    // auth equivalent for XML-RPC calls.
     pub(crate) async fn call(
         &self,
         method: &str,
         mut params: BTreeMap<String, Value>,
     ) -> Result<Value> {
-        params.insert(AUTH_QUERY_PARAM.into(), Value::from(self.api_key.as_str()));
+        if let Some(api_key) = self.api_key.as_deref() {
+            params.insert(AUTH_QUERY_PARAM.into(), Value::from(api_key));
+        }
 
         let body = build_request(method, params);
         let url = format!("{}/xmlrpc.cgi", self.base_url);

--- a/src/xmlrpc/client_tests.rs
+++ b/src/xmlrpc/client_tests.rs
@@ -1,5 +1,7 @@
 #![expect(clippy::unwrap_used)]
 
+use std::collections::BTreeMap;
+
 use super::XmlRpcClient;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -41,7 +43,7 @@ async fn fault_response_maps_to_error() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let err = client.get_bug("1").await.unwrap_err();
     let msg = err.to_string();
     assert!(msg.contains("102"), "should contain fault code: {msg}");
@@ -60,8 +62,27 @@ async fn http_error_maps_to_xmlrpc_error() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let err = client.get_bug("1").await.unwrap_err();
     let msg = err.to_string();
     assert!(msg.contains("500"), "should contain status code: {msg}");
+}
+
+#[tokio::test]
+async fn anonymous_xmlrpc_call_omits_api_key() {
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/xmlrpc.cgi"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), None);
+    let _ = client.call("Bug.get", BTreeMap::new()).await;
+
+    let requests = mock.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let body = std::str::from_utf8(&requests[0].body).unwrap();
+    assert!(!body.contains(crate::http::AUTH_QUERY_PARAM));
 }

--- a/src/xmlrpc/comment_tests.rs
+++ b/src/xmlrpc/comment_tests.rs
@@ -88,7 +88,7 @@ async fn xmlrpc_get_comments_since_parses_full_response() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(reqwest::Client::new(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(reqwest::Client::new(), &mock.uri(), Some("test-key"));
     let comments = client.get_comments_since(42, None).await.unwrap();
 
     assert_eq!(comments.len(), 2);
@@ -120,7 +120,7 @@ async fn xmlrpc_get_comments_since_serializes_new_since() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(reqwest::Client::new(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(reqwest::Client::new(), &mock.uri(), Some("test-key"));
     let comments = client
         .get_comments_since(42, Some("2026-01-01T00:00:00Z"))
         .await

--- a/src/xmlrpc/user_tests.rs
+++ b/src/xmlrpc/user_tests.rs
@@ -49,7 +49,7 @@ async fn create_user_returns_id_from_response() {
         .mount(&mock)
         .await;
 
-    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), "test-key");
+    let client = XmlRpcClient::new(test_http_client(), &mock.uri(), Some("test-key"));
     let params = CreateUserParams {
         email: "alice@example.com".into(),
         login: Some("alice".into()),


### PR DESCRIPTION
## Summary
- allow named and inline servers to omit API key sources for public read-only commands
- build anonymous REST/XML-RPC clients without attaching Bugzilla API key credentials
- reject writes and identity-derived commands before network access when no credential source exists
- document public read-only configuration and add regression coverage for anonymous TLS detection

## Test Plan
- `cargo build && BZR_BIN=target/debug/bzr agent-skills/tests/flag-drift-check.sh && agent-skills/tests/drift-check.sh && cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo test && git diff --check`
- pre-push hook: `cargo test`

Closes #380
