### PR TITLE
feat(cli): add bug my filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `--server-tls-insecure`, `--server-tls-ca-cert`,
   `--server-tls-pin-sha256`, and session-only `--server-tls-pin-now`.
   These settings are never persisted to config. (#381)
+- `bug my` now accepts the shared practical bug filters for product,
+  component, priority, severity, created/changed dates, whiteboard, target
+  milestone, version, operating system, platform, resolution, QA contact, and
+  URL. (#382)
 - `bug update` now accepts `--url` and `--target-milestone`, matching fields
   that `bug create` can already set. (#363)
 - `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -108,8 +108,12 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │   ├── search [<QUERY>] [--from-url <URL>] [--save-as [NAME]] [--limit <N>] [--offset <N>] [--paginate] [--count] [--fields <F>] [--exclude-fields <F>]
 │   │          [--sort <FIELD>] [--order asc|desc]
 │   ├── history <ID> [--since <DATE>]
-│   ├── my [--created] [--cc] [--all] [--status <S>...] [--limit <N>] [--offset <N>] [--paginate] [--count]
-│   │       [--fields <F>] [--exclude-fields <F>] [--sort <FIELD>] [--order asc|desc]
+│   ├── my [--created] [--cc] [--all] [--status <S>...] [--product <P>...] [--component <C>...]
+│   │       [--priority <P>...] [--severity <S>...] [--resolution <R>...] [--version <V>...]
+│   │       [--op-sys <OS>...] [--platform <P>...] [--whiteboard <W>...] [--target-milestone <M>...]
+│   │       [--qa-contact <Q>...] [--url <U>...] [--created-since <D>] [--changed-since <D>]
+│   │       [--limit <N>] [--offset <N>] [--paginate] [--count] [--fields <F>] [--exclude-fields <F>]
+│   │       [--sort <FIELD>] [--order asc|desc]
 │   ├── create [--from-json <PATH>] [--template <T>] [--product <P>] [--component <C>] --summary <S>
 │   │          [--version <V>] [--description <D>] [--description-file <PATH>] [--priority <P>] [--severity <S>]
 │   │          [--assignee <A>] [--op-sys <OS>] [--rep-platform <PLAT>]
@@ -481,6 +485,7 @@ bzr bug my --created          # bugs I created
 bzr bug my --cc               # bugs I'm CC'd on
 bzr bug my --all              # all of the above
 bzr bug my --status NEW --limit 20
+bzr bug my --product Core --target-milestone 5.0 --changed-since 2026-04-01
 bzr bug my --all --status '!CLOSED'         # all non-closed bugs
 bzr bug my --status NEW --status ASSIGNED   # OR filter
 bzr bug my --status NEW --status '!RESOLVED'  # mixed positive and negated
@@ -492,6 +497,20 @@ bzr bug my --status NEW --status '!RESOLVED'  # mixed positive and negated
 | `--cc` | No | | Show bugs I'm CC'd on (instead of assigned) |
 | `--all` | No | | Show all bugs related to me (assigned + created + CC'd) |
 | `--status <S>` | No | | Filter by status (repeatable; `!` prefix to exclude) |
+| `--product <P>` | No | | Filter by product (repeatable; `!` prefix to exclude) |
+| `--component <C>` | No | | Filter by component (repeatable; `!` prefix to exclude) |
+| `--priority <P>` | No | | Filter by priority (repeatable; `!` prefix to exclude) |
+| `--severity <S>` | No | | Filter by severity (repeatable; `!` prefix to exclude) |
+| `--created-since <DATE>` | No | | Filter to bugs created at or after this date. Accepts `YYYY-MM-DD`, `YYYY-MM-DDTHH:MM:SS`, `YYYY-MM-DDTHH:MM:SSZ`, or `YYYY-MM-DDTHH:MM:SS±HH:MM`; malformed input exits 7. |
+| `--changed-since <DATE>` | No | | Filter to bugs last modified at or after this date. Same accepted forms as `--created-since`. |
+| `--whiteboard <W>` | No | | Filter by Status Whiteboard substring (repeatable; `!` prefix to exclude) |
+| `--target-milestone <M>` | No | | Filter by Target Milestone (repeatable; `!` prefix to exclude) |
+| `--version <V>` | No | | Filter by version (repeatable; `!` prefix to exclude) |
+| `--op-sys <OS>` | No | | Filter by operating system (repeatable; `!` prefix to exclude) |
+| `--platform <P>` | No | | Filter by platform/hardware (repeatable; `!` prefix to exclude) |
+| `--resolution <R>` | No | | Filter by resolution (repeatable; `!` prefix to exclude; empty matches open bugs) |
+| `--qa-contact <Q>` | No | | Filter by QA contact login (repeatable; `!` prefix to exclude) |
+| `--url <U>` | No | | Filter by URL field substring (repeatable; `!` prefix to exclude) |
 | `--limit <N>` | No | 50 | Max results per category. With `--all`, each of the three categories (assigned, created, CC'd) is queried separately up to this limit; duplicates across categories are removed. |
 | `--offset <N>` | No | | Skip the first N matches in each category. Mutually exclusive with `--paginate`; cannot be combined with `--count`. |
 | `--paginate` | No | | Retrieve every matching page of each category, looping internally past `--limit`, then de-duplicate. Cannot be combined with `--count`. |

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -387,7 +387,7 @@ pub struct CreateArgs {
 }
 
 /// Arguments for `bug my`.
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Default)]
 #[expect(
     clippy::struct_excessive_bools,
     reason = "each bool is a distinct CLI view flag (--created, --cc, --all, --count); they are not a state enum"
@@ -413,6 +413,54 @@ pub struct MyArgs {
     /// Filter by status (repeatable for OR; prefix with ! to exclude)
     #[arg(long)]
     pub status: Vec<String>,
+    /// Filter by product (repeatable for OR; prefix with ! to exclude)
+    #[arg(long)]
+    pub product: Vec<String>,
+    /// Filter by component (repeatable for OR; prefix with ! to exclude)
+    #[arg(long)]
+    pub component: Vec<String>,
+    /// Filter by priority (repeatable for OR; prefix with ! to exclude)
+    #[arg(long)]
+    pub priority: Vec<String>,
+    /// Filter by severity (repeatable for OR; prefix with ! to exclude)
+    #[arg(long)]
+    pub severity: Vec<String>,
+    /// Filter to bugs created at or after this date.
+    ///
+    /// Accepts `YYYY-MM-DD` (interpreted as 00:00:00 UTC),
+    /// `YYYY-MM-DDTHH:MM:SS`, `YYYY-MM-DDTHH:MM:SSZ`, or
+    /// `YYYY-MM-DDTHH:MM:SS±HH:MM`. Malformed input exits 7.
+    #[arg(long, value_name = "DATE")]
+    pub created_since: Option<String>,
+    /// Filter to bugs last modified at or after this date.
+    ///
+    /// Same accepted forms as `--created-since`.
+    #[arg(long, value_name = "DATE")]
+    pub changed_since: Option<String>,
+    /// Filter by Status Whiteboard substring (repeatable for OR; prefix with ! to exclude)
+    #[arg(long)]
+    pub whiteboard: Vec<String>,
+    /// Filter by Target Milestone (repeatable for OR; prefix with ! to exclude)
+    #[arg(long)]
+    pub target_milestone: Vec<String>,
+    /// Filter by Version (repeatable for OR; prefix with ! to exclude)
+    #[arg(long)]
+    pub version: Vec<String>,
+    /// Filter by Operating System (repeatable for OR; prefix with ! to exclude)
+    #[arg(long)]
+    pub op_sys: Vec<String>,
+    /// Filter by Platform (repeatable for OR; prefix with ! to exclude)
+    #[arg(long)]
+    pub platform: Vec<String>,
+    /// Filter by Resolution (repeatable for OR; prefix with ! to exclude); empty matches open bugs
+    #[arg(long)]
+    pub resolution: Vec<String>,
+    /// Filter by QA Contact login (repeatable for OR; prefix with ! to exclude)
+    #[arg(long)]
+    pub qa_contact: Vec<String>,
+    /// Filter by URL field substring (repeatable for OR; prefix with ! to exclude)
+    #[arg(long)]
+    pub url: Vec<String>,
     /// Max results per category (assigned/created/cc).
     ///
     /// With `--all`, the limit applies independently to each of

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -1568,6 +1568,81 @@ fn parse_bug_my_defaults() {
 }
 
 #[test]
+fn bug_my_parses_shared_filter_set() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "bug",
+        "my",
+        "--product",
+        "Core",
+        "--component",
+        "Networking",
+        "--priority",
+        "P1",
+        "--severity",
+        "S2",
+        "--created-since",
+        "2026-04-01",
+        "--changed-since",
+        "2026-04-15T12:00:00Z",
+        "--whiteboard",
+        "needs-review",
+        "--target-milestone",
+        "5.0",
+        "--version",
+        "9.4",
+        "--op-sys",
+        "Linux",
+        "--platform",
+        "x86_64",
+        "--resolution",
+        "FIXED",
+        "--qa-contact",
+        "qa@example.com",
+        "--url",
+        "github.com/foo",
+    ])
+    .unwrap();
+    let Commands::Bug {
+        action:
+            BugAction::My(super::MyArgs {
+                product,
+                component,
+                priority,
+                severity,
+                created_since,
+                changed_since,
+                whiteboard,
+                target_milestone,
+                version,
+                op_sys,
+                platform,
+                resolution,
+                qa_contact,
+                url,
+                ..
+            }),
+    } = cli.command
+    else {
+        panic!("expected Bug My");
+    };
+    assert_eq!(product, vec!["Core"]);
+    assert_eq!(component, vec!["Networking"]);
+    assert_eq!(priority, vec!["P1"]);
+    assert_eq!(severity, vec!["S2"]);
+    assert_eq!(created_since.as_deref(), Some("2026-04-01"));
+    assert_eq!(changed_since.as_deref(), Some("2026-04-15T12:00:00Z"));
+    assert_eq!(whiteboard, vec!["needs-review"]);
+    assert_eq!(target_milestone, vec!["5.0"]);
+    assert_eq!(version, vec!["9.4"]);
+    assert_eq!(op_sys, vec!["Linux"]);
+    assert_eq!(platform, vec!["x86_64"]);
+    assert_eq!(resolution, vec!["FIXED"]);
+    assert_eq!(qa_contact, vec!["qa@example.com"]);
+    assert_eq!(url, vec!["github.com/foo"]);
+}
+
+#[test]
 fn parse_bug_my_all_conflicts_with_created() {
     let result = Cli::try_parse_from(["bzr", "bug", "my", "--all", "--created"]);
     assert!(result.is_err(), "--all should conflict with --created");

--- a/src/commands/bug/my.rs
+++ b/src/commands/bug/my.rs
@@ -1,9 +1,10 @@
-use crate::cli::{FieldArgs, MyArgs};
+use crate::cli::MyArgs;
 use crate::client::BugzillaClient;
 use crate::error::Result;
 use crate::output::resources::bug::{canonical_field_list, write_bugs, ColumnSpec};
 use crate::output::writers::Writers;
 use crate::types::{OutputFormat, SearchParams};
+use crate::validation::parse_optional_date;
 
 pub(super) async fn handle(
     client: &BugzillaClient,
@@ -11,60 +12,37 @@ pub(super) async fn handle(
     format: OutputFormat,
     w: &mut Writers<'_>,
 ) -> Result<()> {
-    let MyArgs {
-        created,
-        cc,
-        all,
-        status,
-        limit,
-        field_args: FieldArgs {
-            fields,
-            exclude_fields,
-        },
-        sort_args,
-        page_args: crate::cli::PageArgs { offset, paginate },
-        count,
-    } = args;
+    let offset = args.page_args.offset;
+    let paginate = args.page_args.paginate;
+    super::ensure_no_paging_with_count(args.count, offset, paginate)?;
 
-    super::ensure_no_paging_with_count(*count, *offset, *paginate)?;
-
-    let spec = ColumnSpec::new(fields.as_deref(), exclude_fields.as_deref());
+    let fields = args.field_args.fields.as_deref();
+    let exclude_fields = args.field_args.exclude_fields.as_deref();
+    let spec = ColumnSpec::new(fields, exclude_fields);
 
     let whoami = client.whoami().await?;
     let email = whoami.name;
     let mut all_bugs: Vec<crate::types::Bug> = Vec::new();
     let mut seen_ids = std::collections::HashSet::new();
 
-    // Build search params for each enabled filter, varying one field.
-    let mut base = SearchParams {
-        status: status.clone(),
-        limit: Some(*limit),
-        offset: *offset,
-        include_fields: canonical_field_list(fields.as_deref()),
-        exclude_fields: canonical_field_list(exclude_fields.as_deref()),
-        order: Some(crate::validation::build_order(
-            sort_args.sort.as_deref(),
-            sort_args.order,
-        )),
-        ..Default::default()
-    };
+    let mut base = build_base_search_params(args)?;
     // `--count` needs every distinct match, so fetch IDs only and lift the
     // per-category limit; the dedup below then yields the true distinct count.
-    if *count {
+    if args.count {
         base = super::count_search_params(base);
     }
     let mut searches = Vec::new();
-    if *all || (!created && !cc) {
+    if args.all || (!args.created && !args.cc) {
         let mut p = base.clone();
         p.assigned_to = vec![email.clone()];
         searches.push(p);
     }
-    if *all || *created {
+    if args.all || args.created {
         let mut p = base.clone();
         p.creator = vec![email.clone()];
         searches.push(p);
     }
-    if *all || *cc {
+    if args.all || args.cc {
         let mut p = base;
         p.cc = Some(email.clone());
         searches.push(p);
@@ -75,17 +53,17 @@ pub(super) async fn handle(
     // `truncated` means at least one category had more rows than `--limit`.
     let mut truncated = false;
     for params in &searches {
-        let page = crate::commands::runtime::paging::fetch_page(client, params, *paginate).await?;
+        let page = crate::commands::runtime::paging::fetch_page(client, params, paginate).await?;
         truncated |= page.truncated;
         for bug in page.bugs {
             // When counting, only the deduped id set matters — don't retain rows.
-            if seen_ids.insert(bug.id) && !*count {
+            if seen_ids.insert(bug.id) && !args.count {
                 all_bugs.push(bug);
             }
         }
     }
 
-    if *count {
+    if args.count {
         crate::output::result_types::write_count(seen_ids.len(), format, w.out);
         return Ok(());
     }
@@ -97,12 +75,44 @@ pub(super) async fn handle(
     };
     crate::commands::runtime::paging::write_truncation_note(
         &page,
-        Some(*limit),
-        *offset,
+        Some(args.limit),
+        offset,
         format,
         w,
     );
     Ok(())
+}
+
+fn build_base_search_params(args: &MyArgs) -> Result<SearchParams> {
+    let creation_time = parse_optional_date(args.created_since.as_deref(), "--created-since")?;
+    let last_change_time = parse_optional_date(args.changed_since.as_deref(), "--changed-since")?;
+
+    Ok(SearchParams {
+        product: args.product.clone(),
+        component: args.component.clone(),
+        status: args.status.clone(),
+        priority: args.priority.clone(),
+        severity: args.severity.clone(),
+        limit: Some(args.limit),
+        offset: args.page_args.offset,
+        include_fields: canonical_field_list(args.field_args.fields.as_deref()),
+        exclude_fields: canonical_field_list(args.field_args.exclude_fields.as_deref()),
+        creation_time,
+        last_change_time,
+        whiteboard: args.whiteboard.clone(),
+        target_milestone: args.target_milestone.clone(),
+        version: args.version.clone(),
+        op_sys: args.op_sys.clone(),
+        platform: args.platform.clone(),
+        resolution: args.resolution.clone(),
+        qa_contact: args.qa_contact.clone(),
+        url: args.url.clone(),
+        order: Some(crate::validation::build_order(
+            args.sort_args.sort.as_deref(),
+            args.sort_args.order,
+        )),
+        ..Default::default()
+    })
 }
 
 #[cfg(test)]

--- a/src/commands/bug/my_tests.rs
+++ b/src/commands/bug/my_tests.rs
@@ -54,6 +54,7 @@ async fn bug_my_returns_assigned_by_default() {
         },
         sort_args: crate::cli::SortArgs::default(),
         count: false,
+        ..Default::default()
     });
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result =
@@ -98,6 +99,7 @@ async fn bug_my_passes_status_limit_and_field_filters() {
         },
         sort_args: crate::cli::SortArgs::default(),
         count: false,
+        ..Default::default()
     });
     let mut __io2 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -110,6 +112,73 @@ async fn bug_my_passes_status_limit_and_field_filters() {
     .await;
     let _ = __io2.out_str().to_string();
     assert!(result.is_ok(), "bug my with filters failed: {result:?}");
+}
+
+#[tokio::test]
+async fn bug_my_all_passes_shared_filters_to_each_category() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mount_whoami(&mock).await;
+
+    for identity_filter in ["assigned_to", "creator", "cc"] {
+        Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .and(query_param(identity_filter, "dev@test.com"))
+            .and(query_param("product", "Core"))
+            .and(query_param("component", "Networking"))
+            .and(query_param("priority", "P1"))
+            .and(query_param("severity", "S2"))
+            .and(query_param("creation_time", "2026-04-01T00:00:00Z"))
+            .and(query_param("last_change_time", "2026-04-15T12:00:00Z"))
+            .and(query_param("whiteboard", "needs-review"))
+            .and(query_param("target_milestone", "5.0"))
+            .and(query_param("version", "9.4"))
+            .and(query_param("op_sys", "Linux"))
+            .and(query_param("platform", "x86_64"))
+            .and(query_param("resolution", "FIXED"))
+            .and(query_param("qa_contact", "qa@example.com"))
+            .and(query_param("url", "github.com/foo"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+            .expect(1)
+            .mount(&mock)
+            .await;
+    }
+
+    let action = BugAction::My(crate::cli::MyArgs {
+        page_args: crate::cli::PageArgs::default(),
+        created: false,
+        cc: false,
+        all: true,
+        status: vec![],
+        limit: 50,
+        field_args: crate::cli::FieldArgs {
+            fields: None,
+            exclude_fields: None,
+        },
+        sort_args: crate::cli::SortArgs::default(),
+        count: false,
+        product: vec!["Core".into()],
+        component: vec!["Networking".into()],
+        priority: vec!["P1".into()],
+        severity: vec!["S2".into()],
+        created_since: Some("2026-04-01".into()),
+        changed_since: Some("2026-04-15T12:00:00Z".into()),
+        whiteboard: vec!["needs-review".into()],
+        target_milestone: vec!["5.0".into()],
+        version: vec!["9.4".into()],
+        op_sys: vec!["Linux".into()],
+        platform: vec!["x86_64".into()],
+        resolution: vec!["FIXED".into()],
+        qa_contact: vec!["qa@example.com".into()],
+        url: vec!["github.com/foo".into()],
+    });
+    let mut __io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
+            .await;
+    assert!(
+        result.is_ok(),
+        "bug my --all with shared filters failed: {result:?}"
+    );
 }
 
 #[tokio::test]
@@ -140,6 +209,7 @@ async fn bug_my_created_only_runs_creator_search_not_assigned() {
         },
         sort_args: crate::cli::SortArgs::default(),
         count: false,
+        ..Default::default()
     });
     let mut __io3 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -181,6 +251,7 @@ async fn bug_my_cc_only_runs_cc_search_not_assigned_or_creator() {
         },
         sort_args: crate::cli::SortArgs::default(),
         count: false,
+        ..Default::default()
     });
     let mut __io4 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -229,6 +300,7 @@ async fn bug_my_all_deduplicates() {
         },
         sort_args: crate::cli::SortArgs::default(),
         count: false,
+        ..Default::default()
     });
     let mut __io5 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
@@ -278,6 +350,7 @@ async fn bug_my_all_count_reports_distinct_total() {
         },
         sort_args: crate::cli::SortArgs::default(),
         count: true,
+        ..Default::default()
     });
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result =


### PR DESCRIPTION
## Summary
- Add product/component/priority/severity/date and extended Bugzilla search filters to `bug my`
- Apply those filters to assigned, created, and CC category searches, including `--all`
- Update CLI docs, changelog, and drift coverage

## Test Plan
- cargo test bug_my
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build
- agent-skills/tests/drift-check.sh
- BZR_BIN=target/debug/bzr agent-skills/tests/flag-drift-check.sh
- git diff --check

Closes #382