### PR TITLE
feat(cli): support query update from url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   component, priority, severity, created/changed dates, whiteboard, target
   milestone, version, operating system, platform, resolution, QA contact, and
   URL. (#382)
+- `query update` now accepts `--from-url <URL>` to refresh an existing saved
+  query from an updated Bugzilla `buglist.cgi` URL without delete-and-recreate.
+  (#383)
 - `bug update` now accepts `--url` and `--target-milestone`, matching fields
   that `bug create` can already set. (#363)
 - `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -220,12 +220,13 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │   │               [--created-since <D>] [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
 │   ├── list
 │   ├── show <NAME>
-│   ├── update <NAME> [--search <Q>] [--product <P>...] [--component <C>...] [--status <S>...]
-│   │                 [--assignee <A>...] [--creator <C>...] [--priority <P>...] [--severity <S>...]
-│   │                 [--resolution <R>...] [--version <V>...] [--op-sys <OS>...] [--platform <P>...]
-│   │                 [--whiteboard <W>...] [--target-milestone <M>...] [--qa-contact <Q>...] [--url <U>...]
+│   ├── update <NAME> (--from-url <URL> | [--search <Q>] [--product <P>...] [--component <C>...]
+│   │                 [--status <S>...] [--assignee <A>...] [--creator <C>...] [--priority <P>...]
+│   │                 [--severity <S>...] [--resolution <R>...] [--version <V>...] [--op-sys <OS>...]
+│   │                 [--platform <P>...] [--whiteboard <W>...] [--target-milestone <M>...]
+│   │                 [--qa-contact <Q>...] [--url <U>...] [--clear <FIELD>])
 │   │                 [--limit <N>] [--fields <F>] [--exclude-fields <F>] [--created-since <D>]
-│   │                 [--changed-since <D>] [--clear <FIELD>] [--sort <FIELD>] [--order asc|desc]
+│   │                 [--changed-since <D>] [--sort <FIELD>] [--order asc|desc]
 │   ├── delete <NAME>
 │   └── run <NAME> [--limit <N>] [--offset <N>] [--paginate] [--count]
 │                  [--fields <F>] [--exclude-fields <F>] [--server <NAME>]
@@ -1797,14 +1798,39 @@ replaces that field's saved list; a scalar flag (`--limit`, `--fields`,
 it unchanged. `--clear <FIELD>` (repeatable; names match the long flags, e.g.
 `status`, `limit`, `search`, `created-since`, `sort`) resets a saved field. At
 least one change is required, and an update that would leave the query with no
-filters is rejected (exit 7). Raw passthrough params from a `--from-url` query
-are preserved. `--sort` / `--order` set the persisted ordering. If a field is
-both set and cleared in one call, `--clear` wins.
+filters is rejected (exit 7). Raw passthrough params from an existing
+`--from-url` query are preserved during manual updates. `--sort` / `--order`
+set the persisted ordering. If a field is both set and cleared in one call,
+`--clear` wins.
+
+`--from-url <URL>` refreshes the saved query from a Bugzilla `buglist.cgi` URL.
+This replaces the saved URL-derived filters, raw passthrough params, source
+URL, and associated server with the newly parsed URL. It is mutually exclusive
+with `--search`, manual filter flags, and `--clear`. `--limit`, `--fields`,
+`--exclude-fields`, `--created-since`, `--changed-since`, `--sort`, and
+`--order` may still be supplied as stored overrides for the refreshed query.
 
 ```bash
 bzr query update firefox-new --status ASSIGNED
 bzr query update firefox-new --limit 100 --clear severity
+bzr query update firefox-web --from-url "https://bugzilla.example.com/buglist.cgi?product=Firefox&bug_status=NEW"
 ```
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `<NAME>` | Yes | Query name |
+| `--from-url <URL>` | No | Refresh query from a Bugzilla buglist.cgi URL. Mutually exclusive with `--search`, manual filter flags, and `--clear`. |
+| `--search <Q>` | No | Replace the saved free-text search |
+| `--limit <N>` | No | Replace the saved limit; with `--from-url`, overrides the URL's `limit=` value |
+| `--fields <F>` | No | Replace the saved field selection; with `--from-url`, stores this selection on the refreshed query |
+| `--exclude-fields <F>` | No | Replace the saved field exclusion; with `--from-url`, stores this exclusion on the refreshed query |
+| `--created-since <DATE>` | No | Replace the saved `creation_time` filter. Same accepted forms as [`bzr bug list --created-since`](#date-format). |
+| `--changed-since <DATE>` | No | Replace the saved `last_change_time` filter. Same accepted forms as [`bzr bug list --changed-since`](#date-format). |
+| `--clear <FIELD>` | No | Reset a saved field during manual updates. Not valid with `--from-url`. |
+
+Manual `bzr bug list` filter flags are also accepted for non-URL updates; see
+[`query save`](#bzr-query-save) and [bug list](#bzr-bug-list) for the shared
+filter syntax.
 
 ### `bzr query delete`
 

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -2673,6 +2673,126 @@ fn parse_query_save_rejects_from_url_with_bzl_parity_filter() {
 }
 
 #[test]
+fn parse_query_update_accepts_from_url_with_refresh_overrides() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "query",
+        "update",
+        "saved",
+        "--from-url",
+        "https://bz/buglist.cgi?product=Firefox",
+        "--limit",
+        "25",
+        "--fields",
+        "id,summary",
+        "--exclude-fields",
+        "creator",
+        "--changed-since",
+        "2026-04-01",
+        "--sort",
+        "priority",
+    ])
+    .unwrap();
+
+    match cli.command {
+        Commands::Query {
+            action:
+                QueryAction::Update(super::query::UpdateArgs {
+                    name,
+                    from_url,
+                    limit,
+                    fields,
+                    exclude_fields,
+                    changed_since,
+                    sort_args,
+                    ..
+                }),
+        } => {
+            assert_eq!(name, "saved");
+            assert_eq!(
+                from_url.as_deref(),
+                Some("https://bz/buglist.cgi?product=Firefox")
+            );
+            assert_eq!(limit, Some(25));
+            assert_eq!(fields.as_deref(), Some("id,summary"));
+            assert_eq!(exclude_fields.as_deref(), Some("creator"));
+            assert_eq!(changed_since.as_deref(), Some("2026-04-01"));
+            assert_eq!(sort_args.sort.as_deref(), Some("priority"));
+        }
+        _ => panic!("expected Query Update"),
+    }
+}
+
+#[test]
+fn parse_query_update_rejects_from_url_with_filter_flag() {
+    let result = Cli::try_parse_from([
+        "bzr",
+        "query",
+        "update",
+        "saved",
+        "--from-url",
+        "https://bz/buglist.cgi?product=Firefox",
+        "--product",
+        "Firefox",
+    ]);
+
+    match result {
+        Ok(_) => panic!("expected ArgumentConflict, got Ok"),
+        Err(err) => assert!(
+            err.kind() == clap::error::ErrorKind::ArgumentConflict,
+            "expected ArgumentConflict, got {:?}",
+            err.kind()
+        ),
+    }
+}
+
+#[test]
+fn parse_query_update_rejects_from_url_with_search() {
+    let result = Cli::try_parse_from([
+        "bzr",
+        "query",
+        "update",
+        "saved",
+        "--from-url",
+        "https://bz/buglist.cgi?product=Firefox",
+        "--search",
+        "crash",
+    ]);
+
+    match result {
+        Ok(_) => panic!("expected ArgumentConflict, got Ok"),
+        Err(err) => assert!(
+            err.kind() == clap::error::ErrorKind::ArgumentConflict,
+            "expected ArgumentConflict, got {:?}",
+            err.kind()
+        ),
+    }
+}
+
+#[test]
+fn parse_query_update_rejects_from_url_with_clear() {
+    let result = Cli::try_parse_from([
+        "bzr",
+        "query",
+        "update",
+        "saved",
+        "--from-url",
+        "https://bz/buglist.cgi?product=Firefox",
+        "--clear",
+        "status",
+    ]);
+
+    match result {
+        Ok(_) => panic!("expected ArgumentConflict, got Ok"),
+        Err(err) => assert!(
+            err.kind() == clap::error::ErrorKind::ArgumentConflict,
+            "expected ArgumentConflict, got {:?}",
+            err.kind()
+        ),
+    }
+}
+
+#[test]
 fn parse_bug_update_see_also_add_repeated_flag() {
     let cli = Cli::try_parse_from([
         "bzr",

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -1,9 +1,10 @@
 use clap::{Args, Subcommand};
 
-/// Argument IDs of the structured filter flags on `query save`. Centralized so
-/// the mutual-exclusivity lists on `--from-url` / `--search` stay in sync when a
-/// filter flag is added or renamed (rather than hand-maintaining two literal
-/// lists). Keep in lockstep with the `Vec<String>` filter fields on `Save`.
+/// Argument IDs of the structured filter flags on saved-query commands.
+/// Centralized so the mutual-exclusivity lists on `--from-url` / `--search`
+/// stay in sync when a filter flag is added or renamed (rather than
+/// hand-maintaining two literal lists). Keep in lockstep with the `Vec<String>`
+/// filter fields on `SaveArgs` and `UpdateArgs`.
 const FILTER_FLAG_ARGS: [&str; 15] = [
     "product",
     "component",
@@ -132,6 +133,14 @@ pub struct DeleteArgs {
 pub struct UpdateArgs {
     /// Query name
     pub name: String,
+    /// Refresh this saved query from a Bugzilla `buglist.cgi` URL.
+    ///
+    /// Replaces the saved query's URL-derived filters, raw passthrough params,
+    /// source URL, and saved server. Mutually exclusive with manual filter
+    /// flags, `--search`, and `--clear`.
+    #[arg(long, conflicts_with = "search", conflicts_with = "clear")]
+    #[arg(conflicts_with_all = FILTER_FLAG_ARGS)]
+    pub from_url: Option<String>,
     /// Replace the free-text search
     #[arg(long)]
     pub search: Option<String>,
@@ -375,10 +384,18 @@ pub enum QueryAction {
     /// `--from-url` query are preserved. If a field is both set and
     /// cleared in one call, `--clear` wins.
     ///
+    /// `--from-url` refreshes the saved query from a Bugzilla
+    /// `buglist.cgi` URL, replacing URL-derived filters, raw
+    /// pass-through params, source URL, and saved server. It is
+    /// mutually exclusive with `--search`, manual filter flags, and
+    /// `--clear`; `--limit`, `--fields`, date filters, and sorting
+    /// may still be supplied as stored overrides.
+    ///
     /// Examples:
     ///
     ///   bzr query update firefox-new --status ASSIGNED
     ///   bzr query update firefox-new --limit 100 --clear severity
+    ///   bzr query update firefox-web --from-url 'https://bz/buglist.cgi?product=Firefox'
     ///
     /// See bzr-query-save(1) to create one and bzr-query-show(1) to
     /// inspect the result.

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -52,6 +52,38 @@ fn explicit_sort_order(sort_args: &crate::cli::SortArgs) -> Option<String> {
         .map(|_| crate::validation::build_order(sort_args.sort.as_deref(), sort_args.order))
 }
 
+#[derive(Clone, Copy)]
+struct UrlQueryOverrides<'a> {
+    limit: Option<u32>,
+    fields: Option<&'a str>,
+    exclude_fields: Option<&'a str>,
+    creation_time: Option<&'a str>,
+    last_change_time: Option<&'a str>,
+    sort_args: &'a crate::cli::SortArgs,
+}
+
+fn saved_query_from_url(url_str: &str, overrides: UrlQueryOverrides<'_>) -> Result<SavedQuery> {
+    let config = Config::load()?;
+    let parsed = crate::url_parser::parse_bugzilla_url(url_str, &config)?;
+    let mut query = parsed.query;
+    query.limit = overrides.limit.or(query.limit);
+    query.fields = overrides.fields.map(ToOwned::to_owned).or(query.fields);
+    query.exclude_fields = overrides
+        .exclude_fields
+        .map(ToOwned::to_owned)
+        .or(query.exclude_fields);
+    query.creation_time = overrides
+        .creation_time
+        .map(ToOwned::to_owned)
+        .or(query.creation_time);
+    query.last_change_time = overrides
+        .last_change_time
+        .map(ToOwned::to_owned)
+        .or(query.last_change_time);
+    query.order = explicit_sort_order(overrides.sort_args);
+    Ok(query)
+}
+
 fn handle_save(
     args: &crate::cli::query::SaveArgs,
     format: OutputFormat,
@@ -90,18 +122,17 @@ fn handle_save(
         crate::validation::parse_optional_date(changed_since.as_deref(), "--changed-since")?;
 
     let query = if let Some(url_str) = from_url {
-        let config = Config::load()?;
-        let parsed = crate::url_parser::parse_bugzilla_url(url_str, &config)?;
-        let mut query = parsed.query;
-        // A flag value overrides the URL-parsed value; otherwise the parsed
-        // value is kept.
-        query.limit = (*limit).or(query.limit);
-        query.fields = fields.clone().or(query.fields);
-        query.exclude_fields = exclude_fields.clone().or(query.exclude_fields);
-        query.creation_time = creation_time.or(query.creation_time);
-        query.last_change_time = last_change_time.or(query.last_change_time);
-        query.order = explicit_sort_order(sort_args);
-        query
+        saved_query_from_url(
+            url_str,
+            UrlQueryOverrides {
+                limit: *limit,
+                fields: fields.as_deref(),
+                exclude_fields: exclude_fields.as_deref(),
+                creation_time: creation_time.as_deref(),
+                last_change_time: last_change_time.as_deref(),
+                sort_args,
+            },
+        )?
     } else {
         let kind = if search.is_some() {
             QueryKind::Search
@@ -313,8 +344,13 @@ fn handle_update(
 ) -> Result<()> {
     let crate::cli::query::UpdateArgs {
         name,
+        from_url,
+        limit,
+        fields,
+        exclude_fields,
         created_since,
         changed_since,
+        sort_args,
         ..
     } = args;
 
@@ -323,8 +359,39 @@ fn handle_update(
         crate::validation::parse_optional_date(created_since.as_deref(), "--created-since")?;
     let last_change_time =
         crate::validation::parse_optional_date(changed_since.as_deref(), "--changed-since")?;
+    let replacement = from_url
+        .as_deref()
+        .map(|url_str| {
+            saved_query_from_url(
+                url_str,
+                UrlQueryOverrides {
+                    limit: *limit,
+                    fields: fields.as_deref(),
+                    exclude_fields: exclude_fields.as_deref(),
+                    creation_time: creation_time.as_deref(),
+                    last_change_time: last_change_time.as_deref(),
+                    sort_args,
+                },
+            )
+        })
+        .transpose()?;
 
     Config::update_locked(|config| {
+        if let Some(query) = replacement {
+            if !config.queries.contains_key(name.as_str()) {
+                return Err(BzrError::config(format!("query '{name}' not found")));
+            }
+            if !query.has_filters() {
+                return Err(BzrError::InputValidation(
+                    "update would leave the query with no filters; a saved query must keep at \
+                     least one filter set"
+                        .into(),
+                ));
+            }
+            config.queries.insert(name.clone(), query);
+            return Ok(());
+        }
+
         let Some(q) = config.queries.get_mut(name.as_str()) else {
             return Err(BzrError::config(format!("query '{name}' not found")));
         };

--- a/src/commands/query_tests.rs
+++ b/src/commands/query_tests.rs
@@ -1690,6 +1690,7 @@ async fn query_save_persists_explicit_sort() {
 fn empty_update(name: &str) -> QueryAction {
     QueryAction::Update(UpdateArgs {
         name: name.into(),
+        from_url: None,
         search: None,
         product: vec![],
         component: vec![],
@@ -1923,6 +1924,71 @@ async fn query_update_sets_dates_and_sort() {
     assert!(q.creation_time.is_some());
     assert!(q.last_change_time.is_some());
     assert!(q.order.is_some());
+}
+
+#[tokio::test]
+async fn query_update_from_url_replaces_existing_query() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    let original_url = format!(
+        "{}/buglist.cgi?product=OldProduct&bug_status=NEW&f1=old&o1=substring&v1=stale&limit=25",
+        mock.uri()
+    );
+    run_q(&url_save_action("web", original_url)).await.unwrap();
+
+    let refreshed_url = format!(
+        "{}/buglist.cgi?product=NewProduct&bug_status=ASSIGNED&priority=P1\
+         &f1=qa_contact&o1=changedfrom&v1=qa%40example.com&limit=5&order=Bug+Number",
+        mock.uri()
+    );
+    let mut update = empty_update("web");
+    if let QueryAction::Update(UpdateArgs {
+        from_url,
+        limit,
+        fields,
+        exclude_fields,
+        created_since,
+        changed_since,
+        sort_args,
+        ..
+    }) = &mut update
+    {
+        *from_url = Some(refreshed_url);
+        *limit = Some(77);
+        *fields = Some("id,summary".into());
+        *exclude_fields = Some("creator".into());
+        *created_since = Some("2026-04-01".into());
+        *changed_since = Some("2026-04-15T12:00:00Z".into());
+        sort_args.sort = Some("priority".into());
+    }
+
+    run_q(&update).await.unwrap();
+
+    let config = Config::load().unwrap();
+    let q = &config.queries["web"];
+    assert_eq!(q.kind, crate::types::QueryKind::Url);
+    assert_eq!(q.product, vec!["NewProduct"]);
+    assert_eq!(q.status, vec!["ASSIGNED"]);
+    assert_eq!(q.priority, vec!["P1"]);
+    assert_eq!(q.limit, Some(77));
+    assert_eq!(q.fields.as_deref(), Some("id,summary"));
+    assert_eq!(q.exclude_fields.as_deref(), Some("creator"));
+    assert_eq!(q.creation_time.as_deref(), Some("2026-04-01T00:00:00Z"));
+    assert_eq!(q.last_change_time.as_deref(), Some("2026-04-15T12:00:00Z"));
+    assert_eq!(q.order.as_deref(), Some("priority ASC, bug_id"));
+    assert_eq!(q.server.as_deref(), Some("test"));
+    assert!(q
+        .source_url
+        .as_deref()
+        .is_some_and(|url| url.contains("product=NewProduct")));
+    assert!(q
+        .raw_params
+        .contains(&("f1".to_string(), "qa_contact".to_string())));
+    assert!(q
+        .raw_params
+        .contains(&("order".to_string(), "Bug Number".to_string())));
+    assert!(!q
+        .raw_params
+        .contains(&("v1".to_string(), "stale".to_string())));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Add `query update --from-url <URL>` to refresh an existing saved query from a Bugzilla `buglist.cgi` URL
- Reuse the saved-query URL parser and replace URL-derived filters, raw params, source URL, server, and stored overrides coherently
- Keep manual filter flags, `--search`, and `--clear` mutually exclusive with URL refresh; update docs, changelog, and parser coverage

## Test Plan
- cargo test query_
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build
- agent-skills/tests/drift-check.sh
- BZR_BIN=target/debug/bzr agent-skills/tests/flag-drift-check.sh
- git diff --check
- git push pre-push hook: cargo test

Closes #383