### PR TITLE
feat(cli): expand bug template metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `query update` now accepts `--from-url <URL>` to refresh an existing saved
   query from an updated Bugzilla `buglist.cgi` URL without delete-and-recreate.
   (#383)
+- Bug templates now support the create metadata fields accepted by
+  `bug create`: URL, whiteboard, target milestone, deadline, CC, keywords,
+  groups, and flags. (#384)
 - `bug update` now accepts `--url` and `--target-milestone`, matching fields
   that `bug create` can already set. (#363)
 - `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -204,12 +204,18 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 ├── template
 │   ├── save <NAME> [--product <P>] [--component <C>] [--version <V>] [--priority <P>]
 │   │               [--severity <S>] [--assignee <A>] [--op-sys <OS>] [--rep-platform <PLAT>]
-│   │               [--description <D>]
+│   │               [--description <D>] [--url <U>] [--whiteboard <W>]
+│   │               [--target-milestone <M>]
+│   │               [--deadline <DATE>] [--cc <C>...] [--keywords <K>...]
+│   │               [--groups <G>...] [--flag <F>...]
 │   ├── list
 │   ├── show <NAME>
 │   ├── update <NAME> [--product <P>] [--component <C>] [--version <V>] [--priority <P>]
 │   │                 [--severity <S>] [--assignee <A>] [--op-sys <OS>] [--rep-platform <PLAT>]
-│   │                 [--description <D>] [--clear <FIELD>]
+│   │                 [--description <D>] [--url <U>] [--whiteboard <W>]
+│   │                 [--target-milestone <M>]
+│   │                 [--deadline <DATE>] [--cc <C>...] [--keywords <K>...]
+│   │                 [--groups <G>...] [--flag <F>...] [--clear <FIELD>]
 │   └── delete <NAME>
 ├── query
 │   ├── save <NAME> (--from-url <URL> | [--product <P>...] [--component <C>...] [--status <S>...]
@@ -1643,15 +1649,21 @@ troubleshooting.
 
 ## `bzr template` -- Bug Template Management
 
-Templates store named sets of default field values for bug creation. They are saved in the config file and can be used with `bzr bug create --template`.
+Templates store named sets of default field values for bug creation. They are
+saved in the config file and can be used with `bzr bug create --template`.
 
 ### `bzr template save`
 
-Save a named template with default field values.
+Save a named template with default field values for `bug create`. Templates can
+store routing fields and one-call create metadata: URL, whiteboard, target
+milestone, deadline, CC, keywords, groups, and flags.
 
 ```bash
-bzr template save security-bug --product Security --component Triage --priority P1 --severity critical
+bzr template save security-bug --product Security --component Triage \
+  --priority P1 --severity critical
 bzr template save kernel-bug --product Fedora --component kernel --assignee dev@example.com
+bzr template save security-routing --product Security --component Triage \
+  --whiteboard needs-triage --cc triage@example.com --flag 'review?'
 ```
 
 | Option | Required | Description |
@@ -1666,10 +1678,23 @@ bzr template save kernel-bug --product Fedora --component kernel --assignee dev@
 | `--op-sys <OS>` | No | Default operating system |
 | `--rep-platform <PLAT>` | No | Default hardware platform |
 | `--description <D>` | No | Default description |
+| `--url <U>` | No | Default URL field |
+| `--whiteboard <W>` | No | Default Status Whiteboard |
+| `--target-milestone <M>` | No | Default Target Milestone |
+| `--deadline <DATE>` | No | Default deadline (`YYYY-MM-DD`) |
+| `--cc <C>...` | No | Default CC entries (comma-separated, repeatable) |
+| `--keywords <K>...` | No | Default keywords (comma-separated, repeatable) |
+| `--groups <G>...` | No | Default groups (comma-separated, repeatable) |
+| `--flag <F>...` | No | Default Bugzilla flag updates. See [Flag Syntax](#flag-syntax). |
 
 At least one field must be set.
 
-Agent note: templates are agent-friendly because they remove repeated server-specific defaults from future `bug create` calls. Prefer them when agents repeatedly file similar bugs.
+When used with `bzr bug create --template <NAME>`, these values are applied as
+defaults. Explicit `bug create` flags still override the template values.
+
+Agent note: templates are agent-friendly because they remove repeated
+server-specific defaults from future `bug create` calls. Prefer them when agents
+repeatedly file similar bugs.
 
 ### `bzr template list`
 
@@ -1680,6 +1705,9 @@ bzr template list
 bzr --json template list
 ```
 
+JSON output includes every stored template field, including the create metadata
+fields. Unset fields are omitted from the saved config and from JSON values.
+
 ### `bzr template show`
 
 Show details of a template.
@@ -1689,18 +1717,25 @@ bzr template show security-bug
 bzr --json template show security-bug
 ```
 
+Use `--json` when an agent needs the full stored-default object, including
+`url`, `whiteboard`, `target_milestone`, `deadline`, `cc`, `keywords`,
+`groups`, and `flags`.
+
 ### `bzr template update`
 
 Edit an existing template in place. A supplied field flag replaces that field;
-an omitted flag leaves it unchanged. `--clear <FIELD>` (repeatable; names match
-the long flags: `product`, `component`, `version`, `priority`, `severity`,
-`assignee`, `op-sys`, `rep-platform`, `description`) resets a field. At least one
-change is required, and a fully-cleared template is rejected (exit 7). If a field
-is both set and cleared in one call, `--clear` wins.
+an omitted flag leaves it unchanged. `--clear <FIELD>` is repeatable and resets a
+stored field. Valid clear names are `product`, `component`, `version`,
+`priority`, `severity`, `assignee`, `op-sys`, `rep-platform`, `description`,
+`url`, `whiteboard`, `target-milestone`, `deadline`, `cc`, `keywords`, `groups`,
+`flag`, and `flags`. At least one change is required, and a fully-cleared
+template is rejected (exit 7). If a field is both set and cleared in one call,
+`--clear` wins.
 
 ```bash
 bzr template update security-bug --severity blocker
 bzr template update security-bug --clear assignee
+bzr template update security-bug --target-milestone M1 --clear whiteboard
 ```
 
 ### `bzr template delete`

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -1697,6 +1697,49 @@ fn parse_template_save_with_fields() {
 }
 
 #[test]
+fn parse_template_save_with_create_metadata_fields() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "template",
+        "save",
+        "routing",
+        "--url",
+        "https://example.com/repro",
+        "--whiteboard",
+        "needs-triage",
+        "--target-milestone",
+        "M1",
+        "--deadline",
+        "2026-12-31",
+        "--cc",
+        "a@example.com,b@example.com",
+        "--keywords",
+        "regression,security",
+        "--groups",
+        "confidential",
+        "--flag",
+        "review?(qa@example.com)",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Template {
+            action: TemplateAction::Save { name, fields },
+        } => {
+            assert_eq!(name, "routing");
+            assert_eq!(fields.url.as_deref(), Some("https://example.com/repro"));
+            assert_eq!(fields.whiteboard.as_deref(), Some("needs-triage"));
+            assert_eq!(fields.target_milestone.as_deref(), Some("M1"));
+            assert_eq!(fields.deadline.as_deref(), Some("2026-12-31"));
+            assert_eq!(fields.cc, vec!["a@example.com", "b@example.com"]);
+            assert_eq!(fields.keywords, vec!["regression", "security"]);
+            assert_eq!(fields.groups, vec!["confidential"]);
+            assert_eq!(fields.flag, vec!["review?(qa@example.com)"]);
+        }
+        _ => panic!("expected Template Save"),
+    }
+}
+
+#[test]
 fn parse_query_save_list_kind() {
     let cli = Cli::try_parse_from([
         "bzr",

--- a/src/cli/template.rs
+++ b/src/cli/template.rs
@@ -33,6 +33,30 @@ pub struct TemplateFields {
     /// Default description
     #[arg(long)]
     pub description: Option<String>,
+    /// Default URL
+    #[arg(long)]
+    pub url: Option<String>,
+    /// Default whiteboard
+    #[arg(long)]
+    pub whiteboard: Option<String>,
+    /// Default target milestone
+    #[arg(long)]
+    pub target_milestone: Option<String>,
+    /// Default deadline (`YYYY-MM-DD`)
+    #[arg(long, value_name = "DATE")]
+    pub deadline: Option<String>,
+    /// Default CC addresses
+    #[arg(long, value_delimiter = ',')]
+    pub cc: Vec<String>,
+    /// Default keywords
+    #[arg(long, value_delimiter = ',')]
+    pub keywords: Vec<String>,
+    /// Default groups
+    #[arg(long, value_delimiter = ',')]
+    pub groups: Vec<String>,
+    /// Default Bugzilla flag updates (for example `review?`)
+    #[arg(long)]
+    pub flag: Vec<String>,
 }
 
 impl TemplateFields {
@@ -49,6 +73,14 @@ impl TemplateFields {
             op_sys: self.op_sys.clone(),
             rep_platform: self.rep_platform.clone(),
             description: self.description.clone(),
+            url: self.url.clone(),
+            whiteboard: self.whiteboard.clone(),
+            target_milestone: self.target_milestone.clone(),
+            deadline: self.deadline.clone(),
+            cc: self.cc.clone(),
+            keywords: self.keywords.clone(),
+            groups: self.groups.clone(),
+            flags: self.flag.clone(),
         }
     }
 }
@@ -60,7 +92,7 @@ pub struct UpdateArgs {
     pub name: String,
     #[command(flatten)]
     pub fields: TemplateFields,
-    /// Reset a field to unset (repeatable). Names match the long flags.
+    /// Reset a field to unset (repeatable).
     #[arg(long, value_name = "FIELD")]
     pub clear: Vec<String>,
 }
@@ -70,11 +102,14 @@ pub enum TemplateAction {
     /// Save (or replace) a named bug-creation template.
     ///
     /// Templates store reusable defaults for `bzr bug create`. At
-    /// least one default field must be supplied (`--product`,
-    /// `--component`, `--version`, `--priority`, `--severity`,
-    /// `--assignee`, `--op-sys`, `--rep-platform`, or
-    /// `--description`); empty templates are rejected with exit
-    /// code 7 (input validation).
+    /// least one default field must be supplied. Supported defaults
+    /// include the routing fields (`--product`, `--component`,
+    /// `--version`, `--priority`, `--severity`, `--assignee`,
+    /// `--op-sys`, `--rep-platform`, and `--description`) plus
+    /// create metadata (`--url`, `--whiteboard`,
+    /// `--target-milestone`, `--deadline`, `--cc`, `--keywords`,
+    /// `--groups`, and `--flag`). Empty templates are rejected with
+    /// exit code 7 (input validation).
     ///
     /// Saving over an existing template name replaces it. Templates
     /// are stored locally in `~/.config/bzr/config.toml` and never
@@ -86,6 +121,8 @@ pub enum TemplateAction {
     ///     --component Vulnerabilities --severity critical
     ///   bzr template save fedora-kernel --product Fedora \
     ///     --component kernel --priority high
+    ///   bzr template save security-routing --product Security \
+    ///     --component Triage --cc triage@example.com --flag review?
     ///
     /// See bzr-template-show(1) to inspect a template,
     /// bzr-template-delete(1) to remove one, and bzr-bug-create(1)
@@ -103,18 +140,21 @@ pub enum TemplateAction {
     /// Merges the supplied flags into the named template without
     /// re-specifying the rest: a flag replaces that field, an
     /// omitted flag leaves it unchanged. Use `--clear <field>`
-    /// (repeatable) to reset a field to unset; valid names are the
-    /// long flag names (`product`, `component`, `version`,
-    /// `priority`, `severity`, `assignee`, `op-sys`, `rep-platform`,
-    /// `description`). At least one change (a field flag or
-    /// `--clear`) is required, and the result must keep at least one
-    /// field set (a fully-cleared template is rejected, exit 7). If a
-    /// field is both set and cleared in one call, `--clear` wins.
+    /// (repeatable) to reset a field to unset. Valid names are
+    /// `product`, `component`, `version`, `priority`, `severity`,
+    /// `assignee`, `op-sys`, `rep-platform`, `description`, `url`,
+    /// `whiteboard`, `target-milestone`, `deadline`, `cc`,
+    /// `keywords`, `groups`, `flag`, and `flags`. At least one
+    /// change (a field flag or `--clear`) is required, and the result
+    /// must keep at least one field set (a fully-cleared template is
+    /// rejected, exit 7). If a field is both set and cleared in one
+    /// call, `--clear` wins.
     ///
     /// Examples:
     ///
     ///   bzr template update security-bug --severity blocker
     ///   bzr template update security-bug --clear assignee
+    ///   bzr template update security-bug --cc triage@example.com
     ///
     /// See bzr-template-save(1) to create one and
     /// bzr-template-show(1) to inspect the result.

--- a/src/commands/bug/create.rs
+++ b/src/commands/bug/create.rs
@@ -26,6 +26,14 @@ struct MergedFields {
     assigned_to: Option<String>,
     op_sys: Option<String>,
     rep_platform: Option<String>,
+    url: Option<String>,
+    whiteboard: Option<String>,
+    target_milestone: Option<String>,
+    deadline: Option<String>,
+    cc: Vec<String>,
+    keywords: Vec<String>,
+    groups: Vec<String>,
+    flags: Vec<String>,
     template_description: Option<String>,
 }
 
@@ -185,6 +193,7 @@ fn merge_fields(
         assignee,
         op_sys,
         rep_platform,
+        create_fields,
         ..
     } = args;
     let resolved_product = product
@@ -224,8 +233,40 @@ fn merge_fields(
         rep_platform: rep_platform
             .clone()
             .or_else(|| tmpl.and_then(|t| t.rep_platform.clone())),
+        url: create_fields
+            .url
+            .clone()
+            .or_else(|| tmpl.and_then(|t| t.url.clone())),
+        whiteboard: create_fields
+            .whiteboard
+            .clone()
+            .or_else(|| tmpl.and_then(|t| t.whiteboard.clone())),
+        target_milestone: create_fields
+            .target_milestone
+            .clone()
+            .or_else(|| tmpl.and_then(|t| t.target_milestone.clone())),
+        deadline: create_fields
+            .deadline
+            .clone()
+            .or_else(|| tmpl.and_then(|t| t.deadline.clone())),
+        cc: merge_template_vec(&create_fields.cc, tmpl, |t| &t.cc),
+        keywords: merge_template_vec(&create_fields.keywords, tmpl, |t| &t.keywords),
+        groups: merge_template_vec(&create_fields.groups, tmpl, |t| &t.groups),
+        flags: merge_template_vec(&create_fields.flag, tmpl, |t| &t.flags),
         template_description: tmpl.and_then(|t| t.description.clone()),
     })
+}
+
+fn merge_template_vec(
+    cli_values: &[String],
+    tmpl: Option<&crate::types::BugTemplate>,
+    template_values: impl FnOnce(&crate::types::BugTemplate) -> &[String],
+) -> Vec<String> {
+    if cli_values.is_empty() {
+        tmpl.map(template_values).unwrap_or_default().to_vec()
+    } else {
+        cli_values.to_vec()
+    }
 }
 
 /// One bug's worth of structured input for `bug create --from-json`. Keys match
@@ -579,18 +620,15 @@ pub(super) async fn handle(
         return handle_from_json(client, args, arg, format, w).await;
     }
 
-    let flags = crate::commands::runtime::flags::parse_flags(&create_fields.flag)?;
-    let deadline = crate::validation::parse_optional_date_only(
-        create_fields.deadline.as_deref(),
-        "--deadline",
-    )?;
-
     let resolved_description =
         resolve_description(description.as_deref(), description_file.as_deref())?;
     let editor_flow_active = resolved_description.is_none();
 
     let tmpl = load_template(template_name.as_deref())?;
     let merged = merge_fields(args, tmpl.as_ref())?;
+    let flags = crate::commands::runtime::flags::parse_flags(&merged.flags)?;
+    let deadline =
+        crate::validation::parse_optional_date_only(merged.deadline.as_deref(), "--deadline")?;
 
     let (resolved_summary, final_description): (Option<String>, Option<String>) =
         if editor_flow_active {
@@ -618,15 +656,15 @@ pub(super) async fn handle(
         op_sys: merged.op_sys,
         rep_platform: merged.rep_platform,
         alias: create_fields.alias.clone(),
-        url: create_fields.url.clone(),
-        whiteboard: create_fields.whiteboard.clone(),
-        target_milestone: create_fields.target_milestone.clone(),
+        url: merged.url,
+        whiteboard: merged.whiteboard,
+        target_milestone: merged.target_milestone,
         deadline,
         blocks: blocks.clone(),
         depends_on: depends_on.clone(),
-        cc: create_fields.cc.clone(),
-        keywords: create_fields.keywords.clone(),
-        groups: create_fields.groups.clone(),
+        cc: merged.cc,
+        keywords: merged.keywords,
+        groups: merged.groups,
         flags,
     };
     create_and_report(client, &params, format, w).await

--- a/src/commands/bug/create_tests.rs
+++ b/src/commands/bug/create_tests.rs
@@ -491,6 +491,159 @@ async fn bug_create_with_template_fills_missing_fields() {
 }
 
 #[tokio::test]
+async fn bug_create_template_applies_create_metadata_defaults() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let save = TemplateAction::Save {
+        name: "routing".into(),
+        fields: TemplateFields {
+            product: Some("TestProduct".into()),
+            component: Some("General".into()),
+            url: Some("https://example.com/repro".into()),
+            whiteboard: Some("needs-triage".into()),
+            target_milestone: Some("M1".into()),
+            deadline: Some("2026-12-31".into()),
+            cc: vec!["cc@example.com".into()],
+            keywords: vec!["regression".into()],
+            groups: vec!["security".into()],
+            flag: vec!["review?(qa@example.com)".into()],
+            ..Default::default()
+        },
+    };
+    let mut save_io = crate::test_helpers::CapturedIo::new();
+    crate::commands::template::execute(
+        &save,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut save_io.writers(),
+    )
+    .await
+    .unwrap();
+    let _ = save_io.out_str().to_string();
+
+    crate::commands::runtime::dry_run::set(true);
+    let action = BugAction::Create(crate::cli::CreateArgs {
+        from_json: None,
+        template: Some("routing".into()),
+        product: None,
+        component: None,
+        summary: Some("From template".into()),
+        version: None,
+        description: Some("body".into()),
+        description_file: None,
+        priority: None,
+        severity: None,
+        assignee: None,
+        op_sys: None,
+        rep_platform: None,
+        blocks: vec![],
+        depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs::default(),
+    });
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    crate::commands::runtime::dry_run::set(false);
+    assert!(result.is_ok(), "template create dry-run failed: {result:?}");
+
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    let changes = &parsed["changes"];
+    assert_eq!(changes["url"], "https://example.com/repro");
+    assert_eq!(changes["whiteboard"], "needs-triage");
+    assert_eq!(changes["target_milestone"], "M1");
+    assert_eq!(changes["deadline"], "2026-12-31");
+    assert_eq!(changes["cc"], serde_json::json!(["cc@example.com"]));
+    assert_eq!(changes["keywords"], serde_json::json!(["regression"]));
+    assert_eq!(changes["groups"], serde_json::json!(["security"]));
+    assert_eq!(changes["flags"][0]["name"], "review");
+    assert_eq!(changes["flags"][0]["status"], "?");
+    assert_eq!(changes["flags"][0]["requestee"], "qa@example.com");
+}
+
+#[tokio::test]
+async fn bug_create_cli_create_metadata_overrides_template() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let save = TemplateAction::Save {
+        name: "routing".into(),
+        fields: TemplateFields {
+            product: Some("TestProduct".into()),
+            component: Some("General".into()),
+            url: Some("https://example.com/template".into()),
+            whiteboard: Some("template-whiteboard".into()),
+            target_milestone: Some("TemplateM".into()),
+            deadline: Some("2026-01-01".into()),
+            cc: vec!["template-cc@example.com".into()],
+            keywords: vec!["template-keyword".into()],
+            groups: vec!["template-group".into()],
+            flag: vec!["review?".into()],
+            ..Default::default()
+        },
+    };
+    let mut save_io = crate::test_helpers::CapturedIo::new();
+    crate::commands::template::execute(
+        &save,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut save_io.writers(),
+    )
+    .await
+    .unwrap();
+    let _ = save_io.out_str().to_string();
+
+    crate::commands::runtime::dry_run::set(true);
+    let action = BugAction::Create(crate::cli::CreateArgs {
+        from_json: None,
+        template: Some("routing".into()),
+        product: None,
+        component: None,
+        summary: Some("From template".into()),
+        version: None,
+        description: Some("body".into()),
+        description_file: None,
+        priority: None,
+        severity: None,
+        assignee: None,
+        op_sys: None,
+        rep_platform: None,
+        blocks: vec![],
+        depends_on: vec![],
+        create_fields: crate::cli::CreateFieldArgs {
+            alias: None,
+            url: Some("https://example.com/cli".into()),
+            whiteboard: Some("cli-whiteboard".into()),
+            target_milestone: Some("CliM".into()),
+            deadline: Some("2026-12-31".into()),
+            cc: vec!["cli-cc@example.com".into()],
+            keywords: vec!["cli-keyword".into()],
+            groups: vec!["cli-group".into()],
+            flag: vec!["approval+".into()],
+        },
+    });
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    crate::commands::runtime::dry_run::set(false);
+    assert!(result.is_ok(), "template create dry-run failed: {result:?}");
+
+    let parsed: serde_json::Value = serde_json::from_str(io.out_str().trim()).unwrap();
+    let changes = &parsed["changes"];
+    assert_eq!(changes["url"], "https://example.com/cli");
+    assert_eq!(changes["whiteboard"], "cli-whiteboard");
+    assert_eq!(changes["target_milestone"], "CliM");
+    assert_eq!(changes["deadline"], "2026-12-31");
+    assert_eq!(changes["cc"], serde_json::json!(["cli-cc@example.com"]));
+    assert_eq!(changes["keywords"], serde_json::json!(["cli-keyword"]));
+    assert_eq!(changes["groups"], serde_json::json!(["cli-group"]));
+    assert_eq!(changes["flags"][0]["name"], "approval");
+    assert_eq!(changes["flags"][0]["status"], "+");
+}
+
+#[tokio::test]
 async fn bug_create_reads_description_from_file() {
     let (_lock, mock, _tmp) = setup_test_env().await;
 
@@ -1320,11 +1473,11 @@ async fn from_json_batch_dry_run_emits_single_object_and_no_write() {
 }
 
 #[test]
-fn preview_params_propagates_every_merged_field() {
+fn preview_params_propagates_editor_field_values() {
     // The editor preview is built from MergedFields::preview_params. Every
-    // resolved field must flow into the CreateBugParams the editor template
-    // renders; dropping any one (or replacing the whole body with a default)
-    // would silently show the user a blank field in the $EDITOR buffer.
+    // editor-visible field must flow into the CreateBugParams the editor
+    // template renders; dropping any one would silently show the user a blank
+    // field in the $EDITOR buffer.
     let merged = super::MergedFields {
         product: "Prod".into(),
         component: "Comp".into(),
@@ -1334,6 +1487,14 @@ fn preview_params_propagates_every_merged_field() {
         assigned_to: Some("dev@example.com".into()),
         op_sys: Some("Linux".into()),
         rep_platform: Some("ARM".into()),
+        url: Some("https://example.com/repro".into()),
+        whiteboard: Some("needs-triage".into()),
+        target_milestone: Some("M1".into()),
+        deadline: Some("2026-12-31".into()),
+        cc: vec!["cc@example.com".into()],
+        keywords: vec!["regression".into()],
+        groups: vec!["security".into()],
+        flags: vec![],
         template_description: None,
     };
 
@@ -1371,6 +1532,14 @@ async fn run_editor_flow_returns_parsed_editor_output() {
         assigned_to: None,
         op_sys: None,
         rep_platform: None,
+        url: None,
+        whiteboard: None,
+        target_milestone: None,
+        deadline: None,
+        cc: vec![],
+        keywords: vec![],
+        groups: vec![],
+        flags: vec![],
         template_description: None,
     };
     let result = super::run_editor_flow(Some("Pre-fill"), &merged);

--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -3,7 +3,7 @@
 //! Template operations are pure local file I/O — no network client needed.
 
 use crate::cli::TemplateAction;
-use crate::commands::runtime::shared::merge_set;
+use crate::commands::runtime::shared::{merge_set, merge_vec};
 use crate::config::Config;
 use crate::error::{BzrError, Result};
 use crate::output::resources::template::{
@@ -26,7 +26,8 @@ pub async fn execute(
 ) -> Result<()> {
     match action {
         TemplateAction::Save { name, fields } => {
-            let template = fields.to_template();
+            let mut template = fields.to_template();
+            validate_template(&mut template)?;
 
             // Require at least one field to be set
             if template_is_empty(&template) {
@@ -83,9 +84,24 @@ fn template_is_empty(t: &BugTemplate) -> bool {
         && t.op_sys.is_none()
         && t.rep_platform.is_none()
         && t.description.is_none()
+        && t.url.is_none()
+        && t.whiteboard.is_none()
+        && t.target_milestone.is_none()
+        && t.deadline.is_none()
+        && t.cc.is_empty()
+        && t.keywords.is_empty()
+        && t.groups.is_empty()
+        && t.flags.is_empty()
 }
 
-/// Reset the named field to unset. The name matches the long flag (kebab-case).
+/// Validate template defaults that share parsing rules with `bug create`.
+fn validate_template(t: &mut BugTemplate) -> Result<()> {
+    t.deadline = crate::validation::parse_optional_date_only(t.deadline.as_deref(), "--deadline")?;
+    crate::commands::runtime::flags::parse_flags(&t.flags)?;
+    Ok(())
+}
+
+/// Reset the named field to unset. Most names match the long flag (kebab-case).
 fn clear_template_field(t: &mut BugTemplate, field: &str) -> Result<()> {
     match field {
         "product" => t.product = None,
@@ -97,10 +113,19 @@ fn clear_template_field(t: &mut BugTemplate, field: &str) -> Result<()> {
         "op-sys" => t.op_sys = None,
         "rep-platform" => t.rep_platform = None,
         "description" => t.description = None,
+        "url" => t.url = None,
+        "whiteboard" => t.whiteboard = None,
+        "target-milestone" => t.target_milestone = None,
+        "deadline" => t.deadline = None,
+        "cc" => t.cc.clear(),
+        "keywords" => t.keywords.clear(),
+        "groups" => t.groups.clear(),
+        "flag" | "flags" => t.flags.clear(),
         other => {
             return Err(BzrError::InputValidation(format!(
                 "unknown --clear field '{other}'; valid fields: product, component, \
-                 version, priority, severity, assignee, op-sys, rep-platform, description"
+                 version, priority, severity, assignee, op-sys, rep-platform, description, url, \
+                 whiteboard, target-milestone, deadline, cc, keywords, groups, flag, flags"
             )))
         }
     }
@@ -121,18 +146,7 @@ fn handle_update(
         clear,
     } = args;
 
-    let sets = [
-        &fields.product,
-        &fields.component,
-        &fields.version,
-        &fields.priority,
-        &fields.severity,
-        &fields.assignee,
-        &fields.op_sys,
-        &fields.rep_platform,
-        &fields.description,
-    ];
-    if sets.iter().all(|f| f.is_none()) && clear.is_empty() {
+    if template_is_empty(&fields.to_template()) && clear.is_empty() {
         return Err(BzrError::InputValidation(
             "no changes specified: provide a field flag or --clear <field>".into(),
         ));
@@ -151,9 +165,18 @@ fn handle_update(
         merge_set(&mut t.op_sys, fields.op_sys.as_deref());
         merge_set(&mut t.rep_platform, fields.rep_platform.as_deref());
         merge_set(&mut t.description, fields.description.as_deref());
+        merge_set(&mut t.url, fields.url.as_deref());
+        merge_set(&mut t.whiteboard, fields.whiteboard.as_deref());
+        merge_set(&mut t.target_milestone, fields.target_milestone.as_deref());
+        merge_set(&mut t.deadline, fields.deadline.as_deref());
+        merge_vec(&mut t.cc, &fields.cc);
+        merge_vec(&mut t.keywords, &fields.keywords);
+        merge_vec(&mut t.groups, &fields.groups);
+        merge_vec(&mut t.flags, &fields.flag);
         for field in clear {
             clear_template_field(t, field)?;
         }
+        validate_template(t)?;
         if template_is_empty(t) {
             return Err(BzrError::InputValidation(
                 "update would clear all fields; a template must keep at least one field set".into(),

--- a/src/commands/template_tests.rs
+++ b/src/commands/template_tests.rs
@@ -106,6 +106,85 @@ async fn template_save_with_single_field_succeeds() {
 }
 
 #[tokio::test]
+async fn template_save_and_show_create_metadata_fields() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let action = TemplateAction::Save {
+        name: "routing".into(),
+        fields: TemplateFields {
+            url: Some("https://example.com/repro".into()),
+            whiteboard: Some("needs-triage".into()),
+            target_milestone: Some("M1".into()),
+            deadline: Some("2026-12-31".into()),
+            cc: vec!["cc@example.com".into()],
+            keywords: vec!["regression".into()],
+            groups: vec!["security".into()],
+            flag: vec!["review?".into()],
+            ..Default::default()
+        },
+    };
+    let mut save_io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut save_io.writers(),
+    )
+    .await;
+    let _ = save_io.out_str().to_string();
+    assert!(result.is_ok(), "template save failed: {result:?}");
+
+    let mut show_io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(
+        &TemplateAction::Show {
+            name: "routing".into(),
+        },
+        None,
+        OutputFormat::Json,
+        None,
+        &mut show_io.writers(),
+    )
+    .await;
+    assert!(result.is_ok(), "template show failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(show_io.out_str().trim()).unwrap();
+    assert_eq!(parsed["url"], "https://example.com/repro");
+    assert_eq!(parsed["whiteboard"], "needs-triage");
+    assert_eq!(parsed["target_milestone"], "M1");
+    assert_eq!(parsed["deadline"], "2026-12-31");
+    assert_eq!(parsed["cc"], serde_json::json!(["cc@example.com"]));
+    assert_eq!(parsed["keywords"], serde_json::json!(["regression"]));
+    assert_eq!(parsed["groups"], serde_json::json!(["security"]));
+    assert_eq!(parsed["flags"], serde_json::json!(["review?"]));
+}
+
+#[tokio::test]
+async fn template_save_rejects_malformed_deadline() {
+    let mut cap_io = crate::test_helpers::CapturedIo::new();
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+
+    let action = TemplateAction::Save {
+        name: "bad-deadline".into(),
+        fields: TemplateFields {
+            product: Some("TestProduct".into()),
+            deadline: Some("2026-99-99".into()),
+            ..Default::default()
+        },
+    };
+    let err = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut cap_io.writers(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+    assert!(err.to_string().contains("--deadline"));
+}
+
+#[tokio::test]
 async fn template_delete_unknown_errors() {
     let mut __cap_io = crate::test_helpers::CapturedIo::new();
     let (_lock, _mock, _tmp) = setup_test_env().await;
@@ -456,6 +535,70 @@ async fn template_update_clear_resets_field() {
 }
 
 #[tokio::test]
+async fn template_update_merges_and_clears_create_metadata_fields() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    run(&save_action("routing")).await.unwrap();
+
+    run(&TemplateAction::Update(UpdateArgs {
+        name: "routing".into(),
+        fields: TemplateFields {
+            url: Some("https://example.com/updated".into()),
+            whiteboard: Some("needs-routing".into()),
+            target_milestone: Some("M2".into()),
+            deadline: Some("2026-12-31".into()),
+            cc: vec!["cc@example.com".into()],
+            keywords: vec!["regression".into()],
+            groups: vec!["security".into()],
+            flag: vec!["review+".into()],
+            ..Default::default()
+        },
+        clear: vec![],
+    }))
+    .await
+    .unwrap();
+
+    let config = Config::load().unwrap();
+    let t = &config.templates["routing"];
+    assert_eq!(t.url.as_deref(), Some("https://example.com/updated"));
+    assert_eq!(t.whiteboard.as_deref(), Some("needs-routing"));
+    assert_eq!(t.target_milestone.as_deref(), Some("M2"));
+    assert_eq!(t.deadline.as_deref(), Some("2026-12-31"));
+    assert_eq!(t.cc, vec!["cc@example.com"]);
+    assert_eq!(t.keywords, vec!["regression"]);
+    assert_eq!(t.groups, vec!["security"]);
+    assert_eq!(t.flags, vec!["review+"]);
+
+    run(&TemplateAction::Update(UpdateArgs {
+        name: "routing".into(),
+        fields: TemplateFields::default(),
+        clear: vec![
+            "url".into(),
+            "whiteboard".into(),
+            "target-milestone".into(),
+            "deadline".into(),
+            "cc".into(),
+            "keywords".into(),
+            "groups".into(),
+            "flags".into(),
+        ],
+    }))
+    .await
+    .unwrap();
+
+    let config = Config::load().unwrap();
+    let t = &config.templates["routing"];
+    assert!(t.url.is_none());
+    assert!(t.whiteboard.is_none());
+    assert!(t.target_milestone.is_none());
+    assert!(t.deadline.is_none());
+    assert!(t.cc.is_empty());
+    assert!(t.keywords.is_empty());
+    assert!(t.groups.is_empty());
+    assert!(t.flags.is_empty());
+    assert_eq!(t.product.as_deref(), Some("TestProduct"));
+}
+
+#[tokio::test]
 async fn template_update_unknown_template_errors() {
     let (_lock, _mock, _tmp) = setup_test_env().await;
     let err = run(&update_action(
@@ -541,6 +684,14 @@ fn clear_template_field_handles_every_name() {
         op_sys: Some("o".into()),
         rep_platform: Some("rp".into()),
         description: Some("d".into()),
+        url: Some("u".into()),
+        whiteboard: Some("w".into()),
+        target_milestone: Some("tm".into()),
+        deadline: Some("2026-12-31".into()),
+        cc: vec!["cc@example.com".into()],
+        keywords: vec!["k".into()],
+        groups: vec!["g".into()],
+        flags: vec!["review?".into()],
     };
     for name in [
         "product",
@@ -552,6 +703,15 @@ fn clear_template_field_handles_every_name() {
         "op-sys",
         "rep-platform",
         "description",
+        "url",
+        "whiteboard",
+        "target-milestone",
+        "deadline",
+        "cc",
+        "keywords",
+        "groups",
+        "flag",
+        "flags",
     ] {
         super::clear_template_field(&mut t, name).unwrap();
     }

--- a/src/output/resources/template.rs
+++ b/src/output/resources/template.rs
@@ -3,7 +3,9 @@ use std::io::Write;
 
 use crate::types::{BugTemplate, OutputFormat};
 
-use crate::output::formatting::{write_field, write_formatted, write_optional_field};
+use crate::output::formatting::{
+    write_field, write_formatted, write_list_field, write_optional_field,
+};
 
 fn template_saved_message(name: &str, verb: &str) -> String {
     format!("{verb} template '{name}'")
@@ -88,6 +90,18 @@ pub fn write_template_detail<W: Write + ?Sized>(
         write_optional_field(out, "OS", view.template.op_sys.as_deref());
         write_optional_field(out, "Platform", view.template.rep_platform.as_deref());
         write_optional_field(out, "Description", view.template.description.as_deref());
+        write_optional_field(out, "URL", view.template.url.as_deref());
+        write_optional_field(out, "Whiteboard", view.template.whiteboard.as_deref());
+        write_optional_field(
+            out,
+            "Target Milestone",
+            view.template.target_milestone.as_deref(),
+        );
+        write_optional_field(out, "Deadline", view.template.deadline.as_deref());
+        write_list_field(out, "CC", &view.template.cc);
+        write_list_field(out, "Keywords", &view.template.keywords);
+        write_list_field(out, "Groups", &view.template.groups);
+        write_list_field(out, "Flags", &view.template.flags);
     });
 }
 

--- a/src/output/resources/template_tests.rs
+++ b/src/output/resources/template_tests.rs
@@ -16,6 +16,14 @@ fn make_template() -> BugTemplate {
         op_sys: None,
         rep_platform: None,
         description: Some("Default description".into()),
+        url: Some("https://example.com/repro".into()),
+        whiteboard: Some("needs-triage".into()),
+        target_milestone: Some("M1".into()),
+        deadline: Some("2026-12-31".into()),
+        cc: vec!["cc@example.com".into()],
+        keywords: vec!["regression".into()],
+        groups: vec!["security".into()],
+        flags: vec!["review?".into()],
     }
 }
 
@@ -37,6 +45,11 @@ fn template_list_json_serializes() {
     assert!(parsed["default"].is_object());
     assert_eq!(parsed["default"]["product"], "Widget");
     assert_eq!(parsed["default"]["component"], "Backend");
+    assert_eq!(
+        parsed["default"]["cc"],
+        serde_json::json!(["cc@example.com"])
+    );
+    assert_eq!(parsed["default"]["flags"], serde_json::json!(["review?"]));
 }
 
 #[test]
@@ -57,6 +70,7 @@ fn template_detail_json_with_flatten() {
     assert_eq!(parsed["name"], "test-tmpl");
     assert_eq!(parsed["product"], "Widget");
     assert_eq!(parsed["priority"], "P1");
+    assert_eq!(parsed["target_milestone"], "M1");
     assert!(parsed["version"].is_null());
 }
 
@@ -72,6 +86,14 @@ fn template_empty_fields_omitted_in_json() {
         op_sys: None,
         rep_platform: None,
         description: None,
+        url: None,
+        whiteboard: None,
+        target_milestone: None,
+        deadline: None,
+        cc: vec![],
+        keywords: vec![],
+        groups: vec![],
+        flags: vec![],
     };
     let json = serde_json::to_string(&template).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -109,6 +131,14 @@ fn template_summary_line_without_fields_is_name_only() {
             op_sys: None,
             rep_platform: None,
             description: None,
+            url: None,
+            whiteboard: None,
+            target_milestone: None,
+            deadline: None,
+            cc: vec![],
+            keywords: vec![],
+            groups: vec![],
+            flags: vec![],
         },
     );
     assert_eq!(line, "zzz");
@@ -138,6 +168,14 @@ fn write_template_detail_table_renders_missing_fields_as_dash() {
         op_sys: None,
         rep_platform: None,
         description: Some("Default description".into()),
+        url: Some("https://example.com/repro".into()),
+        whiteboard: Some("needs-triage".into()),
+        target_milestone: Some("M1".into()),
+        deadline: Some("2026-12-31".into()),
+        cc: vec!["cc@example.com".into()],
+        keywords: vec!["regression".into()],
+        groups: vec!["security".into()],
+        flags: vec!["review?".into()],
     };
 
     let output = capture_detail("default", &template, OutputFormat::Table);
@@ -150,6 +188,14 @@ fn write_template_detail_table_renders_missing_fields_as_dash() {
     assert!(output.contains("  -"));
     assert!(output.contains("Description"));
     assert!(output.contains("Default description"));
+    assert!(output.contains("URL"));
+    assert!(output.contains("https://example.com/repro"));
+    assert!(output.contains("Target Milestone"));
+    assert!(output.contains("M1"));
+    assert!(output.contains("CC"));
+    assert!(output.contains("cc@example.com"));
+    assert!(output.contains("Flags"));
+    assert!(output.contains("review?"));
 }
 
 #[test]
@@ -168,6 +214,14 @@ fn write_template_list_table_renders_sorted_summaries() {
             op_sys: None,
             rep_platform: None,
             description: None,
+            url: None,
+            whiteboard: None,
+            target_milestone: None,
+            deadline: None,
+            cc: vec![],
+            keywords: vec![],
+            groups: vec![],
+            flags: vec![],
         },
     );
 

--- a/src/types/bug.rs
+++ b/src/types/bug.rs
@@ -974,6 +974,22 @@ pub struct BugTemplate {
     pub rep_platform: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub whiteboard: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_milestone: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deadline: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cc: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub keywords: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub groups: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub flags: Vec<String>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- extend bug templates with create metadata defaults: URL, whiteboard, target milestone, deadline, CC, keywords, groups, and flags
- apply template metadata in `bug create --template`, with explicit create flags overriding template values
- expose the new fields in template JSON/detail output and document the workflow

Closes #384

## Verification
- cargo fmt --check
- cargo test template_
- cargo test bug_create_cli_create_metadata_overrides_template
- cargo test bug_create_template_applies_create_metadata_defaults
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build
- agent-skills/tests/drift-check.sh
- BZR_BIN=target/debug/bzr agent-skills/tests/flag-drift-check.sh
- git diff --check
- cargo test
