### PR TITLE
feat(cli): expand bug clone metadata overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Bug templates now support the create metadata fields accepted by
   `bug create`: URL, whiteboard, target milestone, deadline, CC, keywords,
   groups, and flags. (#384)
+- `bug clone` now copies URL, whiteboard, target milestone, and deadline from
+  the source bug, and accepts create-time metadata overrides for URL,
+  whiteboard, target milestone, deadline, CC, keywords, groups, and flags.
+  (#385)
 - `bug update` now accepts `--url` and `--target-milestone`, matching fields
   that `bug create` can already set. (#363)
 - `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -123,6 +123,8 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │   ├── clone <ID> [--summary <S>] [--product <P>] [--component <C>] [--version <V>]
 │   │              [--description <D>] [--priority <P>] [--severity <S>] [--assignee <A>]
 │   │              [--op-sys <OS>] [--rep-platform <PLAT>]
+│   │              [--url <U>] [--whiteboard <W>] [--target-milestone <T>] [--deadline <DATE>]
+│   │              [--cc <C>...] [--keywords <K>...] [--groups <G>...] [--flag <F>...]
 │   │              [--no-comment] [--add-depends-on] [--add-blocks] [--no-cc] [--no-keywords]
 │   ├── update [<ID...>] [--from-json <PATH>] [--status <S>] [--resolution <R>] [--dupe-of <ID>]
 │   │                   [--assignee <A>] [--priority <P>] [--severity <S>] [--summary <S>]
@@ -661,13 +663,27 @@ bzr bug create --from-json bugs.json --json | jq '.created'
 
 ### `bzr bug clone`
 
-Clone an existing bug, copying its fields into a new bug. Override flags (`--summary`, `--product`, `--component`, `--version`, `--description`, `--priority`, `--severity`, `--assignee`, `--op-sys`, `--rep-platform`) take precedence over values copied from the source.
+Clone an existing bug, copying its fields into a new bug. Override flags
+(`--summary`, `--product`, `--component`, `--version`, `--description`,
+`--priority`, `--severity`, `--assignee`, `--op-sys`, `--rep-platform`,
+`--url`, `--whiteboard`, `--target-milestone`, and `--deadline`) take
+precedence over values copied from the source.
+
+By default, clone copies product, component, version, summary, comment #0 as
+the new description, priority, severity, assignee, operating system, hardware
+platform, URL, whiteboard, target milestone, deadline, CC, and keywords.
+Aliases, groups, and flags are not copied. Use `--cc` or `--keywords` to
+replace the copied lists; these conflict with `--no-cc` and `--no-keywords`.
+Use `--groups` and `--flag` to set those create-time fields explicitly on the
+new bug.
 
 ```bash
 bzr bug clone 12345
 bzr bug clone 12345 --summary "Variant: different environment"
 bzr bug clone 12345 --component NewComponent --add-depends-on
-bzr bug clone 12345 --no-comment --no-cc
+bzr bug clone 12345 --url https://example.com/repro --flag review?
+bzr bug clone 12345 --cc qa@example.com --keywords regression,security
+bzr bug clone 12345 --no-comment --no-cc --no-keywords
 ```
 
 | Option | Required | Description |
@@ -683,13 +699,24 @@ bzr bug clone 12345 --no-comment --no-cc
 | `--assignee <A>` | No | Override assignee |
 | `--op-sys <OS>` | No | Override operating system |
 | `--rep-platform <PLAT>` | No | Override hardware platform |
+| `--url <U>` | No | Override URL |
+| `--whiteboard <W>` | No | Override Status Whiteboard |
+| `--target-milestone <T>` | No | Override Target Milestone |
+| `--deadline <DATE>` | No | Override deadline (`YYYY-MM-DD`) |
+| `--cc <C>...` | No | Replace copied CC list (comma-separated, repeatable) |
+| `--keywords <K>...` | No | Replace copied keywords (comma-separated, repeatable) |
+| `--groups <G>...` | No | Add the cloned bug to groups; not copied from source |
+| `--flag <F>...` | No | Set or request flags; not copied from source |
 | `--no-comment` | No | Skip the "Cloned from bug #N" comment |
 | `--add-depends-on` | No | Make the new bug depend on the source bug |
 | `--add-blocks` | No | Make the new bug block the source bug |
 | `--no-cc` | No | Don't copy the CC list from the source bug |
 | `--no-keywords` | No | Don't copy keywords from the source bug |
 
-Agent note: cloning without overrides copies metadata from the source bug, which may be broader than an agent intends. For predictable automation, use explicit overrides such as `--summary`, `--component`, `--description`, `--no-cc`, or `--no-keywords`.
+Agent note: cloning without overrides copies metadata from the source bug,
+which may be broader than an agent intends. For predictable automation, use
+explicit overrides such as `--summary`, `--component`, `--description`,
+`--url`, `--whiteboard`, `--cc`, `--keywords`, `--no-cc`, or `--no-keywords`.
 
 ### `bzr bug update`
 

--- a/src/cli/bug.rs
+++ b/src/cli/bug.rs
@@ -79,6 +79,42 @@ pub struct CreateFieldArgs {
     pub flag: Vec<String>,
 }
 
+/// Create-time metadata overrides accepted by `bug clone`.
+///
+/// This intentionally omits `--alias`: a clone must never copy the source
+/// alias, and assigning a new unique alias while cloning is a narrower workflow
+/// than the metadata fields users commonly need to adjust.
+#[derive(Args, Debug, Clone, Default)]
+pub struct CloneCreateFieldArgs {
+    /// Override the URL field.
+    #[arg(long)]
+    pub url: Option<String>,
+    /// Override the Status Whiteboard.
+    #[arg(long)]
+    pub whiteboard: Option<String>,
+    /// Override the Target Milestone.
+    #[arg(long)]
+    pub target_milestone: Option<String>,
+    /// Override the deadline date (`YYYY-MM-DD`).
+    #[arg(long, value_name = "DATE")]
+    pub deadline: Option<String>,
+    /// Replace the copied CC list (comma-separated, repeatable).
+    #[arg(long, value_delimiter = ',', conflicts_with = "no_cc")]
+    pub cc: Vec<String>,
+    /// Replace the copied keywords (comma-separated, repeatable).
+    #[arg(long, value_delimiter = ',', conflicts_with = "no_keywords")]
+    pub keywords: Vec<String>,
+    /// Add the cloned bug to these groups (comma-separated, repeatable).
+    #[arg(long, value_delimiter = ',')]
+    pub groups: Vec<String>,
+    /// Set or request a flag using Bugzilla flag syntax (repeatable).
+    ///
+    /// Accepted forms: `name+` (granted), `name-` (denied), `name?`
+    /// (request), or `name?(user@example.com)` (request a specific user).
+    #[arg(long)]
+    pub flag: Vec<String>,
+}
+
 /// Shared comment flags for the convenience verbs (`resolve`, `close`,
 /// `reopen`, `dup`), which post a comment atomically with the state change —
 /// the same `--comment` / `--comment-file` / `--comment-private` set `bug
@@ -523,6 +559,8 @@ pub struct CloneArgs {
     /// Override hardware platform
     #[arg(long)]
     pub rep_platform: Option<String>,
+    #[command(flatten)]
+    pub create_fields: CloneCreateFieldArgs,
     /// Skip adding "Cloned from bug #N" comment
     #[arg(long)]
     pub no_comment: bool,
@@ -983,16 +1021,18 @@ pub enum BugAction {
     ///
     /// Copies the source bug's product, component, version, summary,
     /// description, priority, severity, assignee, op-sys,
-    /// rep-platform, CC list, and keywords into a new bug. Pass any
-    /// of the override flags (`--summary`, `--product`, ...) to
-    /// change values for the clone; unspecified fields inherit from
-    /// the source.
+    /// rep-platform, URL, whiteboard, target milestone, deadline, CC
+    /// list, and keywords into a new bug. Pass any of the override
+    /// flags (`--summary`, `--product`, `--url`, ...) to change values
+    /// for the clone; unspecified fields inherit from the source.
     ///
     /// By default the new bug gets a "Cloned from bug #N" comment;
     /// disable with `--no-comment`. Use `--add-depends-on` to link
     /// the new bug as a dependency of the source, or `--add-blocks`
     /// to make it block the source. `--no-cc` and `--no-keywords`
-    /// skip copying those lists.
+    /// skip copying those lists; `--cc` and `--keywords` replace the
+    /// copied lists. `--groups` and `--flag` are explicit additions
+    /// for the new bug and are not copied from the source.
     ///
     /// Examples:
     ///

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,7 +13,9 @@ pub mod template;
 mod user;
 
 pub use attachment::AttachmentAction;
-pub use bug::{BugAction, CommentArgs, CreateFieldArgs, FieldArgs, PageArgs, SortArgs};
+pub use bug::{
+    BugAction, CloneCreateFieldArgs, CommentArgs, CreateFieldArgs, FieldArgs, PageArgs, SortArgs,
+};
 pub use bug::{
     CloneArgs, CloseArgs, CreateArgs, DupArgs, HistoryArgs, ListArgs, MyArgs, ReopenArgs,
     ResolveArgs, SearchArgs, UpdateArgs, ViewArgs,

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -1669,6 +1669,89 @@ fn parse_bug_clone_minimal() {
 }
 
 #[test]
+fn parse_bug_clone_with_create_metadata_overrides() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "bug",
+        "clone",
+        "123",
+        "--url",
+        "https://example.com/repro",
+        "--whiteboard",
+        "needs-routing",
+        "--target-milestone",
+        "M1",
+        "--deadline",
+        "2026-12-31",
+        "--cc",
+        "a@example.com,b@example.com",
+        "--keywords",
+        "regression,security",
+        "--groups",
+        "confidential",
+        "--flag",
+        "review?(qa@example.com)",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Bug {
+            action:
+                BugAction::Clone(super::CloneArgs {
+                    id, create_fields, ..
+                }),
+        } => {
+            assert_eq!(id, "123");
+            assert_eq!(
+                create_fields.url.as_deref(),
+                Some("https://example.com/repro")
+            );
+            assert_eq!(create_fields.whiteboard.as_deref(), Some("needs-routing"));
+            assert_eq!(create_fields.target_milestone.as_deref(), Some("M1"));
+            assert_eq!(create_fields.deadline.as_deref(), Some("2026-12-31"));
+            assert_eq!(create_fields.cc, vec!["a@example.com", "b@example.com"]);
+            assert_eq!(create_fields.keywords, vec!["regression", "security"]);
+            assert_eq!(create_fields.groups, vec!["confidential"]);
+            assert_eq!(create_fields.flag, vec!["review?(qa@example.com)"]);
+        }
+        _ => panic!("expected Bug Clone"),
+    }
+}
+
+#[test]
+fn parse_bug_clone_cc_override_conflicts_with_no_cc() {
+    let result = Cli::try_parse_from([
+        "bzr",
+        "bug",
+        "clone",
+        "123",
+        "--no-cc",
+        "--cc",
+        "a@example.com",
+    ]);
+    let Err(err) = result else {
+        panic!("--cc should conflict with --no-cc");
+    };
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn parse_bug_clone_keywords_override_conflicts_with_no_keywords() {
+    let result = Cli::try_parse_from([
+        "bzr",
+        "bug",
+        "clone",
+        "123",
+        "--no-keywords",
+        "--keywords",
+        "regression",
+    ]);
+    let Err(err) = result else {
+        panic!("--keywords should conflict with --no-keywords");
+    };
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
 fn parse_template_save_with_fields() {
     let cli = Cli::try_parse_from([
         "bzr",

--- a/src/commands/bug/clone.rs
+++ b/src/commands/bug/clone.rs
@@ -1,9 +1,11 @@
 use crate::cli::CloneArgs;
 use crate::client::BugzillaClient;
+use crate::commands::runtime::flags::parse_flags;
 use crate::error::Result;
 use crate::output::result_types::{write_result, ActionResult, DryRunResult, ResourceKind};
 use crate::output::writers::Writers;
 use crate::types::{CreateBugParams, OutputFormat};
+use crate::validation::parse_optional_date_only;
 
 pub(super) async fn handle(
     client: &BugzillaClient,
@@ -23,12 +25,16 @@ pub(super) async fn handle(
         assignee,
         op_sys,
         rep_platform,
+        create_fields,
         no_comment,
         add_depends_on,
         add_blocks,
         no_cc,
         no_keywords,
     } = args;
+
+    let flags = parse_flags(&create_fields.flag)?;
+    let deadline = parse_optional_date_only(create_fields.deadline.as_deref(), "--deadline")?;
 
     // Fetch source bug with all fields needed for cloning
     let source = client.get_bug(id, None, None).await?;
@@ -71,14 +77,19 @@ pub(super) async fn handle(
         assigned_to: assignee.clone().or(source.assigned_to),
         op_sys: op_sys.clone().or(source.op_sys),
         rep_platform: rep_platform.clone().or(source.rep_platform),
+        url: create_fields.url.clone().or(source.url),
+        whiteboard: create_fields.whiteboard.clone().or(source.whiteboard),
+        target_milestone: create_fields
+            .target_milestone
+            .clone()
+            .or(source.target_milestone),
+        deadline: deadline.or(source.deadline),
         blocks,
         depends_on,
-        cc: if *no_cc { vec![] } else { source.cc },
-        keywords: if *no_keywords {
-            vec![]
-        } else {
-            source.keywords
-        },
+        cc: clone_list(source.cc, &create_fields.cc, *no_cc),
+        keywords: clone_list(source.keywords, &create_fields.keywords, *no_keywords),
+        groups: create_fields.groups.clone(),
+        flags,
         ..Default::default()
     };
 
@@ -115,6 +126,20 @@ pub(super) async fn handle(
         w.out,
     );
     Ok(())
+}
+
+fn clone_list(
+    source_values: Vec<String>,
+    override_values: &[String],
+    omit_source: bool,
+) -> Vec<String> {
+    if omit_source {
+        Vec::new()
+    } else if override_values.is_empty() {
+        source_values
+    } else {
+        override_values.to_vec()
+    }
 }
 
 /// Emit the would-be clone payload without writing, marked `"action":"dry-run"`.

--- a/src/commands/bug/clone_tests.rs
+++ b/src/commands/bug/clone_tests.rs
@@ -7,6 +7,28 @@ use crate::cli::BugAction;
 use crate::test_helpers::setup_test_env;
 use crate::types::OutputFormat;
 
+fn clone_args(id: &str) -> crate::cli::CloneArgs {
+    crate::cli::CloneArgs {
+        id: id.to_string(),
+        summary: None,
+        product: None,
+        component: None,
+        version: None,
+        description: None,
+        priority: None,
+        severity: None,
+        assignee: None,
+        op_sys: None,
+        rep_platform: None,
+        create_fields: crate::cli::CloneCreateFieldArgs::default(),
+        no_comment: false,
+        add_depends_on: false,
+        add_blocks: false,
+        no_cc: false,
+        no_keywords: false,
+    }
+}
+
 #[tokio::test]
 async fn bug_clone_copies_fields() {
     let (_lock, mock, _tmp) = setup_test_env().await;
@@ -83,24 +105,7 @@ async fn bug_clone_copies_fields() {
         .mount(&mock)
         .await;
 
-    let action = BugAction::Clone(crate::cli::CloneArgs {
-        id: "100".to_string(),
-        summary: None,
-        product: None,
-        component: None,
-        version: None,
-        description: None,
-        priority: None,
-        severity: None,
-        assignee: None,
-        op_sys: None,
-        rep_platform: None,
-        no_comment: false,
-        add_depends_on: false,
-        add_blocks: false,
-        no_cc: false,
-        no_keywords: false,
-    });
+    let action = BugAction::Clone(clone_args("100"));
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result =
         crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
@@ -161,24 +166,7 @@ async fn bug_clone_reports_id_when_comment_post_fails() {
         .mount(&mock)
         .await;
 
-    let action = BugAction::Clone(crate::cli::CloneArgs {
-        id: "100".to_string(),
-        summary: None,
-        product: None,
-        component: None,
-        version: None,
-        description: None,
-        priority: None,
-        severity: None,
-        assignee: None,
-        op_sys: None,
-        rep_platform: None,
-        no_comment: false,
-        add_depends_on: false,
-        add_blocks: false,
-        no_cc: false,
-        no_keywords: false,
-    });
+    let action = BugAction::Clone(clone_args("100"));
     let mut __io = crate::test_helpers::CapturedIo::new();
     let result =
         crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut __io.writers())
@@ -257,24 +245,9 @@ async fn bug_clone_no_comment_skips_comment() {
         .mount(&mock)
         .await;
 
-    let action = BugAction::Clone(crate::cli::CloneArgs {
-        id: "100".to_string(),
-        summary: None,
-        product: None,
-        component: None,
-        version: None,
-        description: None,
-        priority: None,
-        severity: None,
-        assignee: None,
-        op_sys: None,
-        rep_platform: None,
-        no_comment: true,
-        add_depends_on: false,
-        add_blocks: false,
-        no_cc: false,
-        no_keywords: false,
-    });
+    let mut args = clone_args("100");
+    args.no_comment = true;
+    let action = BugAction::Clone(args);
     let mut __io2 = crate::test_helpers::CapturedIo::new();
     let result = crate::commands::bug::execute(
         &action,
@@ -304,8 +277,12 @@ async fn bug_clone_dry_run_reads_source_but_creates_nothing() {
                 "product": "TestProduct",
                 "component": "General",
                 "version": "2.0",
-                "cc": [],
-                "keywords": []
+                "url": "https://example.com/source",
+                "whiteboard": "needs-triage",
+                "target_milestone": "M2",
+                "deadline": "2026-12-31",
+                "cc": ["watcher@test.com"],
+                "keywords": ["regression"]
             }]
         })))
         .mount(&mock)
@@ -328,24 +305,7 @@ async fn bug_clone_dry_run_reads_source_but_creates_nothing() {
         .mount(&mock)
         .await;
 
-    let action = BugAction::Clone(crate::cli::CloneArgs {
-        id: "100".to_string(),
-        summary: None,
-        product: None,
-        component: None,
-        version: None,
-        description: None,
-        priority: None,
-        severity: None,
-        assignee: None,
-        op_sys: None,
-        rep_platform: None,
-        no_comment: false,
-        add_depends_on: false,
-        add_blocks: false,
-        no_cc: false,
-        no_keywords: false,
-    });
+    let action = BugAction::Clone(clone_args("100"));
     let mut io = crate::test_helpers::CapturedIo::new();
     let result =
         crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
@@ -359,4 +319,95 @@ async fn bug_clone_dry_run_reads_source_but_creates_nothing() {
     assert_eq!(parsed["ids"], serde_json::json!([]));
     assert_eq!(parsed["changes"]["product"], "TestProduct");
     assert_eq!(parsed["changes"]["summary"], "Original bug");
+    assert_eq!(parsed["changes"]["url"], "https://example.com/source");
+    assert_eq!(parsed["changes"]["whiteboard"], "needs-triage");
+    assert_eq!(parsed["changes"]["target_milestone"], "M2");
+    assert_eq!(parsed["changes"]["deadline"], "2026-12-31");
+    assert_eq!(
+        parsed["changes"]["cc"],
+        serde_json::json!(["watcher@test.com"])
+    );
+    assert_eq!(
+        parsed["changes"]["keywords"],
+        serde_json::json!(["regression"])
+    );
+}
+
+#[tokio::test]
+async fn bug_clone_dry_run_applies_create_metadata_overrides() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    crate::commands::runtime::dry_run::set(true);
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": [{
+                "id": 100,
+                "summary": "Original bug",
+                "status": "NEW",
+                "product": "TestProduct",
+                "component": "General",
+                "version": "2.0",
+                "url": "https://example.com/source",
+                "whiteboard": "source-whiteboard",
+                "target_milestone": "M2",
+                "deadline": "2026-12-30",
+                "cc": ["source-watcher@test.com"],
+                "keywords": ["source-keyword"]
+            }]
+        })))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/100/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": { "100": { "comments": [{
+                "id": 1, "bug_id": 100, "count": 0, "text": "Original description",
+                "creator": "dev@test.com", "creation_time": "2025-01-01T00:00:00Z"
+            }] } }
+        })))
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 999})))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let mut args = clone_args("100");
+    args.create_fields = crate::cli::CloneCreateFieldArgs {
+        url: Some("https://example.com/override".into()),
+        whiteboard: Some("override-whiteboard".into()),
+        target_milestone: Some("M3".into()),
+        deadline: Some("2026-12-31".into()),
+        cc: vec!["override-watcher@test.com".into()],
+        keywords: vec!["override-keyword".into()],
+        groups: vec!["confidential".into()],
+        flag: vec!["review?(qa@example.com)".into()],
+    };
+    let action = BugAction::Clone(args);
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result =
+        crate::commands::bug::execute(&action, None, OutputFormat::Json, None, &mut io.writers())
+            .await;
+    let output = io.out_str().to_string();
+    crate::commands::runtime::dry_run::set(false);
+
+    assert!(result.is_ok(), "dry-run clone failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+    let changes = &parsed["changes"];
+    assert_eq!(changes["url"], "https://example.com/override");
+    assert_eq!(changes["whiteboard"], "override-whiteboard");
+    assert_eq!(changes["target_milestone"], "M3");
+    assert_eq!(changes["deadline"], "2026-12-31");
+    assert_eq!(
+        changes["cc"],
+        serde_json::json!(["override-watcher@test.com"])
+    );
+    assert_eq!(changes["keywords"], serde_json::json!(["override-keyword"]));
+    assert_eq!(changes["groups"], serde_json::json!(["confidential"]));
+    assert_eq!(changes["flags"][0]["name"], "review");
+    assert_eq!(changes["flags"][0]["status"], "?");
+    assert_eq!(changes["flags"][0]["requestee"], "qa@example.com");
 }


### PR DESCRIPTION
## Summary

- add clone-only create metadata flags for URL, whiteboard, target milestone, deadline, CC, keywords, groups, and flags
- copy source URL, whiteboard, target milestone, and deadline into the resolved clone payload unless overridden
- document copied, omitted, and explicit-only clone metadata behavior

Closes #385

## Tests

- cargo fmt --check
- git diff --check
- cargo test bug_clone
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build
- agent-skills/tests/drift-check.sh
- BZR_BIN=target/debug/bzr agent-skills/tests/flag-drift-check.sh
- cargo test