### PR TITLE
feat(attachment): add upload comment file source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the source bug, and accepts create-time metadata overrides for URL,
   whiteboard, target milestone, deadline, CC, keywords, groups, and flags.
   (#385)
+- `attachment upload` now accepts `--comment-file <PATH>` and the shared `-`
+  stdin convention for `--comment` and `--comment-file`, while rejecting empty
+  attachment comments consistently. (#386)
 - `bug update` now accepts `--url` and `--target-milestone`, matching fields
   that `bug create` can already set. (#363)
 - `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -158,7 +158,8 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │   ├── view <ATTACHMENT_ID>
 │   ├── download <ATTACHMENT_ID> [--bug <ID>] [-o|--out <FILE>] [--out-dir <DIR>]
 │   ├── upload <BUG_ID> <FILE> [--summary <S>] [--content-type <MIME>] [--comment <BODY>]
-│   │                          [--comment-private] [--private|--no-private] [--patch|--no-patch] [--flag <F>...]
+│   │                          [--comment-file <PATH>] [--comment-private]
+│   │                          [--private|--no-private] [--patch|--no-patch] [--flag <F>...]
 │   └── update <ATTACHMENT_ID> [--summary <S>] [--file-name <N>] [--content-type <MIME>]
 │                               [--obsolete|--no-obsolete] [--patch|--no-patch]
 │                               [--private|--no-private] [--flag <F>...]
@@ -1027,12 +1028,16 @@ The bulk shapes emit an `AttachmentBatchResult` (table or JSON): per-bug success
 
 Upload a file as an attachment to a bug. MIME type is auto-detected from the file extension if not specified. Add `--private` to mark the attachment as visible only to users with elevated permissions on the server.
 
+Post an attachment comment with `--comment` or `--comment-file`; a value of `-` for either option reads the comment from stdin. Empty or whitespace-only comments are rejected.
+
 ```bash
 bzr attachment upload 12345 screenshot.png
 bzr attachment upload 12345 data.csv --summary "Performance data" --content-type text/csv
 bzr attachment upload 12345 patch.diff --flag "review?(alice@example.com)"
 bzr attachment upload 12345 secret.bin --summary "internal trace" --private
 bzr attachment upload 12345 fix.patch --comment "see #6789 for context"
+bzr attachment upload 12345 fix.patch --comment-file notes.md
+printf '%s\n' "Generated test log" | bzr attachment upload 12345 logs.txt --comment-file -
 bzr attachment upload 12345 patch.diff --comment "sensitive context" --comment-private
 bzr attachment upload 12345 fix.patch --patch
 ```
@@ -1045,8 +1050,9 @@ bzr attachment upload 12345 fix.patch --patch
 | `--content-type <MIME>` | No | MIME type (auto-detected if omitted; defaults to `text/plain` when `--patch` is set without an explicit type) |
 | `--private` / `--no-private` | No | Mark the attachment private (or explicitly public; default public) |
 | `--patch` / `--no-patch` | No | Mark the attachment a patch (or non-patch; default non-patch); `--patch` defaults `--content-type` to `text/plain` |
-| `--comment <BODY>` | No | Post a comment alongside the attachment in the same API call |
-| `--comment-private` | No | Mark the comment posted via `--comment` private. Issues a follow-up `Bug.update` call (two API round-trips). Requires `--comment`. |
+| `--comment <BODY>` | No | Post a comment alongside the attachment in the same API call; `-` reads stdin (mutually exclusive with `--comment-file`) |
+| `--comment-file <PATH>` | No | Read the attachment comment from a UTF-8 file; `-` reads stdin (mutually exclusive with `--comment`; missing or non-UTF-8 paths exit 7) |
+| `--comment-private` | No | Mark the comment posted via `--comment` or `--comment-file` private. Issues a follow-up `Bug.update` call (two API round-trips). Requires one comment source. |
 | `--flag <F>` | No | Set flags (repeatable; see [Flag Syntax](#flag-syntax)) |
 
 Agent note: for clearer audit trails, agents should usually pass `--summary` explicitly instead of relying on the filename-derived default.

--- a/src/cli/attachment.rs
+++ b/src/cli/attachment.rs
@@ -46,20 +46,26 @@ pub struct UploadArgs {
     /// inherits the bug's default privacy unless `--comment-private`
     /// is also set, in which case a follow-up `Bug.update` call
     /// flips the new comment private (two API round-trips total).
-    #[arg(long)]
+    /// Use `--comment -` to read the comment from stdin.
+    #[arg(long, conflicts_with = "comment_file")]
     pub comment: Option<String>,
-    /// Mark the comment posted via `--comment` private.
+    /// Read the attachment comment from a UTF-8 file.
+    ///
+    /// Use `--comment-file -` to read the comment from stdin.
+    #[arg(long, value_name = "PATH", conflicts_with = "comment")]
+    pub comment_file: Option<std::path::PathBuf>,
+    /// Mark the comment posted via `--comment` or `--comment-file` private.
     ///
     /// Issues a follow-up `Bug.update` call after the upload to flip
     /// the just-created comment's `is_private` flag. The Bugzilla
     /// `Bug.add_attachment` API does not accept comment privacy in
     /// the upload itself, so this is a two-call workflow internally.
     ///
-    /// Requires `--comment <BODY>`; using `--comment-private` alone
-    /// is a usage error (exit 7). Marking a comment private requires
-    /// `editbugs` permission or `insider` group membership; on 403 the
-    /// attachment remains uploaded but the comment stays public, and
-    /// the command exits non-zero with a stderr warning.
+    /// Requires `--comment <BODY>` or `--comment-file <PATH>`; using
+    /// `--comment-private` alone is a usage error (exit 7). Marking a
+    /// comment private requires `editbugs` permission or `insider` group
+    /// membership; on 403 the attachment remains uploaded but the comment
+    /// stays public, and the command exits non-zero with a stderr warning.
     #[arg(long)]
     pub comment_private: bool,
     /// Set, request, or clear a flag using Bugzilla flag syntax.
@@ -232,12 +238,13 @@ pub enum AttachmentAction {
     /// `--summary` sets the attachment's display label;
     /// it defaults to the file name if omitted.
     ///
-    /// `--comment <BODY>` posts a comment alongside the attachment
-    /// in a single API call. Use this when the attachment needs
-    /// explanatory context — typical for patches.
+    /// `--comment <BODY>` or `--comment-file <PATH>` posts a comment
+    /// alongside the attachment in a single API call. Use this when
+    /// the attachment needs explanatory context -- typical for patches.
+    /// Pass `-` to either option to read the comment from stdin.
     ///
-    /// `--comment-private` (used together with `--comment`) marks the
-    /// new comment private after upload. This requires `editbugs`
+    /// `--comment-private` (used together with one comment source)
+    /// marks the new comment private after upload. This requires `editbugs`
     /// permission. Permission errors leave the attachment uploaded and
     /// the comment public; rerun privacy via the web UI.
     ///
@@ -254,9 +261,11 @@ pub enum AttachmentAction {
     ///   bzr attachment upload 12345 fix.patch \
     ///     --flag 'review?(maintainer@example.com)'
     ///   bzr attachment upload 12345 fix.patch --comment "see #4567 for context"
+    ///   bzr attachment upload 12345 fix.patch --comment-file notes.md
+    ///   bzr attachment upload 12345 trace.log --comment-file -
     ///   bzr attachment upload 12345 patch.diff \
     ///     --comment "private context" --comment-private
-    ///   bzr attachment upload 12345 fix.patch --is-patch
+    ///   bzr attachment upload 12345 fix.patch --patch
     ///
     /// See bzr-attachment-update(1) to modify metadata after upload.
     #[command(verbatim_doc_comment)]

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -2240,6 +2240,110 @@ fn parse_attachment_upload_with_comment() {
 }
 
 #[test]
+fn parse_attachment_upload_with_comment_dash() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "attachment",
+        "upload",
+        "42",
+        "patch.diff",
+        "--comment",
+        "-",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action:
+                AttachmentAction::Upload(super::attachment::UploadArgs {
+                    bug_id, comment, ..
+                }),
+        } => {
+            assert_eq!(bug_id, 42);
+            assert_eq!(comment.as_deref(), Some("-"));
+        }
+        _ => panic!("expected Attachment Upload"),
+    }
+}
+
+#[test]
+fn parse_attachment_upload_with_comment_file() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "attachment",
+        "upload",
+        "42",
+        "patch.diff",
+        "--comment-file",
+        "notes.md",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action:
+                AttachmentAction::Upload(super::attachment::UploadArgs {
+                    bug_id,
+                    comment_file,
+                    ..
+                }),
+        } => {
+            assert_eq!(bug_id, 42);
+            assert_eq!(
+                comment_file.as_deref(),
+                Some(std::path::Path::new("notes.md"))
+            );
+        }
+        _ => panic!("expected Attachment Upload"),
+    }
+}
+
+#[test]
+fn parse_attachment_upload_with_comment_file_dash() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "attachment",
+        "upload",
+        "42",
+        "patch.diff",
+        "--comment-file",
+        "-",
+    ])
+    .unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action:
+                AttachmentAction::Upload(super::attachment::UploadArgs {
+                    bug_id,
+                    comment_file,
+                    ..
+                }),
+        } => {
+            assert_eq!(bug_id, 42);
+            assert_eq!(comment_file.as_deref(), Some(std::path::Path::new("-")));
+        }
+        _ => panic!("expected Attachment Upload"),
+    }
+}
+
+#[test]
+fn parse_attachment_upload_comment_and_comment_file_conflict() {
+    let result = Cli::try_parse_from([
+        "bzr",
+        "attachment",
+        "upload",
+        "42",
+        "patch.diff",
+        "--comment",
+        "inline",
+        "--comment-file",
+        "notes.md",
+    ]);
+    let Err(err) = result else {
+        panic!("--comment and --comment-file should conflict");
+    };
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
 fn parse_attachment_upload_without_comment_defaults_to_none() {
     let cli = Cli::try_parse_from(["bzr", "attachment", "upload", "42", "f.txt"]).unwrap();
     match cli.command {

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -5,7 +5,7 @@ use base64::Engine;
 
 use crate::cli::AttachmentAction;
 use crate::client::BugzillaClient;
-use crate::error::Result;
+use crate::error::{BzrError, Result};
 use crate::output::resources::attachment::{
     write_attachment, write_attachment_batch, write_attachments, AttachmentBatchResult,
     AttachmentDownloadResult, BatchSummary, BugDownloadResult, DownloadedFile, TargetStatus,
@@ -99,6 +99,7 @@ async fn upload(
         patch,
         no_patch,
         comment,
+        comment_file,
         comment_private,
         flag,
     } = args;
@@ -116,6 +117,11 @@ async fn upload(
         (None, false) => guess_content_type(file_name).to_string(),
     };
     let flags = super::runtime::flags::parse_flags(flag)?;
+    let comment = resolve_upload_comment(
+        comment.as_deref(),
+        comment_file.as_deref(),
+        *comment_private,
+    )?;
     let size = data.len();
     let upload_params = UploadAttachmentParams {
         bug_id: *bug_id,
@@ -125,7 +131,7 @@ async fn upload(
         data,
         flags,
         is_private,
-        comment: comment.clone(),
+        comment,
         is_patch,
     };
     let att_id = client.upload_attachment(&upload_params).await?;
@@ -139,6 +145,34 @@ async fn upload(
         w.out,
     );
     Ok(())
+}
+
+fn resolve_upload_comment(
+    comment: Option<&str>,
+    comment_file: Option<&Path>,
+    comment_private: bool,
+) -> Result<Option<String>> {
+    let body = super::runtime::shared::materialize_body_source(
+        super::runtime::shared::classify_body_source(
+            comment,
+            comment_file,
+            "--comment",
+            "--comment-file",
+        )?,
+        "--comment-file",
+    )?;
+    if body.is_none() && comment_private {
+        return Err(BzrError::InputValidation(
+            "--comment-private requires --comment or --comment-file".into(),
+        ));
+    }
+    let Some(text) = body else {
+        return Ok(None);
+    };
+    if text.trim().is_empty() {
+        return Err(BzrError::InputValidation("empty comment, aborting".into()));
+    }
+    Ok(Some(text))
 }
 
 async fn update(
@@ -208,9 +242,10 @@ fn validate_action(action: &AttachmentAction) -> Result<()> {
         AttachmentAction::Upload(crate::cli::attachment::UploadArgs {
             comment_private: true,
             comment: None,
+            comment_file: None,
             ..
         }) => Err(crate::error::BzrError::InputValidation(
-            "--comment-private requires --comment".into(),
+            "--comment-private requires --comment or --comment-file".into(),
         )),
         AttachmentAction::Download { ids, bug_ids, .. } if ids.is_empty() && bug_ids.is_empty() => {
             Err(crate::error::BzrError::InputValidation(

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -104,6 +104,7 @@ async fn attachment_upload_api_error_propagates() {
         patch: false,
         no_patch: false,
         comment: None,
+        comment_file: None,
         comment_private: false,
         flag: vec![],
     });
@@ -178,6 +179,7 @@ async fn attachment_upload_returns_id() {
         patch: false,
         no_patch: false,
         comment: None,
+        comment_file: None,
         comment_private: false,
         flag: vec![],
     });
@@ -223,6 +225,7 @@ async fn attachment_upload_with_comment_includes_comment_in_request() {
         patch: false,
         no_patch: false,
         comment: Some("see this".into()),
+        comment_file: None,
         comment_private: false,
         flag: vec![],
     });
@@ -238,6 +241,127 @@ async fn attachment_upload_with_comment_includes_comment_in_request() {
         result.is_ok(),
         "upload with --comment should succeed: {result:?}"
     );
+}
+
+#[tokio::test]
+async fn attachment_upload_with_comment_file_includes_comment_in_request() {
+    use wiremock::matchers::body_string_contains;
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/42/attachment"))
+        .and(body_string_contains("\"comment\":\"from file body\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [202]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let upload_file = tmp.path().join("upload.txt");
+    let comment_file = tmp.path().join("comment.txt");
+    std::fs::write(&upload_file, "test content").unwrap();
+    std::fs::write(&comment_file, "from file body").unwrap();
+
+    let action = AttachmentAction::Upload(UploadArgs {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: Some("Test".into()),
+        content_type: Some("text/plain".into()),
+        private: false,
+        no_private: false,
+        patch: false,
+        no_patch: false,
+        comment: None,
+        comment_file: Some(comment_file),
+        comment_private: false,
+        flag: vec![],
+    });
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "upload with --comment-file should succeed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn attachment_upload_rejects_whitespace_comment() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    let (_lock, _mock, tmp) = setup_test_env().await;
+
+    let upload_file = tmp.path().join("upload.txt");
+    std::fs::write(&upload_file, "test content").unwrap();
+
+    let action = AttachmentAction::Upload(UploadArgs {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: Some("Test".into()),
+        content_type: Some("text/plain".into()),
+        private: false,
+        no_private: false,
+        patch: false,
+        no_patch: false,
+        comment: Some(" \n\t".into()),
+        comment_file: None,
+        comment_private: false,
+        flag: vec![],
+    });
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
+    assert!(matches!(
+        result,
+        Err(crate::error::BzrError::InputValidation(_))
+    ));
+}
+
+#[tokio::test]
+async fn attachment_upload_rejects_whitespace_comment_file() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    let (_lock, _mock, tmp) = setup_test_env().await;
+
+    let upload_file = tmp.path().join("upload.txt");
+    let comment_file = tmp.path().join("comment.txt");
+    std::fs::write(&upload_file, "test content").unwrap();
+    std::fs::write(&comment_file, " \n\t").unwrap();
+
+    let action = AttachmentAction::Upload(UploadArgs {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: Some("Test".into()),
+        content_type: Some("text/plain".into()),
+        private: false,
+        no_private: false,
+        patch: false,
+        no_patch: false,
+        comment: None,
+        comment_file: Some(comment_file),
+        comment_private: false,
+        flag: vec![],
+    });
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
+    assert!(matches!(
+        result,
+        Err(crate::error::BzrError::InputValidation(_))
+    ));
 }
 
 #[tokio::test]
@@ -268,6 +392,7 @@ async fn attachment_upload_with_is_patch_defaults_content_type_to_text_plain() {
         patch: true,
         no_patch: false,
         comment: None,
+        comment_file: None,
         comment_private: false,
         flag: vec![],
     });
@@ -315,6 +440,7 @@ async fn attachment_upload_is_patch_with_explicit_content_type_keeps_content_typ
         patch: true,
         no_patch: false,
         comment: None,
+        comment_file: None,
         comment_private: false,
         flag: vec![],
     });
@@ -562,6 +688,7 @@ async fn attachment_upload_with_comment_private_flips_privacy() {
         patch: false,
         no_patch: false,
         comment: Some("sensitive".into()),
+        comment_file: None,
         comment_private: true,
         flag: vec![],
     });
@@ -576,6 +703,77 @@ async fn attachment_upload_with_comment_private_flips_privacy() {
     assert!(
         result.is_ok(),
         "two-call workflow should succeed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn attachment_upload_comment_private_with_comment_file_flips_privacy() {
+    use wiremock::matchers::body_string_contains;
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    let (_lock, mock, tmp) = setup_test_env().await;
+
+    let upload_file = tmp.path().join("p.diff");
+    let comment_file = tmp.path().join("comment.txt");
+    std::fs::write(&upload_file, "diff --git a/x b/x").unwrap();
+    std::fs::write(&comment_file, "file sensitive").unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/42/attachment"))
+        .and(body_string_contains("\"comment\":\"file sensitive\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ids": [200]})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/42/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bugs": {
+                "42": {
+                    "comments": [
+                        {"id": 555, "bug_id": 42, "text": "file sensitive", "is_private": false, "attachment_id": 200}
+                    ]
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/42"))
+        .and(body_string_contains("\"comment_is_private\""))
+        .and(body_string_contains("\"555\":true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"bugs": []})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = AttachmentAction::Upload(UploadArgs {
+        bug_id: 42,
+        file: upload_file.to_string_lossy().into_owned(),
+        summary: Some("test".into()),
+        content_type: Some("text/x-diff".into()),
+        private: false,
+        no_private: false,
+        patch: false,
+        no_patch: false,
+        comment: None,
+        comment_file: Some(comment_file),
+        comment_private: true,
+        flag: vec![],
+    });
+    let result = super::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "comment-file two-call workflow should succeed: {result:?}"
     );
 }
 
@@ -596,6 +794,7 @@ async fn attachment_upload_comment_private_without_comment_is_input_error() {
         patch: false,
         no_patch: false,
         comment: None,
+        comment_file: None,
         comment_private: true,
         flag: vec![],
     });
@@ -657,6 +856,7 @@ async fn attachment_upload_comment_private_partial_failure_propagates_error() {
         patch: false,
         no_patch: false,
         comment: Some("x".into()),
+        comment_file: None,
         comment_private: true,
         flag: vec![],
     });
@@ -713,6 +913,7 @@ async fn attachment_upload_comment_private_no_matching_comment_is_data_integrity
         patch: false,
         no_patch: false,
         comment: Some("x".into()),
+        comment_file: None,
         comment_private: true,
         flag: vec![],
     });

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1323,6 +1323,7 @@ async fn attachment_upload_integration() {
         patch: false,
         no_patch: false,
         comment: None,
+        comment_file: None,
         comment_private: false,
         flag: vec![],
     });
@@ -1369,6 +1370,7 @@ async fn attachment_upload_with_comment_integration() {
         patch: false,
         no_patch: false,
         comment: Some("see #6789 for context".to_string()),
+        comment_file: None,
         comment_private: false,
         flag: vec![],
     });
@@ -1414,6 +1416,7 @@ async fn attachment_upload_with_is_patch_integration() {
         patch: true,
         no_patch: false,
         comment: None,
+        comment_file: None,
         comment_private: false,
         flag: vec![],
     });
@@ -1482,6 +1485,7 @@ async fn attachment_upload_with_comment_private_integration() {
         patch: false,
         no_patch: false,
         comment: Some("sensitive".into()),
+        comment_file: None,
         comment_private: true,
         flag: vec![],
     });


### PR DESCRIPTION
## Summary
- add `attachment upload --comment-file <PATH>` with shared `-` stdin handling
- reject empty or whitespace-only upload comments before sending the attachment request
- allow `--comment-private` with either inline or file-sourced comments
- update CLI docs and changelog

Closes #386

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test attachment_upload --lib`
- `cargo test attachment_upload --test integration`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `agent-skills/tests/drift-check.sh`
- `BZR_BIN=target/debug/bzr agent-skills/tests/flag-drift-check.sh`
- `cargo test`