### PR TITLE
feat(attachment): stream single downloads to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `attachment upload` now accepts `--comment-file <PATH>` and the shared `-`
   stdin convention for `--comment` and `--comment-file`, while rejecting empty
   attachment comments consistently. (#386)
+- `attachment download <ID> --out -` now streams a single attachment's raw bytes
+  to stdout without writing a file or emitting formatted result output. (#387)
 - `bug update` now accepts `--url` and `--target-milestone`, matching fields
   that `bug create` can already set. (#363)
 - `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -970,13 +970,14 @@ bzr --json attachment view 9876 | jq '.summary, .size'
 
 ### `bzr attachment download`
 
-Download one or more attachments to disk.
+Download one or more attachments to disk, or stream one attachment's bytes to stdout.
 
 **Synopsis:**
 
 ```
 bzr attachment download <ID>...
 bzr attachment download <ID> --out <PATH>
+bzr attachment download <ID> --out -
 bzr attachment download [<ID>...] --bug <BUG_ID>... [--out-dir <DIR>]
 ```
 
@@ -986,8 +987,11 @@ bzr attachment download [<ID>...] --bug <BUG_ID>... [--out-dir <DIR>]
 |---|---|
 | `<ID>` | Attachment ID(s). Repeatable as positional arguments. |
 | `--bug <BUG_ID>` | Download every attachment for the given bug. Repeatable. |
-| `-o`, `--out <PATH>` | Output file path. Single-attachment shape only; conflicts with `--out-dir` and `--bug`. |
+| `-o`, `--out <PATH>` | Output file path, or `-` for stdout. Single-attachment shape only. |
 | `--out-dir <DIR>` | Output directory for batch downloads. Default: `./attachments`. Files land at `<out-dir>/<bug-id>/<att-id>.<file_name>`. |
+
+`--out` conflicts with `--out-dir` and `--bug`. Use `./-` if you need a literal file
+named `-`.
 
 **Examples:**
 
@@ -997,6 +1001,9 @@ bzr attachment download 9876
 
 # Single attachment, custom path
 bzr attachment download 9876 --out patch.diff
+
+# Single attachment to stdout
+bzr attachment download 9876 --out - > patch.diff
 
 # Multiple attachment IDs into a directory
 bzr attachment download 9876 9877 9878 --out-dir /tmp/patches
@@ -1010,7 +1017,13 @@ bzr attachment download --bug 12345 9876 --out-dir /tmp/mixed
 
 **Output:**
 
-The single-attachment shape emits a one-line `Downloaded attachment #N to PATH (BYTES bytes)` summary or a `DownloadResult` JSON object.
+The single-attachment file-output shape emits a one-line
+`Downloaded attachment #N to PATH (BYTES bytes)` summary or a `DownloadResult` JSON
+object.
+
+With `--out -`, stdout is the raw attachment byte stream. `--json`, `--output json`,
+and `--output table` do not emit a `DownloadResult`; success is reported by exit code
+only, and stderr is left for diagnostics.
 
 The bulk shapes emit an `AttachmentBatchResult` (table or JSON): per-bug success rows with each saved file, per-attachment rows for positional IDs, and a `Summary: X succeeded, Y failed, Z total bytes` trailer. Bug-level and per-attachment failures are written to stderr in table mode.
 

--- a/src/cli/attachment.rs
+++ b/src/cli/attachment.rs
@@ -182,8 +182,9 @@ pub enum AttachmentAction {
     ///
     /// Three argument shapes are accepted:
     ///
-    /// 1. Single attachment, free-form path:
+    /// 1. Single attachment, free-form path or stdout:
     ///    bzr attachment download 9876 --out patch.diff
+    ///    bzr attachment download 9876 --out - > patch.diff
     ///
     /// 2. Multiple attachment IDs (positional):
     ///    bzr attachment download 9876 9877 9878 [--out-dir DIR]
@@ -195,12 +196,15 @@ pub enum AttachmentAction {
     /// `<out-dir>/<bug-id>/<att-id>.<file_name>`. The attachment-ID
     /// prefix avoids same-name collisions on a single bug. `--out-dir`
     /// defaults to `./attachments` and is created (recursively) on
-    /// demand. `--out` is only valid for shape 1.
+    /// demand. `--out` is only valid for shape 1. Use `--out -`
+    /// to write the raw bytes to stdout; result formatting is
+    /// suppressed so the byte stream stays clean.
     ///
     /// Examples:
     ///
     ///   bzr attachment download 9876
     ///   bzr attachment download 9876 --out patch.diff
+    ///   bzr attachment download 9876 --out - > patch.diff
     ///   bzr attachment download 9876 9877 9878 --out-dir /tmp/patches
     ///   bzr attachment download --bug 12345 --bug 67890 --out-dir /tmp/all
     ///   bzr attachment download --bug 12345 9876 --out-dir /tmp/mixed
@@ -216,7 +220,7 @@ pub enum AttachmentAction {
         #[arg(long = "bug", value_name = "BUG_ID")]
         bug_ids: Vec<u64>,
 
-        /// Output file path (single-attachment shape only).
+        /// Output file path, or `-` for stdout (single-attachment shape only).
         #[arg(
             short = 'o',
             long = "out",

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -1172,6 +1172,20 @@ fn parse_attachment_download_with_out() {
 }
 
 #[test]
+fn parse_attachment_download_with_out_dash() {
+    let cli = Cli::try_parse_from(["bzr", "attachment", "download", "100", "--out", "-"]).unwrap();
+    match cli.command {
+        Commands::Attachment {
+            action: AttachmentAction::Download { ids, out, .. },
+        } => {
+            assert_eq!(ids, vec![100]);
+            assert_eq!(out.as_deref(), Some("-"));
+        }
+        _ => panic!("expected Attachment Download"),
+    }
+}
+
+#[test]
 fn parse_attachment_download_multiple_positional_ids() {
     let cli = Cli::try_parse_from(["bzr", "attachment", "download", "100", "200", "300"]).unwrap();
     match cli.command {

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -386,10 +386,10 @@ fn single_download_dest(out: Option<&str>, server_filename: &str) -> Result<std:
     }
 }
 
-/// Single-attachment download: writes one decoded blob to `out` (if
-/// supplied) or to the attachment's stored `file_name` in the current
-/// directory. Paired with `download_batch` for bulk shapes; both paths
-/// are first-class.
+/// Single-attachment download: writes one decoded blob to stdout when
+/// `--out -` is supplied, otherwise to `out` or the attachment's stored
+/// `file_name` in the current directory. Paired with `download_batch`
+/// for bulk shapes; both paths are first-class.
 async fn download_single(
     client: &BugzillaClient,
     id: u64,
@@ -398,6 +398,10 @@ async fn download_single(
     w: &mut Writers<'_>,
 ) -> Result<()> {
     let (filename, data) = client.download_attachment(id).await?;
+    if out == Some("-") {
+        w.out.write_all(&data)?;
+        return Ok(());
+    }
     let dest = single_download_dest(out, &filename)?;
     std::fs::write(&dest, &data)?;
     let dest = dest.to_string_lossy().into_owned();

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -1431,6 +1431,54 @@ async fn attachment_download_batch_legacy_single_id_unchanged() {
 }
 
 #[tokio::test]
+async fn attachment_download_single_out_dash_streams_bytes_without_result() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/9876"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "attachments": {
+                "9876": one_att(9876, 12345, "trace.bin", b"raw\0bytes\n"),
+            }
+        })))
+        .mount(&mock)
+        .await;
+
+    let dash_path = std::path::Path::new("-");
+    assert!(
+        !dash_path.exists(),
+        "stdout-mode test requires no pre-existing file named '-' in the cwd",
+    );
+
+    let action = AttachmentAction::Download {
+        ids: vec![9876],
+        bug_ids: vec![],
+        out: Some("-".into()),
+        out_dir: "./attachments".into(),
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    let wrote_dash_file = dash_path.exists();
+    if wrote_dash_file {
+        std::fs::remove_file(dash_path).unwrap();
+    }
+
+    assert!(result.is_ok(), "expected stdout download, got {result:?}");
+    assert_eq!(io.out, b"raw\0bytes\n");
+    assert!(
+        io.err.is_empty(),
+        "stderr should stay empty: {:?}",
+        io.err_str()
+    );
+    assert!(
+        !wrote_dash_file,
+        "--out - must stream to stdout, not create a file named '-'",
+    );
+}
+
+#[tokio::test]
 async fn attachment_download_batch_bug_not_found_partial_failure() {
     let (_lock, mock, tmp) = setup_test_env().await;
 


### PR DESCRIPTION
## Summary
- add `attachment download <ID> --out -` for raw single-attachment streaming
- suppress formatted stdout output in stream mode so bytes are not corrupted
- document stdout behavior and the literal `./-` filename escape

Closes #387

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test attachment_download --test integration`
- `cargo test attachment_download --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `agent-skills/tests/drift-check.sh`
- `BZR_BIN=target/debug/bzr agent-skills/tests/flag-drift-check.sh`
- `cargo test`
- pre-push hook: `cargo test`