### PR TITLE
feat(component): resolve updates by product and name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   attachment comments consistently. (#386)
 - `attachment download <ID> --out -` now streams a single attachment's raw bytes
   to stdout without writing a file or emitting formatted result output. (#387)
+- `component update` now accepts `--product <PRODUCT> --component <COMPONENT>`
+  and JSON `product`/`component` targets, resolving exact component names
+  without a separate ID lookup. (#388)
 - `bug update` now accepts `--url` and `--target-milestone`, matching fields
   that `bug create` can already set. (#363)
 - `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept

--- a/agent-skills/skills/bzr-reference/reference/commands.md
+++ b/agent-skills/skills/bzr-reference/reference/commands.md
@@ -88,7 +88,8 @@ Operate on bugs.
 ## component
 - `bzr component list --product Fedora [--json]`        # components of a product
 - `bzr component view Fedora kernel [--json]`           # one component's detail
-- `bzr component create ...` / `bzr component update ...` (admin only)
+- `bzr component create ...` / `bzr component update --product Fedora --component kernel ...`
+  (admin only)
 - `bzr product view <product>` also lists components inline.
 
 ## template

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -193,7 +193,8 @@ bzr [--server <NAME>] [--server-url <URL>] [--server-api-key-env <ENV>] [--serve
 │   ├── list --product <P>
 │   ├── view <PRODUCT> <COMPONENT>
 │   ├── create [--from-json <PATH>] [--product <P>] [--name <N>] [--description <D>] [--default-assignee <E>]
-│   └── update [<ID>] [--from-json <PATH>] [--name <N>] [--description <D>] [--default-assignee <E>]
+│   └── update [<ID>] [--from-json <PATH>] [--product <P>] [--component <C>]
+│              [--name <N>] [--description <D>] [--default-assignee <E>]
 ├── config
 │   ├── set-server <NAME> --url <URL> [--api-key <KEY> | --api-key-env <ENV_VAR>] [--email <EMAIL>] [--auth-method <METHOD>]
 │   │                     [--tls-insecure] [--tls-ca-cert <PATH>] [--tls-pin-sha256 <HEX>] [--tls-pin-now] [--tls-pin-clear]
@@ -1458,10 +1459,11 @@ Agent note: this is safer after confirming the product exists with `bzr --json p
 
 ### `bzr component update`
 
-Update an existing component (requires admin privileges).
+Update an existing component by ID or exact product/component name (requires admin privileges).
 
 ```bash
 bzr component update 42 --name "renamed-component"
+bzr component update --product MyApp --component Backend --description "Updated backend"
 bzr component update 42 --default-assignee newdev@example.com
 bzr component update --from-json component-update.json --name "renamed-component"
 bzr --dry-run component update 42 --default-assignee newdev@example.com
@@ -1469,11 +1471,17 @@ bzr --dry-run component update 42 --default-assignee newdev@example.com
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `<ID>` | Yes unless JSON supplies `id` | Component ID |
+| `<ID>` | Yes unless another target is supplied | Component ID |
+| `--product <P>` | With `--component` for name target | Product containing the component |
+| `--component <C>` | With `--product` for name target | Existing component name, exact match |
 | `--from-json <PATH>` | No | Read component update fields from a JSON object (`-` reads stdin). Schema: `bzr schema component-update-input` |
 | `--name <N>` | No | New name |
 | `--description <D>` | No | New description |
 | `--default-assignee <E>` | No | New default assignee |
+
+Use either `<ID>`, JSON `id`, CLI `--product`/`--component`, or JSON
+`product`/`component` as the target. `--name` is always the new name, not the
+target component name.
 
 ---
 

--- a/schemas/component-update-input.json
+++ b/schemas/component-update-input.json
@@ -2,13 +2,21 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/randomparity/bzr/schemas/component-update-input.json",
   "title": "ComponentUpdateInput",
-  "description": "Object payload accepted by `component update --from-json`. The target component ID may be supplied by positional CLI argument or by the JSON `id` field, but not both.",
+  "description": "Object payload accepted by `component update --from-json`.",
   "type": "object",
   "properties": {
     "id": {
       "type": ["integer", "null"],
       "minimum": 0,
       "examples": [42]
+    },
+    "product": {
+      "type": ["string", "null"],
+      "examples": ["MyApp"]
+    },
+    "component": {
+      "type": ["string", "null"],
+      "examples": ["Backend"]
     },
     "name": {
       "type": ["string", "null"],

--- a/src/cli/component.rs
+++ b/src/cli/component.rs
@@ -89,31 +89,40 @@ pub enum ComponentAction {
         default_assignee: Option<String>,
     },
 
-    /// Update an existing component by ID (admin only).
+    /// Update an existing component by ID or product/name (admin only).
     ///
     /// Requires Bugzilla admin permissions. Pass any of the flags
     /// to change that property: `--name`, `--description`,
     /// `--default-assignee`. Only the supplied fields are modified.
     ///
-    /// The numeric `<id>` is the component ID, not the name.
-    /// Discover IDs via `bzr product view <product>` (look for
-    /// `components[].id`).
+    /// The numeric `<id>` is the component ID, not the name. As a
+    /// human-oriented alternative, pass `--product <PRODUCT>` with
+    /// `--component <COMPONENT>` to resolve the current component name
+    /// exactly within that product. `--name` remains the new component
+    /// name.
     ///
     /// Examples:
     ///
     ///   bzr component update 42 --description "Updated description"
+    ///   bzr component update --product MyApp --component Backend \
+    ///     --description "Updated description"
     ///   bzr component update 42 --default-assignee newowner@example.com
     ///
     /// See bzr-component-create(1) for new components and
-    /// bzr-product-view(1) to find component IDs.
+    /// bzr-product-view(1) to inspect component IDs and names.
     #[command(verbatim_doc_comment)]
     Update {
         /// Read component update fields from a JSON object (`-` reads stdin)
         #[arg(long, value_name = "PATH")]
         from_json: Option<String>,
         /// Component ID
-        #[arg(required_unless_present = "from_json")]
         id: Option<u64>,
+        /// Product name for name-based targeting
+        #[arg(long, value_name = "PRODUCT")]
+        product: Option<String>,
+        /// Current component name for name-based targeting
+        #[arg(long, value_name = "COMPONENT")]
+        component: Option<String>,
         /// New name
         #[arg(long)]
         name: Option<String>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -577,7 +577,7 @@ pub enum Commands {
     ///   bzr component create --product MyProduct --name Backend \
     ///     --description "Backend services" \
     ///     --default-assignee dev@example.com
-    ///   bzr component update --product MyProduct --name Backend \
+    ///   bzr component update --product MyProduct --component Backend \
     ///     --description "Updated description"
     ///
     /// See bzr-component-create(1) and bzr-component-update(1) for

--- a/src/cli/mod_tests.rs
+++ b/src/cli/mod_tests.rs
@@ -540,6 +540,39 @@ fn parse_component_update_from_json_stdin() {
 }
 
 #[test]
+fn parse_component_update_with_product_component_target() {
+    let cli = Cli::try_parse_from([
+        "bzr",
+        "component",
+        "update",
+        "--product",
+        "MyApp",
+        "--component",
+        "Backend",
+        "--description",
+        "Updated",
+    ])
+    .unwrap();
+    let Commands::Component {
+        action:
+            ComponentAction::Update {
+                id,
+                product,
+                component,
+                description,
+                ..
+            },
+    } = cli.command
+    else {
+        panic!("expected component update");
+    };
+    assert!(id.is_none());
+    assert_eq!(product.as_deref(), Some("MyApp"));
+    assert_eq!(component.as_deref(), Some("Backend"));
+    assert_eq!(description.as_deref(), Some("Updated"));
+}
+
+#[test]
 fn parse_user_create_from_json_stdin() {
     let cli = Cli::try_parse_from(["bzr", "user", "create", "--from-json", "-"]).unwrap();
     let Commands::User {

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -1,4 +1,5 @@
 use crate::cli::ComponentAction;
+use crate::client::BugzillaClient;
 use crate::error::{BzrError, Result};
 use crate::output::resources::component::{write_component, write_components};
 use crate::output::result_types::{write_result, ActionResult, DryRunResult, ResourceKind};
@@ -21,9 +22,45 @@ struct JsonCreateComponent {
 #[serde(deny_unknown_fields)]
 struct JsonUpdateComponent {
     id: Option<u64>,
+    product: Option<String>,
+    component: Option<String>,
     name: Option<String>,
     description: Option<String>,
     default_assignee: Option<String>,
+}
+
+enum ComponentUpdateTarget {
+    Id(u64),
+    Named { product: String, component: String },
+}
+
+struct ComponentUpdateInput {
+    target: ComponentUpdateTarget,
+    params: UpdateComponentParams,
+}
+
+struct UpdateParamSources<'a> {
+    from_json: Option<&'a str>,
+    id: Option<u64>,
+    product: Option<&'a str>,
+    component: Option<&'a str>,
+    name: Option<&'a str>,
+    description: Option<&'a str>,
+    default_assignee: Option<&'a str>,
+}
+
+struct UpdateTargetSources<'a> {
+    cli_id: Option<u64>,
+    json_id: Option<u64>,
+    cli_product: Option<&'a str>,
+    cli_component: Option<&'a str>,
+    json_product: Option<String>,
+    json_component: Option<String>,
+}
+
+struct NamedComponentTarget {
+    product: String,
+    component: String,
 }
 
 pub async fn execute(
@@ -91,39 +128,71 @@ pub async fn execute(
         ComponentAction::Update {
             from_json,
             id,
+            product,
+            component,
             name,
             description,
             default_assignee,
         } => {
-            let (id, params) = build_update_params(
-                from_json.as_deref(),
-                *id,
-                name.as_deref(),
-                description.as_deref(),
-                default_assignee.as_deref(),
-            )?;
-            if super::runtime::dry_run::enabled() {
-                let ids = [id];
-                let message = format!("Would update component #{id}");
-                write_result(
-                    &DryRunResult::new(ResourceKind::Component, &ids, &params),
-                    &message,
-                    format,
-                    w.out,
-                );
-                return Ok(());
-            }
-            let client = super::runtime::shared::connect_and_configure(server, api).await?;
-            client.update_component(id, &params).await?;
-            write_result(
-                &ActionResult::updated(id, ResourceKind::Component),
-                &format!("Updated component #{id}"),
-                format,
-                w.out,
-            );
+            let sources = UpdateParamSources {
+                from_json: from_json.as_deref(),
+                id: *id,
+                product: product.as_deref(),
+                component: component.as_deref(),
+                name: name.as_deref(),
+                description: description.as_deref(),
+                default_assignee: default_assignee.as_deref(),
+            };
+            execute_update(&sources, server, format, api, w).await?;
         }
     }
     Ok(())
+}
+
+async fn execute_update(
+    sources: &UpdateParamSources<'_>,
+    server: Option<&str>,
+    format: OutputFormat,
+    api: Option<ApiMode>,
+    w: &mut Writers<'_>,
+) -> Result<()> {
+    let update = build_update_input(sources)?;
+    if super::runtime::dry_run::enabled() {
+        if let ComponentUpdateTarget::Id(id) = &update.target {
+            write_update_dry_run(*id, &update.params, format, w);
+            return Ok(());
+        }
+    }
+    let client = super::runtime::shared::connect_and_configure(server, api).await?;
+    let id = resolve_update_target_id(&client, &update.target).await?;
+    if super::runtime::dry_run::enabled() {
+        write_update_dry_run(id, &update.params, format, w);
+        return Ok(());
+    }
+    client.update_component(id, &update.params).await?;
+    write_result(
+        &ActionResult::updated(id, ResourceKind::Component),
+        &format!("Updated component #{id}"),
+        format,
+        w.out,
+    );
+    Ok(())
+}
+
+fn write_update_dry_run(
+    id: u64,
+    params: &UpdateComponentParams,
+    format: OutputFormat,
+    w: &mut Writers<'_>,
+) {
+    let ids = [id];
+    let message = format!("Would update component #{id}");
+    write_result(
+        &DryRunResult::new(ResourceKind::Component, &ids, params),
+        &message,
+        format,
+        w.out,
+    );
 }
 
 #[must_use]
@@ -169,34 +238,142 @@ fn build_create_params(
     })
 }
 
-fn build_update_params(
-    from_json: Option<&str>,
-    id: Option<u64>,
-    name: Option<&str>,
-    description: Option<&str>,
-    default_assignee: Option<&str>,
-) -> Result<(u64, UpdateComponentParams)> {
-    let mut input = if let Some(arg) = from_json {
+fn build_update_input(sources: &UpdateParamSources<'_>) -> Result<ComponentUpdateInput> {
+    let mut input = if let Some(arg) = sources.from_json {
         super::runtime::from_json::read_object::<JsonUpdateComponent>(arg)?
     } else {
         JsonUpdateComponent::default()
     };
-    let target = super::runtime::from_json::resolve_u64_target(
-        id,
-        input.id.take(),
-        "--from-json object cannot combine positional component ID with JSON id",
-        "--from-json object requires a component id",
-    )?;
-    super::runtime::from_json::merge_string(&mut input.name, name);
-    super::runtime::from_json::merge_string(&mut input.description, description);
-    super::runtime::from_json::merge_string(&mut input.default_assignee, default_assignee);
+    let target = resolve_update_target(UpdateTargetSources {
+        cli_id: sources.id,
+        json_id: input.id.take(),
+        cli_product: sources.product,
+        cli_component: sources.component,
+        json_product: input.product.take(),
+        json_component: input.component.take(),
+    })?;
+    super::runtime::from_json::merge_string(&mut input.name, sources.name);
+    super::runtime::from_json::merge_string(&mut input.description, sources.description);
+    super::runtime::from_json::merge_string(&mut input.default_assignee, sources.default_assignee);
     let params = UpdateComponentParams {
         name: input.name,
         description: input.description,
         default_assignee: input.default_assignee,
     };
     validate_update_params(&params)?;
-    Ok((target, params))
+    Ok(ComponentUpdateInput { target, params })
+}
+
+fn resolve_update_target(sources: UpdateTargetSources<'_>) -> Result<ComponentUpdateTarget> {
+    if sources.cli_id.is_some() && sources.json_id.is_some() {
+        return Err(BzrError::InputValidation(
+            "--from-json object cannot combine positional component ID with JSON id".into(),
+        ));
+    }
+    let cli_named = named_target_from_cli(sources.cli_product, sources.cli_component)?;
+    let json_named = named_target_from_json(sources.json_product, sources.json_component)?;
+    let id = sources.cli_id.or(sources.json_id);
+
+    if id.is_some() && (cli_named.is_some() || json_named.is_some()) {
+        return Err(BzrError::InputValidation(
+            "component update target must use either component ID or --product/--component, \
+             not both"
+                .into(),
+        ));
+    }
+    if cli_named.is_some() && json_named.is_some() {
+        return Err(BzrError::InputValidation(
+            "--from-json object cannot combine CLI --product/--component with JSON \
+             product/component target fields"
+                .into(),
+        ));
+    }
+    if let Some(id) = id {
+        return Ok(ComponentUpdateTarget::Id(id));
+    }
+    let named = cli_named.or(json_named).ok_or_else(|| {
+        BzrError::InputValidation(
+            "component update requires a component target: pass <ID>, \
+             --product <PRODUCT> --component <COMPONENT>, or JSON id/product/component \
+             via --from-json"
+                .into(),
+        )
+    })?;
+    Ok(ComponentUpdateTarget::Named {
+        product: named.product,
+        component: named.component,
+    })
+}
+
+fn named_target_from_cli(
+    product: Option<&str>,
+    component: Option<&str>,
+) -> Result<Option<NamedComponentTarget>> {
+    match (product, component) {
+        (Some(product), Some(component)) => Ok(Some(NamedComponentTarget {
+            product: product.to_string(),
+            component: component.to_string(),
+        })),
+        (Some(_), None) => Err(BzrError::InputValidation(
+            "--product requires --component to target component update by name".into(),
+        )),
+        (None, Some(_)) => Err(BzrError::InputValidation(
+            "--component requires --product to target component update by name".into(),
+        )),
+        (None, None) => Ok(None),
+    }
+}
+
+fn named_target_from_json(
+    product: Option<String>,
+    component: Option<String>,
+) -> Result<Option<NamedComponentTarget>> {
+    match (product, component) {
+        (Some(product), Some(component)) => Ok(Some(NamedComponentTarget { product, component })),
+        (Some(_), None) | (None, Some(_)) => Err(BzrError::InputValidation(
+            "--from-json: 'product' and 'component' must be supplied together for \
+             name-based component update targeting"
+                .into(),
+        )),
+        (None, None) => Ok(None),
+    }
+}
+
+async fn resolve_update_target_id(
+    client: &BugzillaClient,
+    target: &ComponentUpdateTarget,
+) -> Result<u64> {
+    match target {
+        ComponentUpdateTarget::Id(id) => Ok(*id),
+        ComponentUpdateTarget::Named { product, component } => {
+            let product_data = client.get_product(product).await?;
+            find_component_id(&product_data, product, component)
+        }
+    }
+}
+
+fn find_component_id(
+    product_data: &crate::types::Product,
+    product: &str,
+    component_name: &str,
+) -> Result<u64> {
+    let mut found = None;
+    for component in &product_data.components {
+        if component.name != component_name {
+            continue;
+        }
+        if found.is_some() {
+            return Err(BzrError::InputValidation(format!(
+                "component name '{component_name}' is ambiguous in product '{product}'; \
+                 use numeric component ID"
+            )));
+        }
+        found = Some(component.id);
+    }
+    found.ok_or_else(|| BzrError::NotFound {
+        resource: "component",
+        id: format!("{product}/{component_name}"),
+    })
 }
 
 fn validate_update_params(params: &UpdateComponentParams) -> Result<()> {

--- a/src/commands/component_tests.rs
+++ b/src/commands/component_tests.rs
@@ -40,6 +40,31 @@ async fn mount_product_with_components(mock: &wiremock::MockServer) {
         .await;
 }
 
+/// Mock `GET /rest/product?names=MyApp` returning duplicate component names.
+async fn mount_product_with_duplicate_components(mock: &wiremock::MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/rest/product"))
+        .and(query_param("names", "MyApp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "products": [{
+                "id": 1,
+                "name": "MyApp",
+                "description": "App",
+                "is_active": true,
+                "components": [
+                    {"id": 10, "name": "Backend", "description": "be", "is_active": true,
+                     "default_assignee": "dev@example.com"},
+                    {"id": 12, "name": "Backend", "description": "duplicate", "is_active": true,
+                     "default_assignee": "other@example.com"}
+                ],
+                "versions": [],
+                "milestones": []
+            }]
+        })))
+        .mount(mock)
+        .await;
+}
+
 #[tokio::test]
 async fn component_list_returns_components() {
     let (_lock, mock, _tmp) = setup_test_env().await;
@@ -237,6 +262,8 @@ async fn component_update_succeeds() {
     let action = ComponentAction::Update {
         from_json: None,
         id: Some(10),
+        product: None,
+        component: None,
         name: Some("Updated".to_string()),
         description: None,
         default_assignee: None,
@@ -258,6 +285,164 @@ async fn component_update_succeeds() {
 }
 
 #[tokio::test]
+async fn component_update_by_product_and_component_resolves_id() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mount_product_with_components(&mock).await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/component/10"))
+        .and(body_json(serde_json::json!({"description": "Updated"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 10})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let action = ComponentAction::Update {
+        from_json: None,
+        id: None,
+        product: Some("MyApp".to_string()),
+        component: Some("Backend".to_string()),
+        name: None,
+        description: Some("Updated".to_string()),
+        default_assignee: None,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    assert!(
+        result.is_ok(),
+        "component update by product/name failed: {result:?}"
+    );
+    let parsed = serde_json::from_str::<serde_json::Value>(io.out_str().trim()).unwrap();
+    assert_eq!(parsed["id"], 10);
+    assert_eq!(parsed["action"], "updated");
+}
+
+#[tokio::test]
+async fn component_update_from_json_uses_product_component_target() {
+    let (_lock, mock, tmp) = setup_test_env().await;
+    mount_product_with_components(&mock).await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/component/10"))
+        .and(body_json(serde_json::json!({"description": "Updated"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": 10})))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let json = r#"{"product":"MyApp","component":"Backend","description":"Updated"}"#;
+    let action = ComponentAction::Update {
+        from_json: Some(write_json_file(&tmp, json)),
+        id: None,
+        product: None,
+        component: None,
+        name: None,
+        description: None,
+        default_assignee: None,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    assert!(
+        result.is_ok(),
+        "component update from JSON product/name target failed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn component_update_rejects_id_and_product_component_target() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    let action = ComponentAction::Update {
+        from_json: None,
+        id: Some(10),
+        product: Some("MyApp".to_string()),
+        component: Some("Backend".to_string()),
+        name: None,
+        description: Some("Updated".to_string()),
+        default_assignee: None,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    assert!(
+        matches!(result, Err(BzrError::InputValidation(ref msg))
+            if msg.contains("either component ID or --product/--component")),
+        "expected mixed-target validation, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn component_update_rejects_product_without_component() {
+    let (_lock, _mock, _tmp) = setup_test_env().await;
+    let action = ComponentAction::Update {
+        from_json: None,
+        id: None,
+        product: Some("MyApp".to_string()),
+        component: None,
+        name: None,
+        description: Some("Updated".to_string()),
+        default_assignee: None,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    assert!(
+        matches!(result, Err(BzrError::InputValidation(ref msg))
+            if msg.contains("--product requires --component")),
+        "expected missing component validation, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn component_update_named_target_unknown_component_is_not_found() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mount_product_with_components(&mock).await;
+
+    let action = ComponentAction::Update {
+        from_json: None,
+        id: None,
+        product: Some("MyApp".to_string()),
+        component: Some("Missing".to_string()),
+        name: None,
+        description: Some("Updated".to_string()),
+        default_assignee: None,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    assert!(
+        matches!(result, Err(BzrError::NotFound { resource: "component", ref id })
+            if id == "MyApp/Missing"),
+        "expected component not found, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn component_update_named_target_duplicate_component_is_ambiguous() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+    mount_product_with_duplicate_components(&mock).await;
+
+    let action = ComponentAction::Update {
+        from_json: None,
+        id: None,
+        product: Some("MyApp".to_string()),
+        component: Some("Backend".to_string()),
+        name: None,
+        description: Some("Updated".to_string()),
+        default_assignee: None,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    assert!(
+        matches!(result, Err(BzrError::InputValidation(ref msg))
+            if msg.contains("ambiguous") && msg.contains("numeric component ID")),
+        "expected duplicate component ambiguity, got {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn component_update_dry_run_makes_no_write_and_marks_payload() {
     let (_lock, mock, _tmp) = setup_test_env().await;
 
@@ -271,6 +456,8 @@ async fn component_update_dry_run_makes_no_write_and_marks_payload() {
     let action = ComponentAction::Update {
         from_json: None,
         id: Some(10),
+        product: None,
+        component: None,
         name: Some("Updated".to_string()),
         description: None,
         default_assignee: Some("owner@test.com".to_string()),
@@ -312,6 +499,8 @@ async fn component_update_from_json_uses_json_target() {
     let action = ComponentAction::Update {
         from_json: Some(write_json_file(&tmp, json)),
         id: None,
+        product: None,
+        component: None,
         name: None,
         description: None,
         default_assignee: Some("owner@test.com".to_string()),
@@ -332,6 +521,8 @@ async fn component_update_from_json_rejects_positional_and_json_target() {
     let action = ComponentAction::Update {
         from_json: Some(write_json_file(&tmp, json)),
         id: Some(11),
+        product: None,
+        component: None,
         name: None,
         description: None,
         default_assignee: None,
@@ -343,6 +534,52 @@ async fn component_update_from_json_rejects_positional_and_json_target() {
         matches!(result, Err(crate::error::BzrError::InputValidation(ref msg))
             if msg.contains("cannot combine positional component ID")),
         "expected target conflict, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn component_update_from_json_rejects_id_and_product_component_target() {
+    let (_lock, _mock, tmp) = setup_test_env().await;
+    let json = r#"{"id":10,"product":"MyApp","component":"Backend","description":"Updated"}"#;
+    let action = ComponentAction::Update {
+        from_json: Some(write_json_file(&tmp, json)),
+        id: None,
+        product: None,
+        component: None,
+        name: None,
+        description: None,
+        default_assignee: None,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    assert!(
+        matches!(result, Err(BzrError::InputValidation(ref msg))
+            if msg.contains("either component ID or --product/--component")),
+        "expected JSON mixed-target validation, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn component_update_from_json_rejects_partial_product_component_target() {
+    let (_lock, _mock, tmp) = setup_test_env().await;
+    let json = r#"{"product":"MyApp","description":"Updated"}"#;
+    let action = ComponentAction::Update {
+        from_json: Some(write_json_file(&tmp, json)),
+        id: None,
+        product: None,
+        component: None,
+        name: None,
+        description: None,
+        default_assignee: None,
+    };
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    assert!(
+        matches!(result, Err(BzrError::InputValidation(ref msg))
+            if msg.contains("'product' and 'component' must be supplied together")),
+        "expected partial JSON name-target validation, got {result:?}"
     );
 }
 
@@ -422,6 +659,8 @@ async fn component_update_without_fields_is_rejected() {
     let action = ComponentAction::Update {
         from_json: None,
         id: Some(10),
+        product: None,
+        component: None,
         name: None,
         description: None,
         default_assignee: None,

--- a/src/commands/runtime/from_json.rs
+++ b/src/commands/runtime/from_json.rs
@@ -49,19 +49,6 @@ pub(crate) fn resolve_string_target(
     }
 }
 
-pub(crate) fn resolve_u64_target(
-    positional: Option<u64>,
-    json: Option<u64>,
-    conflict: &str,
-    missing: &str,
-) -> Result<u64> {
-    match (positional, json) {
-        (Some(_), Some(_)) => Err(BzrError::InputValidation(conflict.into())),
-        (Some(value), None) | (None, Some(value)) => Ok(value),
-        (None, None) => Err(BzrError::InputValidation(missing.into())),
-    }
-}
-
 fn parse_object<T: DeserializeOwned>(raw: &str) -> Result<T> {
     let value: serde_json::Value = serde_json::from_str(raw)
         .map_err(|e| BzrError::InputValidation(format!("--from-json: invalid JSON: {e}")))?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1604,6 +1604,8 @@ async fn component_update_integration() {
     let action = bzr::cli::ComponentAction::Update {
         from_json: None,
         id: Some(10),
+        product: None,
+        component: None,
         name: Some("Updated".to_string()),
         description: None,
         default_assignee: None,


### PR DESCRIPTION
## Summary
- add `component update --product <PRODUCT> --component <COMPONENT>` targeting
- support JSON `product`/`component` targets for `component update --from-json`
- document numeric and name-based workflows, update schema and agent command references

Closes #388

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test component_update --lib`
- `cargo test component --lib`
- `cargo test component_update --test integration`
- `cargo test schema --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `agent-skills/tests/drift-check.sh`
- `BZR_BIN=target/debug/bzr agent-skills/tests/flag-drift-check.sh`
- `cargo test`
- pre-push hook: `cargo test`