### PR TITLE
fix(commands): reject no-op mutation commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `attachment update <ID>` and `comment tag <COMMENT_ID>` now reject no-op
+  invocations before contacting Bugzilla and suggest the flags needed to make a
+  change. (#389)
 - Documented that `bug create` has no Bugzilla-backed idempotency-key support
   and that agents should inspect before retrying ambiguous create failures.
   (#370)

--- a/src/commands/attachment.rs
+++ b/src/commands/attachment.rs
@@ -257,8 +257,29 @@ fn validate_action(action: &AttachmentAction) -> Result<()> {
         } if ids.len() != 1 => Err(crate::error::BzrError::InputValidation(
             "--out requires exactly one attachment ID".into(),
         )),
+        AttachmentAction::Update(args) if !update_has_changes(args) => {
+            Err(crate::error::BzrError::InputValidation(
+                "no attachment fields to update; specify at least one of --summary, --file-name, \
+                 --content-type, --obsolete/--no-obsolete, --patch/--no-patch, \
+                 --private/--no-private, or --flag"
+                    .into(),
+            ))
+        }
         _ => Ok(()),
     }
+}
+
+fn update_has_changes(args: &crate::cli::attachment::UpdateArgs) -> bool {
+    args.summary.is_some()
+        || args.file_name.is_some()
+        || args.content_type.is_some()
+        || args.obsolete
+        || args.no_obsolete
+        || args.patch
+        || args.no_patch
+        || args.private
+        || args.no_private
+        || !args.flag.is_empty()
 }
 
 /// Maps file extensions (compared case-insensitively) to their MIME type.

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -571,6 +571,46 @@ async fn attachment_update_unset_bools_are_omitted() {
     assert!(!body.contains("is_private"), "body: {body}");
 }
 
+#[tokio::test]
+async fn attachment_update_without_changes_is_rejected_before_put() {
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/attachment/8"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let action = AttachmentAction::Update(UpdateArgs {
+        id: 8,
+        summary: None,
+        file_name: None,
+        content_type: None,
+        obsolete: false,
+        no_obsolete: false,
+        patch: false,
+        no_patch: false,
+        private: false,
+        no_private: false,
+        flag: vec![],
+    });
+    let mut io = crate::test_helpers::CapturedIo::new();
+    let result = super::execute(&action, None, OutputFormat::Json, None, &mut io.writers()).await;
+
+    let err = result.unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+    let msg = err.to_string();
+    assert!(
+        msg.contains("no attachment fields to update"),
+        "error should name the missing change: {msg}"
+    );
+    assert!(
+        msg.contains("--summary") && msg.contains("--flag"),
+        "error should suggest update flags: {msg}"
+    );
+}
+
 #[test]
 fn guess_content_type_text_plain() {
     assert_eq!(guess_content_type("file.txt"), "text/plain");

--- a/src/commands/comment.rs
+++ b/src/commands/comment.rs
@@ -26,6 +26,7 @@ pub async fn execute(
     api: Option<ApiMode>,
     w: &mut Writers<'_>,
 ) -> Result<()> {
+    validate_action(action)?;
     let client = super::runtime::shared::connect_and_configure(server, api).await?;
 
     match action {
@@ -107,6 +108,15 @@ pub async fn execute(
         }
     }
     Ok(())
+}
+
+fn validate_action(action: &CommentAction) -> Result<()> {
+    match action {
+        CommentAction::Tag { add, remove, .. } if add.is_empty() && remove.is_empty() => Err(
+            BzrError::InputValidation("no comment tag changes; specify --add or --remove".into()),
+        ),
+        _ => Ok(()),
+    }
 }
 
 /// Read comment body from stdin (pipe) or $EDITOR (TTY).

--- a/src/commands/comment_tests.rs
+++ b/src/commands/comment_tests.rs
@@ -215,3 +215,42 @@ async fn comment_list_rejects_malformed_since_with_exit_code_7() {
         "error should echo the offending input: {msg}"
     );
 }
+
+#[tokio::test]
+async fn comment_tag_without_changes_is_rejected_before_put() {
+    let mut __cap_io = crate::test_helpers::CapturedIo::new();
+    let (_lock, mock, _tmp) = setup_test_env().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/comment/100/tags"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let action = CommentAction::Tag {
+        comment_id: 100,
+        add: vec![],
+        remove: vec![],
+    };
+    let result = crate::commands::comment::execute(
+        &action,
+        None,
+        OutputFormat::Json,
+        None,
+        &mut __cap_io.writers(),
+    )
+    .await;
+
+    let err = result.unwrap_err();
+    assert_eq!(err.exit_code(), 7);
+    let msg = err.to_string();
+    assert!(
+        msg.contains("no comment tag changes"),
+        "error should name the missing change: {msg}"
+    );
+    assert!(
+        msg.contains("--add") && msg.contains("--remove"),
+        "error should suggest tag flags: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary
- reject empty attachment update payloads before creating a Bugzilla client
- reject comment tag calls with no --add/--remove changes before creating a Bugzilla client
- add regression tests proving both no-op mutations exit 7 and make no PUT request

Closes #389

## Tests
- cargo test without_changes_is_rejected_before_put --lib
- cargo test attachment_update --lib
- cargo test comment_tag --lib
- cargo test attachment_update --test integration
- cargo test comment_tag --test integration
- cargo fmt --check
- git diff --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build
- cargo test