### PR TITLE
feat(schema): publish error envelope contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `component update` now accepts `--product <PRODUCT> --component <COMPONENT>`
   and JSON `product`/`component` targets, resolving exact component names
   without a separate ID lookup. (#388)
+- `bzr schema error` now publishes the JSON error envelope emitted on stderr
+  under `--json` and `--output ndjson`. (#390)
 - `bug update` now accepts `--url` and `--target-milestone`, matching fields
   that `bug create` can already set. (#363)
 - `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -2032,6 +2032,7 @@ bzr schema                      # list schema names
 bzr schema bug                  # the bug object (bug view / list elements)
 bzr schema bug-create-input     # `bug create --from-json` payload
 bzr schema bug-update-input     # `bug update --from-json` payload
+bzr schema error                # stderr error envelope under JSON-family output
 bzr schema product-create-input # `product create --from-json` payload
 bzr schema batch-result | jq .  # the batch `bug update` envelope
 ```
@@ -2046,7 +2047,7 @@ Available schemas: `bug`, `comment`, `attachment`, `product`, `component`,
 mutation/result envelopes `action-result`, `batch-result`,
 `batch-create-result`, `multi-bug-view`, `tag-result`, `membership-result`,
 `count-result`, `download-result`, `upload-result`, `config-result`,
-`search-result`, `dry-run-result`; and the structured input contracts
+`search-result`, `dry-run-result`, `error`; and the structured input contracts
 `bug-create-input`, `bug-update-input`, `product-create-input`,
 `product-update-input`, `component-create-input`, `component-update-input`,
 `user-create-input`, `user-update-input`, `group-create-input`,
@@ -2174,6 +2175,8 @@ When `--json` is active, errors are emitted as JSON on stderr:
 ```json
 {"error":{"type":"api","message":"Bugzilla API error: Invalid Bug ID (code 101)","exit_code":4}}
 ```
+
+The error envelope schema is published as `bzr schema error`.
 
 ---
 

--- a/schemas/error.json
+++ b/schemas/error.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/randomparity/bzr/schemas/error.json",
+  "title": "ErrorEnvelope",
+  "description": "Structured error object emitted on stderr under `--json` and `--output ndjson`.",
+  "type": "object",
+  "properties": {
+    "error": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "exit_code": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 14
+        }
+      },
+      "required": [
+        "type",
+        "message",
+        "exit_code"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "error"
+  ],
+  "additionalProperties": false
+}

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -41,6 +41,7 @@ pub(crate) const SCHEMAS: &[(&str, &str)] = schema_registry![
     "count-result",
     "download-result",
     "dry-run-result",
+    "error",
     "field-value",
     "group",
     "group-create-input",

--- a/src/commands/schema_tests.rs
+++ b/src/commands/schema_tests.rs
@@ -403,6 +403,7 @@ fn execute_list_json_is_array_of_names() {
     assert!(names.iter().any(|n| n == "bug-update-input"));
     assert!(names.iter().any(|n| n == "component-create-input"));
     assert!(names.iter().any(|n| n == "component-update-input"));
+    assert!(names.iter().any(|n| n == "error"));
     assert!(names.iter().any(|n| n == "group-create-input"));
     assert!(names.iter().any(|n| n == "group-update-input"));
     assert!(names.iter().any(|n| n == "product-create-input"));

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -202,21 +202,18 @@ fn exit_code_maps_non_validation_variant() {
 }
 
 #[test]
-fn exit_code_maps_highest_tls_code() {
-    // Guards the upper bound documented on `exit_code`: the TLS variants
-    // return 13, the largest code, and must survive the `u8::try_from`
-    // conversion without collapsing to the `unwrap_or(1)` fallback.
-    let err = BzrError::PinMismatch {
-        server: "example.com".into(),
-        expected: "sha256//old".into(),
-        actual: "sha256//new".into(),
+fn exit_code_maps_highest_code() {
+    let err = BzrError::MidAirCollision {
+        id: 123,
+        expected: "2026-06-22T01:02:03Z".into(),
+        actual: "2026-06-22T01:02:04Z".into(),
     };
-    assert_eq!(err.exit_code(), 13);
+    assert_eq!(err.exit_code(), 14);
     let code = exit_code(&err);
     let rendered = format!("{code:?}");
     assert!(
-        rendered.contains("13"),
-        "expected ExitCode debug to include 13, got {rendered}"
+        rendered.contains("14"),
+        "expected ExitCode debug to include 14, got {rendered}"
     );
 }
 
@@ -250,6 +247,101 @@ fn format_dispatch_error_ndjson_renders_compact_json_object() {
     assert!(!out.contains('\n'), "ndjson error must be one line: {out}");
     let parsed: serde_json::Value = serde_json::from_str(&out).expect("output must be valid JSON");
     assert_eq!(parsed["error"]["exit_code"], err.exit_code());
+}
+
+fn schema_from_command(name: &str) -> serde_json::Value {
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    let mut writers = bzr::output::writers::Writers::new(&mut out, &mut err);
+
+    bzr::commands::schema::execute(Some(name), OutputFormat::Json, &mut writers)
+        .expect("schema must be published");
+
+    serde_json::from_slice(&out).expect("schema output must be valid JSON")
+}
+
+fn assert_error_matches_schema(schema: &serde_json::Value, value: &serde_json::Value) {
+    let envelope_required = schema
+        .get("required")
+        .and_then(serde_json::Value::as_array)
+        .expect("schema must declare required top-level fields");
+    assert!(
+        envelope_required.iter().any(|field| field == "error"),
+        "schema must require the top-level error envelope"
+    );
+
+    let error_schema = schema
+        .pointer("/properties/error")
+        .expect("schema must describe error property");
+    let required = error_schema
+        .get("required")
+        .and_then(serde_json::Value::as_array)
+        .expect("error property must declare required fields");
+    let error = value
+        .get("error")
+        .and_then(serde_json::Value::as_object)
+        .expect("formatted value must contain an error object");
+    let properties = error_schema
+        .get("properties")
+        .and_then(serde_json::Value::as_object)
+        .expect("error property must declare nested properties");
+
+    for key in ["type", "message", "exit_code"] {
+        assert!(
+            required.iter().any(|field| field == key),
+            "schema must require error.{key}"
+        );
+        assert!(error.contains_key(key), "formatted error missing {key}");
+        assert!(
+            properties.contains_key(key),
+            "schema must describe error.{key}"
+        );
+    }
+
+    assert!(error["type"].is_string());
+    assert!(error["message"].is_string());
+    assert!(error["exit_code"].is_i64() || error["exit_code"].is_u64());
+
+    let exit_code = error["exit_code"]
+        .as_i64()
+        .expect("formatted exit_code must fit in i64");
+    let exit_code_schema = properties
+        .get("exit_code")
+        .expect("schema must describe error.exit_code");
+    let minimum = exit_code_schema
+        .get("minimum")
+        .and_then(serde_json::Value::as_i64)
+        .expect("schema must declare error.exit_code minimum");
+    let maximum = exit_code_schema
+        .get("maximum")
+        .and_then(serde_json::Value::as_i64)
+        .expect("schema must declare error.exit_code maximum");
+    assert!(
+        (minimum..=maximum).contains(&exit_code),
+        "formatted exit_code {exit_code} outside schema bounds {minimum}..={maximum}"
+    );
+}
+
+#[test]
+fn format_dispatch_error_json_family_matches_published_schema() {
+    let schema = schema_from_command("error");
+    let errors = [
+        BzrError::InputValidation("bad input".into()),
+        BzrError::MidAirCollision {
+            id: 123,
+            expected: "2026-06-22T01:02:03Z".into(),
+            actual: "2026-06-22T01:02:04Z".into(),
+        },
+    ];
+
+    for err in errors {
+        for format in [OutputFormat::Json, OutputFormat::Ndjson] {
+            let out = format_dispatch_error(&err, format);
+            let parsed: serde_json::Value =
+                serde_json::from_str(&out).expect("output must be valid JSON");
+            assert_error_matches_schema(&schema, &parsed);
+        }
+    }
 }
 
 #[test]

--- a/tests/functional/phases/18-completion-schema.sh
+++ b/tests/functional/phases/18-completion-schema.sh
@@ -40,7 +40,8 @@ test_begin "116. schema (list)"
 run_bzr schema
 if assert_success && assert_json_valid &&
 	assert_json_exists 'index("bug")' &&
-	assert_json_exists 'index("bug-create-input")'; then test_pass; fi
+	assert_json_exists 'index("bug-create-input")' &&
+	assert_json_exists 'index("error")'; then test_pass; fi
 
 test_begin "117. schema bug (valid draft 2020-12 schema)"
 run_bzr schema bug
@@ -53,8 +54,17 @@ if assert_success && assert_json_valid &&
 	assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema" &&
 	assert_json '.["$defs"].bugUpdateInputObject.additionalProperties' "false"; then test_pass; fi
 
+test_begin "119. schema error (valid error envelope schema)"
+run_bzr schema error
+if assert_success && assert_json_valid &&
+	assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema" &&
+	assert_json '.properties.error.type' "object" &&
+	assert_json_exists '.properties.error.required | index("type")' &&
+	assert_json_exists '.properties.error.required | index("message")' &&
+	assert_json_exists '.properties.error.required | index("exit_code")'; then test_pass; fi
+
 # Error JSON routes to stderr even under --json, so assert there.
-test_begin "119. schema unknown name (input error, exit 7)"
+test_begin "120. schema unknown name (input error, exit 7)"
 run_bzr schema nosuchschema
 if assert_exit_code 7 && assert_stderr_contains '"type":"input"'; then test_pass; fi
 


### PR DESCRIPTION
## Summary
- Add `schemas/error.json` and register `bzr schema error` for JSON-family stderr errors.
- Document the error schema in the CLI reference and changelog.
- Add drift coverage for JSON/NDJSON formatted errors, including the current highest exit code.

Closes #390

## Test Plan
- Red: `cargo test format_dispatch_error_json_family_matches_published_schema --bin bzr` failed before `error` was registered.
- `cargo test format_dispatch_error_json_family_matches_published_schema --bin bzr`
- `cargo test exit_code_maps_highest_code --bin bzr`
- `cargo test schema --lib`
- `shellcheck tests/functional/phases/18-completion-schema.sh`
- `shfmt -d tests/functional/phases/18-completion-schema.sh`
- `cargo build`
- `target/debug/bzr schema error | jq -e '.properties.error.properties.type.type == "string" and .properties.error.properties.message.type == "string" and .properties.error.properties.exit_code.type == "integer" and .properties.error.properties.exit_code.maximum == 14'`
- `target/debug/bzr --json schema | jq -e 'index("error") != null'`
- `cargo fmt --check`
- `git diff --check`
- Added-line length checks for the changed diff and `schemas/error.json`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- Pre-push hook: `cargo test`
