### PR TITLE
docs(cli): guard current long flag names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   without a separate ID lookup. (#388)
 - `bzr schema error` now publishes the JSON error envelope emitted on stderr
   under `--json` and `--output ndjson`. (#390)
+- CLI docs, source help comments, schema descriptions, and bundled agent-skill
+  docs are guarded against stale long flag names such as `--is-patch`,
+  `--format json`, and `--ndjson`. (#391)
 - `bug update` now accepts `--url` and `--target-milestone`, matching fields
   that `bug create` can already set. (#363)
 - `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept
@@ -182,7 +185,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   (#305)
 
 - `bzr schema [NAME]` publishes checked-in JSON Schemas (draft 2020-12) for the
-  `--format json` output of each command family — the read-resource objects
+  `--json` output of each command family — the read-resource objects
   (`bug`, `comment`, `attachment`, `product`, `component`, `classification`,
   `user`, `group`, `field-value`) and the mutation/result envelopes
   (`action-result`, `batch-result`, `batch-create-result`, `multi-bug-view`,

--- a/docs/bzr-cli.md
+++ b/docs/bzr-cli.md
@@ -2038,7 +2038,7 @@ bzr schema batch-result | jq .  # the batch `bug update` envelope
 ```
 
 Listing honors `--output`: a name-per-line table at a TTY, a JSON array under
-`--json`, one JSON string per line under `--ndjson`. Printing a named schema
+`--json`, one JSON string per line under `--output ndjson`. Printing a named schema
 emits the schema document verbatim. An unknown name exits 7 with the list of
 valid names.
 
@@ -2164,7 +2164,7 @@ goes to stderr under `ndjson`, keeping stdout one clean record per line.
 ### Published schemas
 
 `bzr schema` prints checked-in JSON Schemas (draft 2020-12) describing the
-`--format json` shape of each command family, so an agent can validate output
+`--json` shape of each command family, so an agent can validate output
 against a contract instead of branching per command. See
 [`bzr schema`](#bzr-schema----published-json-schemas).
 

--- a/schemas/attachment.json
+++ b/schemas/attachment.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/randomparity/bzr/schemas/attachment.json",
   "title": "Attachment",
-  "description": "A bug attachment as emitted in `--format json` output.",
+  "description": "A bug attachment as emitted in `--json` output.",
   "type": "object",
   "properties": {
     "id": {

--- a/schemas/classification.json
+++ b/schemas/classification.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/randomparity/bzr/schemas/classification.json",
   "title": "Classification",
-  "description": "A Bugzilla classification as emitted in `--format json` output.",
+  "description": "A Bugzilla classification as emitted in `--json` output.",
   "type": "object",
   "properties": {
     "id": {

--- a/schemas/comment.json
+++ b/schemas/comment.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/randomparity/bzr/schemas/comment.json",
   "title": "Comment",
-  "description": "A bug comment as emitted in `--format json` output.",
+  "description": "A bug comment as emitted in `--json` output.",
   "type": "object",
   "properties": {
     "id": {

--- a/schemas/component.json
+++ b/schemas/component.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/randomparity/bzr/schemas/component.json",
   "title": "Component",
-  "description": "A product component as emitted in `--format json` output.",
+  "description": "A product component as emitted in `--json` output.",
   "type": "object",
   "properties": {
     "id": {

--- a/schemas/field-value.json
+++ b/schemas/field-value.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/randomparity/bzr/schemas/field-value.json",
   "title": "FieldValue",
-  "description": "An allowable value for a Bugzilla field as emitted in `--format json` output.",
+  "description": "An allowable value for a Bugzilla field as emitted in `--json` output.",
   "type": "object",
   "properties": {
     "name": {

--- a/schemas/group.json
+++ b/schemas/group.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/randomparity/bzr/schemas/group.json",
   "title": "Group",
-  "description": "A Bugzilla group (`GroupInfo`) as emitted in `--format json` output.",
+  "description": "A Bugzilla group (`GroupInfo`) as emitted in `--json` output.",
   "type": "object",
   "properties": {
     "id": {

--- a/schemas/product.json
+++ b/schemas/product.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/randomparity/bzr/schemas/product.json",
   "title": "Product",
-  "description": "A Bugzilla product as emitted in `--format json` output.",
+  "description": "A Bugzilla product as emitted in `--json` output.",
   "type": "object",
   "properties": {
     "id": {

--- a/schemas/user.json
+++ b/schemas/user.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/randomparity/bzr/schemas/user.json",
   "title": "User",
-  "description": "A Bugzilla user (`BugzillaUser`) as emitted in `--format json` output.",
+  "description": "A Bugzilla user (`BugzillaUser`) as emitted in `--json` output.",
   "type": "object",
   "properties": {
     "id": {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -675,7 +675,7 @@ pub enum Commands {
 
     /// Print a published JSON Schema for a command's JSON contract.
     ///
-    /// `--format json` output shapes and selected `--from-json` input payloads
+    /// `--json` output shapes and selected `--from-json` input payloads
     /// are documented as checked-in JSON Schema (draft 2020-12) so agents can
     /// validate against a contract instead of branching per command. Run
     /// without a name to list the available schema names; pass one to print

--- a/src/commands/attachment_tests.rs
+++ b/src/commands/attachment_tests.rs
@@ -404,10 +404,7 @@ async fn attachment_upload_with_is_patch_defaults_content_type_to_text_plain() {
         &mut __cap_io.writers(),
     )
     .await;
-    assert!(
-        result.is_ok(),
-        "upload --is-patch should succeed: {result:?}"
-    );
+    assert!(result.is_ok(), "upload --patch should succeed: {result:?}");
 }
 
 #[tokio::test]
@@ -454,7 +451,7 @@ async fn attachment_upload_is_patch_with_explicit_content_type_keeps_content_typ
     .await;
     assert!(
         result.is_ok(),
-        "upload --is-patch with explicit ct should succeed: {result:?}"
+        "upload --patch with explicit ct should succeed: {result:?}"
     );
 }
 

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -1,7 +1,7 @@
 //! `bzr schema` — publish JSON Schemas for the tool's JSON contracts.
 //!
 //! Purely local: no config, network, or auth. Each schema describes either a
-//! `--format json` output body or a `--from-json` input payload so agents can
+//! `--json` output body or a `--from-json` input payload so agents can
 //! validate against a contract instead of branching per command. The schema
 //! files are checked into `schemas/` at the repo root and embedded here at build
 //! time; drift tests validate representative serialized values and structured
@@ -92,7 +92,7 @@ fn write_one(name: &str, w: &mut Writers<'_>) -> Result<()> {
 }
 
 /// List available schema names: one per line for table, a JSON array for
-/// `--json`, one name per line for `--ndjson`.
+/// `--json`, one name per line for `--output ndjson`.
 fn write_list(format: OutputFormat, w: &mut Writers<'_>) {
     let names = available_names();
     let table = names.join("\n");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1430,7 +1430,7 @@ async fn attachment_upload_with_is_patch_integration() {
     .await;
     assert!(
         result.is_ok(),
-        "upload with --is-patch should succeed: {result:?}"
+        "upload with --patch should succeed: {result:?}"
     );
 }
 
@@ -2624,6 +2624,80 @@ fn cli_and_docs_avoid_misleading_trim_phrasing() {
             );
         }
     }
+}
+
+fn push_files_with_extension(
+    dir: &std::path::Path,
+    extension: &str,
+    files: &mut Vec<std::path::PathBuf>,
+) {
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            push_files_with_extension(&path, extension, files);
+        } else if path.extension().is_some_and(|e| e == extension) {
+            files.push(path);
+        }
+    }
+}
+
+fn check_stale_flag_line(
+    path: &std::path::Path,
+    line_no: usize,
+    line: &str,
+    forbidden: &[(&str, &str)],
+    findings: &mut Vec<String>,
+) {
+    for (old, replacement) in forbidden {
+        if line.contains(old) {
+            findings.push(format!(
+                "{}:{line_no}: replace {old:?} with {replacement:?}",
+                path.display()
+            ));
+        }
+    }
+}
+
+#[test]
+fn docs_and_help_comments_use_current_long_flags() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let forbidden = [
+        ("--is-patch", "--patch"),
+        ("--format json", "--json or --output json"),
+        ("--ndjson", "--output ndjson"),
+    ];
+    let mut findings = Vec::new();
+
+    let mut prose_files = vec![root.join("README.md"), root.join("docs/bzr-cli.md")];
+    push_files_with_extension(&root.join("agent-skills"), "md", &mut prose_files);
+    push_files_with_extension(&root.join("schemas"), "json", &mut prose_files);
+    prose_files.sort();
+
+    for path in prose_files {
+        let content = std::fs::read_to_string(&path).unwrap();
+        for (idx, line) in content.lines().enumerate() {
+            check_stale_flag_line(&path, idx + 1, line, &forbidden, &mut findings);
+        }
+    }
+
+    let mut source_files = Vec::new();
+    push_files_with_extension(&root.join("src"), "rs", &mut source_files);
+    source_files.sort();
+    for path in source_files {
+        let content = std::fs::read_to_string(&path).unwrap();
+        for (idx, line) in content.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("///") || trimmed.starts_with("//!") {
+                check_stale_flag_line(&path, idx + 1, line, &forbidden, &mut findings);
+            }
+        }
+    }
+
+    assert!(
+        findings.is_empty(),
+        "stale CLI flag references:\n{}",
+        findings.join("\n")
+    );
 }
 
 // ── #206 --json field trimming ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- replace stale current-doc references to removed long flags with current spellings
- add an integration drift guard for README/docs, bundled agent-skill docs, schema descriptions, and Rust help comments
- update schema descriptions and attachment patch assertions to use the current `--patch`/`--json`/`--output ndjson` names

Closes #391

## Verification
- baseline `cargo build`
- baseline `cargo test`
- red `cargo test docs_and_help_comments_use_current_long_flags --test integration` against docs/help comments
- red `cargo test docs_and_help_comments_use_current_long_flags --test integration` after extending the guard to schemas
- `cargo test docs_and_help_comments_use_current_long_flags --test integration`
- `cargo test cli_and_docs_avoid_misleading_trim_phrasing --test integration`
- `cargo test attachment_upload_with_is_patch --test integration`
- `cargo test attachment_upload_is_patch --lib`
- `cargo test attachment_upload_with_is_patch --lib`
- `cargo test schema --lib`
- `rg -n -- '--is-patch|--format json|--ndjson' README.md docs/bzr-cli.md agent-skills/README.md agent-skills/skills src schemas`
- `cargo fmt --check`
- `git diff --check`
- `shellcheck agent-skills/tests/flag-drift-check.sh agent-skills/tests/flag-drift-check-test.sh`
- added-line length check
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- pre-push `cargo test`

Note: `shfmt -d agent-skills/tests/flag-drift-check.sh agent-skills/tests/flag-drift-check-test.sh` still reports pre-existing indentation diffs in untouched scripts, so those unrelated changes are not included.