### PR TITLE
docs(agent): refresh bzr skills for CLI follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - CLI docs, source help comments, schema descriptions, and bundled agent-skill
   docs are guarded against stale long flag names such as `--is-patch`,
   `--format json`, and `--ndjson`. (#391)
+- Bundled bzr agent skills now teach the new CLI UX follow-ups: public
+  read-only servers, stateless TLS trust flags, richer `bug my` filters,
+  `query update --from-url`, richer templates and clone overrides, attachment
+  stdin comments, single-attachment stdout downloads, and the error schema.
+  (#392)
 - `bug update` now accepts `--url` and `--target-milestone`, matching fields
   that `bug create` can already set. (#363)
 - `bug resolve`, `bug close`, `bug reopen`, and `bug dup` now accept

--- a/agent-skills/skills/bzr-file-bug/SKILL.md
+++ b/agent-skills/skills/bzr-file-bug/SKILL.md
@@ -22,8 +22,19 @@ bzr template list
 bzr bug create --template <name> --summary "..." --description "..."
 ```
 
-A template supplies saved field defaults (product, component, etc.) so you only
-fill in what is bug-specific.
+A template supplies saved field defaults so you only fill in what is bug-specific.
+Templates can carry routing fields and create metadata: `--product`,
+`--component`, `--version`, `--priority`, `--severity`, `--assignee`,
+`--op-sys`, `--rep-platform`, `--description`, `--url`, `--whiteboard`,
+`--target-milestone`, `--deadline`, `--cc`, `--keywords`, `--groups`, and
+`--flag`.
+
+```
+bzr template save security-routing \
+  --product Security --component Triage \
+  --severity critical --cc triage@example.com --flag review?
+bzr template update security-routing --target-milestone next --clear assignee
+```
 
 ## 3. Write a good report
 
@@ -49,6 +60,14 @@ flags that mirror `bug update` are `--alias`, `--url`, `--whiteboard`,
 bzr bug create --product <P> --component <C> --summary "..." --description "..." \
   --keywords regression,crash --cc qa@example.com \
   --target-milestone 9.0 --flag "review?(maintainer@example.com)"
+```
+
+To file a close variant of an existing bug, prefer `bug clone` and override only
+the fields that should differ from the source:
+
+```
+bzr bug clone 12345 --summary "Backport to 9.4" \
+  --version "9.4" --target-milestone 9.4 --add-depends-on
 ```
 
 ## Structured or batch filing

--- a/agent-skills/skills/bzr-reference/SKILL.md
+++ b/agent-skills/skills/bzr-reference/SKILL.md
@@ -23,18 +23,33 @@ bzr bug search "crash on boot" --json | jq -r '.[].id'
 
 See `reference/json-recipes.md` for extraction patterns.
 
-## Authentication
+## Server access
 
-A server is configured with `bzr config set-server`. The API key comes from an
-environment variable or the OS keychain. Check the active server and identity:
+A named server is configured with `bzr config set-server`. Omit credentials for
+public read-only Bugzilla exploration; add an API key source only when you need
+writes or identity-derived commands such as `whoami` and `bug my`:
 
 ```
-bzr config show     # lists servers and credential sources
-bzr whoami          # confirms the authenticated user
+bzr config set-server public-bz --url https://bugzilla.example.com
+bzr --server public-bz server info --json
+
+export BZR_API_KEY=...
+bzr config set-server my-bz --url https://bugzilla.example.com --api-key-env BZR_API_KEY
+bzr whoami --json
 ```
 
-If `whoami` fails, the server or credentials are not set up — see the
-`bzr-setup` skill.
+For one-off runs, skip config entirely with `--server-url <url>`. It also works
+without `--server-api-key-env` for public read-only commands:
+
+```
+bzr --server-url https://bugzilla.example.com bug view 12345 --json
+bzr --server-url https://bugzilla.example.com --server-api-key-env BZR_API_KEY whoami --json
+```
+
+Inline server TLS trust flags are `--server-tls-insecure`,
+`--server-tls-ca-cert <path>`, `--server-tls-pin-sha256 <pin>`, and
+`--server-tls-pin-now`. Named servers use the matching `config set-server`
+`--tls-*` flags. If `whoami` fails, see the `bzr-setup` skill.
 
 ## Command groups
 
@@ -71,6 +86,9 @@ These work on any command (place them before the subcommand):
 - `--server-url <url>` (+ `--server-api-key-env <env>`, optional
   `--server-email <email>`) — a fully stateless inline server, no config file
   needed; ideal for CI and agents. See the `bzr-setup` skill.
+- `--server-tls-insecure` / `--server-tls-ca-cert <path>` /
+  `--server-tls-pin-sha256 <pin>` / `--server-tls-pin-now` — TLS trust controls
+  for that one inline server invocation.
 
 ## Structured input
 
@@ -79,7 +97,8 @@ components, users, and groups accept `--from-json <path|->`. Explicit CLI flags
 override matching JSON fields, and unknown JSON keys exit 7 instead of being
 ignored. Bugs support object and array payloads; admin resources accept one
 object payload. Use `bzr schema <name>` to inspect the contract, e.g.
-`bug-create-input`, `product-update-input`, or `component-create-input`.
+`bug-create-input`, `bug-update-input`, `product-update-input`,
+`component-create-input`, or `error`.
 
 ## Cardinal rules
 
@@ -89,6 +108,6 @@ object payload. Use `bzr schema <name>` to inspect the contract, e.g.
   `bzr-triage-bug` skill walks this through.
 - **Keep writes explicit and minimal.** Change only the fields you intend to.
 
-This reference is authored against **bzr 0.5.0**. If `bzr --version` is much
+This reference is authored against **bzr 0.5.1-dev**. If `bzr --version` is much
 newer and a command here is rejected, the surface may have moved; check
 `bzr <group> --help`.

--- a/agent-skills/skills/bzr-reference/reference/commands.md
+++ b/agent-skills/skills/bzr-reference/reference/commands.md
@@ -1,11 +1,14 @@
-# bzr command surface (authored against bzr 0.5.0)
+# bzr command surface (authored against bzr 0.5.1-dev)
 
 Global (place before the subcommand): `--json` (force JSON; long form
 `--output json`), `--output ndjson` (one compact record per line, for `jq -c`),
 `--dry-run` (preview a bug mutation, no write), `-y`/`--yes` (skip the batch
 confirmation prompt), `--timeout <secs>`, `--retry <n>`, `--config <path>`
-(alternate config.toml), and the stateless inline server trio
-`--server-url <url>` / `--server-api-key-env <env>` / `--server-email <email>`.
+(alternate config.toml), and stateless inline server flags:
+`--server-url <url>` (credentials optional for public read-only commands),
+`--server-api-key-env <env>`, `--server-email <email>`, and one of the inline
+TLS trust flags `--server-tls-ca-cert`, `--server-tls-pin-sha256`,
+`--server-tls-pin-now`, or `--server-tls-insecure`.
 `--help` works on any group.
 
 ## bug
@@ -22,13 +25,21 @@ Operate on bugs.
     --target-milestone --deadline --cc --keywords --groups --flag`.
   - `bzr bug create --from-json <path|->`   # one object = one bug; an array batches
 - `bzr bug clone 12345`
+  - Override create fields on the clone: `--summary --product --component
+    --version --description --priority --severity --assignee --op-sys
+    --rep-platform --url --whiteboard --target-milestone --deadline --cc
+    --keywords --groups --flag`.
 - `bzr bug update 12345 --status RESOLVED --resolution FIXED --flag "review+(a@b.com)"`
   - `--expect-unchanged-since <last_change_time>`   # abort (exit 14) on mid-air collision
 - `bzr bug resolve 12345 [--as WONTFIX]` (sugar over `update`)
 - `bzr bug close 12345 [--status CLOSED]` / `reopen 12345 [--status REOPENED]`
   (default to stock statuses VERIFIED / CONFIRMED) / `dup 12345 100`
 - `bzr bug history 12345 [--since 2025-01-01]`
-- `bzr bug my [--status \!CLOSED]`
+- `bzr bug my [--status \!CLOSED] [--product Foo] [--component Bar]`
+  - Supports the shared list filters: `--product --component --priority
+    --severity --created-since --changed-since --whiteboard --target-milestone
+    --version --op-sys --platform --resolution --qa-contact --url`, plus
+    `--count`, `--fields`, sorting, paging, and `--all`/`--created`/`--cc`.
 - A `-` value for `--description`/`--description-file`/`--comment-file`/`--from-json`
   reads from stdin.
 
@@ -43,7 +54,10 @@ Operate on bugs.
 - `bzr attachment list 12345 [--json]`
 - `bzr attachment view <id> [--json]`           # one attachment's metadata
 - `bzr attachment download 12345`
+- `bzr attachment download <id> --out - > attachment.bin`
+  - `--out -` streams one attachment's raw bytes to stdout and suppresses result output.
 - `bzr attachment upload 12345 patch.diff --flag "review?(a@b.com)" --comment "context"`
+  - `--comment <body>` and `--comment-file <path|->` post context with the upload.
   - `--comment-private` marks that comment private; `--patch`/`--no-patch` and
     `--private`/`--no-private` set the booleans.
 - `bzr attachment update <id> ...`
@@ -52,6 +66,10 @@ Operate on bugs.
 
 ## config
 - `bzr config set-server my-bz --url https://bugzilla.example.com --api-key-env BZR_API_KEY`
+- `bzr config set-server public-bz --url https://bugzilla.example.com`
+  - Omit `--api-key*` for public read-only servers.
+- TLS trust: `--tls-ca-cert <path>`, `--tls-pin-sha256 <pin>`,
+  `--tls-pin-now`, `--tls-insecure`, or `--tls-pin-clear`.
 - `bzr config show`
 - `bzr config set-default my-bz`
 - `bzr config set-keyring my-bz` / `bzr config unset-keyring my-bz`
@@ -94,7 +112,11 @@ Operate on bugs.
 
 ## template
 - `bzr template save fedora-kernel --product Fedora --component kernel`
-- `bzr template update fedora-kernel --component drm`   # merge fields in place
+  - Templates can also store `--version --priority --severity --assignee
+    --op-sys --rep-platform --description --url --whiteboard
+    --target-milestone --deadline --cc --keywords --groups --flag`.
+- `bzr template update fedora-kernel --component drm --cc triage@example.com`
+  - Merge fields in place; `--clear <field>` unsets a stored field.
 - `bzr template list` / `bzr template show <name>` / `bzr template delete <name>`
 - Apply at create: `bzr bug create --template fedora-kernel --summary "..."`
 
@@ -102,6 +124,9 @@ Operate on bugs.
 - `bzr query save my-open --assignee you@example.com --status NEW --status ASSIGNED`
   - `--sort <field> --order asc|desc` persists the result order with the query.
 - `bzr query update my-open --status ASSIGNED --clear assignee`  # edit in place; `--clear <field>` drops a field
+- `bzr query update my-open --from-url 'https://bz/buglist.cgi?product=Foo'`
+  - Refreshes saved URL-derived filters while allowing stored overrides such as
+    `--limit`, `--fields`, dates, and sort order.
 - `bzr query run my-open [--json]`
 - `bzr query list` / `bzr query show <name>` / `bzr query delete <name>`
 
@@ -113,3 +138,4 @@ Operate on bugs.
 - `bzr schema bug`        # print one schema (draft 2020-12) for `--json` output
 - `bzr schema bug-create-input`  # `bug create --from-json` payload
 - `bzr schema bug-update-input`  # `bug update --from-json` payload
+- `bzr schema error`      # common JSON/NDJSON error envelope

--- a/agent-skills/skills/bzr-reference/reference/commands.yml
+++ b/agent-skills/skills/bzr-reference/reference/commands.yml
@@ -1,4 +1,4 @@
-# bzr command manifest — authored against bzr 0.5.0.
+# bzr command manifest — authored against bzr 0.5.1-dev.
 # Format: "<group>: <verb> <verb> ...". Consumed by tests/drift-check.sh.
 bug: list view search create clone update history my resolve close reopen dup
 comment: list add tag search-tags

--- a/agent-skills/skills/bzr-reference/reference/json-recipes.md
+++ b/agent-skills/skills/bzr-reference/reference/json-recipes.md
@@ -3,6 +3,9 @@
 All read paths support `--json`. Pipe to `jq`.
 
 ```
+# Public read-only Bugzilla, no config or API key
+bzr --server-url https://bugzilla.example.com server info --json | jq -r '.version'
+
 # Bug ids from a search
 bzr bug search "memory leak" --json | jq -r '.[].id'
 

--- a/agent-skills/skills/bzr-search-report/SKILL.md
+++ b/agent-skills/skills/bzr-search-report/SKILL.md
@@ -8,6 +8,10 @@ description: Use when searching Bugzilla or producing a bug report/digest with b
 ## Ad-hoc search
 
 ```
+# Public read-only server, no config or API key
+bzr --server-url https://bugzilla.example.com bug search "crash on startup" --json \
+  | jq -r '.[] | "\(.id)\t\(.status)\t\(.summary)"'
+
 bzr bug search "crash on startup" --json | jq -r '.[] | "\(.id)\t\(.status)\t\(.summary)"'
 bzr bug list --product Foo --status NEW --json | jq -r '.[].id'
 ```
@@ -46,14 +50,23 @@ place rather than re-saving it:
 ```
 bzr query save my-open --status NEW --status ASSIGNED --sort changed --order desc
 bzr query update my-open --status ASSIGNED --clear assignee   # --clear drops a field
+bzr query update imported --from-url 'https://bz/buglist.cgi?product=Foo'
 ```
+
+`query update --from-url` refreshes a saved Bugzilla URL import without losing
+allowed overrides such as `--limit`, `--fields`, date filters, and sort order.
 
 ## Your own bugs
 
 ```
-bzr bug my --status \!CLOSED --json | jq 'length'                 # count
-bzr bug my --status \!CLOSED --json | jq -r '.[] | "\(.id)\t\(.summary)"'
+bzr bug my --status \!CLOSED --product Foo --json | jq 'length'      # count
+bzr bug my --status \!CLOSED --component Bar --changed-since 2026-01-01 --json \
+  | jq -r '.[] | "\(.id)\t\(.summary)"'
 ```
+
+`bug my` supports the same product/component/status/date/metadata filters as
+`bug list`, plus `--all`, `--created`, `--cc`, `--count`, `--fields`,
+`--sort`, paging, and `--limit` per category.
 
 ## Build a digest
 

--- a/agent-skills/skills/bzr-setup/SKILL.md
+++ b/agent-skills/skills/bzr-setup/SKILL.md
@@ -1,15 +1,25 @@
 ---
 name: bzr-setup
-description: Use when bzr is not yet configured for a Bugzilla server, or when bzr whoami fails — configures a server URL and credentials (env var or OS keychain) and verifies the connection.
+description: Configure bzr for public or authenticated Bugzilla servers, credentials, and TLS trust.
 ---
 
 # Set up bzr for a Bugzilla server
 
-Goal: go from no configuration to a working, authenticated bzr.
+Goal: go from no configuration to a working bzr. Public read-only servers do not
+need credentials; writes and identity-derived commands do.
 
 ## 1. Add the server
 
-Pick a short name and the Bugzilla base URL. Choose a credential source:
+Pick a short name and the Bugzilla base URL. For public read-only exploration,
+omit the API key:
+
+```
+bzr config set-server public-bz --url https://bugzilla.example.com
+bzr --server public-bz server info --json
+bzr --server public-bz bug view 12345 --json
+```
+
+For writes, private bugs, `whoami`, or `bug my`, choose a credential source.
 
 Environment variable (good for CI / agents):
 ```
@@ -28,6 +38,13 @@ bzr config set-server my-bz --url https://bugzilla.example.com
 bzr config set-keyring my-bz
 ```
 
+If the server uses non-default TLS trust, set one named-server trust mode:
+
+```
+bzr config set-server lab --url https://bugzilla.lab --tls-ca-cert /path/ca.pem
+bzr config set-server pinned --url https://bugzilla.example.com --tls-pin-now
+```
+
 Set it as default if you have more than one:
 ```
 bzr config set-default my-bz
@@ -36,9 +53,12 @@ bzr config set-default my-bz
 ## Stateless: no config file at all
 
 For CI or agents, skip config entirely and define the server inline per
-invocation. Nothing is read from or written to `config.toml`:
+invocation. Nothing is read from or written to `config.toml`. The API key env
+var is optional for public read-only commands:
 
 ```
+bzr --server-url https://bugzilla.example.com server info --json
+
 export BZR_API_KEY=...
 bzr --server-url https://bugzilla.example.com \
     --server-api-key-env BZR_API_KEY \
@@ -46,16 +66,21 @@ bzr --server-url https://bugzilla.example.com \
 ```
 
 Add `--server-email <addr>` only if the server needs the Bugzilla 5.0 whoami
-fallback. To use a sandboxed config file instead of the default, point any
-command at it with `--config <path>` (overrides `BZR_CONFIG` and the default
+fallback. For self-hosted TLS, use exactly one inline trust flag:
+`--server-tls-ca-cert <path>`, `--server-tls-pin-sha256 <pin>`,
+`--server-tls-pin-now`, or, only for controlled test systems,
+`--server-tls-insecure`.
+
+To use a sandboxed config file instead of the default, point any command at it
+with `--config <path>` (overrides `BZR_CONFIG` and the default
 `$XDG_CONFIG_HOME/bzr/config.toml`).
 
 ## 2. Verify
 
 ```
-bzr config show     # confirm the server and credential source
-bzr whoami          # confirm authentication works
-bzr server info     # confirm the server is reachable and its capabilities
+bzr config show                 # confirm server URLs and credential sources
+bzr server info --json          # confirm the server is reachable
+bzr whoami --json               # confirm authentication, when credentials exist
 ```
 
 If `whoami` fails: re-check the URL, that the API key is valid, and that the

--- a/agent-skills/skills/bzr-triage-bug/SKILL.md
+++ b/agent-skills/skills/bzr-triage-bug/SKILL.md
@@ -31,6 +31,11 @@ bzr bug update <id> --flag "review+(alice@example.com)"
 # Add context as a comment rather than overwriting the description
 bzr comment add <id> --body "Reproduced on Fedora 42; root cause is X."
 
+# Attach evidence or a patch with context in the same upload
+bzr attachment upload <id> trace.log --comment-file notes.md
+printf '%s\n' "Patch generated from branch foo." \
+  | bzr attachment upload <id> fix.patch --patch --comment-file -
+
 # Tag a comment for workflow
 bzr comment tag <id> --add needs-info
 ```
@@ -66,6 +71,16 @@ bzr bug update <id> --status RESOLVED --resolution FIXED \
 This is the cardinal read-before-write rule made enforceable. To rehearse a
 change without writing, add `--dry-run` — bzr validates and prints the would-be
 payload (`"action":"dry-run"`) without calling the API.
+
+### Attachment reads
+
+Use JSON metadata for decisions, and use stdout only for the raw bytes of one
+attachment:
+
+```
+bzr attachment list <id> --json | jq -r '.[] | "\(.id)\t\(.file_name)"'
+bzr attachment download <attachment-id> --out - > patch.diff
+```
 
 ## 3. Verify
 


### PR DESCRIPTION
## Summary
- refresh bundled bzr agent skills for the final #379 CLI UX follow-ups
- teach public read-only servers, inline TLS trust, richer `bug my` filters, query URL refresh, templates, clone overrides, attachment stdin comments, attachment stdout downloads, and `schema error`
- update the agent-skill command reference version marker and changelog

Closes #392

## Verification
- baseline `make skills-test`
- checked current command help for `config set-server`, `bug my`, `query update`, `attachment upload`, `attachment download`, `bug clone`, `template save`, `template update`, and `bug create`
- `cargo test docs_and_help_comments_use_current_long_flags --test integration`
- `make skills-test`
- `rg -n -- '--is-patch|--format json|--ndjson' README.md docs/bzr-cli.md agent-skills/README.md agent-skills/skills src schemas`
- `git diff --check`
- `cargo fmt --check`
- added-line length check
- `sh agent-skills/tests/validate-skills.sh`
- pre-commit hook (`cargo fmt --check`, clippy, test layout)
- pre-push `cargo test`