### PR TITLE
test: expand functional CLI coverage

### DIFF
--- a/docs/superpowers/plans/2026-06-22-functional-cli-coverage.md
+++ b/docs/superpowers/plans/2026-06-22-functional-cli-coverage.md
@@ -1,0 +1,1436 @@
+# Functional CLI Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand the functional suite so every new post-0.5.0 command and option is exercised against the real Bugzilla Docker containers with real persisted server data.
+
+**Architecture:** Keep the existing shell-based phase runner. Add focused fixtures and assertions to the existing phase files, plus one new bug-update-from-json phase, so coverage follows the CLI's domain areas without a second test harness. TLS functional coverage is explicitly out of scope and deferred to GitHub issue #406.
+
+**Tech Stack:** Bash functional tests, Docker/Podman Bugzilla 5.0/5.2/5.3 containers, `bzr` release/debug binary, `jq`, `curl`, `shellcheck`, `shfmt`, Rust `cargo test`.
+
+---
+
+## Scope
+
+In scope:
+
+- Credentialless named and inline HTTP server reads against the running Bugzilla container.
+- Write and identity-command credential checks against real configured server entries.
+- Product, component, user, and group create/update `--from-json` and `--dry-run`.
+- `bug update --from-json`, `--url`, `--target-milestone`, richer `bug my` filters, richer templates, richer clones, and convenience verb `--expect-unchanged-since`.
+- `query update --from-url` and `query run --count`.
+- Attachment/comment body-source and no-op paths: `attachment upload --comment-file`, stdin comment forms, `attachment download --out -`, no-op `attachment update`, and no-op `comment tag`.
+- Schema list coverage for every published input schema.
+- Functional README refresh.
+
+Out of scope:
+
+- Functional tests for `--server-tls-insecure`, `--server-tls-ca-cert`,
+  `--server-tls-pin-sha256`, and `--server-tls-pin-now`.
+- HTTPS proxy/certificate fixture work. That follow-up is tracked in
+  https://github.com/randomparity/bzr/issues/406.
+
+## Files
+
+- Modify `tests/functional/lib.sh`: shared helpers for unique fixture names,
+  exact stdout/file comparison, Docker/Podman SQL execution, JSON fixture writes,
+  and schema-list assertions.
+- Modify `tests/functional/run-tests.sh`: source the new
+  `08d-bug-update-from-json` phase.
+- Create `tests/functional/phases/08d-bug-update-from-json.sh`: structured bug
+  update functional tests.
+- Modify `tests/functional/phases/01-config.sh`: credentialless named server
+  config.
+- Modify `tests/functional/phases/02-server-auth.sh`: named and inline
+  credentialless HTTP read/write-boundary tests.
+- Modify `tests/functional/phases/03-products.sh`: product `--from-json` and
+  `--dry-run` tests.
+- Modify `tests/functional/phases/04-components.sh`: component `--from-json`,
+  named-target update, and `--dry-run` tests.
+- Modify `tests/functional/phases/06-users.sh`: user `--from-json` and
+  `--dry-run` tests.
+- Modify `tests/functional/phases/07-groups.sh`: group `--from-json`,
+  `--dry-run`, and product group-control fixture setup.
+- Modify `tests/functional/phases/08-bugs.sh`: `bug update --url` and
+  `--target-milestone` readback.
+- Modify `tests/functional/phases/08c-bugs-create-fields.sh`: remaining create
+  metadata, flag, and group coverage.
+- Modify `tests/functional/phases/10-bug-clone.sh`: clone metadata override
+  and inherited metadata readback.
+- Modify `tests/functional/phases/11b-bug-verbs.sh`: convenience verb
+  `--expect-unchanged-since`.
+- Modify `tests/functional/phases/12-my-bugs.sh`: richer `bug my` filters.
+- Modify `tests/functional/phases/13-templates.sh`: template metadata storage,
+  clear, and create-from-template readback.
+- Modify `tests/functional/phases/14-queries.sh`: `query update --from-url` and
+  `query run --count`.
+- Modify `tests/functional/phases/16-attachments.sh`: attachment comment-file,
+  stdin comment, stdout download, content-type update, flag update, and no-op
+  rejection.
+- Modify `tests/functional/phases/17-global-options.sh`: dry-run coverage for
+  supported non-bug mutation families.
+- Modify `tests/functional/phases/17b-arg-validation.sh`: command conflict and
+  no-op rejection coverage.
+- Modify `tests/functional/phases/18-completion-schema.sh`: all input schema
+  names.
+- Modify `tests/functional/README.md`: current phase list, real-server fixture
+  data, cross-version behavior, and explicit TLS deferral.
+
+### Task 1: Branch Baseline and Coverage Ledger
+
+**Files:**
+
+- Modify: `docs/superpowers/plans/2026-06-22-functional-cli-coverage.md`
+
+- [ ] **Step 1: Confirm branch and clean tree**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: branch is not `main` or `master`; no uncommitted changes except this
+plan if the plan is still being edited.
+
+- [ ] **Step 2: Run the current single-version baseline**
+
+Run:
+
+```bash
+BZR_BZ_VERSION=bz50 tests/functional/setup-bugzilla.sh start
+BZR_BZ_VERSION=bz50 tests/functional/run-tests.sh
+```
+
+Expected: existing tests pass or any failure is unrelated and recorded before
+adding coverage. Do not start writing new assertions on top of an unexplained
+baseline failure.
+
+- [ ] **Step 3: Record the coverage target in the implementation PR**
+
+Use this checklist in the PR body and update it as tasks land:
+
+```markdown
+Functional coverage added:
+
+- [ ] Credentialless named and inline HTTP server reads
+- [ ] Credential failure boundaries for writes and identity commands
+- [ ] Admin `--from-json`
+- [ ] Admin `--dry-run`
+- [ ] `bug update --from-json`
+- [ ] Bug URL and target-milestone update/readback
+- [ ] `bug my` shared filters
+- [ ] Template metadata
+- [ ] Clone metadata
+- [ ] Query `--from-url` update and run `--count`
+- [ ] Attachment/comment source and stdout download paths
+- [ ] No-op rejection paths
+- [ ] Input schema list coverage
+- [ ] Functional README refresh
+
+Deferred:
+
+- TLS functional coverage: #406
+```
+
+- [ ] **Step 4: Commit the planning artifact if desired**
+
+Run:
+
+```bash
+git add -f docs/superpowers/plans/2026-06-22-functional-cli-coverage.md
+git commit -m "docs: plan functional CLI coverage"
+```
+
+Expected: one docs-only commit. If the branch owner does not want a plan-only
+commit, skip this step and keep the plan staged for the first implementation
+commit.
+
+### Task 2: Shared Functional Helpers and Real-Server Fixtures
+
+**Files:**
+
+- Modify: `tests/functional/lib.sh`
+
+- [ ] **Step 1: Add helpers to `tests/functional/lib.sh`**
+
+Append these helpers after `wait_for_changed`:
+
+```bash
+# unique_name <prefix> — per-run fixture id safe for Bugzilla names.
+unique_name() {
+    local prefix="$1"
+    printf '%s-%s-%s' "$prefix" "$$" "$RANDOM"
+    return 0
+}
+
+# write_json_fixture <path> <json> — writes compact JSON without a trailing
+# shell-expanded newline surprise.
+write_json_fixture() {
+    local path="$1"
+    local json="$2"
+    printf '%s' "$json" >"$path"
+    return 0
+}
+
+# assert_stdout_equals_file <path> — raw stdout exactly matches file bytes.
+assert_stdout_equals_file() {
+    local path="$1"
+    if ! cmp -s "$BZR_STDOUT" "$path"; then
+        test_fail "stdout does not exactly match '$path'"
+        return 1
+    fi
+}
+
+# assert_schema_list_contains <name> — schema list stdout contains a schema name.
+assert_schema_list_contains() {
+    local name="$1"
+    assert_json_exists "index(\"$name\")"
+}
+
+container_runtime() {
+    if command -v podman >/dev/null 2>&1; then
+        printf '%s' podman
+        return 0
+    fi
+    if command -v docker >/dev/null 2>&1; then
+        printf '%s' docker
+        return 0
+    fi
+    return 1
+}
+
+bugzilla_container_name() {
+    printf '%s' "${BZR_FUNC_CONTAINER:-bzr-func-test-${BZ_VERSION}}"
+    return 0
+}
+
+# run_bugzilla_sql_file <path> — execute SQL inside the running Bugzilla
+# container. Use this only for fixture capabilities that Bugzilla's public API
+# cannot create, such as flag types and product group controls.
+run_bugzilla_sql_file() {
+    local sql_file="$1"
+    local runtime
+    local container
+    runtime=$(container_runtime)
+    container=$(bugzilla_container_name)
+    "$runtime" exec -i "$container" mysql -u root bugs <"$sql_file"
+}
+```
+
+- [ ] **Step 2: Run shell lint for the helper edit**
+
+Run:
+
+```bash
+shellcheck tests/functional/lib.sh
+shfmt -d tests/functional/lib.sh
+```
+
+Expected: both commands exit 0. If `shfmt -d` prints a diff, apply that format
+with `shfmt -w tests/functional/lib.sh`.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add tests/functional/lib.sh
+git commit -m "test: add functional fixture helpers"
+```
+
+Expected: one commit containing only helper changes.
+
+### Task 3: Seed Flag and Group Capabilities in the Real Containers
+
+**Files:**
+
+- Modify: `tests/functional/phases/02-server-auth.sh`
+- Modify: `tests/functional/phases/07-groups.sh`
+
+- [ ] **Step 1: Add global flag types after server/auth checks**
+
+In `tests/functional/phases/02-server-auth.sh`, before the final `echo ""`,
+insert:
+
+```bash
+test_begin "8b. fixture flag types exist"
+_FLAG_SQL=$(mktemp /tmp/bzr-func-flags.XXXXXX.sql)
+cat >"$_FLAG_SQL" <<'SQL'
+INSERT INTO flagtypes
+    (name, description, target_type, is_active, is_requestable,
+     is_requesteeble, is_multiplicable, sortkey)
+SELECT 'review', 'Functional test review flag for bugs', 'b', 1, 1, 1, 1, 10
+WHERE NOT EXISTS (
+    SELECT 1 FROM flagtypes WHERE name = 'review' AND target_type = 'b'
+);
+
+INSERT INTO flagtypes
+    (name, description, target_type, is_active, is_requestable,
+     is_requesteeble, is_multiplicable, sortkey)
+SELECT 'review', 'Functional test review flag for attachments', 'a', 1, 1, 1, 1, 10
+WHERE NOT EXISTS (
+    SELECT 1 FROM flagtypes WHERE name = 'review' AND target_type = 'a'
+);
+
+INSERT INTO flaginclusions (type_id, product_id, component_id)
+SELECT id, NULL, NULL
+FROM flagtypes
+WHERE name = 'review'
+  AND target_type IN ('b', 'a')
+  AND NOT EXISTS (
+      SELECT 1 FROM flaginclusions WHERE flaginclusions.type_id = flagtypes.id
+  );
+SQL
+if run_bugzilla_sql_file "$_FLAG_SQL"; then
+    test_pass
+else
+    test_fail "could not seed functional flag types"
+fi
+rm -f "$_FLAG_SQL"
+unset _FLAG_SQL
+```
+
+- [ ] **Step 2: Add product group-control setup after group creation**
+
+In `tests/functional/phases/07-groups.sh`, after test `27. group update
+functest-grp`, insert:
+
+```bash
+test_begin "27a. fixture group enabled for FuncTestProd bugs"
+_GROUP_SQL=$(mktemp /tmp/bzr-func-group-control.XXXXXX.sql)
+cat >"$_GROUP_SQL" <<'SQL'
+INSERT INTO group_control_map
+    (group_id, product_id, entry, membercontrol, othercontrol, canedit,
+     editcomponents, editbugs, canconfirm)
+SELECT g.id, p.id, 0, 1, 1, 1, 0, 1, 1
+FROM groups AS g
+JOIN products AS p ON p.name = 'FuncTestProd'
+WHERE g.name = 'functest-grp'
+ON DUPLICATE KEY UPDATE
+    membercontrol = 1,
+    othercontrol = 1,
+    canedit = 1,
+    editbugs = 1,
+    canconfirm = 1;
+SQL
+if run_bugzilla_sql_file "$_GROUP_SQL"; then
+    test_pass
+else
+    test_fail "could not enable functest-grp for FuncTestProd"
+fi
+rm -f "$_GROUP_SQL"
+unset _GROUP_SQL
+```
+
+- [ ] **Step 3: Verify fixture capability on bz50**
+
+Run:
+
+```bash
+BZR_BZ_VERSION=bz50 tests/functional/setup-bugzilla.sh reset
+BZR_BZ_VERSION=bz50 tests/functional/run-tests.sh
+```
+
+Expected: the new fixture tests pass and existing phases still pass.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add tests/functional/phases/02-server-auth.sh tests/functional/phases/07-groups.sh
+git commit -m "test: seed functional Bugzilla flag fixtures"
+```
+
+Expected: one commit containing only fixture-capability setup.
+
+### Task 4: Credentialless HTTP Server Coverage
+
+**Files:**
+
+- Modify: `tests/functional/phases/01-config.sh`
+- Modify: `tests/functional/phases/02-server-auth.sh`
+- Modify: `tests/functional/phases/08-bugs.sh`
+- Modify: `tests/functional/phases/17b-arg-validation.sh`
+
+- [ ] **Step 1: Add a credentialless named server**
+
+In `tests/functional/phases/01-config.sh`, after test `3a. config set-server
+auto-detect`, insert:
+
+```bash
+test_begin "3b. config set-server public without credentials"
+run_bzr config set-server public --url "$BZ_URL"
+if assert_success; then
+    run_bzr config show
+    if assert_json '.servers.public.url' "$BZ_URL" &&
+        assert_json '.servers.public.api_key_source' "none"; then test_pass; fi
+fi
+```
+
+- [ ] **Step 2: Add named credentialless read and write-boundary tests**
+
+In `tests/functional/phases/02-server-auth.sh`, after test `8a. --server auto
+whoami`, insert:
+
+```bash
+test_begin "8c. credentialless named server info"
+run_bzr_raw --json --server public server info
+if assert_success && assert_json_exists '.version'; then test_pass; fi
+
+test_begin "8d. credentialless named whoami fails before network auth"
+run_bzr_raw --json --server public whoami
+if assert_exit_code 3 && assert_stderr_contains "requires credentials"; then test_pass; fi
+
+test_begin "8e. credentialless named write fails before mutation"
+run_bzr_raw --json --server public bug create \
+    --product FuncTestProd --component Backend --summary "public write" \
+    --description "should not write" --op-sys Linux --rep-platform PC
+if assert_exit_code 3 && assert_stderr_contains "requires credentials"; then test_pass; fi
+
+test_begin "8f. inline credentialless server info"
+run_bzr_raw --json --server-url "$BZ_URL" server info
+if assert_success && assert_json_exists '.version'; then test_pass; fi
+
+test_begin "8g. inline credentialed whoami"
+export BZR_FUNC_INLINE_KEY="$API_KEY"
+run_bzr_raw --json --server-url "$BZ_URL" \
+    --server-api-key-env BZR_FUNC_INLINE_KEY --server-email "$ADMIN_EMAIL" whoami
+if assert_success && assert_json_exists '.id'; then test_pass; fi
+unset BZR_FUNC_INLINE_KEY
+```
+
+- [ ] **Step 3: Add credentialless reads of real bug data after fixtures exist**
+
+In `tests/functional/phases/08-bugs.sh`, after test `35. bug view`, insert:
+
+```bash
+test_begin "35a. credentialless named bug view"
+if [[ -n "$BUG1" ]]; then
+    run_bzr_raw --json --server public bug view "$BUG1"
+    if assert_success && assert_json '.summary' "Bug one"; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "35b. inline credentialless bug list"
+run_bzr_raw --json --server-url "$BZ_URL" bug list --product FuncTestProd --limit 1
+if assert_success && assert_json_array_min_length '.' 1; then test_pass; fi
+```
+
+These checks intentionally live in phase 8, after `FuncTestProd` and `BUG1`
+exist, so anonymous reads prove real persisted Bugzilla data is visible without
+credentials.
+
+- [ ] **Step 4: Add parse-level credential/TLS boundary checks without TLS I/O**
+
+In `tests/functional/phases/17b-arg-validation.sh`, after test `125.
+--server-url + --server conflict`, insert:
+
+```bash
+test_begin "125a. --server-api-key-env requires --server-url"
+run_bzr --server-api-key-env BZR_FUNC_INLINE_KEY server info
+if assert_exit_code 2 && assert_stderr_contains "required"; then test_pass; fi
+
+test_begin "125b. --server-tls-insecure requires --server-url"
+run_bzr --server-tls-insecure server info
+if assert_exit_code 2 && assert_stderr_contains "required"; then test_pass; fi
+
+test_begin "125c. ad-hoc TLS flags are mutually exclusive"
+run_bzr --server-url "$BZ_URL" --server-tls-insecure \
+    --server-tls-pin-now server info
+if assert_exit_code 2 && assert_stderr_contains "cannot be used with"; then test_pass; fi
+```
+
+This covers the CLI boundary for TLS flags while keeping HTTPS behavior out of
+scope for this plan.
+
+- [ ] **Step 5: Verify and commit**
+
+Run:
+
+```bash
+BZR_BZ_VERSION=bz50 tests/functional/setup-bugzilla.sh reset
+BZR_BZ_VERSION=bz50 tests/functional/run-tests.sh
+shellcheck tests/functional/phases/01-config.sh tests/functional/phases/02-server-auth.sh tests/functional/phases/08-bugs.sh tests/functional/phases/17b-arg-validation.sh
+shfmt -d tests/functional/phases/01-config.sh tests/functional/phases/02-server-auth.sh tests/functional/phases/08-bugs.sh tests/functional/phases/17b-arg-validation.sh
+```
+
+Expected: functional run passes, shellcheck exits 0, and shfmt prints no diff.
+
+Commit:
+
+```bash
+git add tests/functional/phases/01-config.sh tests/functional/phases/02-server-auth.sh tests/functional/phases/08-bugs.sh tests/functional/phases/17b-arg-validation.sh
+git commit -m "test: cover credentialless server functional paths"
+```
+
+### Task 5: Admin `--from-json` and `--dry-run`
+
+**Files:**
+
+- Modify: `tests/functional/phases/03-products.sh`
+- Modify: `tests/functional/phases/04-components.sh`
+- Modify: `tests/functional/phases/06-users.sh`
+- Modify: `tests/functional/phases/07-groups.sh`
+- Modify: `tests/functional/phases/17-global-options.sh`
+
+- [ ] **Step 1: Product structured input**
+
+Append to `tests/functional/phases/03-products.sh` before `unset _PV`:
+
+```bash
+_PJSON_DIR=$(mktemp -d /tmp/bzr-func-product-json.XXXXXX)
+_PJ_NAME=$(unique_name prodjson)
+write_json_fixture "$_PJSON_DIR/create.json" \
+    "{\"name\":\"$_PJ_NAME\",\"description\":\"product json\",\"version\":\"8.8\",\"is_open\":true}"
+write_json_fixture "$_PJSON_DIR/update.json" \
+    "{\"name\":\"$_PJ_NAME\",\"description\":\"product json updated\",\"is_open\":false}"
+write_json_fixture "$_PJSON_DIR/bad.json" \
+    "{\"name\":\"bad\",\"description\":\"bad\",\"unknown\":true}"
+
+test_begin "13c. product create --from-json"
+run_bzr product create --from-json "$_PJSON_DIR/create.json"
+if assert_success; then
+    run_bzr product view "$_PJ_NAME"
+    if assert_json '.name' "$_PJ_NAME" &&
+        assert_json_contains '[.versions[].name] | join(",")' "8.8"; then test_pass; fi
+fi
+
+test_begin "13d. product update --from-json"
+run_bzr product update --from-json "$_PJSON_DIR/update.json"
+if assert_success; then
+    run_bzr product view "$_PJ_NAME"
+    if assert_json '.is_active' "false"; then test_pass; fi
+fi
+
+test_begin "13e. product create --from-json unknown key"
+run_bzr product create --from-json "$_PJSON_DIR/bad.json"
+if assert_exit_code 7 && assert_stderr_contains "unknown field"; then test_pass; fi
+
+test_begin "13f. product create --from-json CLI override"
+_PJ_OVERRIDE=$(unique_name prodjson-override)
+run_bzr product create --from-json "$_PJSON_DIR/create.json" --name "$_PJ_OVERRIDE"
+if assert_success; then
+    run_bzr product view "$_PJ_OVERRIDE"
+    if assert_json '.name' "$_PJ_OVERRIDE"; then test_pass; fi
+fi
+
+rm -r "$_PJSON_DIR"
+unset _PJSON_DIR _PJ_NAME _PJ_OVERRIDE
+```
+
+- [ ] **Step 2: Component structured input and named-target update**
+
+Append to `tests/functional/phases/04-components.sh` before `echo ""`:
+
+```bash
+_CJSON_DIR=$(mktemp -d /tmp/bzr-func-component-json.XXXXXX)
+_CJ_NAME=$(unique_name compjson)
+write_json_fixture "$_CJSON_DIR/create.json" \
+    "{\"product\":\"FuncTestProd\",\"name\":\"$_CJ_NAME\",\"description\":\"component json\",\"default_assignee\":\"$ADMIN_EMAIL\"}"
+write_json_fixture "$_CJSON_DIR/update-by-name.json" \
+    "{\"product\":\"FuncTestProd\",\"component\":\"$_CJ_NAME\",\"description\":\"component json updated\"}"
+
+test_begin "15c. component create --from-json"
+run_bzr component create --from-json "$_CJSON_DIR/create.json"
+if assert_success; then
+    run_bzr component view FuncTestProd "$_CJ_NAME"
+    if assert_json '.name' "$_CJ_NAME"; then test_pass; fi
+fi
+
+test_begin "15d. component update --product --component target"
+run_bzr component update --product FuncTestProd --component "$_CJ_NAME" \
+    --description "component named target updated"
+if [[ $BZR_EXIT -eq 0 ]]; then
+    run_bzr component view FuncTestProd "$_CJ_NAME"
+    if assert_json '.description' "component named target updated"; then test_pass; fi
+elif grep -q "32614" "$BZR_STDERR" 2>/dev/null; then
+    test_skip "component update REST endpoint not available"
+else
+    assert_success
+fi
+
+test_begin "15e. component update --from-json named target"
+run_bzr component update --from-json "$_CJSON_DIR/update-by-name.json"
+if [[ $BZR_EXIT -eq 0 ]]; then
+    run_bzr component view FuncTestProd "$_CJ_NAME"
+    if assert_json '.description' "component json updated"; then test_pass; fi
+elif grep -q "32614" "$BZR_STDERR" 2>/dev/null; then
+    test_skip "component update REST endpoint not available"
+else
+    assert_success
+fi
+
+rm -r "$_CJSON_DIR"
+unset _CJSON_DIR _CJ_NAME
+```
+
+- [ ] **Step 3: User structured input**
+
+Append to `tests/functional/phases/06-users.sh` before `echo ""`:
+
+```bash
+_UJSON_DIR=$(mktemp -d /tmp/bzr-func-user-json.XXXXXX)
+_UJ_LOGIN="$(unique_name userjson)@test.bzr"
+write_json_fixture "$_UJSON_DIR/create.json" \
+    "{\"email\":\"$_UJ_LOGIN\",\"full_name\":\"User Json\",\"password\":\"TestPass1!\"}"
+write_json_fixture "$_UJSON_DIR/update.json" \
+    "{\"user\":\"$_UJ_LOGIN\",\"disable_login\":true,\"login_denied_text\":\"json disabled\"}"
+
+test_begin "24a. user create --from-json"
+run_bzr user create --from-json "$_UJSON_DIR/create.json"
+if assert_success; then
+    run_bzr user search "$_UJ_LOGIN" --details
+    if assert_stdout_contains "$_UJ_LOGIN"; then test_pass; fi
+fi
+
+test_begin "24b. user update --from-json"
+run_bzr user update --from-json "$_UJSON_DIR/update.json"
+if assert_success; then
+    run_bzr user search "$_UJ_LOGIN" --details
+    if assert_success &&
+        assert_json "[.[] | select(.name == \"$_UJ_LOGIN\")][0].can_login" \
+            "false"; then test_pass; fi
+fi
+
+rm -r "$_UJSON_DIR"
+unset _UJSON_DIR _UJ_LOGIN
+```
+
+- [ ] **Step 4: Group structured input**
+
+Append to `tests/functional/phases/07-groups.sh` before `echo ""`:
+
+```bash
+_GJSON_DIR=$(mktemp -d /tmp/bzr-func-group-json.XXXXXX)
+_GJ_NAME=$(unique_name groupjson)
+write_json_fixture "$_GJSON_DIR/create.json" \
+    "{\"name\":\"$_GJ_NAME\",\"description\":\"group json\",\"is_active\":true}"
+write_json_fixture "$_GJSON_DIR/update.json" \
+    "{\"group\":\"$_GJ_NAME\",\"description\":\"group json updated\",\"is_active\":false}"
+
+test_begin "32a. group create --from-json"
+run_bzr group create --from-json "$_GJSON_DIR/create.json"
+if assert_success; then
+    run_bzr group view "$_GJ_NAME"
+    if assert_json '.name' "$_GJ_NAME"; then test_pass; fi
+fi
+
+test_begin "32b. group update --from-json"
+run_bzr group update --from-json "$_GJSON_DIR/update.json"
+if assert_success; then
+    run_bzr group view "$_GJ_NAME"
+    if assert_json '.description' "group json updated"; then test_pass; fi
+fi
+
+rm -r "$_GJSON_DIR"
+unset _GJSON_DIR _GJ_NAME
+```
+
+- [ ] **Step 5: Admin dry-run no-write checks**
+
+Append to `tests/functional/phases/17-global-options.sh` after the existing
+`--dry-run bug create` test:
+
+```bash
+test_begin "103d. --dry-run product create previews without writing"
+_DP=$(unique_name dryprod)
+run_bzr --dry-run product create --name "$_DP" --description "dry product"
+if assert_success && assert_json '.resource' "product" && assert_json '.action' "dry-run"; then
+    run_bzr product view "$_DP"
+    if assert_failure; then test_pass; fi
+fi
+unset _DP
+
+test_begin "103e. --dry-run component update by name resolves but does not write"
+run_bzr --dry-run component update --product FuncTestProd --component Backend \
+    --description "dry component update"
+if [[ $BZR_EXIT -eq 0 ]]; then
+    run_bzr component view FuncTestProd Backend
+    if assert_stdout_not_contains "dry component update"; then test_pass; fi
+elif grep -q "32614" "$BZR_STDERR" 2>/dev/null; then
+    test_skip "component update REST endpoint not available"
+else
+    assert_success
+fi
+
+test_begin "103f. --dry-run user update previews without writing"
+run_bzr --dry-run user update testuser@test.bzr --disable-login false
+if assert_success && assert_json '.resource' "user" && assert_json '.action' "dry-run"; then
+    test_pass
+fi
+
+test_begin "103g. --dry-run group update previews without writing"
+run_bzr --dry-run group update functest-grp --description "dry group update"
+if assert_success && assert_json '.resource' "group" && assert_json '.action' "dry-run"; then
+    run_bzr group view functest-grp
+    if assert_stdout_not_contains "dry group update"; then test_pass; fi
+fi
+```
+
+- [ ] **Step 6: Verify and commit**
+
+Run:
+
+```bash
+BZR_BZ_VERSION=bz50 tests/functional/setup-bugzilla.sh reset
+BZR_BZ_VERSION=bz50 tests/functional/run-tests.sh
+shellcheck tests/functional/phases/03-products.sh tests/functional/phases/04-components.sh tests/functional/phases/06-users.sh tests/functional/phases/07-groups.sh tests/functional/phases/17-global-options.sh
+shfmt -d tests/functional/phases/03-products.sh tests/functional/phases/04-components.sh tests/functional/phases/06-users.sh tests/functional/phases/07-groups.sh tests/functional/phases/17-global-options.sh
+```
+
+Commit:
+
+```bash
+git add tests/functional/phases/03-products.sh tests/functional/phases/04-components.sh tests/functional/phases/06-users.sh tests/functional/phases/07-groups.sh tests/functional/phases/17-global-options.sh
+git commit -m "test: cover admin structured input and dry runs"
+```
+
+### Task 6: Bug Update Fields and Structured Input
+
+**Files:**
+
+- Modify: `tests/functional/run-tests.sh`
+- Modify: `tests/functional/phases/08-bugs.sh`
+- Create: `tests/functional/phases/08d-bug-update-from-json.sh`
+
+- [ ] **Step 1: Add URL and target-milestone update readback**
+
+In `tests/functional/phases/08-bugs.sh`, after test `42a. bug update
+--deadline`, insert:
+
+```bash
+test_begin "42c. bug update --url and --target-milestone"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug update "$BUG1" --url "http://example.com/updated-$BUG1" \
+        --target-milestone "---"
+    if assert_success; then
+        run_bzr bug view "$BUG1"
+        if assert_json '.url' "http://example.com/updated-$BUG1" &&
+            assert_json '.target_milestone' "---"; then test_pass; fi
+    fi
+else test_skip "no BUG1"; fi
+```
+
+- [ ] **Step 2: Add the new phase to `run-tests.sh`**
+
+In `tests/functional/run-tests.sh`, change the phase list segment:
+
+```bash
+08-bugs 08b-bugs-paging 08c-bugs-create-fields \
+09-bug-relationships
+```
+
+to:
+
+```bash
+08-bugs 08b-bugs-paging 08c-bugs-create-fields 08d-bug-update-from-json \
+09-bug-relationships
+```
+
+- [ ] **Step 3: Create `08d-bug-update-from-json.sh`**
+
+Create `tests/functional/phases/08d-bug-update-from-json.sh` with:
+
+```bash
+# 08d-bug-update-from-json
+# Sourced by run-tests.sh in order; assumes lib.sh helpers and the
+# orchestrator preamble (constants, shared globals, cleanup trap).
+# shellcheck shell=bash
+
+echo "── Phase 8d: Bug update --from-json ────────────────────────"
+
+_UJ_DIR=$(mktemp -d /tmp/bzr-func-bug-update-json.XXXXXX)
+_UJ_CREATE=(--product FuncTestProd --component Backend --op-sys Linux --rep-platform PC --description d)
+
+test_begin "152. bug update --from-json object with positional ID"
+_UJ_ONE=$(make_bug "${_UJ_CREATE[@]}" --summary "update json object")
+write_json_fixture "$_UJ_DIR/object.json" \
+    '{"priority":"High","whiteboard":"json-object","url":"http://example.com/json-object"}'
+run_bzr bug update "$_UJ_ONE" --from-json "$_UJ_DIR/object.json"
+if assert_success; then
+    run_bzr bug view "$_UJ_ONE"
+    if assert_json '.priority' "High" &&
+        assert_json '.whiteboard' "json-object" &&
+        assert_json '.url' "http://example.com/json-object"; then test_pass; fi
+fi
+
+test_begin "153. bug update --from-json object target from JSON"
+_UJ_TWO=$(make_bug "${_UJ_CREATE[@]}" --summary "update json target")
+write_json_fixture "$_UJ_DIR/target.json" \
+    "{\"id\":$_UJ_TWO,\"severity\":\"major\",\"whiteboard\":\"json-target\"}"
+run_bzr bug update --from-json "$_UJ_DIR/target.json"
+if assert_success; then
+    run_bzr bug view "$_UJ_TWO"
+    if assert_json '.severity' "major" &&
+        assert_json '.whiteboard' "json-target"; then test_pass; fi
+fi
+
+test_begin "154. bug update --from-json array partial failure"
+_UJ_THREE=$(make_bug "${_UJ_CREATE[@]}" --summary "update json array valid")
+write_json_fixture "$_UJ_DIR/array.json" \
+    "[{\"id\":$_UJ_THREE,\"priority\":\"Low\"},{\"id\":999999,\"priority\":\"High\"}]"
+run_bzr bug update --from-json "$_UJ_DIR/array.json"
+if assert_exit_code 11 &&
+    assert_json '.succeeded[0]' "$_UJ_THREE" &&
+    assert_json '.failed[0].id' "999999"; then
+    run_bzr bug view "$_UJ_THREE"
+    if assert_json '.priority' "Low"; then test_pass; fi
+fi
+
+test_begin "155. bug update --from-json stdin with CLI override"
+_UJ_FOUR=$(make_bug "${_UJ_CREATE[@]}" --summary "update json override")
+write_json_fixture "$_UJ_DIR/stdin.json" \
+    "{\"id\":$_UJ_FOUR,\"priority\":\"Low\",\"whiteboard\":\"json-loses\"}"
+run_bzr bug update --from-json - --whiteboard "cli-wins" <"$_UJ_DIR/stdin.json"
+if assert_success; then
+    run_bzr bug view "$_UJ_FOUR"
+    if assert_json '.priority' "Low" &&
+        assert_json '.whiteboard' "cli-wins"; then test_pass; fi
+fi
+
+test_begin "156. bug update --from-json unknown key"
+_UJ_FIVE=$(make_bug "${_UJ_CREATE[@]}" --summary "update json bad")
+write_json_fixture "$_UJ_DIR/bad.json" "{\"id\":$_UJ_FIVE,\"bogus\":true}"
+run_bzr bug update --from-json "$_UJ_DIR/bad.json"
+if assert_exit_code 7 && assert_stderr_contains "unknown field"; then test_pass; fi
+
+test_begin "157. bug update --from-json no-op rejected"
+_UJ_SIX=$(make_bug "${_UJ_CREATE[@]}" --summary "update json noop")
+write_json_fixture "$_UJ_DIR/noop.json" "{\"id\":$_UJ_SIX}"
+run_bzr bug update --from-json "$_UJ_DIR/noop.json"
+if assert_exit_code 7 && assert_stderr_contains "no fields to update"; then test_pass; fi
+
+rm -r "$_UJ_DIR"
+unset _UJ_DIR _UJ_CREATE _UJ_ONE _UJ_TWO _UJ_THREE _UJ_FOUR _UJ_FIVE _UJ_SIX
+echo ""
+```
+
+- [ ] **Step 4: Verify and commit**
+
+Run:
+
+```bash
+BZR_BZ_VERSION=bz50 tests/functional/setup-bugzilla.sh reset
+BZR_BZ_VERSION=bz50 tests/functional/run-tests.sh
+shellcheck tests/functional/run-tests.sh tests/functional/phases/08-bugs.sh tests/functional/phases/08d-bug-update-from-json.sh
+shfmt -d tests/functional/run-tests.sh tests/functional/phases/08-bugs.sh tests/functional/phases/08d-bug-update-from-json.sh
+```
+
+Commit:
+
+```bash
+git add tests/functional/run-tests.sh tests/functional/phases/08-bugs.sh tests/functional/phases/08d-bug-update-from-json.sh
+git commit -m "test: cover structured bug updates functionally"
+```
+
+### Task 7: Bug Create, Clone, Template, and My-Filter Coverage
+
+**Files:**
+
+- Modify: `tests/functional/phases/08c-bugs-create-fields.sh`
+- Modify: `tests/functional/phases/10-bug-clone.sh`
+- Modify: `tests/functional/phases/11b-bug-verbs.sh`
+- Modify: `tests/functional/phases/12-my-bugs.sh`
+- Modify: `tests/functional/phases/13-templates.sh`
+
+- [ ] **Step 1: Expand bug create metadata coverage**
+
+In `tests/functional/phases/08c-bugs-create-fields.sh`, after test `146a`,
+insert:
+
+```bash
+test_begin "146b. bug create --target-milestone and --deadline round-trip"
+MID=$(make_bug "${_CF[@]}" --summary "milestone create" \
+    --target-milestone "---" --deadline 2026-12-30)
+run_bzr bug view "$MID"
+if assert_success &&
+    assert_json '.target_milestone' "---" &&
+    assert_json '.deadline' "2026-12-30"; then test_pass; fi
+
+test_begin "146c. bug create --groups succeeds with fixture group"
+GID=$(make_bug "${_CF[@]}" --summary "group create" --groups functest-grp)
+if [[ -n "$GID" ]]; then
+    run_bzr bug view "$GID"
+    if assert_success && assert_json '.id' "$GID"; then test_pass; fi
+fi
+
+test_begin "146d. bug create --flag round-trips"
+FID=$(make_bug "${_CF[@]}" --summary "flag create" --flag 'review?')
+run_bzr bug view "$FID"
+if assert_success &&
+    assert_json_contains '[.flags[].name] | join(",")' "review"; then test_pass; fi
+```
+
+- [ ] **Step 2: Expand clone metadata coverage**
+
+Append to `tests/functional/phases/10-bug-clone.sh` before `echo ""`:
+
+```bash
+test_begin "57a. bug clone copies source metadata"
+if [[ -n "$BUG3" ]]; then
+    run_bzr bug update "$BUG3" --url "http://example.com/source-$BUG3" \
+        --whiteboard "clone-source-$BUG3" --target-milestone "---" \
+        --deadline 2026-12-29
+    if assert_success; then
+        run_bzr bug clone "$BUG3" --op-sys Linux --rep-platform PC --no-comment
+        if assert_success && assert_json_exists '.id'; then
+            _CL_META=$(jq -r '.id' "$BZR_STDOUT")
+            run_bzr bug view "$_CL_META"
+            if assert_json '.url' "http://example.com/source-$BUG3" &&
+                assert_json '.whiteboard' "clone-source-$BUG3" &&
+                assert_json '.deadline' "2026-12-29"; then test_pass; fi
+        fi
+    fi
+else test_skip "no BUG3"; fi
+
+test_begin "57b. bug clone metadata overrides"
+if [[ -n "$BUG3" ]]; then
+    _CL_WB="clone-override-$$"
+    run_bzr bug clone "$BUG3" --op-sys Linux --rep-platform PC --no-comment \
+        --url "http://example.com/clone-override" --whiteboard "$_CL_WB" \
+        --target-milestone "---" --deadline 2026-12-28 \
+        --cc "$ADMIN_EMAIL" --flag 'review?'
+    if assert_success && assert_json_exists '.id'; then
+        _CL_OVERRIDE=$(jq -r '.id' "$BZR_STDOUT")
+        run_bzr bug view "$_CL_OVERRIDE"
+        if assert_json '.url' "http://example.com/clone-override" &&
+            assert_json '.whiteboard' "$_CL_WB" &&
+            assert_json_contains '[.flags[].name] | join(",")' "review"; then test_pass; fi
+    fi
+else test_skip "no BUG3"; fi
+unset _CL_META _CL_WB _CL_OVERRIDE
+```
+
+- [ ] **Step 3: Add convenience verb concurrency guard coverage**
+
+Append to `tests/functional/phases/11b-bug-verbs.sh` before `unset _VERB_CREATE`:
+
+```bash
+test_begin "134a. bug resolve --expect-unchanged-since happy path"
+VID=$(make_bug "${_VERB_CREATE[@]}" --summary "verb resolve guarded")
+run_bzr bug view "$VID"
+if assert_success; then
+    LCT=$(jq -r '.last_change_time' "$BZR_STDOUT" 2>/dev/null || true)
+    run_bzr bug resolve "$VID" --expect-unchanged-since "$LCT"
+    if assert_success; then
+        run_bzr bug view "$VID"
+        if assert_json '.status' "RESOLVED"; then test_pass; fi
+    fi
+fi
+
+test_begin "134b. bug dup --expect-unchanged-since detects collision"
+SRC=$(make_bug "${_VERB_CREATE[@]}" --summary "verb dup guarded source")
+TGT=$(make_bug "${_VERB_CREATE[@]}" --summary "verb dup guarded target")
+run_bzr bug view "$SRC"
+if assert_success; then
+    LCT=$(jq -r '.last_change_time' "$BZR_STDOUT" 2>/dev/null || true)
+    run_bzr bug update "$SRC" --whiteboard "verb-guard-touch"
+    if wait_for_changed "$SRC" "$LCT"; then
+        run_bzr bug dup "$SRC" "$TGT" --expect-unchanged-since "$LCT"
+        if assert_exit_code 14; then test_pass; fi
+    else
+        test_skip "last_change_time did not advance within retry budget"
+    fi
+fi
+```
+
+- [ ] **Step 4: Expand `bug my` filters**
+
+Append to `tests/functional/phases/12-my-bugs.sh` before `echo ""`:
+
+```bash
+test_begin "64d. bug my --product --component"
+run_bzr bug my --all --product FuncTestProd --component Backend
+if assert_success && assert_json_array_min_length '.' 1; then test_pass; fi
+
+test_begin "64e. bug my --priority --severity"
+_MY_PS_MARK=$(unique_name my-priority)
+_MY_PS_ID=$(make_bug --marker "$_MY_PS_MARK" --product FuncTestProd --component Backend \
+    --op-sys Linux --rep-platform PC --description d --summary "my priority filter" \
+    --priority High --severity major)
+run_bzr bug my --all --priority High --severity major --whiteboard "$_MY_PS_MARK"
+if assert_success && assert_stdout_contains "$_MY_PS_ID"; then test_pass; fi
+
+test_begin "64f. bug my --whiteboard --url"
+_MY_MARK="my-filter-$$"
+_MY_ID=$(make_bug --marker "$_MY_MARK" --product FuncTestProd --component Backend \
+    --op-sys Linux --rep-platform PC --description d --summary "my filter" \
+    --url "http://example.com/$_MY_MARK")
+run_bzr bug my --all --whiteboard "$_MY_MARK" --url "$_MY_MARK"
+if assert_success && assert_stdout_contains "$_MY_ID"; then test_pass; fi
+
+test_begin "64g. bug my --changed-since malformed"
+run_bzr bug my --changed-since "not-a-date"
+if assert_exit_code 7; then test_pass; fi
+unset _MY_PS_MARK _MY_PS_ID _MY_MARK _MY_ID
+```
+
+- [ ] **Step 5: Expand template metadata coverage**
+
+Append to `tests/functional/phases/13-templates.sh` before deleting `func-tmpl`:
+
+```bash
+test_begin "69a. template save metadata fields"
+run_bzr template save meta-tmpl --product FuncTestProd --component Backend \
+    --priority Normal --severity normal --url "http://example.com/template" \
+    --whiteboard "template-wb" --target-milestone "---" --deadline 2026-12-27 \
+    --cc "$ADMIN_EMAIL" --flag 'review?'
+if assert_success; then
+    run_bzr template show meta-tmpl
+    if assert_json '.url' "http://example.com/template" &&
+        assert_json '.whiteboard' "template-wb" &&
+        assert_json '.deadline' "2026-12-27"; then test_pass; fi
+fi
+
+test_begin "69b. bug create --template metadata applies"
+run_bzr bug create --template meta-tmpl --summary "Bug from meta template" \
+    --description "Description from meta template" --op-sys Linux --rep-platform PC
+if assert_success && assert_json_exists '.id'; then
+    _TMETA_BUG=$(jq -r '.id' "$BZR_STDOUT")
+    run_bzr bug view "$_TMETA_BUG"
+    if assert_json '.url' "http://example.com/template" &&
+        assert_json '.whiteboard' "template-wb" &&
+        assert_json_contains '[.flags[].name] | join(",")' "review"; then test_pass; fi
+fi
+
+test_begin "69c. template update --clear metadata"
+run_bzr template update meta-tmpl --clear url --clear whiteboard --cc "$ADMIN_EMAIL"
+if assert_success; then
+    run_bzr template show meta-tmpl
+    if assert_json '.url' "null" &&
+        assert_json '.whiteboard' "null" &&
+        assert_json_contains '.cc | join(",")' "$ADMIN_EMAIL"; then test_pass; fi
+fi
+
+test_begin "69d. template delete metadata template"
+run_bzr template delete meta-tmpl
+if assert_success; then
+    run_bzr template show meta-tmpl
+    if assert_failure; then test_pass; fi
+fi
+unset _TMETA_BUG
+```
+
+- [ ] **Step 6: Verify and commit**
+
+Run:
+
+```bash
+BZR_BZ_VERSION=bz50 tests/functional/setup-bugzilla.sh reset
+BZR_BZ_VERSION=bz50 tests/functional/run-tests.sh
+shellcheck tests/functional/phases/08c-bugs-create-fields.sh tests/functional/phases/10-bug-clone.sh tests/functional/phases/11b-bug-verbs.sh tests/functional/phases/12-my-bugs.sh tests/functional/phases/13-templates.sh
+shfmt -d tests/functional/phases/08c-bugs-create-fields.sh tests/functional/phases/10-bug-clone.sh tests/functional/phases/11b-bug-verbs.sh tests/functional/phases/12-my-bugs.sh tests/functional/phases/13-templates.sh
+```
+
+Commit:
+
+```bash
+git add tests/functional/phases/08c-bugs-create-fields.sh tests/functional/phases/10-bug-clone.sh tests/functional/phases/11b-bug-verbs.sh tests/functional/phases/12-my-bugs.sh tests/functional/phases/13-templates.sh
+git commit -m "test: expand bug workflow functional coverage"
+```
+
+### Task 8: Query Functional Coverage
+
+**Files:**
+
+- Modify: `tests/functional/phases/14-queries.sh`
+- Modify: `tests/functional/phases/17b-arg-validation.sh`
+
+- [ ] **Step 1: Add `query run --count`**
+
+In `tests/functional/phases/14-queries.sh`, after test `82. query run with
+fields override`, insert:
+
+```bash
+test_begin "82a. query run --count"
+_QCOUNT_MARK=$(unique_name query-count)
+make_bug --marker "$_QCOUNT_MARK" --product FuncTestProd --component Backend \
+    --op-sys Linux --rep-platform PC --description d --summary "query count 1" >/dev/null
+make_bug --marker "$_QCOUNT_MARK" --product FuncTestProd --component Backend \
+    --op-sys Linux --rep-platform PC --description d --summary "query count 2" >/dev/null
+run_bzr query save count-bugs --product FuncTestProd --whiteboard "$_QCOUNT_MARK" --limit 1
+if assert_success && assert_json '.action' "saved"; then
+    run_bzr query run count-bugs --count
+    if assert_success && assert_count 2; then test_pass; fi
+fi
+unset _QCOUNT_MARK
+```
+
+Also update test `87. query delete remaining` so it deletes `count-bugs`
+between `prod-bugs` and `complex`:
+
+```bash
+run_bzr query delete prod-bugs
+if assert_success; then
+    run_bzr query delete count-bugs
+    if assert_success; then
+        run_bzr query delete complex
+        if assert_success; then test_pass; fi
+    fi
+fi
+```
+
+- [ ] **Step 2: Add `query update --from-url` using the real server URL**
+
+In `tests/functional/phases/14-queries.sh`, after test `82a`, insert:
+
+```bash
+test_begin "82b. query update --from-url"
+_Q_URL="${BZ_URL}/buglist.cgi?product=FuncTestProd&component=Backend&bug_status=NEW&query_format=advanced"
+run_bzr query update complex --from-url "$_Q_URL" --limit 2
+if assert_success; then
+    run_bzr query show complex
+    if assert_json '.product[0]' "FuncTestProd" &&
+        assert_json '.component[0]' "Backend" &&
+        assert_json '.limit' "2"; then test_pass; fi
+fi
+unset _Q_URL
+```
+
+- [ ] **Step 3: Add count conflict checks**
+
+In `tests/functional/phases/17b-arg-validation.sh`, after test `122. bug list
+--offset + --paginate conflict`, insert:
+
+```bash
+test_begin "122a. query run --count + --offset conflict"
+run_bzr query run prod-bugs --count --offset 1
+if assert_exit_code 7 && assert_stderr_contains "cannot be combined with --offset"; then test_pass; fi
+
+test_begin "122b. query run --count + --paginate conflict"
+run_bzr query run prod-bugs --count --paginate
+if assert_exit_code 7 && assert_stderr_contains "cannot be combined with --offset"; then test_pass; fi
+```
+
+- [ ] **Step 4: Verify and commit**
+
+Run:
+
+```bash
+BZR_BZ_VERSION=bz50 tests/functional/setup-bugzilla.sh reset
+BZR_BZ_VERSION=bz50 tests/functional/run-tests.sh
+shellcheck tests/functional/phases/14-queries.sh tests/functional/phases/17b-arg-validation.sh
+shfmt -d tests/functional/phases/14-queries.sh tests/functional/phases/17b-arg-validation.sh
+```
+
+Commit:
+
+```bash
+git add tests/functional/phases/14-queries.sh tests/functional/phases/17b-arg-validation.sh
+git commit -m "test: cover query update and count options"
+```
+
+### Task 9: Attachment and Comment Functional Coverage
+
+**Files:**
+
+- Modify: `tests/functional/phases/16-attachments.sh`
+- Modify: `tests/functional/phases/17b-arg-validation.sh`
+
+- [ ] **Step 1: Add attachment comment-file and stdin tests**
+
+In `tests/functional/phases/16-attachments.sh`, after test `100h`, insert:
+
+```bash
+test_begin "100k. attachment upload --comment-file"
+if [[ -n "$BUG1" ]]; then
+    _ACF=$(mktemp /tmp/bzr-func-attachment-comment.XXXXXX)
+    printf 'attachment comment from file' >"$_ACF"
+    run_bzr attachment upload "$BUG1" /tmp/bzr-func-test.txt \
+        --summary "comment file upload" --comment-file "$_ACF"
+    if assert_success; then
+        run_bzr comment list "$BUG1"
+        if assert_stdout_contains "attachment comment from file"; then test_pass; fi
+    fi
+    rm -f "$_ACF"
+else test_skip "no BUG1"; fi
+
+test_begin "100l. attachment upload --comment-file -"
+if [[ -n "$BUG1" ]]; then
+    _ACF=$(mktemp /tmp/bzr-func-attachment-comment.XXXXXX)
+    printf 'attachment comment from stdin' >"$_ACF"
+    run_bzr attachment upload "$BUG1" /tmp/bzr-func-test.txt \
+        --summary "comment stdin upload" --comment-file - <"$_ACF"
+    if assert_success; then
+        run_bzr comment list "$BUG1"
+        if assert_stdout_contains "attachment comment from stdin"; then test_pass; fi
+    fi
+    rm -f "$_ACF"
+else test_skip "no BUG1"; fi
+
+test_begin "100m. attachment upload empty --comment-file rejected"
+if [[ -n "$BUG1" ]]; then
+    _ACF=$(mktemp /tmp/bzr-func-attachment-comment.XXXXXX)
+    printf '   ' >"$_ACF"
+    run_bzr attachment upload "$BUG1" /tmp/bzr-func-test.txt \
+        --summary "empty comment upload" --comment-file "$_ACF"
+    if assert_exit_code 7 && assert_stderr_contains "empty attachment comment"; then test_pass; fi
+    rm -f "$_ACF"
+else test_skip "no BUG1"; fi
+unset _ACF
+```
+
+- [ ] **Step 2: Add raw stdout download**
+
+In `tests/functional/phases/16-attachments.sh`, after test `98. attachment
+download`, insert:
+
+```bash
+test_begin "98a. attachment download --out - streams raw bytes"
+if [[ -n "${ATTACH_ID:-}" ]] && [[ "$ATTACH_ID" != "null" ]]; then
+    run_bzr_raw attachment download "$ATTACH_ID" --out -
+    if assert_success && assert_stdout_equals_file /tmp/bzr-func-test.txt; then test_pass; fi
+else
+    test_skip "no attachment ID"
+fi
+```
+
+- [ ] **Step 3: Add attachment update content-type and flag**
+
+In `tests/functional/phases/16-attachments.sh`, after test `151. attachment
+update --file-name round-trips`, insert:
+
+```bash
+test_begin "152. attachment update --content-type and --flag"
+if [[ -n "${_AID:-}" ]]; then
+    run_bzr attachment update "$_AID" --content-type text/plain --flag 'review?'
+    if assert_success; then
+        run_bzr attachment view "$_AID"
+        if assert_json '.content_type' "text/plain" &&
+            assert_json_contains '[.flags[].name] | join(",")' "review"; then test_pass; fi
+    fi
+else test_skip "no attachment id"; fi
+```
+
+- [ ] **Step 4: Add no-op rejection tests**
+
+In `tests/functional/phases/17b-arg-validation.sh`, before the final `echo ""`,
+insert:
+
+```bash
+test_begin "128. attachment update no fields rejected"
+run_bzr attachment update 1
+if assert_exit_code 7 && assert_stderr_contains "no attachment fields to update"; then test_pass; fi
+
+test_begin "129. comment tag no changes rejected"
+run_bzr comment tag 1
+if assert_exit_code 7 && assert_stderr_contains "no comment tag changes"; then test_pass; fi
+```
+
+- [ ] **Step 5: Verify and commit**
+
+Run:
+
+```bash
+BZR_BZ_VERSION=bz50 tests/functional/setup-bugzilla.sh reset
+BZR_BZ_VERSION=bz50 tests/functional/run-tests.sh
+shellcheck tests/functional/phases/16-attachments.sh tests/functional/phases/17b-arg-validation.sh
+shfmt -d tests/functional/phases/16-attachments.sh tests/functional/phases/17b-arg-validation.sh
+```
+
+Commit:
+
+```bash
+git add tests/functional/phases/16-attachments.sh tests/functional/phases/17b-arg-validation.sh
+git commit -m "test: expand attachment and comment functional coverage"
+```
+
+### Task 10: Schema and README Refresh
+
+**Files:**
+
+- Modify: `tests/functional/phases/18-completion-schema.sh`
+- Modify: `tests/functional/README.md`
+
+- [ ] **Step 1: Expand schema list assertions**
+
+In `tests/functional/phases/18-completion-schema.sh`, replace the schema list
+assertion with:
+
+```bash
+if assert_success && assert_json_valid &&
+    assert_schema_list_contains "bug" &&
+    assert_schema_list_contains "bug-create-input" &&
+    assert_schema_list_contains "bug-update-input" &&
+    assert_schema_list_contains "product-create-input" &&
+    assert_schema_list_contains "product-update-input" &&
+    assert_schema_list_contains "component-create-input" &&
+    assert_schema_list_contains "component-update-input" &&
+    assert_schema_list_contains "user-create-input" &&
+    assert_schema_list_contains "user-update-input" &&
+    assert_schema_list_contains "group-create-input" &&
+    assert_schema_list_contains "group-update-input" &&
+    assert_schema_list_contains "error"; then test_pass; fi
+```
+
+- [ ] **Step 2: Add per-schema smoke checks**
+
+After the existing `schema bug-update-input` test, insert:
+
+```bash
+test_begin "118a. schema product-create-input"
+run_bzr schema product-create-input
+if assert_success && assert_json_valid &&
+    assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema"; then test_pass; fi
+
+test_begin "118b. schema component-update-input"
+run_bzr schema component-update-input
+if assert_success && assert_json_valid &&
+    assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema"; then test_pass; fi
+
+test_begin "118c. schema user-update-input"
+run_bzr schema user-update-input
+if assert_success && assert_json_valid &&
+    assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema"; then test_pass; fi
+
+test_begin "118d. schema group-update-input"
+run_bzr schema group-update-input
+if assert_success && assert_json_valid &&
+    assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema"; then test_pass; fi
+```
+
+- [ ] **Step 3: Refresh `tests/functional/README.md`**
+
+Replace the stale "Test Structure" section with:
+
+```markdown
+## Test Structure
+
+Tests run in dependency order across the phase files sourced by
+`tests/functional/run-tests.sh`:
+
+1. Build and isolated config setup
+2. Server/auth detection and fixture capability setup
+3. Products and components
+4. Fields, classifications, users, and groups
+5. Bug create/read/update/search/paging/relationships/collision/clone workflows
+6. Batch updates and convenience verbs
+7. My-bug filters, templates, and saved queries
+8. Comments and attachments, including private-resource hybrid/XML-RPC paths
+9. Global options, argument validation, completion, schema, and sequence tests
+
+The suite creates real Bugzilla data in the running container and reads it back
+through the CLI. Count and paging assertions use per-run unique whiteboard
+markers so repeated runs against an already-started container stay stable.
+
+TLS functional coverage for ad-hoc `--server-tls-*` flags is intentionally not
+part of this suite expansion. It needs an HTTPS fixture in front of Bugzilla and
+is tracked separately in GitHub issue #406.
+```
+
+- [ ] **Step 4: Verify and commit**
+
+Run:
+
+```bash
+BZR_BZ_VERSION=bz50 tests/functional/setup-bugzilla.sh reset
+BZR_BZ_VERSION=bz50 tests/functional/run-tests.sh
+shellcheck tests/functional/phases/18-completion-schema.sh
+shfmt -d tests/functional/phases/18-completion-schema.sh
+```
+
+Commit:
+
+```bash
+git add tests/functional/phases/18-completion-schema.sh tests/functional/README.md
+git commit -m "test: refresh functional schema coverage docs"
+```
+
+### Task 11: Cross-Version Verification and Final Cleanup
+
+**Files:**
+
+- Read: `tests/functional/run-all-versions.sh`
+- Read: all modified files
+
+- [ ] **Step 1: Run focused Rust tests for changed command contracts**
+
+Run:
+
+```bash
+cargo test --lib from_json
+cargo test --lib dry_run
+cargo test --lib query_run_count
+cargo test --lib schema
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 2: Run shell checks on all functional scripts**
+
+Run:
+
+```bash
+shellcheck tests/functional/*.sh tests/functional/phases/*.sh tests/functional/versions/*/*.sh
+shfmt -d tests/functional/*.sh tests/functional/phases/*.sh tests/functional/versions/*/*.sh
+```
+
+Expected: shellcheck exits 0 and shfmt prints no diff.
+
+- [ ] **Step 3: Run all Bugzilla versions**
+
+Run:
+
+```bash
+tests/functional/run-all-versions.sh
+```
+
+Expected: `bz50`, `bz52`, and `bz53` pass. If a version-specific API endpoint
+is unavailable, the relevant test must skip with an explicit message rather than
+failing or silently passing without coverage.
+
+- [ ] **Step 4: Review for unnecessary complexity**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- tests/functional
+```
+
+Check:
+
+- Every new test creates or targets real Bugzilla data unless it is an explicit
+  parse-level conflict or no-op guard.
+- Every exact count uses a per-run unique marker.
+- No test relies on pre-existing shared database totals.
+- No TLS functional fixture was added.
+- No helper is used only once unless it centralizes a fragile shell pattern.
+
+- [ ] **Step 5: Final commit**
+
+Run:
+
+```bash
+git status --short
+git add tests/functional
+git add -f docs/superpowers/plans/2026-06-22-functional-cli-coverage.md
+git commit -m "test: expand functional CLI coverage"
+```
+
+Expected: final commit contains any remaining test and documentation changes.
+
+## Self-Review
+
+Spec coverage:
+
+- Credentialless real-server coverage is handled by Task 4.
+- Admin `--from-json` and `--dry-run` are handled by Task 5.
+- Bug update, create metadata, clone metadata, templates, verb guards, and
+  `bug my` filters are handled by Tasks 6 and 7.
+- Query, attachment, comment, no-op, schema, and README coverage are handled by
+  Tasks 8 through 10.
+- Cross-version verification is handled by Task 11.
+- TLS functional coverage is deliberately excluded and tracked by #406.
+
+Placeholder scan:
+
+- The plan contains no placeholder markers, no unspecified test steps, and no instruction to
+  add generic tests without concrete commands.
+
+Type and naming consistency:
+
+- Shell helper names are defined in Task 2 before later tasks use them.
+- The new phase name `08d-bug-update-from-json` is used consistently in file
+  paths and in `run-tests.sh`.

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -59,22 +59,26 @@ tests/functional/setup-bugzilla.sh stop
 
 ## Test Structure
 
-Tests run in dependency order across 12 phases:
+Tests run in dependency order across the phase files sourced by
+`tests/functional/run-tests.sh`:
 
-1. **Config** — set-server, show, set-default (no network)
-2. **Server & Auth** — server info, whoami, autodetect path
-3. **Products** — create, list, view, update
-4. **Components** — create, update
-5. **Fields & Classifications** — field list, classification view
-6. **Users** — create, search, update
-7. **Groups** — create, view, update, add/remove/list users, REST override fallback
-8. **Bugs** — create, view, list, search, update, history, negative test
-9. **Comments** — add, list, tag, search-tags
-10. **Attachments** — upload, list, download, update
-11. **Global Options** — --output table, --quiet, --server
-12. **Cleanup** — summary and exit code
+1. Build and isolated config setup
+2. Server/auth detection and fixture capability setup
+3. Products and components
+4. Fields, classifications, users, and groups
+5. Bug create/read/update/search/paging/relationships/collision/clone workflows
+6. Batch updates and convenience verbs
+7. My-bug filters, templates, and saved queries
+8. Comments and attachments, including private-resource hybrid/XML-RPC paths
+9. Global options, argument validation, completion, schema, and sequence tests
 
-Total: ~65 tests.
+The suite creates real Bugzilla data in the running container and reads it back
+through the CLI. Count and paging assertions use per-run unique whiteboard
+markers so repeated runs against an already-started container stay stable.
+
+TLS functional coverage for ad-hoc `--server-tls-*` flags is intentionally not
+part of this suite expansion. It needs an HTTPS fixture in front of Bugzilla and
+is tracked separately in GitHub issue #406.
 
 ## Config Isolation
 

--- a/tests/functional/keyring-test.sh
+++ b/tests/functional/keyring-test.sh
@@ -19,33 +19,33 @@ SERVER_NAME="fntest"
 SECRET="functional-test-secret-$RANDOM"
 
 cleanup() {
-  # Best-effort: remove the keychain entry and the temp config.
-  if [[ -x ./target/debug/bzr ]]; then
-    XDG_CONFIG_HOME="$TMP_CONFIG_HOME" \
-      ./target/debug/bzr config unset-keyring "$SERVER_NAME" 2>/dev/null || true
-  fi
-  rm -rf "$TMP_CONFIG_HOME"
-  return 0
+    # Best-effort: remove the keychain entry and the temp config.
+    if [[ -x ./target/debug/bzr ]]; then
+        XDG_CONFIG_HOME="$TMP_CONFIG_HOME" \
+            ./target/debug/bzr config unset-keyring "$SERVER_NAME" 2>/dev/null || true
+    fi
+    rm -rf "$TMP_CONFIG_HOME"
+    return 0
 }
 trap cleanup EXIT
 
 # On Linux, probe for a reachable Secret Service before running.
 if [[ "$(uname -s)" == "Linux" ]]; then
-  if ! command -v secret-tool >/dev/null 2>&1; then
-    echo "SKIP: secret-tool not installed; cannot verify Secret Service."
-    exit 0
-  fi
-  # Probe: lookup a nonexistent entry. Exit code 1 means "not found"
-  # (service is reachable); exit codes >1 mean D-Bus / service
-  # unavailable.
-  set +e
-  secret-tool lookup bzr-probe-svc bzr-probe-acct >/dev/null 2>&1
-  rc=$?
-  set -e
-  if [[ $rc -gt 1 ]]; then
-    echo "SKIP: Secret Service unavailable (rc=$rc)."
-    exit 0
-  fi
+    if ! command -v secret-tool >/dev/null 2>&1; then
+        echo "SKIP: secret-tool not installed; cannot verify Secret Service."
+        exit 0
+    fi
+    # Probe: lookup a nonexistent entry. Exit code 1 means "not found"
+    # (service is reachable); exit codes >1 mean D-Bus / service
+    # unavailable.
+    set +e
+    secret-tool lookup bzr-probe-svc bzr-probe-acct >/dev/null 2>&1
+    rc=$?
+    set -e
+    if [[ $rc -gt 1 ]]; then
+        echo "SKIP: Secret Service unavailable (rc=$rc)."
+        exit 0
+    fi
 fi
 
 echo "Building bzr..."
@@ -56,18 +56,18 @@ export XDG_CONFIG_HOME="$TMP_CONFIG_HOME"
 
 echo "1. Creating server with inline key..."
 "$BZR" config set-server "$SERVER_NAME" \
-  --url "https://example.invalid" \
-  --api-key "initial-inline"
+    --url "https://example.invalid" \
+    --api-key "initial-inline"
 
 echo "2. Migrating inline -> keyring..."
 "$BZR" config migrate-to-keyring "$SERVER_NAME" \
-  --service "$SERVICE_NAME" --yes
+    --service "$SERVICE_NAME" --yes
 
 echo "3. Verifying 'config show' reports api_key_source=keyring..."
 if ! "$BZR" config show --json | grep -q '"api_key_source": *"keyring"'; then
-  echo "FAIL: expected api_key_source=keyring in config show output"
-  "$BZR" config show --json
-  exit 1
+    echo "FAIL: expected api_key_source=keyring in config show output"
+    "$BZR" config show --json
+    exit 1
 fi
 
 echo "4. Overwriting the stored secret via set-keyring..."
@@ -76,7 +76,7 @@ echo "4. Overwriting the stored secret via set-keyring..."
 # functional test does not need an interactive TTY. It has no effect
 # in release builds.
 BZR_KEYRING_TEST_SECRET="$SECRET" "$BZR" config set-keyring "$SERVER_NAME" \
-  --service "$SERVICE_NAME"
+    --service "$SERVICE_NAME"
 
 echo "5. Removing keychain entry via unset-keyring..."
 "$BZR" config unset-keyring "$SERVER_NAME"

--- a/tests/functional/lib.sh
+++ b/tests/functional/lib.sh
@@ -7,10 +7,10 @@ BZ_VERSION="${BZR_BZ_VERSION:-bz50}"
 
 bz_version_num() {
     case "$BZ_VERSION" in
-        bz50) echo 500 ;;
-        bz52) echo 520 ;;
-        bz53) echo 530 ;;
-        *)    echo 0 ;;
+    bz50) echo 500 ;;
+    bz52) echo 520 ;;
+    bz53) echo 530 ;;
+    *) echo 0 ;;
     esac
     return 0
 }
@@ -53,14 +53,14 @@ test_begin() {
 
 test_pass() {
     PASS_COUNT=$((PASS_COUNT + 1))
-    printf "${GREEN}PASS${RESET}\n"
+    printf '%bPASS%b\n' "$GREEN" "$RESET"
     return 0
 }
 
 test_fail() {
     local reason="${1:-}"
     FAIL_COUNT=$((FAIL_COUNT + 1))
-    printf "${RED}FAIL${RESET}"
+    printf '%bFAIL%b' "$RED" "$RESET"
     if [[ -n "$reason" ]]; then
         printf "  (%s)" "$reason"
     fi
@@ -78,7 +78,7 @@ test_fail() {
 test_skip() {
     local reason="${1:-}"
     SKIP_COUNT=$((SKIP_COUNT + 1))
-    printf "${YELLOW}SKIP${RESET}"
+    printf '%bSKIP%b' "$YELLOW" "$RESET"
     if [[ -n "$reason" ]]; then
         printf "  (%s)" "$reason"
     fi
@@ -366,4 +366,64 @@ wait_for_changed() {
         attempt=$((attempt + 1))
     done
     return 1
+}
+
+# unique_name <prefix> — per-run fixture id safe for Bugzilla names.
+unique_name() {
+    local prefix="$1"
+    printf '%s-%s-%s' "$prefix" "$$" "$RANDOM"
+    return 0
+}
+
+# write_json_fixture <path> <json> — writes compact JSON without a trailing
+# shell-expanded newline surprise.
+write_json_fixture() {
+    local path="$1"
+    local json="$2"
+    printf '%s' "$json" >"$path"
+    return 0
+}
+
+# assert_stdout_equals_file <path> — raw stdout exactly matches file bytes.
+assert_stdout_equals_file() {
+    local path="$1"
+    if ! cmp -s "$BZR_STDOUT" "$path"; then
+        test_fail "stdout does not exactly match '$path'"
+        return 1
+    fi
+}
+
+# assert_schema_list_contains <name> — schema list stdout contains a schema name.
+assert_schema_list_contains() {
+    local name="$1"
+    assert_json_exists "index(\"$name\")"
+}
+
+container_runtime() {
+    if command -v podman >/dev/null 2>&1; then
+        printf '%s' podman
+        return 0
+    fi
+    if command -v docker >/dev/null 2>&1; then
+        printf '%s' docker
+        return 0
+    fi
+    return 1
+}
+
+bugzilla_container_name() {
+    printf '%s' "${BZR_FUNC_CONTAINER:-bzr-func-test-${BZ_VERSION}}"
+    return 0
+}
+
+# run_bugzilla_sql_file <path> — execute SQL inside the running Bugzilla
+# container. Use this only for fixture capabilities that Bugzilla's public API
+# cannot create, such as flag types and product group controls.
+run_bugzilla_sql_file() {
+    local sql_file="$1"
+    local runtime
+    local container
+    runtime=$(container_runtime)
+    container=$(bugzilla_container_name)
+    "$runtime" exec -i "$container" mysql -u root bugs <"$sql_file"
 }

--- a/tests/functional/phases/00-build.sh
+++ b/tests/functional/phases/00-build.sh
@@ -38,4 +38,3 @@ if ! curl -sf "${BZ_URL}/rest/version" >/dev/null 2>&1; then
 fi
 echo "  Bugzilla is up."
 echo ""
-

--- a/tests/functional/phases/01-config.sh
+++ b/tests/functional/phases/01-config.sh
@@ -24,6 +24,14 @@ test_begin "3a. config set-server auto-detect"
 run_bzr config set-server auto --url "$BZ_URL" --api-key "$API_KEY" --email "$ADMIN_EMAIL"
 if assert_success; then test_pass; fi
 
+test_begin "3b. config set-server public without credentials"
+run_bzr config set-server public --url "$BZ_URL"
+if assert_success; then
+    run_bzr config show
+    if assert_json '.servers.public.url' "$BZ_URL" &&
+        assert_json '.servers.public.api_key_source' "none"; then test_pass; fi
+fi
+
 test_begin "4. config set-default alt"
 run_bzr config set-default alt
 if assert_success; then test_pass; fi
@@ -94,4 +102,3 @@ rm -rf "$_ALT_DIR"
 unset _ALT_DIR
 
 echo ""
-

--- a/tests/functional/phases/02-server-auth.sh
+++ b/tests/functional/phases/02-server-auth.sh
@@ -56,4 +56,29 @@ fi
 rm -f "$_FLAG_SQL"
 unset _FLAG_SQL
 
+test_begin "8c. credentialless named server info"
+run_bzr_raw --json --server public server info
+if assert_success && assert_json_exists '.version'; then test_pass; fi
+
+test_begin "8d. credentialless named whoami fails before network auth"
+run_bzr_raw --json --server public whoami
+if assert_exit_code 3 && assert_stderr_contains "requires credentials"; then test_pass; fi
+
+test_begin "8e. credentialless named write fails before mutation"
+run_bzr_raw --json --server public bug create \
+    --product FuncTestProd --component Backend --summary "public write" \
+    --description "should not write" --op-sys Linux --rep-platform PC
+if assert_exit_code 3 && assert_stderr_contains "requires credentials"; then test_pass; fi
+
+test_begin "8f. inline credentialless server info"
+run_bzr_raw --json --server-url "$BZ_URL" server info
+if assert_success && assert_json_exists '.version'; then test_pass; fi
+
+test_begin "8g. inline credentialed whoami"
+export BZR_FUNC_INLINE_KEY="$API_KEY"
+run_bzr_raw --json --server-url "$BZ_URL" \
+    --server-api-key-env BZR_FUNC_INLINE_KEY --server-email "$ADMIN_EMAIL" whoami
+if assert_success && assert_json_exists '.id'; then test_pass; fi
+unset BZR_FUNC_INLINE_KEY
+
 echo ""

--- a/tests/functional/phases/02-server-auth.sh
+++ b/tests/functional/phases/02-server-auth.sh
@@ -20,5 +20,40 @@ test_begin "8a. --server auto whoami"
 run_bzr_raw --json --server auto whoami
 if assert_success && assert_json_exists '.id'; then test_pass; fi
 
-echo ""
+test_begin "8b. fixture flag types exist"
+_FLAG_SQL=$(mktemp /tmp/bzr-func-flags.XXXXXX.sql)
+cat >"$_FLAG_SQL" <<'SQL'
+INSERT INTO flagtypes
+    (name, description, target_type, is_active, is_requestable,
+     is_requesteeble, is_multiplicable, sortkey)
+SELECT 'review', 'Functional test review flag for bugs', 'b', 1, 1, 1, 1, 10
+WHERE NOT EXISTS (
+    SELECT 1 FROM flagtypes WHERE name = 'review' AND target_type = 'b'
+);
 
+INSERT INTO flagtypes
+    (name, description, target_type, is_active, is_requestable,
+     is_requesteeble, is_multiplicable, sortkey)
+SELECT 'review', 'Functional test review flag for attachments', 'a', 1, 1, 1, 1, 10
+WHERE NOT EXISTS (
+    SELECT 1 FROM flagtypes WHERE name = 'review' AND target_type = 'a'
+);
+
+INSERT INTO flaginclusions (type_id, product_id, component_id)
+SELECT id, NULL, NULL
+FROM flagtypes
+WHERE name = 'review'
+  AND target_type IN ('b', 'a')
+  AND NOT EXISTS (
+      SELECT 1 FROM flaginclusions WHERE flaginclusions.type_id = flagtypes.id
+  );
+SQL
+if run_bugzilla_sql_file "$_FLAG_SQL"; then
+    test_pass
+else
+    test_fail "could not seed functional flag types"
+fi
+rm -f "$_FLAG_SQL"
+unset _FLAG_SQL
+
+echo ""

--- a/tests/functional/phases/02-server-auth.sh
+++ b/tests/functional/phases/02-server-auth.sh
@@ -26,23 +26,23 @@ cat >"$_FLAG_SQL" <<'SQL'
 INSERT INTO flagtypes
     (name, description, target_type, is_active, is_requestable,
      is_requesteeble, is_multiplicable, sortkey)
-SELECT 'review', 'Functional test review flag for bugs', 'b', 1, 1, 1, 1, 10
+SELECT 'bzr_bug_review', 'Functional test review flag for bugs', 'b', 1, 1, 1, 1, 10
 WHERE NOT EXISTS (
-    SELECT 1 FROM flagtypes WHERE name = 'review' AND target_type = 'b'
+    SELECT 1 FROM flagtypes WHERE name = 'bzr_bug_review' AND target_type = 'b'
 );
 
 INSERT INTO flagtypes
     (name, description, target_type, is_active, is_requestable,
      is_requesteeble, is_multiplicable, sortkey)
-SELECT 'review', 'Functional test review flag for attachments', 'a', 1, 1, 1, 1, 10
+SELECT 'bzr_attachment_review', 'Functional test review flag for attachments', 'a', 1, 1, 1, 1, 10
 WHERE NOT EXISTS (
-    SELECT 1 FROM flagtypes WHERE name = 'review' AND target_type = 'a'
+    SELECT 1 FROM flagtypes WHERE name = 'bzr_attachment_review' AND target_type = 'a'
 );
 
 INSERT INTO flaginclusions (type_id, product_id, component_id)
 SELECT id, NULL, NULL
 FROM flagtypes
-WHERE name = 'review'
+WHERE name IN ('bzr_bug_review', 'bzr_attachment_review')
   AND target_type IN ('b', 'a')
   AND NOT EXISTS (
       SELECT 1 FROM flaginclusions WHERE flaginclusions.type_id = flagtypes.id

--- a/tests/functional/phases/03-products.sh
+++ b/tests/functional/phases/03-products.sh
@@ -11,12 +11,11 @@ echo "── Phase 3: Products ────────────────�
 test_begin "9. product create"
 run_bzr product create --name FuncTestProd --description "Functional test product"
 if [[ $BZR_EXIT -eq 0 ]] && assert_json_exists '.id'; then
-    PRODUCT_ID=$(jq -r '.id' "$BZR_STDOUT")
     test_pass
 elif [[ $BZR_EXIT -ne 0 ]] && grep -q "already exists" "$BZR_STDERR" 2>/dev/null; then
-    test_pass  # idempotent: product exists from a prior run
+    test_pass # idempotent: product exists from a prior run
 else
-    assert_success  # will call test_fail with details
+    assert_success # will call test_fail with details
 fi
 
 test_begin "10. product list"
@@ -52,6 +51,42 @@ if assert_success; then
     if assert_json '.is_active' "false"; then test_pass; fi
 fi
 
-unset _PV
-echo ""
+_PJSON_DIR=$(mktemp -d /tmp/bzr-func-product-json.XXXXXX)
+_PJ_NAME=$(unique_name prodjson)
+write_json_fixture "$_PJSON_DIR/create.json" \
+    "{\"name\":\"$_PJ_NAME\",\"description\":\"product json\",\"version\":\"8.8\",\"is_open\":true}"
+write_json_fixture "$_PJSON_DIR/update.json" \
+    "{\"name\":\"$_PJ_NAME\",\"description\":\"product json updated\",\"is_open\":false}"
+write_json_fixture "$_PJSON_DIR/bad.json" \
+    "{\"name\":\"bad\",\"description\":\"bad\",\"unknown\":true}"
 
+test_begin "13c. product create --from-json"
+run_bzr product create --from-json "$_PJSON_DIR/create.json"
+if assert_success; then
+    run_bzr product view "$_PJ_NAME"
+    if assert_json '.name' "$_PJ_NAME" &&
+        assert_json_contains '[.versions[].name] | join(",")' "8.8"; then test_pass; fi
+fi
+
+test_begin "13d. product update --from-json"
+run_bzr product update --from-json "$_PJSON_DIR/update.json"
+if assert_success; then
+    run_bzr product view "$_PJ_NAME"
+    if assert_json '.is_active' "false"; then test_pass; fi
+fi
+
+test_begin "13e. product create --from-json unknown key"
+run_bzr product create --from-json "$_PJSON_DIR/bad.json"
+if assert_exit_code 7 && assert_stderr_contains "unknown field"; then test_pass; fi
+
+test_begin "13f. product create --from-json CLI override"
+_PJ_OVERRIDE=$(unique_name prodjson-override)
+run_bzr product create --from-json "$_PJSON_DIR/create.json" --name "$_PJ_OVERRIDE"
+if assert_success; then
+    run_bzr product view "$_PJ_OVERRIDE"
+    if assert_json '.name' "$_PJ_OVERRIDE"; then test_pass; fi
+fi
+
+rm -r "$_PJSON_DIR"
+unset _PV _PJSON_DIR _PJ_NAME _PJ_OVERRIDE
+echo ""

--- a/tests/functional/phases/04-components.sh
+++ b/tests/functional/phases/04-components.sh
@@ -14,7 +14,7 @@ if [[ $BZR_EXIT -eq 0 ]]; then
     COMP_ID=$(jq -r '.id' "$BZR_STDOUT" 2>/dev/null || echo "")
     test_pass
 elif grep -q "already" "$BZR_STDERR" 2>/dev/null; then
-    test_pass  # idempotent
+    test_pass # idempotent
 else
     assert_success
 fi
@@ -28,7 +28,7 @@ if [[ -n "${COMP_ID:-}" ]] && [[ "$COMP_ID" != "null" ]]; then
     elif grep -q "32614" "$BZR_STDERR" 2>/dev/null; then
         test_skip "component update REST endpoint not available"
     else
-        assert_success  # report the actual error
+        assert_success # report the actual error
     fi
 else
     # Component was already created in a prior run; try to look up the ID
@@ -56,5 +56,44 @@ test_begin "15b. component view <product> <component>"
 run_bzr component view FuncTestProd Backend
 if assert_success && assert_json '.name' "Backend"; then test_pass; fi
 
-echo ""
+_CJSON_DIR=$(mktemp -d /tmp/bzr-func-component-json.XXXXXX)
+_CJ_NAME=$(unique_name compjson)
+write_json_fixture "$_CJSON_DIR/create.json" \
+    "{\"product\":\"FuncTestProd\",\"name\":\"$_CJ_NAME\",\"description\":\"component json\",\"default_assignee\":\"$ADMIN_EMAIL\"}"
+write_json_fixture "$_CJSON_DIR/update-by-name.json" \
+    "{\"product\":\"FuncTestProd\",\"component\":\"$_CJ_NAME\",\"description\":\"component json updated\"}"
 
+test_begin "15c. component create --from-json"
+run_bzr component create --from-json "$_CJSON_DIR/create.json"
+if assert_success; then
+    run_bzr component view FuncTestProd "$_CJ_NAME"
+    if assert_json '.name' "$_CJ_NAME"; then test_pass; fi
+fi
+
+test_begin "15d. component update --product --component target"
+run_bzr component update --product FuncTestProd --component "$_CJ_NAME" \
+    --description "component named target updated"
+if [[ $BZR_EXIT -eq 0 ]]; then
+    run_bzr component view FuncTestProd "$_CJ_NAME"
+    if assert_json '.description' "component named target updated"; then test_pass; fi
+elif grep -q "32614" "$BZR_STDERR" 2>/dev/null; then
+    test_skip "component update REST endpoint not available"
+else
+    assert_success
+fi
+
+test_begin "15e. component update --from-json named target"
+run_bzr component update --from-json "$_CJSON_DIR/update-by-name.json"
+if [[ $BZR_EXIT -eq 0 ]]; then
+    run_bzr component view FuncTestProd "$_CJ_NAME"
+    if assert_json '.description' "component json updated"; then test_pass; fi
+elif grep -q "32614" "$BZR_STDERR" 2>/dev/null; then
+    test_skip "component update REST endpoint not available"
+else
+    assert_success
+fi
+
+rm -r "$_CJSON_DIR"
+unset _CJSON_DIR _CJ_NAME
+
+echo ""

--- a/tests/functional/phases/05-fields-classifications.sh
+++ b/tests/functional/phases/05-fields-classifications.sh
@@ -46,4 +46,3 @@ if assert_success && assert_json_array_min_length '.' 1 &&
     assert_json_contains '[.[].name] | join(",")' "Unclassified"; then test_pass; fi
 
 echo ""
-

--- a/tests/functional/phases/06-users.sh
+++ b/tests/functional/phases/06-users.sh
@@ -13,7 +13,7 @@ run_bzr user create --email testuser@test.bzr --full-name "Test User" --password
 if [[ $BZR_EXIT -eq 0 ]]; then
     test_pass
 elif grep -q "already" "$BZR_STDERR" 2>/dev/null; then
-    test_pass  # idempotent
+    test_pass # idempotent
 else
     assert_success
 fi
@@ -37,5 +37,30 @@ test_begin "24. user update testuser"
 run_bzr user update testuser@test.bzr --disable-login true --login-denied-text "test disabled"
 if assert_success; then test_pass; fi
 
-echo ""
+_UJSON_DIR=$(mktemp -d /tmp/bzr-func-user-json.XXXXXX)
+_UJ_LOGIN="$(unique_name userjson)@test.bzr"
+write_json_fixture "$_UJSON_DIR/create.json" \
+    "{\"email\":\"$_UJ_LOGIN\",\"full_name\":\"User Json\",\"password\":\"TestPass1!\"}"
+write_json_fixture "$_UJSON_DIR/update.json" \
+    "{\"user\":\"$_UJ_LOGIN\",\"disable_login\":true,\"login_denied_text\":\"json disabled\"}"
 
+test_begin "24a. user create --from-json"
+run_bzr user create --from-json "$_UJSON_DIR/create.json"
+if assert_success; then
+    run_bzr user search "$_UJ_LOGIN" --details
+    if assert_stdout_contains "$_UJ_LOGIN"; then test_pass; fi
+fi
+
+test_begin "24b. user update --from-json"
+run_bzr user update --from-json "$_UJSON_DIR/update.json"
+if assert_success; then
+    run_bzr user search "$_UJ_LOGIN" --details
+    if assert_success &&
+        assert_json "[.[] | select(.name == \"$_UJ_LOGIN\")][0].can_login" \
+            "false"; then test_pass; fi
+fi
+
+rm -r "$_UJSON_DIR"
+unset _UJSON_DIR _UJ_LOGIN
+
+echo ""

--- a/tests/functional/phases/07-groups.sh
+++ b/tests/functional/phases/07-groups.sh
@@ -13,7 +13,7 @@ run_bzr group create --name functest-grp --description "Test group"
 if [[ $BZR_EXIT -eq 0 ]]; then
     test_pass
 elif grep -q "already exists" "$BZR_STDERR" 2>/dev/null; then
-    test_pass  # idempotent
+    test_pass # idempotent
 else
     assert_success
 fi
@@ -37,6 +37,31 @@ fi
 test_begin "27. group update functest-grp"
 run_bzr group update functest-grp --description "Updated group desc"
 if assert_success; then test_pass; fi
+
+test_begin "27a. fixture group enabled for FuncTestProd bugs"
+_GROUP_SQL=$(mktemp /tmp/bzr-func-group-control.XXXXXX.sql)
+cat >"$_GROUP_SQL" <<'SQL'
+INSERT INTO group_control_map
+    (group_id, product_id, entry, membercontrol, othercontrol, canedit,
+     editcomponents, editbugs, canconfirm)
+SELECT g.id, p.id, 0, 1, 1, 1, 0, 1, 1
+FROM groups AS g
+JOIN products AS p ON p.name = 'FuncTestProd'
+WHERE g.name = 'functest-grp'
+ON DUPLICATE KEY UPDATE
+    membercontrol = 1,
+    othercontrol = 1,
+    canedit = 1,
+    editbugs = 1,
+    canconfirm = 1;
+SQL
+if run_bugzilla_sql_file "$_GROUP_SQL"; then
+    test_pass
+else
+    test_fail "could not enable functest-grp for FuncTestProd"
+fi
+rm -f "$_GROUP_SQL"
+unset _GROUP_SQL
 
 # Re-enable testuser before group membership tests (test 24 disables it)
 test_begin "27b. user re-enable for group tests"
@@ -68,4 +93,3 @@ run_bzr group list-users --group functest-grp
 if assert_success && assert_stdout_not_contains "testuser@test.bzr"; then test_pass; fi
 
 echo ""
-

--- a/tests/functional/phases/07-groups.sh
+++ b/tests/functional/phases/07-groups.sh
@@ -92,4 +92,28 @@ test_begin "32. group list-users (after remove)"
 run_bzr group list-users --group functest-grp
 if assert_success && assert_stdout_not_contains "testuser@test.bzr"; then test_pass; fi
 
+_GJSON_DIR=$(mktemp -d /tmp/bzr-func-group-json.XXXXXX)
+_GJ_NAME=$(unique_name groupjson)
+write_json_fixture "$_GJSON_DIR/create.json" \
+    "{\"name\":\"$_GJ_NAME\",\"description\":\"group json\",\"is_active\":true}"
+write_json_fixture "$_GJSON_DIR/update.json" \
+    "{\"group\":\"$_GJ_NAME\",\"description\":\"group json updated\",\"is_active\":false}"
+
+test_begin "32a. group create --from-json"
+run_bzr group create --from-json "$_GJSON_DIR/create.json"
+if assert_success; then
+    run_bzr group view "$_GJ_NAME"
+    if assert_json '.name' "$_GJ_NAME"; then test_pass; fi
+fi
+
+test_begin "32b. group update --from-json"
+run_bzr group update --from-json "$_GJSON_DIR/update.json"
+if assert_success; then
+    run_bzr group view "$_GJ_NAME"
+    if assert_json '.description' "group json updated"; then test_pass; fi
+fi
+
+rm -r "$_GJSON_DIR"
+unset _GJSON_DIR _GJ_NAME
+
 echo ""

--- a/tests/functional/phases/08-bugs.sh
+++ b/tests/functional/phases/08-bugs.sh
@@ -51,10 +51,10 @@ else test_skip "no duplicate source/target"; fi
 test_begin "34d. bug view verifies duplicate transition"
 if [[ -n "$BUG_DUP_SOURCE" ]] && [[ -n "$BUG_DUP_TARGET" ]]; then
     run_bzr bug view "$BUG_DUP_SOURCE" --json
-    if assert_success \
-        && assert_json '.status' "RESOLVED" \
-        && assert_json '.resolution' "DUPLICATE" \
-        && assert_json '.dupe_of' "$BUG_DUP_TARGET"; then
+    if assert_success &&
+        assert_json '.status' "RESOLVED" &&
+        assert_json '.resolution' "DUPLICATE" &&
+        assert_json '.dupe_of' "$BUG_DUP_TARGET"; then
         test_pass
     fi
 else test_skip "no duplicate source/target"; fi
@@ -64,6 +64,16 @@ if [[ -n "$BUG1" ]]; then
     run_bzr bug view "$BUG1"
     if assert_success && assert_json '.summary' "Bug one"; then test_pass; fi
 else test_skip "no BUG1"; fi
+
+test_begin "35a. credentialless named bug view"
+if [[ -n "$BUG1" ]]; then
+    run_bzr_raw --json --server public bug view "$BUG1"
+    if assert_success && assert_json '.summary' "Bug one"; then test_pass; fi
+else test_skip "no BUG1"; fi
+
+test_begin "35b. inline credentialless bug list"
+run_bzr_raw --json --server-url "$BZ_URL" bug list --product FuncTestProd --limit 1
+if assert_success && assert_json_array_min_length '.' 1; then test_pass; fi
 
 test_begin "36. bug view --fields"
 if [[ -n "$BUG1" ]]; then
@@ -154,8 +164,8 @@ if [[ -n "$BUG2" ]]; then
     # filter window includes BUG2 and excludes any older fixtures. Bugzilla
     # matches "at or after" inclusively; subtract 5 minutes to tolerate clock
     # skew between the runner and the container.
-    SINCE_TS=$(date -u -d '5 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
-                || date -u -v-5M '+%Y-%m-%dT%H:%M:%SZ')
+    SINCE_TS=$(date -u -d '5 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
+        date -u -v-5M '+%Y-%m-%dT%H:%M:%SZ')
     run_bzr bug list --product FuncTestProd --changed-since "$SINCE_TS"
     if assert_success && assert_json_array_min_length '.' 1; then test_pass; fi
 else test_skip "no BUG2"; fi
@@ -176,9 +186,9 @@ if [[ -n "$BUG1" ]] && [[ -n "$BUG2" ]]; then
     # BUG1 has whiteboard "wip"; BUG2 does not. Negation must exclude BUG1
     # and include BUG2.
     run_bzr bug list --product FuncTestProd --whiteboard '!wip'
-    if assert_success \
-        && assert_stdout_not_contains "\"id\":$BUG1" \
-        && assert_stdout_contains "$BUG2"; then
+    if assert_success &&
+        assert_stdout_not_contains "\"id\":$BUG1" &&
+        assert_stdout_contains "$BUG2"; then
         test_pass
     fi
 else test_skip "no BUG1/BUG2"; fi
@@ -196,9 +206,9 @@ if [[ -n "$BUG1" ]] && [[ -n "$BUG2" ]]; then
     # must exclude BUG1 and include BUG2 (empty resolution !=
     # "FIXED" by Bugzilla's notequals semantics).
     run_bzr bug list --product FuncTestProd --resolution '!FIXED'
-    if assert_success \
-        && assert_stdout_not_contains "\"id\":$BUG1" \
-        && assert_stdout_contains "$BUG2"; then
+    if assert_success &&
+        assert_stdout_not_contains "\"id\":$BUG1" &&
+        assert_stdout_contains "$BUG2"; then
         test_pass
     fi
 else test_skip "no BUG1/BUG2"; fi
@@ -210,9 +220,9 @@ if assert_failure; then test_pass; fi
 test_begin "46a. bug view multi-ID (all succeed, JSON wrapped shape)"
 if [[ -n "$BUG1" ]] && [[ -n "$BUG2" ]]; then
     run_bzr bug view "$BUG1" "$BUG2"
-    if assert_success \
-        && assert_json_array_length '.bugs' 2 \
-        && assert_json_array_length '.failed' 0; then
+    if assert_success &&
+        assert_json_array_length '.bugs' 2 &&
+        assert_json_array_length '.failed' 0; then
         test_pass
     fi
 else test_skip "no BUG1/BUG2"; fi
@@ -226,10 +236,10 @@ else test_skip "no BUG1"; fi
 test_begin "46c. bug view multi-ID --permissive surfaces per-bug error"
 if [[ -n "$BUG1" ]] && [[ -n "$BUG2" ]]; then
     run_bzr bug view "$BUG1" "$BUG2" 999999 --permissive
-    if assert_success \
-        && assert_json_array_length '.bugs' 2 \
-        && assert_json_array_length '.failed' 1 \
-        && assert_json '.failed[0].id' "999999"; then
+    if assert_success &&
+        assert_json_array_length '.bugs' 2 &&
+        assert_json_array_length '.failed' 1 &&
+        assert_json '.failed[0].id' "999999"; then
         test_pass
     fi
 else test_skip "no BUG1/BUG2"; fi
@@ -237,6 +247,7 @@ else test_skip "no BUG1/BUG2"; fi
 test_begin "47. bug create (bug three — clone source)"
 run_bzr bug create --product FuncTestProd --component Backend --summary "Clone source bug" --description "Description for cloning" --priority Highest --severity critical --op-sys Linux --rep-platform PC
 if assert_success && assert_json_exists '.id'; then
+    # shellcheck disable=SC2034 # consumed by later sourced phases
     BUG3=$(jq -r '.id' "$BZR_STDOUT")
     test_pass
 fi
@@ -247,6 +258,7 @@ if [[ -n "$BUG1" ]] && [[ -n "$BUG2" ]]; then
         --summary "Bug with relationships" --description "Relationship test description" \
         --blocks "$BUG1" --depends-on "$BUG2" --op-sys All --rep-platform All
     if assert_success && assert_json_exists '.id'; then
+        # shellcheck disable=SC2034 # consumed by later sourced phases
         BUG4=$(jq -r '.id' "$BZR_STDOUT")
         test_pass
     fi
@@ -255,7 +267,7 @@ else test_skip "no BUG1/BUG2"; fi
 # ── Bug create: description-source precedence ────────────────────────
 test_begin "48a. bug create --description-file"
 DESC_FILE=$(mktemp /tmp/bzr-func-desc.XXXXXX)
-echo "description from file" > "$DESC_FILE"
+echo "description from file" >"$DESC_FILE"
 run_bzr bug create --product FuncTestProd --component Backend \
     --summary "From file" --description-file "$DESC_FILE" \
     --op-sys All --rep-platform All
@@ -264,7 +276,7 @@ rm -f "$DESC_FILE"
 
 test_begin "48b. bug create --description and --description-file conflict (clap exit 2)"
 DESC_FILE=$(mktemp /tmp/bzr-func-desc.XXXXXX)
-echo "should-not-appear" > "$DESC_FILE"
+echo "should-not-appear" >"$DESC_FILE"
 run_bzr_raw bug create --product FuncTestProd --component Backend \
     --summary "Conflict test" --description literal \
     --description-file "$DESC_FILE" --op-sys All --rep-platform All
@@ -280,7 +292,7 @@ if assert_success; then test_pass; fi
 
 test_begin "48d. bug create --description-file wins over piped stdin"
 DESC_FILE=$(mktemp /tmp/bzr-func-desc.XXXXXX)
-echo "from file" > "$DESC_FILE"
+echo "from file" >"$DESC_FILE"
 run_bzr bug create \
     --product FuncTestProd --component Backend \
     --summary "Precedence file>stdin" --description-file "$DESC_FILE" \
@@ -309,7 +321,7 @@ if assert_exit_code 7; then test_pass; fi
 
 test_begin "48g. bug create empty fake-editor → exit 7 (TTY-conditional)"
 EDITOR_SCRIPT=$(mktemp /tmp/bzr-empty-editor-XXXXXX.sh)
-cat > "$EDITOR_SCRIPT" <<'SH'
+cat >"$EDITOR_SCRIPT" <<'SH'
 #!/bin/sh
 : > "$1"
 SH
@@ -320,9 +332,8 @@ chmod +x "$EDITOR_SCRIPT"
 # expected exit code is 7.
 EDITOR="$EDITOR_SCRIPT" run_bzr_raw bug create \
     --product FuncTestProd --component Backend \
-    --op-sys All --rep-platform All < /dev/null
+    --op-sys All --rep-platform All </dev/null
 if assert_exit_code 7; then test_pass; fi
 rm -f "$EDITOR_SCRIPT"
 
 echo ""
-

--- a/tests/functional/phases/08-bugs.sh
+++ b/tests/functional/phases/08-bugs.sh
@@ -134,6 +134,17 @@ if [[ -n "$BUG1" ]]; then
     fi
 else test_skip "no BUG1"; fi
 
+test_begin "42c. bug update --url and --target-milestone"
+if [[ -n "$BUG1" ]]; then
+    run_bzr bug update "$BUG1" --url "http://example.com/updated-$BUG1" \
+        --target-milestone=---
+    if assert_success; then
+        run_bzr bug view "$BUG1"
+        if assert_json '.url' "http://example.com/updated-$BUG1" &&
+            assert_json '.target_milestone' "---"; then test_pass; fi
+    fi
+else test_skip "no BUG1"; fi
+
 test_begin "42b. bug update reset assignee and QA contact"
 if [[ -n "$BUG1" ]]; then
     run_bzr bug update "$BUG1" --reset-assigned-to --reset-qa-contact

--- a/tests/functional/phases/08-bugs.sh
+++ b/tests/functional/phases/08-bugs.sh
@@ -188,7 +188,7 @@ if assert_exit_code 7; then test_pass; fi
 test_begin "45c. bug list --whiteboard (substring positive includes bug)"
 if [[ -n "$BUG1" ]]; then
     # BUG1 had --whiteboard "wip" set in test 41.
-    run_bzr bug list --product FuncTestProd --whiteboard wip
+    run_bzr bug list --id "$BUG1" --product FuncTestProd --whiteboard wip
     if assert_success && assert_stdout_contains "$BUG1"; then test_pass; fi
 else test_skip "no BUG1"; fi
 
@@ -196,7 +196,7 @@ test_begin "45d. bug list --whiteboard (notsubstring excludes bug)"
 if [[ -n "$BUG1" ]] && [[ -n "$BUG2" ]]; then
     # BUG1 has whiteboard "wip"; BUG2 does not. Negation must exclude BUG1
     # and include BUG2.
-    run_bzr bug list --product FuncTestProd --whiteboard '!wip'
+    run_bzr bug list --id "$BUG1" --id "$BUG2" --product FuncTestProd --whiteboard '!wip'
     if assert_success &&
         assert_stdout_not_contains "\"id\":$BUG1" &&
         assert_stdout_contains "$BUG2"; then
@@ -207,7 +207,7 @@ else test_skip "no BUG1/BUG2"; fi
 test_begin "45e. bug list --resolution FIXED (positive)"
 if [[ -n "$BUG1" ]]; then
     # BUG1 was resolved FIXED in test 43.
-    run_bzr bug list --product FuncTestProd --resolution FIXED
+    run_bzr bug list --id "$BUG1" --product FuncTestProd --resolution FIXED
     if assert_success && assert_stdout_contains "$BUG1"; then test_pass; fi
 else test_skip "no BUG1"; fi
 
@@ -216,7 +216,7 @@ if [[ -n "$BUG1" ]] && [[ -n "$BUG2" ]]; then
     # BUG1 is FIXED; BUG2 is open (empty resolution). The notequals filter
     # must exclude BUG1 and include BUG2 (empty resolution !=
     # "FIXED" by Bugzilla's notequals semantics).
-    run_bzr bug list --product FuncTestProd --resolution '!FIXED'
+    run_bzr bug list --id "$BUG1" --id "$BUG2" --product FuncTestProd --resolution '!FIXED'
     if assert_success &&
         assert_stdout_not_contains "\"id\":$BUG1" &&
         assert_stdout_contains "$BUG2"; then

--- a/tests/functional/phases/08b-bugs-paging.sh
+++ b/tests/functional/phases/08b-bugs-paging.sh
@@ -21,7 +21,7 @@ _PGOTHER="pgother$$x${RANDOM}"
 _PG_CREATE=(--product FuncTestProd --component Backend --op-sys Linux --rep-platform PC --description d)
 
 P1=$(make_bug --marker "$_PGMARK" "${_PG_CREATE[@]}" --summary "paging 1")
-P2=$(make_bug --marker "$_PGMARK" "${_PG_CREATE[@]}" --summary "paging 2")
+make_bug --marker "$_PGMARK" "${_PG_CREATE[@]}" --summary "paging 2" >/dev/null
 P3=$(make_bug --marker "$_PGMARK" "${_PG_CREATE[@]}" --summary "paging 3")
 PX=$(make_bug --marker "$_PGOTHER" "${_PG_CREATE[@]}" --summary "paging foreign")
 
@@ -75,5 +75,5 @@ run_bzr bug list --version "$_VVA"
 if assert_success && assert_json_exists ".[] | select(.id==$VBA)" &&
     assert_json "[.[] | select(.id==$VBB)] | length" "0"; then test_pass; fi
 
-unset _PGMARK _PGOTHER _PG_CREATE P1 P2 P3 PX _VPA _VPB _VVA _VVB VBA VBB
+unset _PGMARK _PGOTHER _PG_CREATE P1 P3 PX _VPA _VPB _VVA _VVB VBA VBB
 echo ""

--- a/tests/functional/phases/08c-bugs-create-fields.sh
+++ b/tests/functional/phases/08c-bugs-create-fields.sh
@@ -66,6 +66,27 @@ if require_version 520 "fix-needed keyword seeded on bz52+"; then
 fi
 unset KID
 
-rm -rf "$_FJ"
-unset _CF _FJ _WB CFID FID OID
+test_begin "146b. bug create --target-milestone and --deadline round-trip"
+MID=$(make_bug "${_CF[@]}" --summary "milestone create" \
+    --target-milestone=--- --deadline 2026-12-30)
+run_bzr bug view "$MID"
+if assert_success &&
+    assert_json '.target_milestone' "---" &&
+    assert_json '.deadline' "2026-12-30"; then test_pass; fi
+
+test_begin "146c. bug create --groups succeeds with fixture group"
+GID=$(make_bug "${_CF[@]}" --summary "group create" --groups functest-grp)
+if [[ -n "$GID" ]]; then
+    run_bzr bug view "$GID"
+    if assert_success && assert_json '.id' "$GID"; then test_pass; fi
+fi
+
+test_begin "146d. bug create --flag round-trips"
+FID=$(make_bug "${_CF[@]}" --summary "flag create" --flag 'review?')
+run_bzr bug view "$FID"
+if assert_success &&
+    assert_json_contains '[.flags[].name] | join(",")' "review"; then test_pass; fi
+
+rm -r "$_FJ"
+unset _CF _FJ _WB CFID FID OID MID GID
 echo ""

--- a/tests/functional/phases/08c-bugs-create-fields.sh
+++ b/tests/functional/phases/08c-bugs-create-fields.sh
@@ -82,10 +82,10 @@ if [[ -n "$GID" ]]; then
 fi
 
 test_begin "146d. bug create --flag round-trips"
-FID=$(make_bug "${_CF[@]}" --summary "flag create" --flag 'review?')
+FID=$(make_bug "${_CF[@]}" --summary "flag create" --flag 'bzr_bug_review?')
 run_bzr bug view "$FID"
 if assert_success &&
-    assert_json_contains '[.flags[].name] | join(",")' "review"; then test_pass; fi
+    assert_json_contains '[.flags[].name] | join(",")' "bzr_bug_review"; then test_pass; fi
 
 rm -r "$_FJ"
 unset _CF _FJ _WB CFID FID OID MID GID

--- a/tests/functional/phases/08c-bugs-create-fields.sh
+++ b/tests/functional/phases/08c-bugs-create-fields.sh
@@ -74,11 +74,18 @@ if assert_success &&
     assert_json '.target_milestone' "---" &&
     assert_json '.deadline' "2026-12-30"; then test_pass; fi
 
-test_begin "146c. bug create --groups succeeds with fixture group"
-GID=$(make_bug "${_CF[@]}" --summary "group create" --groups functest-grp)
+test_begin "146c. bug create --groups restricts public access"
+_GROUP_WB=$(unique_name group-restrict)
+GID=$(make_bug --marker "$_GROUP_WB" "${_CF[@]}" --summary "group create" --groups functest-grp)
 if [[ -n "$GID" ]]; then
     run_bzr bug view "$GID"
-    if assert_success && assert_json '.id' "$GID"; then test_pass; fi
+    if assert_success && assert_json '.id' "$GID"; then
+        run_bzr_raw --json --server public bug view "$GID"
+        if assert_failure; then
+            run_bzr_raw --json --server public bug list --whiteboard "$_GROUP_WB"
+            if assert_success && assert_json_array_length '.' 0; then test_pass; fi
+        fi
+    fi
 fi
 
 test_begin "146d. bug create --flag round-trips"
@@ -88,5 +95,5 @@ if assert_success &&
     assert_json_contains '[.flags[].name] | join(",")' "bzr_bug_review"; then test_pass; fi
 
 rm -r "$_FJ"
-unset _CF _FJ _WB CFID FID OID MID GID
+unset _CF _FJ _WB _GROUP_WB CFID FID OID MID GID
 echo ""

--- a/tests/functional/phases/08d-bug-update-from-json.sh
+++ b/tests/functional/phases/08d-bug-update-from-json.sh
@@ -1,0 +1,71 @@
+# 08d-bug-update-from-json
+# Sourced by run-tests.sh in order; assumes lib.sh helpers and the
+# orchestrator preamble (constants, shared globals, cleanup trap).
+# shellcheck shell=bash
+
+echo "── Phase 8d: Bug update --from-json ────────────────────────"
+
+_UJ_DIR=$(mktemp -d /tmp/bzr-func-bug-update-json.XXXXXX)
+_UJ_CREATE=(--product FuncTestProd --component Backend --op-sys Linux --rep-platform PC --description d)
+
+test_begin "152. bug update --from-json object with positional ID"
+_UJ_ONE=$(make_bug "${_UJ_CREATE[@]}" --summary "update json object")
+write_json_fixture "$_UJ_DIR/object.json" \
+    '{"priority":"High","whiteboard":"json-object","url":"http://example.com/json-object"}'
+run_bzr bug update "$_UJ_ONE" --from-json "$_UJ_DIR/object.json"
+if assert_success; then
+    run_bzr bug view "$_UJ_ONE"
+    if assert_json '.priority' "High" &&
+        assert_json '.whiteboard' "json-object" &&
+        assert_json '.url' "http://example.com/json-object"; then test_pass; fi
+fi
+
+test_begin "153. bug update --from-json object target from JSON"
+_UJ_TWO=$(make_bug "${_UJ_CREATE[@]}" --summary "update json target")
+write_json_fixture "$_UJ_DIR/target.json" \
+    "{\"id\":$_UJ_TWO,\"severity\":\"major\",\"whiteboard\":\"json-target\"}"
+run_bzr bug update --from-json "$_UJ_DIR/target.json"
+if assert_success; then
+    run_bzr bug view "$_UJ_TWO"
+    if assert_json '.severity' "major" &&
+        assert_json '.whiteboard' "json-target"; then test_pass; fi
+fi
+
+test_begin "154. bug update --from-json array partial failure"
+_UJ_THREE=$(make_bug "${_UJ_CREATE[@]}" --summary "update json array valid")
+write_json_fixture "$_UJ_DIR/array.json" \
+    "[{\"id\":$_UJ_THREE,\"priority\":\"Low\"},{\"id\":999999,\"priority\":\"High\"}]"
+run_bzr bug update --from-json "$_UJ_DIR/array.json"
+if assert_exit_code 11 &&
+    assert_json '.succeeded[0]' "$_UJ_THREE" &&
+    assert_json '.failed[0].id' "999999"; then
+    run_bzr bug view "$_UJ_THREE"
+    if assert_json '.priority' "Low"; then test_pass; fi
+fi
+
+test_begin "155. bug update --from-json stdin with CLI override"
+_UJ_FOUR=$(make_bug "${_UJ_CREATE[@]}" --summary "update json override")
+write_json_fixture "$_UJ_DIR/stdin.json" \
+    "{\"id\":$_UJ_FOUR,\"priority\":\"Low\",\"whiteboard\":\"json-loses\"}"
+run_bzr bug update --from-json - --whiteboard "cli-wins" <"$_UJ_DIR/stdin.json"
+if assert_success; then
+    run_bzr bug view "$_UJ_FOUR"
+    if assert_json '.priority' "Low" &&
+        assert_json '.whiteboard' "cli-wins"; then test_pass; fi
+fi
+
+test_begin "156. bug update --from-json unknown key"
+_UJ_FIVE=$(make_bug "${_UJ_CREATE[@]}" --summary "update json bad")
+write_json_fixture "$_UJ_DIR/bad.json" "{\"id\":$_UJ_FIVE,\"bogus\":true}"
+run_bzr bug update --from-json "$_UJ_DIR/bad.json"
+if assert_exit_code 7 && assert_stderr_contains "unknown field"; then test_pass; fi
+
+test_begin "157. bug update --from-json no-op rejected"
+_UJ_SIX=$(make_bug "${_UJ_CREATE[@]}" --summary "update json noop")
+write_json_fixture "$_UJ_DIR/noop.json" "{\"id\":$_UJ_SIX}"
+run_bzr bug update --from-json "$_UJ_DIR/noop.json"
+if assert_exit_code 7 && assert_stderr_contains "no fields to update"; then test_pass; fi
+
+rm -r "$_UJ_DIR"
+unset _UJ_DIR _UJ_CREATE _UJ_ONE _UJ_TWO _UJ_THREE _UJ_FOUR _UJ_FIVE _UJ_SIX
+echo ""

--- a/tests/functional/phases/09-bug-relationships.sh
+++ b/tests/functional/phases/09-bug-relationships.sh
@@ -76,4 +76,3 @@ if [[ -n "$BUG1" ]]; then
 else test_skip "no BUG1"; fi
 
 echo ""
-

--- a/tests/functional/phases/10-bug-clone.sh
+++ b/tests/functional/phases/10-bug-clone.sh
@@ -62,13 +62,13 @@ if [[ -n "$BUG3" ]]; then
     run_bzr bug clone "$BUG3" --op-sys Linux --rep-platform PC --no-comment \
         --url "http://example.com/clone-override" --whiteboard "$_CL_WB" \
         --target-milestone=--- --deadline 2026-12-28 \
-        --cc "$ADMIN_EMAIL" --flag 'review?'
+        --cc "$ADMIN_EMAIL" --flag 'bzr_bug_review?'
     if assert_success && assert_json_exists '.id'; then
         _CL_OVERRIDE=$(jq -r '.id' "$BZR_STDOUT")
         run_bzr bug view "$_CL_OVERRIDE"
         if assert_json '.url' "http://example.com/clone-override" &&
             assert_json '.whiteboard' "$_CL_WB" &&
-            assert_json_contains '[.flags[].name] | join(",")' "review"; then test_pass; fi
+            assert_json_contains '[.flags[].name] | join(",")' "bzr_bug_review"; then test_pass; fi
     fi
 else test_skip "no BUG3"; fi
 unset _CL_META _CL_WB _CL_OVERRIDE

--- a/tests/functional/phases/10-bug-clone.sh
+++ b/tests/functional/phases/10-bug-clone.sh
@@ -39,5 +39,38 @@ if [[ -n "$BUG3" ]]; then
     if assert_success && assert_json_exists '.id'; then test_pass; fi
 else test_skip "no BUG3"; fi
 
-echo ""
+test_begin "57a. bug clone copies source metadata"
+if [[ -n "$BUG3" ]]; then
+    run_bzr bug update "$BUG3" --url "http://example.com/source-$BUG3" \
+        --whiteboard "clone-source-$BUG3" --target-milestone=--- \
+        --deadline 2026-12-29
+    if assert_success; then
+        run_bzr bug clone "$BUG3" --op-sys Linux --rep-platform PC --no-comment
+        if assert_success && assert_json_exists '.id'; then
+            _CL_META=$(jq -r '.id' "$BZR_STDOUT")
+            run_bzr bug view "$_CL_META"
+            if assert_json '.url' "http://example.com/source-$BUG3" &&
+                assert_json '.whiteboard' "clone-source-$BUG3" &&
+                assert_json '.deadline' "2026-12-29"; then test_pass; fi
+        fi
+    fi
+else test_skip "no BUG3"; fi
 
+test_begin "57b. bug clone metadata overrides"
+if [[ -n "$BUG3" ]]; then
+    _CL_WB="clone-override-$$"
+    run_bzr bug clone "$BUG3" --op-sys Linux --rep-platform PC --no-comment \
+        --url "http://example.com/clone-override" --whiteboard "$_CL_WB" \
+        --target-milestone=--- --deadline 2026-12-28 \
+        --cc "$ADMIN_EMAIL" --flag 'review?'
+    if assert_success && assert_json_exists '.id'; then
+        _CL_OVERRIDE=$(jq -r '.id' "$BZR_STDOUT")
+        run_bzr bug view "$_CL_OVERRIDE"
+        if assert_json '.url' "http://example.com/clone-override" &&
+            assert_json '.whiteboard' "$_CL_WB" &&
+            assert_json_contains '[.flags[].name] | join(",")' "review"; then test_pass; fi
+    fi
+else test_skip "no BUG3"; fi
+unset _CL_META _CL_WB _CL_OVERRIDE
+
+echo ""

--- a/tests/functional/phases/11-batch-update.sh
+++ b/tests/functional/phases/11-batch-update.sh
@@ -27,4 +27,3 @@ if [[ -n "$BUG4" ]]; then
 else test_skip "no BUG4"; fi
 
 echo ""
-

--- a/tests/functional/phases/11b-bug-verbs.sh
+++ b/tests/functional/phases/11b-bug-verbs.sh
@@ -59,5 +59,32 @@ if assert_exit_code 11; then
     if assert_json '.status' "RESOLVED"; then test_pass; fi
 fi
 
-unset _VERB_CREATE VID SRC TGT
+test_begin "134a. bug resolve --expect-unchanged-since happy path"
+VID=$(make_bug "${_VERB_CREATE[@]}" --summary "verb resolve guarded")
+run_bzr bug view "$VID"
+if assert_success; then
+    LCT=$(jq -r '.last_change_time' "$BZR_STDOUT" 2>/dev/null || true)
+    run_bzr bug resolve "$VID" --expect-unchanged-since "$LCT"
+    if assert_success; then
+        run_bzr bug view "$VID"
+        if assert_json '.status' "RESOLVED"; then test_pass; fi
+    fi
+fi
+
+test_begin "134b. bug dup --expect-unchanged-since detects collision"
+SRC=$(make_bug "${_VERB_CREATE[@]}" --summary "verb dup guarded source")
+TGT=$(make_bug "${_VERB_CREATE[@]}" --summary "verb dup guarded target")
+run_bzr bug view "$SRC"
+if assert_success; then
+    LCT=$(jq -r '.last_change_time' "$BZR_STDOUT" 2>/dev/null || true)
+    run_bzr bug update "$SRC" --whiteboard "verb-guard-touch"
+    if wait_for_changed "$SRC" "$LCT"; then
+        run_bzr bug dup "$SRC" "$TGT" --expect-unchanged-since "$LCT"
+        if assert_exit_code 14; then test_pass; fi
+    else
+        test_skip "last_change_time did not advance within retry budget"
+    fi
+fi
+
+unset _VERB_CREATE VID SRC TGT LCT
 echo ""

--- a/tests/functional/phases/12-my-bugs.sh
+++ b/tests/functional/phases/12-my-bugs.sh
@@ -36,5 +36,29 @@ test_begin "64c. bug my --status mixed positive and negated"
 run_bzr bug my --all --status NEW --status '!RESOLVED'
 if assert_success; then test_pass; fi
 
-echo ""
+test_begin "64d. bug my --product --component"
+run_bzr bug my --all --product FuncTestProd --component Backend
+if assert_success && assert_json_array_min_length '.' 1; then test_pass; fi
 
+test_begin "64e. bug my --priority --severity"
+_MY_PS_MARK=$(unique_name my-priority)
+_MY_PS_ID=$(make_bug --marker "$_MY_PS_MARK" --product FuncTestProd --component Backend \
+    --op-sys Linux --rep-platform PC --description d --summary "my priority filter" \
+    --priority High --severity major)
+run_bzr bug my --all --priority High --severity major --whiteboard "$_MY_PS_MARK"
+if assert_success && assert_stdout_contains "$_MY_PS_ID"; then test_pass; fi
+
+test_begin "64f. bug my --whiteboard --url"
+_MY_MARK="my-filter-$$"
+_MY_ID=$(make_bug --marker "$_MY_MARK" --product FuncTestProd --component Backend \
+    --op-sys Linux --rep-platform PC --description d --summary "my filter" \
+    --url "http://example.com/$_MY_MARK")
+run_bzr bug my --all --whiteboard "$_MY_MARK" --url "$_MY_MARK"
+if assert_success && assert_stdout_contains "$_MY_ID"; then test_pass; fi
+
+test_begin "64g. bug my --changed-since malformed"
+run_bzr bug my --changed-since "not-a-date"
+if assert_exit_code 7; then test_pass; fi
+unset _MY_PS_MARK _MY_PS_ID _MY_MARK _MY_ID
+
+echo ""

--- a/tests/functional/phases/13-templates.sh
+++ b/tests/functional/phases/13-templates.sh
@@ -40,7 +40,7 @@ test_begin "69a. template save metadata fields"
 run_bzr template save meta-tmpl --product FuncTestProd --component Backend \
     --priority Normal --severity normal --url "http://example.com/template" \
     --whiteboard "template-wb" --target-milestone=--- --deadline 2026-12-27 \
-    --cc "$ADMIN_EMAIL" --flag 'review?'
+    --cc "$ADMIN_EMAIL" --flag 'bzr_bug_review?'
 if assert_success; then
     run_bzr template show meta-tmpl
     if assert_json '.url' "http://example.com/template" &&
@@ -56,7 +56,7 @@ if assert_success && assert_json_exists '.id'; then
     run_bzr bug view "$_TMETA_BUG"
     if assert_json '.url' "http://example.com/template" &&
         assert_json '.whiteboard' "template-wb" &&
-        assert_json_contains '[.flags[].name] | join(",")' "review"; then test_pass; fi
+        assert_json_contains '[.flags[].name] | join(",")' "bzr_bug_review"; then test_pass; fi
 fi
 
 test_begin "69c. template update --clear metadata"

--- a/tests/functional/phases/13-templates.sh
+++ b/tests/functional/phases/13-templates.sh
@@ -36,6 +36,46 @@ if [[ -n "$TMPL_BUG" ]]; then
     fi
 else test_skip "no TMPL_BUG"; fi
 
+test_begin "69a. template save metadata fields"
+run_bzr template save meta-tmpl --product FuncTestProd --component Backend \
+    --priority Normal --severity normal --url "http://example.com/template" \
+    --whiteboard "template-wb" --target-milestone=--- --deadline 2026-12-27 \
+    --cc "$ADMIN_EMAIL" --flag 'review?'
+if assert_success; then
+    run_bzr template show meta-tmpl
+    if assert_json '.url' "http://example.com/template" &&
+        assert_json '.whiteboard' "template-wb" &&
+        assert_json '.deadline' "2026-12-27"; then test_pass; fi
+fi
+
+test_begin "69b. bug create --template metadata applies"
+run_bzr bug create --template meta-tmpl --summary "Bug from meta template" \
+    --description "Description from meta template" --op-sys Linux --rep-platform PC
+if assert_success && assert_json_exists '.id'; then
+    _TMETA_BUG=$(jq -r '.id' "$BZR_STDOUT")
+    run_bzr bug view "$_TMETA_BUG"
+    if assert_json '.url' "http://example.com/template" &&
+        assert_json '.whiteboard' "template-wb" &&
+        assert_json_contains '[.flags[].name] | join(",")' "review"; then test_pass; fi
+fi
+
+test_begin "69c. template update --clear metadata"
+run_bzr template update meta-tmpl --clear url --clear whiteboard --cc "$ADMIN_EMAIL"
+if assert_success; then
+    run_bzr template show meta-tmpl
+    if assert_json '.url' "null" &&
+        assert_json '.whiteboard' "null" &&
+        assert_json_contains '.cc | join(",")' "$ADMIN_EMAIL"; then test_pass; fi
+fi
+
+test_begin "69d. template delete metadata template"
+run_bzr template delete meta-tmpl
+if assert_success; then
+    run_bzr template show meta-tmpl
+    if assert_failure; then test_pass; fi
+fi
+unset _TMETA_BUG
+
 test_begin "70. template delete"
 run_bzr template delete func-tmpl
 if assert_success; then test_pass; fi
@@ -45,4 +85,3 @@ run_bzr template show func-tmpl
 if assert_failure; then test_pass; fi
 
 echo ""
-

--- a/tests/functional/phases/14-queries.sh
+++ b/tests/functional/phases/14-queries.sh
@@ -56,6 +56,30 @@ test_begin "82. query run with fields override"
 run_bzr query run prod-bugs --fields id,summary,status
 if assert_success && assert_json_array_min_length '.' 1; then test_pass; fi
 
+test_begin "82a. query run --count"
+_QCOUNT_MARK=$(unique_name query-count)
+make_bug --marker "$_QCOUNT_MARK" --product FuncTestProd --component Backend \
+    --op-sys Linux --rep-platform PC --description d --summary "query count 1" >/dev/null
+make_bug --marker "$_QCOUNT_MARK" --product FuncTestProd --component Backend \
+    --op-sys Linux --rep-platform PC --description d --summary "query count 2" >/dev/null
+run_bzr query save count-bugs --product FuncTestProd --whiteboard "$_QCOUNT_MARK" --limit 1
+if assert_success && assert_json '.action' "saved"; then
+    run_bzr query run count-bugs --count
+    if assert_success && assert_count 2; then test_pass; fi
+fi
+unset _QCOUNT_MARK
+
+test_begin "82b. query update --from-url"
+_Q_URL="${BZ_URL}/buglist.cgi?product=FuncTestProd&component=Backend&bug_status=NEW&query_format=advanced"
+run_bzr query update complex --from-url "$_Q_URL" --limit 2
+if assert_success; then
+    run_bzr query show complex
+    if assert_json '.product[0]' "FuncTestProd" &&
+        assert_json '.component[0]' "Backend" &&
+        assert_json '.limit' "2"; then test_pass; fi
+fi
+unset _Q_URL
+
 # ── Cleanup and error handling ───────────────────────────────────────
 
 test_begin "83. query delete"
@@ -77,9 +101,11 @@ if assert_failure; then test_pass; fi
 test_begin "87. query delete remaining"
 run_bzr query delete prod-bugs
 if assert_success; then
-    run_bzr query delete complex
-    if assert_success; then test_pass; fi
+    run_bzr query delete count-bugs
+    if assert_success; then
+        run_bzr query delete complex
+        if assert_success; then test_pass; fi
+    fi
 fi
 
 echo ""
-

--- a/tests/functional/phases/15-comments.sh
+++ b/tests/functional/phases/15-comments.sh
@@ -69,8 +69,8 @@ if [[ -n "$BUG1" ]]; then
     if assert_success; then
         run_bzr comment list "$BUG1"
         post_count=$(jq '. | length' "$BZR_STDOUT")
-        if [[ "$post_count" -eq $((pre_count + 1)) ]] \
-            && jq -e '.[-1].text == "atomic comment from #161 test"' "$BZR_STDOUT" >/dev/null; then
+        if [[ "$post_count" -eq $((pre_count + 1)) ]] &&
+            jq -e '.[-1].text == "atomic comment from #161 test"' "$BZR_STDOUT" >/dev/null; then
             test_pass
         else
             test_fail "comment not appended atomically (pre=$pre_count post=$post_count)"
@@ -83,8 +83,8 @@ if [[ -n "$BUG1" ]]; then
     run_bzr bug update "$BUG1" --comment "private atomic comment" --comment-private
     if assert_success; then
         run_bzr --api hybrid comment list "$BUG1"
-        if jq -e '.[-1].is_private == true' "$BZR_STDOUT" >/dev/null \
-            && jq -e '.[-1].text == "private atomic comment"' "$BZR_STDOUT" >/dev/null; then
+        if jq -e '.[-1].is_private == true' "$BZR_STDOUT" >/dev/null &&
+            jq -e '.[-1].text == "private atomic comment"' "$BZR_STDOUT" >/dev/null; then
             test_pass
         else
             test_fail "last comment not private or text mismatch"
@@ -95,7 +95,7 @@ else test_skip "no BUG1"; fi
 test_begin "94f. bug update --comment-file"
 if [[ -n "$BUG1" ]]; then
     tmpfile=$(mktemp)
-    printf 'comment from file\nsecond line\n' > "$tmpfile"
+    printf 'comment from file\nsecond line\n' >"$tmpfile"
     run_bzr bug update "$BUG1" --comment-file "$tmpfile"
     if assert_success; then
         run_bzr comment list "$BUG1"
@@ -132,4 +132,3 @@ fi
 rm -f "$_CBF"
 unset _CB _CBF
 echo ""
-

--- a/tests/functional/phases/15b-comments-private.sh
+++ b/tests/functional/phases/15b-comments-private.sh
@@ -24,9 +24,9 @@ if [[ -n "$BUG1" ]]; then
     run_bzr --api hybrid comment list "$BUG1"
     # 1 description (count 0) + 2 public + 1 private = >= 4
     # AND the private one must be visible (is_private: true present).
-    if assert_success \
-        && assert_json_array_min_length '.' 4 \
-        && [[ "$(jq '[.[] | select(.is_private == true)] | length' "$BZR_STDOUT")" -ge 1 ]]; then
+    if assert_success &&
+        assert_json_array_min_length '.' 4 &&
+        [[ "$(jq '[.[] | select(.is_private == true)] | length' "$BZR_STDOUT")" -ge 1 ]]; then
         test_pass
     fi
 else test_skip "no BUG1"; fi
@@ -34,12 +34,11 @@ else test_skip "no BUG1"; fi
 test_begin "94c. comment list returns private comment in XML-RPC mode"
 if [[ -n "$BUG1" ]]; then
     run_bzr --api xmlrpc comment list "$BUG1"
-    if assert_success \
-        && assert_json_array_min_length '.' 4 \
-        && [[ "$(jq '[.[] | select(.is_private == true)] | length' "$BZR_STDOUT")" -ge 1 ]]; then
+    if assert_success &&
+        assert_json_array_min_length '.' 4 &&
+        [[ "$(jq '[.[] | select(.is_private == true)] | length' "$BZR_STDOUT")" -ge 1 ]]; then
         test_pass
     fi
 else test_skip "no BUG1"; fi
 
 echo ""
-

--- a/tests/functional/phases/16-attachments.sh
+++ b/tests/functional/phases/16-attachments.sh
@@ -9,7 +9,7 @@
 echo "── Phase 15: Attachments ───────────────────────────────────"
 
 test_begin "95. create temp file"
-echo "bzr functional test content $(date +%s)" > /tmp/bzr-func-test.txt
+echo "bzr functional test content $(date +%s)" >/tmp/bzr-func-test.txt
 test_pass
 
 test_begin "96. attachment upload"
@@ -34,6 +34,14 @@ if [[ -n "${ATTACH_ID:-}" ]] && [[ "$ATTACH_ID" != "null" ]]; then
     if assert_success && assert_file_contains /tmp/bzr-func-downloaded.txt "bzr functional test content"; then
         test_pass
     fi
+else
+    test_skip "no attachment ID"
+fi
+
+test_begin "98a. attachment download --out - streams raw bytes"
+if [[ -n "${ATTACH_ID:-}" ]] && [[ "$ATTACH_ID" != "null" ]]; then
+    run_bzr_raw attachment download "$ATTACH_ID" --out -
+    if assert_success && assert_stdout_equals_file /tmp/bzr-func-test.txt; then test_pass; fi
 else
     test_skip "no attachment ID"
 fi
@@ -64,9 +72,9 @@ if [[ -n "$BUG1" ]]; then
             run_bzr comment list "$BUG1"
             if assert_success; then
                 POSTCOMMENT_COUNT=$(jq '. | length' "$BZR_STDOUT" 2>/dev/null || echo "")
-                if [[ -n "$PRECOMMENT_COUNT" ]] \
-                    && [[ -n "$POSTCOMMENT_COUNT" ]] \
-                    && [[ "$POSTCOMMENT_COUNT" -eq $((PRECOMMENT_COUNT + 1)) ]]; then
+                if [[ -n "$PRECOMMENT_COUNT" ]] &&
+                    [[ -n "$POSTCOMMENT_COUNT" ]] &&
+                    [[ "$POSTCOMMENT_COUNT" -eq $((PRECOMMENT_COUNT + 1)) ]]; then
                     test_pass
                 else
                     test_fail "comment count did not grow by 1 (pre=$PRECOMMENT_COUNT post=$POSTCOMMENT_COUNT)"
@@ -82,8 +90,8 @@ if [[ -n "$BUG1" ]]; then
         --summary "patch test" --patch
     if assert_success; then
         run_bzr attachment list "$BUG1"
-        if assert_success \
-            && assert_json '[.[] | select(.summary == "patch test")][-1].is_patch' "true"; then
+        if assert_success &&
+            assert_json '[.[] | select(.summary == "patch test")][-1].is_patch' "true"; then
             test_pass
         fi
     fi
@@ -113,6 +121,43 @@ if [[ -n "$BUG1" ]]; then
         fi
     fi
 else test_skip "no BUG1"; fi
+
+test_begin "100k. attachment upload --comment-file"
+if [[ -n "$BUG1" ]]; then
+    _ACF=$(mktemp /tmp/bzr-func-attachment-comment.XXXXXX)
+    printf 'attachment comment from file' >"$_ACF"
+    run_bzr attachment upload "$BUG1" /tmp/bzr-func-test.txt \
+        --summary "comment file upload" --comment-file "$_ACF"
+    if assert_success; then
+        run_bzr comment list "$BUG1"
+        if assert_stdout_contains "attachment comment from file"; then test_pass; fi
+    fi
+    rm -f "$_ACF"
+else test_skip "no BUG1"; fi
+
+test_begin "100l. attachment upload --comment-file -"
+if [[ -n "$BUG1" ]]; then
+    _ACF=$(mktemp /tmp/bzr-func-attachment-comment.XXXXXX)
+    printf 'attachment comment from stdin' >"$_ACF"
+    run_bzr attachment upload "$BUG1" /tmp/bzr-func-test.txt \
+        --summary "comment stdin upload" --comment-file - <"$_ACF"
+    if assert_success; then
+        run_bzr comment list "$BUG1"
+        if assert_stdout_contains "attachment comment from stdin"; then test_pass; fi
+    fi
+    rm -f "$_ACF"
+else test_skip "no BUG1"; fi
+
+test_begin "100m. attachment upload empty --comment-file rejected"
+if [[ -n "$BUG1" ]]; then
+    _ACF=$(mktemp /tmp/bzr-func-attachment-comment.XXXXXX)
+    printf '   ' >"$_ACF"
+    run_bzr attachment upload "$BUG1" /tmp/bzr-func-test.txt \
+        --summary "empty comment upload" --comment-file "$_ACF"
+    if assert_exit_code 7 && assert_stderr_contains "empty comment, aborting"; then test_pass; fi
+    rm -f "$_ACF"
+else test_skip "no BUG1"; fi
+unset _ACF
 
 test_begin "100i. attachment download --bug bulk into per-bug subdir"
 if [[ -n "$BUG1" ]]; then
@@ -187,7 +232,16 @@ if [[ -n "${_AID:-}" ]]; then
     fi
 else test_skip "no attachment id"; fi
 
+test_begin "152. attachment update --content-type and --flag"
+if [[ -n "${_AID:-}" ]]; then
+    run_bzr attachment update "$_AID" --content-type text/plain --flag 'review?'
+    if assert_success; then
+        run_bzr attachment view "$_AID"
+        if assert_json '.content_type' "text/plain" &&
+            assert_json_contains '[.flags[].name] | join(",")' "review"; then test_pass; fi
+    fi
+else test_skip "no attachment id"; fi
+
 rm -f "$_AF"
 unset _AB _AF _AID
 echo ""
-

--- a/tests/functional/phases/16-attachments.sh
+++ b/tests/functional/phases/16-attachments.sh
@@ -234,11 +234,11 @@ else test_skip "no attachment id"; fi
 
 test_begin "152. attachment update --content-type and --flag"
 if [[ -n "${_AID:-}" ]]; then
-    run_bzr attachment update "$_AID" --content-type text/plain --flag 'review?'
+    run_bzr attachment update "$_AID" --content-type text/plain --flag 'bzr_attachment_review?'
     if assert_success; then
         run_bzr attachment view "$_AID"
         if assert_json '.content_type' "text/plain" &&
-            assert_json_contains '[.flags[].name] | join(",")' "review"; then test_pass; fi
+            assert_json_contains '[.flags[].name] | join(",")' "bzr_attachment_review"; then test_pass; fi
     fi
 else test_skip "no attachment id"; fi
 

--- a/tests/functional/phases/16b-attachments-private.sh
+++ b/tests/functional/phases/16b-attachments-private.sh
@@ -28,9 +28,9 @@ if [[ -n "$BUG1" ]]; then
     # Several public attachments are uploaded earlier in the run and this
     # section adds one private; the list must include ≥3 total AND the
     # private one must be visible (is_private: true present).
-    if assert_success \
-        && assert_json_array_min_length '.' 3 \
-        && [[ "$(jq '[.[] | select(.is_private == true)] | length' "$BZR_STDOUT")" -ge 1 ]]; then
+    if assert_success &&
+        assert_json_array_min_length '.' 3 &&
+        [[ "$(jq '[.[] | select(.is_private == true)] | length' "$BZR_STDOUT")" -ge 1 ]]; then
         test_pass
     fi
 else test_skip "no BUG1"; fi
@@ -38,9 +38,9 @@ else test_skip "no BUG1"; fi
 test_begin "100c. attachment list returns private attachment in XML-RPC mode"
 if [[ -n "$BUG1" ]]; then
     run_bzr --api xmlrpc attachment list "$BUG1"
-    if assert_success \
-        && assert_json_array_min_length '.' 3 \
-        && [[ "$(jq '[.[] | select(.is_private == true)] | length' "$BZR_STDOUT")" -ge 1 ]]; then
+    if assert_success &&
+        assert_json_array_min_length '.' 3 &&
+        [[ "$(jq '[.[] | select(.is_private == true)] | length' "$BZR_STDOUT")" -ge 1 ]]; then
         test_pass
     fi
 else test_skip "no BUG1"; fi
@@ -70,4 +70,3 @@ else
 fi
 
 echo ""
-

--- a/tests/functional/phases/17-global-options.sh
+++ b/tests/functional/phases/17-global-options.sh
@@ -75,5 +75,38 @@ if assert_success && assert_json '.action' "dry-run"; then
 fi
 unset _DM
 
-echo ""
+test_begin "103d. --dry-run product create previews without writing"
+_DP=$(unique_name dryprod)
+run_bzr --dry-run product create --name "$_DP" --description "dry product"
+if assert_success && assert_json '.resource' "product" && assert_json '.action' "dry-run"; then
+    run_bzr product view "$_DP"
+    if assert_failure; then test_pass; fi
+fi
+unset _DP
 
+test_begin "103e. --dry-run component update by name resolves but does not write"
+run_bzr --dry-run component update --product FuncTestProd --component Backend \
+    --description "dry component update"
+if [[ $BZR_EXIT -eq 0 ]]; then
+    run_bzr component view FuncTestProd Backend
+    if assert_stdout_not_contains "dry component update"; then test_pass; fi
+elif grep -q "32614" "$BZR_STDERR" 2>/dev/null; then
+    test_skip "component update REST endpoint not available"
+else
+    assert_success
+fi
+
+test_begin "103f. --dry-run user update previews without writing"
+run_bzr --dry-run user update testuser@test.bzr --disable-login false
+if assert_success && assert_json '.resource' "user" && assert_json '.action' "dry-run"; then
+    test_pass
+fi
+
+test_begin "103g. --dry-run group update previews without writing"
+run_bzr --dry-run group update functest-grp --description "dry group update"
+if assert_success && assert_json '.resource' "group" && assert_json '.action' "dry-run"; then
+    run_bzr group view functest-grp
+    if assert_stdout_not_contains "dry group update"; then test_pass; fi
+fi
+
+echo ""

--- a/tests/functional/phases/17b-arg-validation.sh
+++ b/tests/functional/phases/17b-arg-validation.sh
@@ -69,4 +69,12 @@ test_begin "127. --dry-run on non-mutation (exit 7)"
 run_bzr --dry-run server info
 if assert_exit_code 7 && assert_stderr_contains "only supported for bug create"; then test_pass; fi
 
+test_begin "128. attachment update no fields rejected"
+run_bzr attachment update 1
+if assert_exit_code 7 && assert_stderr_contains "no attachment fields to update"; then test_pass; fi
+
+test_begin "129. comment tag no changes rejected"
+run_bzr comment tag 1
+if assert_exit_code 7 && assert_stderr_contains "no comment tag changes"; then test_pass; fi
+
 echo ""

--- a/tests/functional/phases/17b-arg-validation.sh
+++ b/tests/functional/phases/17b-arg-validation.sh
@@ -24,6 +24,16 @@ test_begin "122. bug list --offset + --paginate conflict"
 run_bzr bug list --offset 1 --paginate
 if assert_exit_code 2 && assert_stderr_contains "cannot be used with"; then test_pass; fi
 
+test_begin "122a. query run --count + --offset conflict"
+run_bzr query run prod-bugs --count --offset 1
+if assert_exit_code 7 &&
+    assert_stderr_contains "cannot be combined with --offset or --paginate"; then test_pass; fi
+
+test_begin "122b. query run --count + --paginate conflict"
+run_bzr query run prod-bugs --count --paginate
+if assert_exit_code 7 &&
+    assert_stderr_contains "cannot be combined with --offset or --paginate"; then test_pass; fi
+
 test_begin "123. bug create --template + --from-json conflict"
 run_bzr bug create --template t --from-json /tmp/none
 if assert_exit_code 2 && assert_stderr_contains "cannot be used with"; then test_pass; fi

--- a/tests/functional/phases/17b-arg-validation.sh
+++ b/tests/functional/phases/17b-arg-validation.sh
@@ -36,6 +36,19 @@ test_begin "125. --server-url + --server conflict"
 run_bzr --server-url http://example.invalid:1 --server test whoami
 if assert_exit_code 2 && assert_stderr_contains "cannot be used with"; then test_pass; fi
 
+test_begin "125a. --server-api-key-env requires --server-url"
+run_bzr --server-api-key-env BZR_FUNC_INLINE_KEY server info
+if assert_exit_code 2 && assert_stderr_contains "required"; then test_pass; fi
+
+test_begin "125b. --server-tls-insecure requires --server-url"
+run_bzr --server-tls-insecure server info
+if assert_exit_code 2 && assert_stderr_contains "required"; then test_pass; fi
+
+test_begin "125c. ad-hoc TLS flags are mutually exclusive"
+run_bzr --server-url "$BZ_URL" --server-tls-insecure \
+    --server-tls-pin-now server info
+if assert_exit_code 2 && assert_stderr_contains "cannot be used with"; then test_pass; fi
+
 # `whoami show` subcommand removed (#323): bare `whoami` only.
 test_begin "126. whoami show (removed subcommand → exit 2)"
 run_bzr whoami show

--- a/tests/functional/phases/18-completion-schema.sh
+++ b/tests/functional/phases/18-completion-schema.sh
@@ -39,29 +39,58 @@ if assert_exit_code 2 && assert_stderr_contains "invalid value"; then test_pass;
 test_begin "116. schema (list)"
 run_bzr schema
 if assert_success && assert_json_valid &&
-	assert_json_exists 'index("bug")' &&
-	assert_json_exists 'index("bug-create-input")' &&
-	assert_json_exists 'index("error")'; then test_pass; fi
+    assert_schema_list_contains "bug" &&
+    assert_schema_list_contains "bug-create-input" &&
+    assert_schema_list_contains "bug-update-input" &&
+    assert_schema_list_contains "product-create-input" &&
+    assert_schema_list_contains "product-update-input" &&
+    assert_schema_list_contains "component-create-input" &&
+    assert_schema_list_contains "component-update-input" &&
+    assert_schema_list_contains "user-create-input" &&
+    assert_schema_list_contains "user-update-input" &&
+    assert_schema_list_contains "group-create-input" &&
+    assert_schema_list_contains "group-update-input" &&
+    assert_schema_list_contains "error"; then test_pass; fi
 
 test_begin "117. schema bug (valid draft 2020-12 schema)"
 run_bzr schema bug
 if assert_success && assert_json_valid &&
-	assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema"; then test_pass; fi
+    assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema"; then test_pass; fi
 
 test_begin "118. schema bug-update-input (valid draft 2020-12 schema)"
 run_bzr schema bug-update-input
 if assert_success && assert_json_valid &&
-	assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema" &&
-	assert_json '.["$defs"].bugUpdateInputObject.additionalProperties' "false"; then test_pass; fi
+    assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema" &&
+    assert_json '.["$defs"].bugUpdateInputObject.additionalProperties' "false"; then test_pass; fi
+
+test_begin "118a. schema product-create-input"
+run_bzr schema product-create-input
+if assert_success && assert_json_valid &&
+    assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema"; then test_pass; fi
+
+test_begin "118b. schema component-update-input"
+run_bzr schema component-update-input
+if assert_success && assert_json_valid &&
+    assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema"; then test_pass; fi
+
+test_begin "118c. schema user-update-input"
+run_bzr schema user-update-input
+if assert_success && assert_json_valid &&
+    assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema"; then test_pass; fi
+
+test_begin "118d. schema group-update-input"
+run_bzr schema group-update-input
+if assert_success && assert_json_valid &&
+    assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema"; then test_pass; fi
 
 test_begin "119. schema error (valid error envelope schema)"
 run_bzr schema error
 if assert_success && assert_json_valid &&
-	assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema" &&
-	assert_json '.properties.error.type' "object" &&
-	assert_json_exists '.properties.error.required | index("type")' &&
-	assert_json_exists '.properties.error.required | index("message")' &&
-	assert_json_exists '.properties.error.required | index("exit_code")'; then test_pass; fi
+    assert_json '.["$schema"]' "https://json-schema.org/draft/2020-12/schema" &&
+    assert_json '.properties.error.type' "object" &&
+    assert_json_exists '.properties.error.required | index("type")' &&
+    assert_json_exists '.properties.error.required | index("message")' &&
+    assert_json_exists '.properties.error.required | index("exit_code")'; then test_pass; fi
 
 # Error JSON routes to stderr even under --json, so assert there.
 test_begin "120. schema unknown name (input error, exit 7)"

--- a/tests/functional/phases/99-sequences.sh
+++ b/tests/functional/phases/99-sequences.sh
@@ -42,8 +42,8 @@ if assert_success && assert_json_exists '.id'; then
                 run_bzr bug view "$SEQ_LIFE"
                 if assert_json '.status' "RESOLVED" && assert_json '.resolution' "FIXED"; then
                     run_bzr comment list "$SEQ_LIFE"
-                    if assert_success \
-                        && [[ "$(jq '[.[] | select(.text | contains("LIFECYCLE-MARKER-105"))] | length' "$BZR_STDOUT")" -ge 1 ]]; then
+                    if assert_success &&
+                        [[ "$(jq '[.[] | select(.text | contains("LIFECYCLE-MARKER-105"))] | length' "$BZR_STDOUT")" -ge 1 ]]; then
                         test_pass
                     else
                         test_fail "resolve comment not found"
@@ -66,17 +66,17 @@ if assert_success && assert_json_exists '.id'; then
     run_bzr bug update "$SEQ_PAR" --whiteboard "parity-marker-106"
     if assert_success; then
         run_bzr --api rest bug view "$SEQ_PAR"
-        if assert_success \
-            && assert_json '.whiteboard' "parity-marker-106" \
-            && assert_json '.summary' "Parity bug"; then
+        if assert_success &&
+            assert_json '.whiteboard' "parity-marker-106" &&
+            assert_json '.summary' "Parity bug"; then
             run_bzr --api hybrid bug view "$SEQ_PAR"
-            if assert_success \
-                && assert_json '.whiteboard' "parity-marker-106" \
-                && assert_json '.summary' "Parity bug"; then
+            if assert_success &&
+                assert_json '.whiteboard' "parity-marker-106" &&
+                assert_json '.summary' "Parity bug"; then
                 run_bzr --api xmlrpc bug view "$SEQ_PAR"
-                if assert_success \
-                    && assert_json '.whiteboard' "parity-marker-106" \
-                    && assert_json '.summary' "Parity bug"; then
+                if assert_success &&
+                    assert_json '.whiteboard' "parity-marker-106" &&
+                    assert_json '.summary' "Parity bug"; then
                     test_pass
                 fi
             fi
@@ -93,9 +93,9 @@ run_bzr bug create --product FuncTestProd --component Backend \
 if assert_success && assert_json_exists '.id'; then
     SEQ_BVALID=$(jq -r '.id' "$BZR_STDOUT")
     run_bzr bug update "$SEQ_BVALID" 999999 --whiteboard "batch-partial-107"
-    if assert_exit_code 11 \
-        && assert_json '.succeeded[0]' "$SEQ_BVALID" \
-        && assert_json '.failed[0].id' "999999"; then
+    if assert_exit_code 11 &&
+        assert_json '.succeeded[0]' "$SEQ_BVALID" &&
+        assert_json '.failed[0].id' "999999"; then
         run_bzr bug view "$SEQ_BVALID"
         if assert_success && assert_json '.whiteboard' "batch-partial-107"; then test_pass; fi
     fi
@@ -113,8 +113,8 @@ if assert_success && assert_json_exists '.id'; then
     if assert_success && assert_json_exists '.id'; then
         SEQ_CDST=$(jq -r '.id' "$BZR_STDOUT")
         run_bzr comment list "$SEQ_CDST"
-        if assert_success \
-            && [[ "$(jq '[.[] | select(.count == 0 and (.text | contains("CLONE-DESC-MARKER-108")))] | length' "$BZR_STDOUT")" -ge 1 ]]; then
+        if assert_success &&
+            [[ "$(jq '[.[] | select(.count == 0 and (.text | contains("CLONE-DESC-MARKER-108")))] | length' "$BZR_STDOUT")" -ge 1 ]]; then
             test_pass
         else
             test_fail "clone comment #0 missing source description"
@@ -123,4 +123,3 @@ if assert_success && assert_json_exists '.id'; then
 else test_skip "create failed"; fi
 
 echo ""
-

--- a/tests/functional/run-all-versions.sh
+++ b/tests/functional/run-all-versions.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Run functional tests against all supported Bugzilla versions.
+# SC2329: cleanup_all is invoked through the EXIT trap.
+# shellcheck disable=SC2329
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -7,7 +7,9 @@
 # globals below are consumed by the sourced phase files; shellcheck cannot
 # follow the dynamic `source` in the phase loop, so disable its unused-variable
 # warning for them here.
-# shellcheck disable=SC2034
+# SC1091: lib.sh is resolved from the computed script directory.
+# SC2329: cleanup is invoked through the EXIT trap.
+# shellcheck disable=SC1091,SC2034,SC2329
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -19,10 +21,10 @@ source "$SCRIPT_DIR/lib.sh"
 # ── Constants ────────────────────────────────────────────────────────
 BZ_VERSION="${BZR_BZ_VERSION:-bz50}"
 case "$BZ_VERSION" in
-    bz50) DEFAULT_PORT=8089 ;;
-    bz52) DEFAULT_PORT=8090 ;;
-    bz53) DEFAULT_PORT=8091 ;;
-    *)    DEFAULT_PORT=8089 ;;
+bz50) DEFAULT_PORT=8089 ;;
+bz52) DEFAULT_PORT=8090 ;;
+bz53) DEFAULT_PORT=8091 ;;
+*) DEFAULT_PORT=8089 ;;
 esac
 BZ_PORT="${BZR_FUNC_PORT:-$DEFAULT_PORT}"
 BZ_URL="http://127.0.0.1:${BZ_PORT}"
@@ -61,7 +63,7 @@ trap cleanup EXIT
 # ══════════════════════════════════════════════════════════════════════
 for _phase in \
     00-build 01-config 02-server-auth 03-products 04-components \
-    05-fields-classifications 06-users 07-groups 08-bugs 08b-bugs-paging 08c-bugs-create-fields \
+    05-fields-classifications 06-users 07-groups 08-bugs 08b-bugs-paging 08c-bugs-create-fields 08d-bug-update-from-json \
     09-bug-relationships 09b-bug-collision \
     10-bug-clone 11-batch-update 11b-bug-verbs 12-my-bugs 13-templates 14-queries \
     15-comments 15b-comments-private 16-attachments 16b-attachments-private \

--- a/tests/functional/setup-bugzilla.sh
+++ b/tests/functional/setup-bugzilla.sh
@@ -20,10 +20,22 @@ fi
 BZ_VERSION="${BZR_BZ_VERSION:-bz50}"
 
 case "$BZ_VERSION" in
-    bz50) DEFAULT_PORT=8089; DEFAULT_TIMEOUT=90 ;;
-    bz52) DEFAULT_PORT=8090; DEFAULT_TIMEOUT=240 ;;
-    bz53) DEFAULT_PORT=8091; DEFAULT_TIMEOUT=240 ;;
-    *)    echo "ERROR: Unknown BZR_BZ_VERSION=$BZ_VERSION (expected bz50, bz52, or bz53)" >&2; exit 1 ;;
+bz50)
+    DEFAULT_PORT=8089
+    DEFAULT_TIMEOUT=90
+    ;;
+bz52)
+    DEFAULT_PORT=8090
+    DEFAULT_TIMEOUT=240
+    ;;
+bz53)
+    DEFAULT_PORT=8091
+    DEFAULT_TIMEOUT=240
+    ;;
+*)
+    echo "ERROR: Unknown BZR_BZ_VERSION=$BZ_VERSION (expected bz50, bz52, or bz53)" >&2
+    exit 1
+    ;;
 esac
 
 CONTAINER_NAME="${BZR_FUNC_CONTAINER:-bzr-func-test-${BZ_VERSION}}"
@@ -33,8 +45,14 @@ HEALTH_TIMEOUT="${BZR_FUNC_TIMEOUT:-$DEFAULT_TIMEOUT}"
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
-log() { echo "==> [$BZ_VERSION] $*"; return 0; }
-err() { echo "ERROR: [$BZ_VERSION] $*" >&2; return 0; }
+log() {
+    echo "==> [$BZ_VERSION] $*"
+    return 0
+}
+err() {
+    echo "ERROR: [$BZ_VERSION] $*" >&2
+    return 0
+}
 
 wait_for_ready() {
     local url="http://127.0.0.1:${BZ_PORT}/rest/version"
@@ -149,15 +167,18 @@ cmd_logs() {
 # ── Main ─────────────────────────────────────────────────────────────
 
 case "${1:-}" in
-    build)  cmd_build ;;
-    start)  cmd_start ;;
-    stop)   cmd_stop ;;
-    status) cmd_status ;;
-    reset)  cmd_reset ;;
-    logs)   shift; cmd_logs "$@" ;;
-    *)
-        echo "Usage: $0 {build|start|stop|status|reset|logs}"
-        echo "  Set BZR_BZ_VERSION=bz50|bz52|bz53 (default: bz50)"
-        exit 1
-        ;;
+build) cmd_build ;;
+start) cmd_start ;;
+stop) cmd_stop ;;
+status) cmd_status ;;
+reset) cmd_reset ;;
+logs)
+    shift
+    cmd_logs "$@"
+    ;;
+*)
+    echo "Usage: $0 {build|start|stop|status|reset|logs}"
+    echo "  Set BZR_BZ_VERSION=bz50|bz52|bz53 (default: bz50)"
+    exit 1
+    ;;
 esac

--- a/tests/functional/versions/bz50/entrypoint.sh
+++ b/tests/functional/versions/bz50/entrypoint.sh
@@ -7,6 +7,7 @@ API_KEY="FuncTest0123456789abcdef0123456789abcdef"
 echo "==> Starting MariaDB..."
 /usr/libexec/mysqld --user=mysql --datadir=/var/lib/mysql &
 MYSQL_PID=$!
+trap 'kill "$MYSQL_PID" 2>/dev/null || true' EXIT
 
 # Wait for MariaDB socket (up to 30s)
 for i in $(seq 1 30); do

--- a/tests/functional/versions/bz52/entrypoint.sh
+++ b/tests/functional/versions/bz52/entrypoint.sh
@@ -7,6 +7,7 @@ API_KEY="FuncTest0123456789abcdef0123456789abcdef"
 echo "==> Starting MariaDB..."
 /usr/libexec/mysqld --user=mysql --datadir=/var/lib/mysql &
 MYSQL_PID=$!
+trap 'kill "$MYSQL_PID" 2>/dev/null || true' EXIT
 
 # Wait for MariaDB socket (up to 30s)
 for i in $(seq 1 30); do

--- a/tests/functional/versions/bz53/entrypoint.sh
+++ b/tests/functional/versions/bz53/entrypoint.sh
@@ -7,6 +7,7 @@ API_KEY="FuncTest0123456789abcdef0123456789abcdef"
 echo "==> Starting MariaDB..."
 /usr/libexec/mysqld --user=mysql --datadir=/var/lib/mysql &
 MYSQL_PID=$!
+trap 'kill "$MYSQL_PID" 2>/dev/null || true' EXIT
 
 # Wait for MariaDB socket (up to 30s)
 for i in $(seq 1 30); do


### PR DESCRIPTION
## Summary

- Expands the shell functional suite across credentialless servers, structured JSON input, dry runs, bug metadata, queries, comments, attachments, schema, and sequence coverage.
- Seeds test-only Bugzilla flag and product-group capabilities so real container runs can exercise flag, private-resource, and grouped-bug workflows.
- Tightens grouped-bug coverage so the suite proves a `--groups` bug is hidden from the credentialless public server.

## Test Plan

- `shellcheck tests/functional/phases/08c-bugs-create-fields.sh`
- `shfmt -i 4 -d tests/functional/phases/08c-bugs-create-fields.sh`
- `git diff --check`
- Mutation check: temporarily removed `--groups functest-grp`; `BZR_BZ_VERSION=bz50 tests/functional/run-tests.sh` failed at test `146c` as expected
- `BZR_BZ_VERSION=bz50 tests/functional/run-tests.sh` (`289 passed, 0 failed, 4 skipped`)
- `git push` pre-push hook (`cargo test`) passed

Not run: full `tests/functional/run-all-versions.sh` matrix.
