### PR TITLE
release: prep v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.6.0] - 2026-06-22
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzr"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "apple-native-keyring-store",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 
 [package]
 name = "bzr"
-version = "0.5.1-dev"
+version = "0.6.0"
 edition = "2021"
 description = "A CLI for Bugzilla, inspired by gh"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump bzr package version from 0.5.1-dev to 0.6.0.
- Date the changelog entry for v0.6.0.
- Refresh Cargo.lock for the release version.

## Test Plan
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test --quiet
- cargo build --release
- cargo publish --dry-run